### PR TITLE
fix: resolve all test warnings and add batch size validation

### DIFF
--- a/claudey
+++ b/claudey
@@ -1,0 +1,1 @@
+../juniper-ml/scripts/claude_interactive.bash

--- a/cly
+++ b/cly
@@ -1,1 +1,0 @@
-../juniper-ml/scripts/default_interactive_session_claude_code.bash

--- a/conf/init.conf
+++ b/conf/init.conf
@@ -43,8 +43,8 @@
 export TRUE="0"
 export FALSE="1"
 
-export DEBUG_FLAG="${TRUE}"
-# export DEBUG_FLAG="${FALSE}"
+# export DEBUG_FLAG="${TRUE}"
+export DEBUG_FLAG="${FALSE}"
 [[ "${DEBUG}" == "" ]] && export DEBUG="${DEBUG_FLAG}"
 
 

--- a/notes/FIX_PLAN_flake8_test_lint_2026-03-13.md
+++ b/notes/FIX_PLAN_flake8_test_lint_2026-03-13.md
@@ -1,0 +1,64 @@
+# Fix Plan: Flake8 Test Lint Failures
+
+**Date**: 2026-03-13
+**Trigger**: `pre-commit run --all-files` — "Lint tests with Flake8 (relaxed)" hook fails with 5 violations
+**Scope**: `src/tests/unit/` — 5 files, 5 violations
+
+---
+
+## Root Cause Analysis
+
+All 5 failures are flake8 lint violations in test files caught by the `flake8-bugbear` and `flake8-comprehensions` plugins. No functional test failures — unit tests and coverage gate both pass.
+
+## Issues and Fixes
+
+### 1. C408 — `dict()` call should be dict literal (3 occurrences)
+
+**Rule**: `flake8-comprehensions` C408 flags `dict(key=val)` calls that can be rewritten as `{"key": val}` literals.
+
+| File | Line | Current | Fix |
+|------|------|---------|-----|
+| `test_cascade_correlation_coverage_deep.py` | 46 | `defaults = dict(input_size=2, ...)` | `defaults = {"input_size": 2, ...}` |
+| `test_cascade_correlation_coverage_final.py` | 41 | `defaults = dict(input_size=2, ...)` | `defaults = {"input_size": 2, ...}` |
+| `test_snapshot_serializer_coverage_final.py` | 32 | `defaults = dict(input_size=2, ...)` | `defaults = {"input_size": 2, ...}` |
+
+### 2. B017 — `pytest.raises(Exception)` too broad (1 occurrence)
+
+**Rule**: `flake8-bugbear` B017 flags `pytest.raises(Exception)` as dangerous because it can mask unrelated exceptions (e.g., typos causing `NameError`). A specific exception type should be used.
+
+| File | Line | Current | Fix |
+|------|------|---------|-----|
+| `test_remaining_coverage_deep.py` | 149 | `with pytest.raises(Exception):` | `with pytest.raises(WebSocketDisconnect):` |
+
+**Analysis**: The test verifies that a WebSocket connection fails when `ws_manager` is `None`. The handler at `src/api/websocket/training_stream.py:33-35` calls `websocket.close(code=1011)`, which causes Starlette's TestClient to raise `WebSocketDisconnect`. This exception type is already used in `src/tests/unit/api/test_websocket_auth.py`.
+
+**Additional change**: Add `from starlette.websockets import WebSocketDisconnect` import.
+
+### 3. B007 — Unused loop control variable (1 occurrence)
+
+**Rule**: `flake8-bugbear` B007 flags loop variables not used in the loop body. Convention is to prefix with `_`.
+
+| File | Line | Current | Fix |
+|------|------|---------|-----|
+| `test_snapshot_serializer_coverage_deep.py` | 207 | `for i, (orig, loaded_unit) in enumerate(...)` | `for _, (orig, loaded_unit) in enumerate(...)` |
+
+## Other Potential Issues
+
+No other issues identified. All other pre-commit hooks pass:
+- Black formatting: Passed
+- isort: Passed
+- Source flake8: Passed
+- MyPy: Passed
+- Bandit security: Passed
+- Unit tests: Passed
+- Coverage gate (80%): Passed
+
+## Verification
+
+After applying all fixes, run:
+```bash
+cd /home/pcalnon/Development/python/Juniper/juniper-cascor
+pre-commit run flake8 --all-files
+```
+
+All 5 violations should be resolved with zero functional impact.

--- a/notes/TEST_WARNING_FIXES_PLAN.md
+++ b/notes/TEST_WARNING_FIXES_PLAN.md
@@ -1,0 +1,125 @@
+# Test Warning Fixes Plan
+
+**Date**: 2026-03-13
+**Author**: Claude Code
+**Status**: Complete
+
+---
+
+## Problem Statement
+
+Running the juniper-cascor test suite with warnings enabled (`-W default` or without `-p no:warnings`) produces multiple categories of warnings. While all 2124 tests pass, the warnings indicate code quality issues and potential bugs that should be addressed.
+
+## Root Cause Analysis
+
+### Issue 1: PytestReturnNotNoneWarning (13 test functions, 4 files)
+
+**Root Cause**: Legacy test functions use a `return True`/`return False` pattern designed for standalone script execution (`if __name__ == "__main__"`). Pytest expects test functions to return `None` — failures should propagate as exceptions, not boolean return values.
+
+**Affected Files**:
+- `src/tests/unit/test_cascor_fix.py` — 2 test functions + 2 helpers
+- `src/tests/unit/test_critical_fixes.py` — 5 test functions + 1 helper
+- `src/tests/unit/test_hdf5.py` — 1 test function + 1 helper
+- `src/tests/unit/test_p1_fixes.py` — 5 test functions + 3 helpers
+
+**Fix**: Remove `return True/False` from test functions and helpers. Replace `return False` with `assert` or `pytest.fail()`. Remove try/except wrappers that swallow exceptions (pytest handles exception reporting). Update `if __name__ == "__main__"` blocks to use try/except for standalone execution.
+
+### Issue 2: RuntimeWarning — Unawaited Coroutine `WebSocketManager.broadcast`
+
+**Root Cause**: In `test_websocket_manager.py::test_broadcast_from_thread_with_loop`, `asyncio.run_coroutine_threadsafe` is mocked. The `broadcast_from_thread()` method calls `self.broadcast(message)` creating a coroutine object, then passes it to the mocked function. Since the mock doesn't schedule the coroutine, it is never awaited. When Python's GC collects the orphaned coroutine, it emits the RuntimeWarning. The warning surfaces during a later test (`test_cascade_correlation_coverage_final.py`) when GC happens to run.
+
+**Affected File**: `src/tests/unit/api/test_websocket_manager.py` (lines 118–127)
+
+**Fix**: After the mock assertion, retrieve the captured coroutine argument and close it explicitly to prevent the GC warning.
+
+### Issue 3: UserWarning — Mismatched Tensor Sizes in `train_output_layer()`
+
+**Root Cause**: `CascadeCorrelationNetwork.train_output_layer()` does not validate that `x` and `y` have the same batch size (dimension 0). When mismatched tensors are passed, PyTorch's `MSELoss` emits a UserWarning about broadcasting before ultimately raising a RuntimeError. The existing test `test_train_with_mismatched_sizes` expects an error, but the warning is emitted before the error.
+
+**Affected Files**:
+- `src/cascade_correlation/cascade_correlation.py` (line ~1256, `train_output_layer()`)
+- `src/tests/unit/test_training_workflow.py` (test passes, but emits warning)
+
+**Fix**: Add batch size validation to `train_output_layer()` immediately after the None check. Raise `ValueError` with a descriptive message if `x.shape[0] != y.shape[0]`. This prevents the warning and provides a clearer error message.
+
+### Issue 4: Third-Party Deprecation/User Warnings (Cannot Fix at Source)
+
+These warnings originate in third-party library code, not in juniper-cascor:
+
+| Warning | Source | Count |
+|---------|--------|-------|
+| Starlette TestClient `timeout` DeprecationWarning | `starlette/testclient.py` | 16 |
+| sentry_sdk `asyncio.iscoroutinefunction` DeprecationWarning | `sentry_sdk/integrations/` | 118 |
+| matplotlib `FigureCanvasAgg` non-interactive UserWarning | `cascor_plotter.py` (plt.show) | 1 |
+
+**Fix**: Replace the blanket `-p no:warnings` in `pytest.ini` with targeted `filterwarnings` entries for these specific third-party warnings. This enables warnings for our own code while suppressing unavoidable upstream noise.
+
+### Issue 5: `pytest.ini` Blanket Warning Suppression
+
+**Root Cause**: `pytest.ini` contains `-p no:warnings` which disables the entire pytest warnings plugin, hiding all warnings including actionable ones from our own code.
+
+**Fix**: Remove `-p no:warnings` from `addopts`. Add a `filterwarnings` section with targeted filters for third-party warnings only.
+
+---
+
+## Implementation Plan
+
+### Step 1: Fix PytestReturnNotNoneWarning (4 files)
+
+For each affected test function:
+1. Remove `return True` / `return False` statements
+2. Remove try/except wrappers that swallow exceptions — let pytest handle failures
+3. Preserve `try/finally` blocks where cleanup is needed (e.g., `os.cpu_count` restoration)
+4. Convert helper function `return False` to `assert False` or `pytest.fail()`
+5. Update `if __name__ == "__main__"` blocks to use try/except for pass/fail detection
+
+### Step 2: Fix Unawaited Coroutine Warning (1 file)
+
+In `test_websocket_manager.py::test_broadcast_from_thread_with_loop`:
+1. After `mock_submit.assert_called_once()`, retrieve the coroutine from `mock_submit.call_args`
+2. Call `.close()` on the coroutine to prevent the GC warning
+
+### Step 3: Add Batch Size Validation to `train_output_layer()` (1 file)
+
+In `cascade_correlation.py::train_output_layer()`:
+1. After the `if x is None or y is None` check (line 1254–1255)
+2. Add: `if x.shape[0] != y.shape[0]: raise ValueError(...)`
+3. This eliminates the torch UserWarning and provides a clearer error
+
+### Step 4: Update `pytest.ini` Warning Configuration (1 file)
+
+1. Remove `-p no:warnings` from `addopts`
+2. Add `filterwarnings` section with targeted filters:
+   - `ignore::DeprecationWarning:starlette.testclient`
+   - `ignore::DeprecationWarning:sentry_sdk`
+   - `ignore:FigureCanvasAgg is non-interactive:UserWarning`
+
+### Step 5: Run Full Test Suite
+
+1. Run `pytest src/tests/ -v` with warnings enabled
+2. Verify all 2124+ tests pass
+3. Verify zero warnings from juniper-cascor code
+4. Confirm only filtered third-party warnings remain suppressed
+
+---
+
+## Files Modified
+
+| File | Change Type |
+|------|-------------|
+| `src/tests/unit/test_cascor_fix.py` | Remove return values, refactor helpers |
+| `src/tests/unit/test_critical_fixes.py` | Remove return values, refactor helpers |
+| `src/tests/unit/test_hdf5.py` | Remove return values, refactor helper |
+| `src/tests/unit/test_p1_fixes.py` | Remove return values, refactor helpers |
+| `src/tests/unit/api/test_websocket_manager.py` | Close unawaited coroutine |
+| `src/cascade_correlation/cascade_correlation.py` | Add batch size validation |
+| `src/tests/pytest.ini` | Replace warning suppression with targeted filters |
+
+## Validation Criteria
+
+- All existing tests pass (0 failures)
+- No PytestReturnNotNoneWarning warnings
+- No RuntimeWarning about unawaited coroutines
+- No UserWarning about mismatched tensor sizes
+- Third-party warnings properly filtered
+- `if __name__ == "__main__"` standalone execution still works

--- a/src/cascade_correlation/cascade_correlation.py
+++ b/src/cascade_correlation/cascade_correlation.py
@@ -1253,6 +1253,8 @@ class CascadeCorrelationNetwork:
         epochs = (epochs, _CASCADE_CORRELATION_NETWORK_OUTPUT_EPOCHS)[epochs is None]
         if x is None or y is None:
             raise ValueError("CascadeCorrelationNetwork: train_output_layer: Input (x) and target (y) tensors must be provided for training the output layer.")
+        if x.shape[0] != y.shape[0]:
+            raise ValueError(f"CascadeCorrelationNetwork: train_output_layer: Batch size mismatch. Input x has {x.shape[0]} samples but target y has {y.shape[0]} samples.")
 
         # Define loss function and optimizer
         criterion = nn.MSELoss()

--- a/src/tests/pytest.ini
+++ b/src/tests/pytest.ini
@@ -20,7 +20,6 @@ timeout_method = signal
 addopts =
     -ra
     -q
-    -p no:warnings
     --strict-markers
     --strict-config
     --continue-on-collection-errors
@@ -30,6 +29,12 @@ addopts =
     # Coverage removed from default addopts for performance (2-3x speedup).
     # Run coverage explicitly: pytest --cov=cascade_correlation --cov=candidate_unit --cov-report=term-missing --cov-report=html:htmlcov --cov-report=xml
     # Note: --cov=correlation was removed entirely (module never imported).
+filterwarnings =
+    # Third-party deprecation warnings (cannot fix at source)
+    ignore::DeprecationWarning:starlette.testclient
+    ignore::DeprecationWarning:sentry_sdk
+    # matplotlib non-interactive backend warning in headless test environments
+    ignore:FigureCanvasAgg is non-interactive:UserWarning
 markers =
     unit: Unit tests for individual components
     integration: Integration tests for full workflows
@@ -44,4 +49,5 @@ markers =
     validation: Tests for input validation functions
     accuracy: Tests for accuracy calculation methods
     early_stopping: Tests for early stopping logic
+    long: Long-running correctness tests (use --run-long)
     requires_juniper_data: Tests that require the juniper-data package to be installed

--- a/src/tests/unit/api/test_control_stream_coverage.py
+++ b/src/tests/unit/api/test_control_stream_coverage.py
@@ -83,10 +83,12 @@ class TestControlStreamMessageSize:
         await control_stream_handler(ws)
 
         # Verify error was sent
-        ws.send_json.assert_any_call({
-            "type": "connection_established",
-            "data": {"channel": "control"},
-        })
+        ws.send_json.assert_any_call(
+            {
+                "type": "connection_established",
+                "data": {"channel": "control"},
+            }
+        )
         # Check that an error about size was sent
         calls = ws.send_json.call_args_list
         assert any("too large" in str(c).lower() or "Message too large" in str(c) for c in calls)

--- a/src/tests/unit/api/test_websocket_manager.py
+++ b/src/tests/unit/api/test_websocket_manager.py
@@ -125,6 +125,9 @@ class TestWebSocketManager:
         with patch("api.websocket.manager.asyncio.run_coroutine_threadsafe") as mock_submit:
             mgr.broadcast_from_thread({"type": "test"})
             mock_submit.assert_called_once()
+            # Close the coroutine to prevent "coroutine was never awaited" RuntimeWarning
+            coro = mock_submit.call_args[0][0]
+            coro.close()
 
     @pytest.mark.asyncio
     async def test_send_personal_message(self):

--- a/src/tests/unit/test_candidate_unit_coverage_deep.py
+++ b/src/tests/unit/test_candidate_unit_coverage_deep.py
@@ -33,13 +33,7 @@ import torch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
-from candidate_unit.candidate_unit import (
-    ActivationWithDerivative,
-    CandidateParametersUpdate,
-    CandidateTrainingResult,
-    CandidateUnit,
-)
-
+from candidate_unit.candidate_unit import ActivationWithDerivative, CandidateParametersUpdate, CandidateTrainingResult, CandidateUnit
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -109,9 +103,10 @@ class TestActivationWithDerivativeEdgeCases:
     @pytest.mark.unit
     def test_numerical_derivative_for_unknown_activation(self):
         """Lines 231-232: Numerical derivative for unknown activation functions."""
+
         # Use a custom function that has __name__ but is not tanh/sigmoid/relu
         def custom_square(x):
-            return x ** 2
+            return x**2
 
         awd = ActivationWithDerivative(custom_square)
         assert awd._activation_name == "custom_square"
@@ -360,9 +355,7 @@ class TestCalculateCorrelationDenomZero:
         # Constant output: all same value -> std=0 -> denominator effectively 0
         output = torch.ones(10)
         residual_error = torch.ones(10)
-        correlation, norm_output, norm_error, num, den = candidate._calculate_correlation(
-            output=output, residual_error=residual_error
-        )
+        correlation, norm_output, norm_error, num, den = candidate._calculate_correlation(output=output, residual_error=residual_error)
         # With the epsilon, denominator won't be exactly zero but correlation
         # should be near zero since numerator is zero (all centered values are 0)
         assert abs(correlation) < 1e-3
@@ -372,9 +365,7 @@ class TestCalculateCorrelationDenomZero:
         """Zero residual error produces near-zero correlation."""
         output = torch.randn(10)
         residual_error = torch.zeros(10)
-        correlation, norm_output, norm_error, num, den = candidate._calculate_correlation(
-            output=output, residual_error=residual_error
-        )
+        correlation, norm_output, norm_error, num, den = candidate._calculate_correlation(output=output, residual_error=residual_error)
         assert abs(correlation) < 1e-3
 
 

--- a/src/tests/unit/test_cascade_correlation_coverage_deep.py
+++ b/src/tests/unit/test_cascade_correlation_coverage_deep.py
@@ -34,39 +34,25 @@ import pytest
 import torch
 
 from candidate_unit.candidate_unit import CandidateTrainingResult, CandidateUnit
-from cascade_correlation.cascade_correlation import (
-    CandidateTrainingManager,
-    CascadeCorrelationNetwork,
-    TrainingResults,
-    ValidateTrainingInputs,
-    ValidateTrainingResults,
-    _plot_decision_boundary_worker,
-    _plot_training_history_worker,
-)
-from cascade_correlation.cascade_correlation_config.cascade_correlation_config import (
-    CascadeCorrelationConfig,
-)
-from cascade_correlation.cascade_correlation_exceptions.cascade_correlation_exceptions import (
-    ConfigurationError,
-    TrainingError,
-    ValidationError,
-)
+from cascade_correlation.cascade_correlation import CandidateTrainingManager, CascadeCorrelationNetwork, TrainingResults, ValidateTrainingInputs, ValidateTrainingResults, _plot_decision_boundary_worker, _plot_training_history_worker
+from cascade_correlation.cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
+from cascade_correlation.cascade_correlation_exceptions.cascade_correlation_exceptions import ConfigurationError, TrainingError, ValidationError
 
 
 # ---------------------------------------------------------------------------
 # Helper: create a small network config for fast tests
 # ---------------------------------------------------------------------------
 def _make_config(**overrides):
-    defaults = dict(
-        input_size=2,
-        output_size=2,
-        random_seed=42,
-        candidate_pool_size=2,
-        candidate_epochs=3,
-        output_epochs=3,
-        max_hidden_units=2,
-        patience=1,
-    )
+    defaults = {
+        "input_size": 2,
+        "output_size": 2,
+        "random_seed": 42,
+        "candidate_pool_size": 2,
+        "candidate_epochs": 3,
+        "output_epochs": 3,
+        "max_hidden_units": 2,
+        "patience": 1,
+    }
     defaults.update(overrides)
     return CascadeCorrelationConfig(**defaults)
 
@@ -96,9 +82,7 @@ class TestPlotWorkerFunctions:
 
             _plot_decision_boundary_worker(network, x_data, y_data, title)
 
-            mock_plotter_instance.plot_decision_boundary.assert_called_once_with(
-                network, x_data, y_data, title
-            )
+            mock_plotter_instance.plot_decision_boundary.assert_called_once_with(network, x_data, y_data, title)
 
     @pytest.mark.unit
     def test_plot_training_history_worker_calls_plotter(self):
@@ -111,9 +95,7 @@ class TestPlotWorkerFunctions:
             history_data = {"loss": [1.0, 0.5]}
             _plot_training_history_worker(history_data)
 
-            mock_plotter_instance.plot_training_history.assert_called_once_with(
-                history_data
-            )
+            mock_plotter_instance.plot_training_history.assert_called_once_with(history_data)
 
 
 # ---------------------------------------------------------------------------
@@ -129,9 +111,7 @@ class TestCalculateOptimalProcessCount:
         real_method = CascadeCorrelationNetwork._calculate_optimal_process_count.__wrapped__ if hasattr(CascadeCorrelationNetwork._calculate_optimal_process_count, "__wrapped__") else None
 
         # Access the real method from the class (bypasses monkeypatch on instance)
-        original_method = CascadeCorrelationNetwork.__dict__.get(
-            "_calculate_optimal_process_count"
-        )
+        original_method = CascadeCorrelationNetwork.__dict__.get("_calculate_optimal_process_count")
         # The conftest monkeypatches the class attribute; we call the real code
         # by reaching into the source module directly.
         import cascade_correlation.cascade_correlation as cc_mod
@@ -212,12 +192,8 @@ class TestExecuteCandidateTraining:
         mock_result = CandidateTrainingResult(candidate_id=0, correlation=0.3, success=True)
 
         with patch.object(network, "_execute_parallel_training", return_value=[]):
-            with patch.object(
-                network, "_execute_sequential_training", return_value=[mock_result]
-            ) as mock_seq:
-                results = network._execute_candidate_training(
-                    tasks=[("task1",)], process_count=2
-                )
+            with patch.object(network, "_execute_sequential_training", return_value=[mock_result]) as mock_seq:
+                results = network._execute_candidate_training(tasks=[("task1",)], process_count=2)
                 mock_seq.assert_called_once()
                 assert len(results) == 1
 
@@ -226,12 +202,8 @@ class TestExecuteCandidateTraining:
         """When both parallel and sequential fail, returns dummy results."""
         network = _make_network()
 
-        with patch.object(
-            network, "_execute_parallel_training", side_effect=RuntimeError("parallel fail")
-        ):
-            with patch.object(
-                network, "_execute_sequential_training", side_effect=RuntimeError("seq fail")
-            ):
+        with patch.object(network, "_execute_parallel_training", side_effect=RuntimeError("parallel fail")):
+            with patch.object(network, "_execute_sequential_training", side_effect=RuntimeError("seq fail")):
                 tasks = [("task0",), ("task1",)]
                 results = network._execute_candidate_training(tasks=tasks, process_count=2)
                 # Should get dummy results
@@ -245,15 +217,9 @@ class TestExecuteCandidateTraining:
         network = _make_network()
         mock_result = CandidateTrainingResult(candidate_id=0, correlation=0.7, success=True)
 
-        with patch.object(
-            network, "_execute_parallel_training", side_effect=Exception("mp crash")
-        ):
-            with patch.object(
-                network, "_execute_sequential_training", return_value=[mock_result]
-            ) as mock_seq:
-                results = network._execute_candidate_training(
-                    tasks=[("task1",)], process_count=2
-                )
+        with patch.object(network, "_execute_parallel_training", side_effect=Exception("mp crash")):
+            with patch.object(network, "_execute_sequential_training", return_value=[mock_result]) as mock_seq:
+                results = network._execute_candidate_training(tasks=[("task1",)], process_count=2)
                 mock_seq.assert_called_once()
                 assert results[0].correlation == 0.7
 
@@ -288,9 +254,7 @@ class TestCollectTrainingResults:
         q.put(r1)
 
         # Short timeout so test doesn't wait long
-        results = network._collect_training_results(
-            q, num_tasks=3, queue_timeout=0.5, request_timeout=0.2
-        )
+        results = network._collect_training_results(q, num_tasks=3, queue_timeout=0.5, request_timeout=0.2)
         assert len(results) == 1
 
     @pytest.mark.unit
@@ -299,9 +263,7 @@ class TestCollectTrainingResults:
         network = _make_network()
         q = queue.Queue()
 
-        results = network._collect_training_results(
-            q, num_tasks=2, queue_timeout=0.3, request_timeout=0.1
-        )
+        results = network._collect_training_results(q, num_tasks=2, queue_timeout=0.3, request_timeout=0.1)
         assert len(results) == 0
 
     @pytest.mark.unit
@@ -312,9 +274,7 @@ class TestCollectTrainingResults:
         mock_q.qsize.return_value = 1
         mock_q.get.side_effect = RuntimeError("broken queue")
 
-        results = network._collect_training_results(
-            mock_q, num_tasks=2, queue_timeout=2.0, request_timeout=0.5
-        )
+        results = network._collect_training_results(mock_q, num_tasks=2, queue_timeout=2.0, request_timeout=0.5)
         assert len(results) == 0
 
 
@@ -368,9 +328,7 @@ class TestStopWorkers:
         # Phase 2 graceful: is_alive True (didn't stop), time check passes,
         # Phase 3 terminate: is_alive True -> terminate, join, is_alive False
         # Final walrus: is_alive False
-        w = self._make_mock_worker(
-            alive_sequence=[True, True, True, False, False]
-        )
+        w = self._make_mock_worker(alive_sequence=[True, True, True, False, False])
         task_q = MagicMock()
 
         network._stop_workers([w], task_q)
@@ -418,12 +376,20 @@ class TestProcessTrainingResults:
 
         results = [
             CandidateTrainingResult(
-                candidate_id=0, candidate_uuid="uuid-0", correlation=0.3,
-                candidate=MagicMock(), success=True, epochs_completed=3,
+                candidate_id=0,
+                candidate_uuid="uuid-0",
+                correlation=0.3,
+                candidate=MagicMock(),
+                success=True,
+                epochs_completed=3,
             ),
             CandidateTrainingResult(
-                candidate_id=1, candidate_uuid="uuid-1", correlation=0.8,
-                candidate=MagicMock(), success=True, epochs_completed=3,
+                candidate_id=1,
+                candidate_uuid="uuid-1",
+                correlation=0.8,
+                candidate=MagicMock(),
+                success=True,
+                epochs_completed=3,
             ),
         ]
         tasks = [("task0",), ("task1",)]
@@ -455,8 +421,12 @@ class TestProcessTrainingResults:
 
         results = [
             CandidateTrainingResult(
-                candidate_id=0, candidate_uuid="uuid-0", correlation=0.5,
-                candidate=MagicMock(), success=True, epochs_completed=3,
+                candidate_id=0,
+                candidate_uuid="uuid-0",
+                correlation=0.5,
+                candidate=MagicMock(),
+                success=True,
+                epochs_completed=3,
             ),
         ]
         tasks = [("t0",), ("t1",), ("t2",)]
@@ -475,9 +445,7 @@ class TestTrainCandidateWorker:
     @pytest.mark.unit
     def test_none_input_returns_tuple(self):
         """task_data_input=None should return (None, None, 0.0, None)."""
-        result = CascadeCorrelationNetwork.train_candidate_worker(
-            task_data_input=None, parallel=False
-        )
+        result = CascadeCorrelationNetwork.train_candidate_worker(task_data_input=None, parallel=False)
         assert result == (None, None, 0.0, None)
 
     @pytest.mark.unit
@@ -488,28 +456,26 @@ class TestTrainCandidateWorker:
         residual = torch.randn(10, 2)
 
         candidate_data = (
-            0,           # candidate_index within tuple
-            2,           # input_size
-            "Tanh",      # activation_name
-            0.1,         # random_value_scale
-            "test-uuid", # candidate_uuid
-            42,          # candidate_seed
-            1.0,         # random_max_value
-            100,         # sequence_max_value
+            0,  # candidate_index within tuple
+            2,  # input_size
+            "Tanh",  # activation_name
+            0.1,  # random_value_scale
+            "test-uuid",  # candidate_uuid
+            42,  # candidate_seed
+            1.0,  # random_max_value
+            100,  # sequence_max_value
         )
         training_inputs = (
-            x_input,     # candidate_input
-            3,           # candidate_epochs
-            y_target,    # y
-            residual,    # residual_error
-            0.01,        # candidate_learning_rate
-            10,          # candidate_display_frequency
+            x_input,  # candidate_input
+            3,  # candidate_epochs
+            y_target,  # y
+            residual,  # residual_error
+            0.01,  # candidate_learning_rate
+            10,  # candidate_display_frequency
         )
         task = (0, candidate_data, training_inputs)
 
-        result = CascadeCorrelationNetwork.train_candidate_worker(
-            task_data_input=task, parallel=False
-        )
+        result = CascadeCorrelationNetwork.train_candidate_worker(task_data_input=task, parallel=False)
         assert isinstance(result, CandidateTrainingResult)
         # Should have a non-None correlation
         assert result.correlation is not None
@@ -517,13 +483,9 @@ class TestTrainCandidateWorker:
     @pytest.mark.unit
     def test_invalid_build_returns_none_tuple(self):
         """If _build_candidate_inputs returns None, returns (None, None, 0.0, None)."""
-        with patch.object(
-            CascadeCorrelationNetwork, "_build_candidate_inputs", return_value=None
-        ):
+        with patch.object(CascadeCorrelationNetwork, "_build_candidate_inputs", return_value=None):
             task = (0, (0, 2, "Tanh", 0.1, "uuid", 42, 1.0, 100), (None,) * 6)
-            result = CascadeCorrelationNetwork.train_candidate_worker(
-                task_data_input=task, parallel=False
-            )
+            result = CascadeCorrelationNetwork.train_candidate_worker(task_data_input=task, parallel=False)
             assert result == (None, None, 0.0, None)
 
 
@@ -541,28 +503,26 @@ class TestBuildCandidateInputs:
         residual = torch.randn(10, 2)
 
         candidate_data = (
-            0,           # candidate_index (element [0] of candidate_data, skipped by [1:])
-            2,           # input_size
-            "Tanh",      # activation_name
-            0.1,         # random_value_scale
-            "test-uuid", # candidate_uuid
-            42,          # candidate_seed
-            1.0,         # random_max_value
-            100,         # sequence_max_value
+            0,  # candidate_index (element [0] of candidate_data, skipped by [1:])
+            2,  # input_size
+            "Tanh",  # activation_name
+            0.1,  # random_value_scale
+            "test-uuid",  # candidate_uuid
+            42,  # candidate_seed
+            1.0,  # random_max_value
+            100,  # sequence_max_value
         )
         training_inputs = (
-            x_input,     # candidate_input
-            3,           # candidate_epochs
-            y_target,    # y
-            residual,    # residual_error
-            0.01,        # candidate_learning_rate
-            10,          # candidate_display_frequency
+            x_input,  # candidate_input
+            3,  # candidate_epochs
+            y_target,  # y
+            residual,  # residual_error
+            0.01,  # candidate_learning_rate
+            10,  # candidate_display_frequency
         )
         task = (0, candidate_data, training_inputs)
 
-        result = CascadeCorrelationNetwork._build_candidate_inputs(
-            task_data_input=task, worker_uuid="worker-uuid-1", worker_id=99
-        )
+        result = CascadeCorrelationNetwork._build_candidate_inputs(task_data_input=task, worker_uuid="worker-uuid-1", worker_id=99)
 
         assert isinstance(result, dict)
         assert result["candidate_index"] == 0
@@ -590,9 +550,7 @@ class TestBuildCandidateInputs:
         training_inputs = (x_input, 5, y_target, residual, 0.05, 20)
         task = (1, candidate_data, training_inputs)
 
-        result = CascadeCorrelationNetwork._build_candidate_inputs(
-            task_data_input=task, worker_uuid="w-uuid", worker_id=1
-        )
+        result = CascadeCorrelationNetwork._build_candidate_inputs(task_data_input=task, worker_uuid="w-uuid", worker_id=1)
 
         assert torch.equal(result["candidate_input"], x_input)
         assert torch.equal(result["y"], y_target)
@@ -623,9 +581,7 @@ class TestWorkerLoop:
         task_q.put(task)
         task_q.put(None)  # Sentinel
 
-        CascadeCorrelationNetwork._worker_loop(
-            task_q, result_q, parallel=False, task_queue_timeout=2.0
-        )
+        CascadeCorrelationNetwork._worker_loop(task_q, result_q, parallel=False, task_queue_timeout=2.0)
 
         # Should have one result
         assert not result_q.empty()
@@ -640,9 +596,7 @@ class TestWorkerLoop:
 
         task_q.put(None)
 
-        CascadeCorrelationNetwork._worker_loop(
-            task_q, result_q, parallel=False, task_queue_timeout=2.0
-        )
+        CascadeCorrelationNetwork._worker_loop(task_q, result_q, parallel=False, task_queue_timeout=2.0)
 
         assert result_q.empty()
 
@@ -656,9 +610,7 @@ class TestWorkerLoop:
         task_q.put(("bad_task",))
         task_q.put(None)  # Sentinel to stop
 
-        CascadeCorrelationNetwork._worker_loop(
-            task_q, result_q, parallel=False, task_queue_timeout=2.0
-        )
+        CascadeCorrelationNetwork._worker_loop(task_q, result_q, parallel=False, task_queue_timeout=2.0)
 
         # Should have a failure result
         assert not result_q.empty()
@@ -918,18 +870,14 @@ class TestGrowNetworkHelpers:
     def test_calculate_train_accuracy_empty_tensors(self):
         """Empty tensors should return 0.0."""
         network = _make_network()
-        result = network._calculate_train_accuracy(
-            x_train=torch.empty(0, 2), y_train=torch.empty(0, 2)
-        )
+        result = network._calculate_train_accuracy(x_train=torch.empty(0, 2), y_train=torch.empty(0, 2))
         assert result == 0.0
 
     @pytest.mark.unit
     def test_calculate_train_accuracy_mismatched_shapes(self):
         """Mismatched batch sizes should return 0.0."""
         network = _make_network()
-        result = network._calculate_train_accuracy(
-            x_train=torch.randn(10, 2), y_train=torch.randn(5, 2)
-        )
+        result = network._calculate_train_accuracy(x_train=torch.randn(10, 2), y_train=torch.randn(5, 2))
         assert result == 0.0
 
     @pytest.mark.unit
@@ -956,36 +904,28 @@ class TestGrowNetworkHelpers:
     def test_retrain_output_layer_empty_tensors(self):
         """Empty tensors should return inf."""
         network = _make_network()
-        result = network._retrain_output_layer(
-            x_train=torch.empty(0, 2), y_train=torch.empty(0, 2)
-        )
+        result = network._retrain_output_layer(x_train=torch.empty(0, 2), y_train=torch.empty(0, 2))
         assert result == float("inf")
 
     @pytest.mark.unit
     def test_retrain_output_layer_mismatched_shapes(self):
         """Mismatched batch sizes should return inf."""
         network = _make_network()
-        result = network._retrain_output_layer(
-            x_train=torch.randn(10, 2), y_train=torch.randn(5, 2)
-        )
+        result = network._retrain_output_layer(x_train=torch.randn(10, 2), y_train=torch.randn(5, 2))
         assert result == float("inf")
 
     @pytest.mark.unit
     def test_retrain_output_layer_zero_epochs(self):
         """epochs <= 0 should return inf."""
         network = _make_network()
-        result = network._retrain_output_layer(
-            x_train=torch.randn(10, 2), y_train=torch.randn(10, 2), epochs=0
-        )
+        result = network._retrain_output_layer(x_train=torch.randn(10, 2), y_train=torch.randn(10, 2), epochs=0)
         assert result == float("inf")
 
     @pytest.mark.unit
     def test_retrain_output_layer_negative_epochs(self):
         """Negative epochs should return inf."""
         network = _make_network()
-        result = network._retrain_output_layer(
-            x_train=torch.randn(10, 2), y_train=torch.randn(10, 2), epochs=-5
-        )
+        result = network._retrain_output_layer(x_train=torch.randn(10, 2), y_train=torch.randn(10, 2), epochs=-5)
         assert result == float("inf")
 
     @pytest.mark.unit
@@ -1227,7 +1167,8 @@ class TestSnapshotMethods:
         fake_file.write_text("fake content")
 
         with patch.object(
-            CascadeCorrelationNetwork, "_load_from_hdf5",
+            CascadeCorrelationNetwork,
+            "_load_from_hdf5",
             side_effect=RuntimeError("corrupt file"),
         ):
             result = CascadeCorrelationNetwork.restore_snapshot(snapshot_path=fake_file)
@@ -1251,6 +1192,7 @@ class TestCandidateTrainingManager:
     def test_valid_start_method_fork(self):
         """'fork' should be accepted on Linux."""
         import sys
+
         if sys.platform == "linux":
             manager = CandidateTrainingManager()
             # We can't actually start the manager in tests, but we can verify
@@ -1258,6 +1200,7 @@ class TestCandidateTrainingManager:
             # address/authkey which we skip here.
             # Just verify no ValueError is raised for the method name
             import multiprocessing as mp
+
             ctx = mp.get_context("fork")
             assert ctx is not None
 
@@ -1379,6 +1322,7 @@ class TestRealCalculateOptimalProcessCount:
                     break
                 # Check if it's a real function (not the lambda from conftest)
                 import inspect
+
                 try:
                     src = inspect.getsource(candidate)
                     if "CASCOR_NUM_PROCESSES" in src:
@@ -1609,9 +1553,7 @@ class TestGetCandidatesHelpers:
             CandidateTrainingResult(candidate_id=1, correlation=0.8, success=True),
             CandidateTrainingResult(candidate_id=2, correlation=0.1, success=False),
         ]
-        count = network.get_candidates_data_count(
-            results, "correlation", lambda c: c >= 0.5
-        )
+        count = network.get_candidates_data_count(results, "correlation", lambda c: c >= 0.5)
         assert count == 2
 
     @pytest.mark.unit
@@ -1620,8 +1562,12 @@ class TestGetCandidatesHelpers:
         network = _make_network()
         results = [
             CandidateTrainingResult(
-                candidate_id=0, candidate_uuid="u0", correlation=0.5,
-                candidate=MagicMock(), success=True, error_message="some error",
+                candidate_id=0,
+                candidate_uuid="u0",
+                correlation=0.5,
+                candidate=MagicMock(),
+                success=True,
+                error_message="some error",
             ),
         ]
         valid_candidates = [True]
@@ -1684,9 +1630,7 @@ class TestWorkerLoopEdgeCases:
         # First call: raises RuntimeError (not Empty)
         task_q.get.side_effect = RuntimeError("broken pipe")
 
-        CascadeCorrelationNetwork._worker_loop(
-            task_q, result_q, parallel=False, task_queue_timeout=1.0
-        )
+        CascadeCorrelationNetwork._worker_loop(task_q, result_q, parallel=False, task_queue_timeout=1.0)
         # Worker should have exited without producing results
         assert result_q.empty()
 

--- a/src/tests/unit/test_cascade_correlation_coverage_final.py
+++ b/src/tests/unit/test_cascade_correlation_coverage_final.py
@@ -15,6 +15,7 @@ Covers:
 - train_candidate_worker: CandidateUnit instantiation error path
 """
 
+import builtins
 import os
 import queue
 import tempfile
@@ -22,40 +23,31 @@ import time
 from queue import Full
 from unittest.mock import MagicMock, PropertyMock, patch
 
-import builtins
 import numpy as np
 import pytest
 import torch
 
 builtins_hasattr = builtins.hasattr
 
-from candidate_unit.candidate_unit import CandidateTrainingResult, CandidateUnit
-from cascade_correlation.cascade_correlation import (
-    CascadeCorrelationNetwork,
-    TrainingResults,
-    ValidateTrainingInputs,
-    ValidateTrainingResults,
-)
-from cascade_correlation.cascade_correlation_config.cascade_correlation_config import (
-    CascadeCorrelationConfig,
-)
-from cascade_correlation.cascade_correlation_exceptions.cascade_correlation_exceptions import (
-    TrainingError,
-)
 from helpers.utilities import set_deterministic_behavior
+
+from candidate_unit.candidate_unit import CandidateTrainingResult, CandidateUnit
+from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork, TrainingResults, ValidateTrainingInputs, ValidateTrainingResults
+from cascade_correlation.cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
+from cascade_correlation.cascade_correlation_exceptions.cascade_correlation_exceptions import TrainingError
 
 
 def _make_config(**overrides):
-    defaults = dict(
-        input_size=2,
-        output_size=2,
-        random_seed=42,
-        candidate_pool_size=2,
-        candidate_epochs=3,
-        output_epochs=3,
-        max_hidden_units=2,
-        patience=1,
-    )
+    defaults = {
+        "input_size": 2,
+        "output_size": 2,
+        "random_seed": 42,
+        "candidate_pool_size": 2,
+        "candidate_epochs": 3,
+        "output_epochs": 3,
+        "max_hidden_units": 2,
+        "patience": 1,
+    }
     defaults.update(overrides)
     return CascadeCorrelationConfig(**defaults)
 
@@ -217,9 +209,7 @@ class TestHDF5RoundTrip:
 
         with tempfile.TemporaryDirectory() as tmpdir:
             filepath = os.path.join(tmpdir, "test_network_state.h5")
-            success = simple_network.save_to_hdf5(
-                filepath, include_training_state=True, include_training_data=False
-            )
+            success = simple_network.save_to_hdf5(filepath, include_training_state=True, include_training_data=False)
             assert success is True
 
     @pytest.mark.unit
@@ -471,9 +461,7 @@ class TestWorkerLoopExceptions:
         task_queue.put(None)  # Sentinel
 
         # Mock train_candidate_worker to return a result
-        mock_result = CandidateTrainingResult(
-            candidate_id=0, candidate_uuid="test", correlation=0.5, candidate=None, success=True
-        )
+        mock_result = CandidateTrainingResult(candidate_id=0, candidate_uuid="test", correlation=0.5, candidate=None, success=True)
 
         with patch.object(CascadeCorrelationNetwork, "train_candidate_worker", return_value=mock_result):
             result_queue.put.side_effect = Full("queue full")
@@ -509,9 +497,7 @@ class TestTrainCandidateWorkerErrors:
     @pytest.mark.unit
     def test_train_candidate_worker_none_input(self):
         """Test train_candidate_worker with None input."""
-        result = CascadeCorrelationNetwork.train_candidate_worker(
-            task_data_input=None, parallel=False
-        )
+        result = CascadeCorrelationNetwork.train_candidate_worker(task_data_input=None, parallel=False)
         assert result == (None, None, 0.0, None)
 
     @pytest.mark.unit
@@ -531,9 +517,7 @@ class TestTrainCandidateWorkerErrors:
         bad_task = (0, candidate_data, training_inputs)
 
         with patch.object(CandidateUnit, "__init__", side_effect=RuntimeError("bad init")):
-            result = CascadeCorrelationNetwork.train_candidate_worker(
-                task_data_input=bad_task, parallel=False
-            )
+            result = CascadeCorrelationNetwork.train_candidate_worker(task_data_input=bad_task, parallel=False)
             # Should return a failure CandidateTrainingResult
             assert isinstance(result, CandidateTrainingResult)
             assert result.success is False

--- a/src/tests/unit/test_cascor_fix.py
+++ b/src/tests/unit/test_cascor_fix.py
@@ -57,13 +57,7 @@ def test_sequential_candidate_training(fast_training_params):
     os.cpu_count = lambda: 1  # Mock to force sequential processing
 
     try:
-        return _get_candidate_training_stats(network, x, y)
-    except Exception as e:
-        print(f"Error during testing: {e}")
-        import traceback
-
-        traceback.print_exc()
-        return False
+        _get_candidate_training_stats(network, x, y)
     finally:
         # Restore original cpu_count
         os.cpu_count = original_cpu_count
@@ -82,14 +76,10 @@ def _get_candidate_training_stats(network, x, y):
     print(f"Training stats type: {type(training_stats)}")
 
     # Extract results from training_stats tuple
-    if isinstance(training_stats, tuple) and len(training_stats) >= 1:
-        candidates_data = training_stats[0]
-        if isinstance(candidates_data, tuple) and len(candidates_data) == 4:
-            return _validate_candidates_correlations(candidates_data)
-        print(f"Invalid candidates_data format: {candidates_data}")
-    else:
-        print(f"Invalid training_stats format: {training_stats}")
-    return False
+    assert isinstance(training_stats, tuple) and len(training_stats) >= 1, f"Invalid training_stats format: {training_stats}"
+    candidates_data = training_stats[0]
+    assert isinstance(candidates_data, tuple) and len(candidates_data) == 4, f"Invalid candidates_data format: {candidates_data}"
+    _validate_candidates_correlations(candidates_data)
 
 
 def _validate_candidates_correlations(candidates_data):
@@ -105,7 +95,6 @@ def _validate_candidates_correlations(candidates_data):
             candidate_corr = candidate.get_correlation()
             print(f"Candidate {i} correlation via get_correlation(): {candidate_corr:.6f}")
 
-    return True
 
 
 # CASCOR-TIMEOUT-001: Added slow marker and extended timeout
@@ -154,21 +143,27 @@ def test_individual_candidates(fast_training_params):
     print(f"Correlations are different: {len(set(correlations)) > 1}")
     print(f"All correlations non-zero: {all(c != 0.0 for c in correlations)}")
 
-    return len(set(correlations)) > 1 and all(c != 0.0 for c in correlations)
+    assert len(set(correlations)) > 1, "Correlations should not all be identical"
+    assert all(c != 0.0 for c in correlations), "All correlations should be non-zero"
 
 
 if __name__ == "__main__":
     print("Running CascadeCorrelationNetwork fix tests...")
 
-    # Test 1: Individual candidate functionality
-    individual_test_passed = test_individual_candidates()
-    print(f"Individual candidate test passed: {individual_test_passed}")
+    results = []
+    for name, func in [
+        ("Individual candidate", test_individual_candidates),
+        ("Network candidate training", test_sequential_candidate_training),
+    ]:
+        try:
+            func(fast_training_params={"candidate_epochs": 5, "candidate_pool_size": 3})
+            print(f"✅ {name} test passed")
+            results.append(True)
+        except Exception as e:
+            print(f"❌ {name} test failed: {e}")
+            results.append(False)
 
-    # Test 2: Network-level candidate training
-    network_test_passed = test_sequential_candidate_training()
-    print(f"Network candidate training test passed: {network_test_passed}")
-
-    if individual_test_passed and network_test_passed:
+    if all(results):
         print("\n✅ All tests passed! The fixes are working correctly.")
     else:
         print("\n❌ Some tests failed. Further debugging needed.")

--- a/src/tests/unit/test_critical_fixes.py
+++ b/src/tests/unit/test_critical_fixes.py
@@ -20,11 +20,7 @@ print("=" * 70)
 def test_1_dataclass_fields():
     """Test that CandidateTrainingResult has correct field names."""
     print("\n[Test 1] CandidateTrainingResult dataclass fields...")
-    try:
-        return _check_dataclass_attributes()
-    except Exception as e:
-        print(f"❌ FAIL: {e}")
-        return False
+    _check_dataclass_attributes()
 
 
 def _check_dataclass_attributes():
@@ -37,31 +33,22 @@ def _check_dataclass_attributes():
     assert not hasattr(result, "candidate_index"), "Old candidate_index field still exists"
     assert not hasattr(result, "best_correlation"), "Old best_correlation field still exists"
     print("✅ PASS: CandidateTrainingResult has correct fields")
-    return True
 
 
 def test_2_network_creation():  # sourcery skip: extract-method
     """Test that network can be created with snapshot_counter."""
     print("\n[Test 2] Network creation and initialization...")
-    try:
-        from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
+    from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
 
-        # from cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
-        from cascade_correlation.cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
+    # from cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
+    from cascade_correlation.cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
 
-        config = CascadeCorrelationConfig(input_size=2, output_size=1, candidate_pool_size=2)
-        network = CascadeCorrelationNetwork(config=config)
+    config = CascadeCorrelationConfig(input_size=2, output_size=1, candidate_pool_size=2)
+    network = CascadeCorrelationNetwork(config=config)
 
-        assert hasattr(network, "snapshot_counter"), "Missing snapshot_counter"
-        assert network.snapshot_counter == 0, f"snapshot_counter should be 0, got {network.snapshot_counter}"
-        print(f"✅ PASS: Network created, snapshot_counter={network.snapshot_counter}")
-        return True
-    except Exception as e:
-        print(f"❌ FAIL: {e}")
-        import traceback
-
-        traceback.print_exc()
-        return False
+    assert hasattr(network, "snapshot_counter"), "Missing snapshot_counter"
+    assert network.snapshot_counter == 0, f"snapshot_counter should be 0, got {network.snapshot_counter}"
+    print(f"✅ PASS: Network created, snapshot_counter={network.snapshot_counter}")
 
 
 # CASCOR-TIMEOUT-001: Added slow marker and extended timeout
@@ -74,101 +61,88 @@ def test_3_candidate_training(fast_training_params):  # sourcery skip: extract-m
     # Use fast_training_params for optimized test execution
     test_epochs = min(5, fast_training_params.get("candidate_epochs", 5))
 
-    try:
-        from candidate_unit.candidate_unit import CandidateTrainingResult, CandidateUnit
+    from candidate_unit.candidate_unit import CandidateTrainingResult, CandidateUnit
 
-        candidate = CandidateUnit(CandidateUnit__input_size=2, CandidateUnit__candidate_index=0, CandidateUnit__log_level_name="WARNING")  # Reduce log noise
+    candidate = CandidateUnit(CandidateUnit__input_size=2, CandidateUnit__candidate_index=0, CandidateUnit__log_level_name="WARNING")  # Reduce log noise
 
-        x = torch.randn(10, 2)
-        residual_error = torch.randn(10)
+    x = torch.randn(10, 2)
+    residual_error = torch.randn(10)
 
-        print(f"Training epochs: {test_epochs}")
+    print(f"Training epochs: {test_epochs}")
 
-        result = candidate.train(x=x, epochs=test_epochs, residual_error=residual_error, learning_rate=0.01)
+    result = candidate.train(x=x, epochs=test_epochs, residual_error=residual_error, learning_rate=0.01)
 
-        assert isinstance(result, CandidateTrainingResult), "train() should return CandidateTrainingResult"
-        assert hasattr(result, "correlation"), "Result missing correlation field"
-        assert hasattr(result, "epochs_completed"), "Result missing epochs_completed"
-        assert result.epochs_completed == test_epochs, f"Expected {test_epochs} epochs, got {result.epochs_completed}"
+    assert isinstance(result, CandidateTrainingResult), "train() should return CandidateTrainingResult"
+    assert hasattr(result, "correlation"), "Result missing correlation field"
+    assert hasattr(result, "epochs_completed"), "Result missing epochs_completed"
+    assert result.epochs_completed == test_epochs, f"Expected {test_epochs} epochs, got {result.epochs_completed}"
 
-        print(f"✅ PASS: Training completed - correlation: {result.correlation:.6f}, epochs: {result.epochs_completed}")
-        return True
-    except Exception as e:
-        print(f"❌ FAIL: {e}")
-        import traceback
-
-        traceback.print_exc()
-        return False
+    print(f"✅ PASS: Training completed - correlation: {result.correlation:.6f}, epochs: {result.epochs_completed}")
 
 
 def test_4_get_single_candidate_data():  # sourcery skip: extract-method
     """Test that get_single_candidate_data uses getattr correctly."""
     print("\n[Test 4] get_single_candidate_data() method...")
-    try:
-        from candidate_unit.candidate_unit import CandidateTrainingResult
-        from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
+    from candidate_unit.candidate_unit import CandidateTrainingResult
+    from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
 
-        # from cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
-        from cascade_correlation.cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
+    # from cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
+    from cascade_correlation.cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
 
-        config = CascadeCorrelationConfig(input_size=2, output_size=1)
-        network = CascadeCorrelationNetwork(config=config)
+    config = CascadeCorrelationConfig(input_size=2, output_size=1)
+    network = CascadeCorrelationNetwork(config=config)
 
-        results = [
-            CandidateTrainingResult(candidate_id=0, correlation=0.3, candidate=None),
-            CandidateTrainingResult(candidate_id=1, correlation=0.7, candidate=None),
-            CandidateTrainingResult(candidate_id=2, correlation=0.5, candidate=None),
-        ]
+    results = [
+        CandidateTrainingResult(candidate_id=0, correlation=0.3, candidate=None),
+        CandidateTrainingResult(candidate_id=1, correlation=0.7, candidate=None),
+        CandidateTrainingResult(candidate_id=2, correlation=0.5, candidate=None),
+    ]
 
-        correlation = network.get_single_candidate_data(results, 1, "correlation", 0.0)
-        assert correlation == 0.7, f"Expected 0.7, got {correlation}"
+    correlation = network.get_single_candidate_data(results, 1, "correlation", 0.0)
+    assert correlation == 0.7, f"Expected 0.7, got {correlation}"
 
-        candidate_id = network.get_single_candidate_data(results, 2, "candidate_id", -1)
-        assert candidate_id == 2, f"Expected 2, got {candidate_id}"
+    candidate_id = network.get_single_candidate_data(results, 2, "candidate_id", -1)
+    assert candidate_id == 2, f"Expected 2, got {candidate_id}"
 
-        default_val = network.get_single_candidate_data(results, 10, "correlation", -999)
-        assert default_val == -999, f"Expected default -999, got {default_val}"
+    default_val = network.get_single_candidate_data(results, 10, "correlation", -999)
+    assert default_val == -999, f"Expected default -999, got {default_val}"
 
-        print("✅ PASS: get_single_candidate_data works correctly")
-        return True
-    except Exception as e:
-        print(f"❌ FAIL: {e}")
-        import traceback
-
-        traceback.print_exc()
-        return False
+    print("✅ PASS: get_single_candidate_data works correctly")
 
 
 def test_5_training_results_dataclass():  # sourcery skip: extract-method
     """Test that TrainingResults dataclass has max_correlation field."""
     print("\n[Test 5] TrainingResults dataclass...")
-    try:
-        import datetime
+    import datetime
 
-        from cascade_correlation.cascade_correlation import TrainingResults
+    from cascade_correlation.cascade_correlation import TrainingResults
 
-        results = TrainingResults(epochs_completed=10, candidate_ids=[0, 1], candidate_uuids=["uuid1", "uuid2"], correlations=[0.3, 0.7], candidate_objects=[None, None], best_candidate_id=1, best_candidate_uuid="uuid2", best_correlation=0.7, best_candidate=None, success_count=2, successful_candidates=2, failed_count=0, error_messages=[], max_correlation=0.7, start_time=datetime.datetime.now(), end_time=datetime.datetime.now())  # This field should exist
+    results = TrainingResults(epochs_completed=10, candidate_ids=[0, 1], candidate_uuids=["uuid1", "uuid2"], correlations=[0.3, 0.7], candidate_objects=[None, None], best_candidate_id=1, best_candidate_uuid="uuid2", best_correlation=0.7, best_candidate=None, success_count=2, successful_candidates=2, failed_count=0, error_messages=[], max_correlation=0.7, start_time=datetime.datetime.now(), end_time=datetime.datetime.now())  # This field should exist
 
-        assert hasattr(results, "max_correlation"), "Missing max_correlation field"
-        assert results.max_correlation == 0.7, f"max_correlation should be 0.7, got {results.max_correlation}"
+    assert hasattr(results, "max_correlation"), "Missing max_correlation field"
+    assert results.max_correlation == 0.7, f"max_correlation should be 0.7, got {results.max_correlation}"
 
-        print("✅ PASS: TrainingResults has max_correlation field")
-        return True
-    except Exception as e:
-        print(f"❌ FAIL: {e}")
-        import traceback
-
-        traceback.print_exc()
-        return False
+    print("✅ PASS: TrainingResults has max_correlation field")
 
 
 def main():
     """Run all validation tests."""
-    results = [("Dataclass Fields", test_1_dataclass_fields())]
-    results.append(("Network Creation", test_2_network_creation()))
-    results.append(("Candidate Training", test_3_candidate_training()))
-    results.append(("get_single_candidate_data", test_4_get_single_candidate_data()))
-    results.append(("TrainingResults Dataclass", test_5_training_results_dataclass()))
+    test_funcs = [
+        ("Dataclass Fields", test_1_dataclass_fields, {}),
+        ("Network Creation", test_2_network_creation, {}),
+        ("Candidate Training", test_3_candidate_training, {"fast_training_params": {"candidate_epochs": 5}}),
+        ("get_single_candidate_data", test_4_get_single_candidate_data, {}),
+        ("TrainingResults Dataclass", test_5_training_results_dataclass, {}),
+    ]
+
+    results = []
+    for test_name, func, kwargs in test_funcs:
+        try:
+            func(**kwargs)
+            results.append((test_name, True))
+        except Exception as e:
+            print(f"❌ FAIL: {e}")
+            results.append((test_name, False))
 
     print("\n" + "=" * 70)
     print("Test Results Summary")

--- a/src/tests/unit/test_hdf5.py
+++ b/src/tests/unit/test_hdf5.py
@@ -21,53 +21,43 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 def test_hdf5_serialization():
     """Test basic HDF5 save/load functionality."""
+    print("Testing HDF5 serialization...")
+
+    # Import required modules
+    from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
+
+    # from cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
+    from cascade_correlation.cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
+
+    # from cascade_correlation.hdf5.serializer import CascadeHDF5Serializer
+    # from cascade_correlation.hdf5.utils import HDF5Utils
+    from snapshots.snapshot_utils import HDF5Utils
+
+    # Create a simple network
+    config = CascadeCorrelationConfig(input_size=2, output_size=1, max_hidden_units=5, learning_rate=0.1, activation_function_name="tanh")
+    network = CascadeCorrelationNetwork(config=config)
+
+    print(f"✓ Created network with UUID: {network.get_uuid()}")
+    print(f"  Architecture: {network.input_size} → {len(network.hidden_units)} → {network.output_size}")
+
+    # Create temporary file for testing
+    with tempfile.NamedTemporaryFile(suffix=".h5", delete=False) as tmp_file:
+        test_file = tmp_file.name
+
     try:
-        print("Testing HDF5 serialization...")
-
-        # Import required modules
-        from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
-
-        # from cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
-        from cascade_correlation.cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
-
-        # from cascade_correlation.hdf5.serializer import CascadeHDF5Serializer
-        # from cascade_correlation.hdf5.utils import HDF5Utils
-        from snapshots.snapshot_utils import HDF5Utils
-
-        # Create a simple network
-        config = CascadeCorrelationConfig(input_size=2, output_size=1, max_hidden_units=5, learning_rate=0.1, activation_function_name="tanh")
-        network = CascadeCorrelationNetwork(config=config)
-
-        print(f"✓ Created network with UUID: {network.get_uuid()}")
-        print(f"  Architecture: {network.input_size} → {len(network.hidden_units)} → {network.output_size}")
-
-        # Create temporary file for testing
-        with tempfile.NamedTemporaryFile(suffix=".h5", delete=False) as tmp_file:
-            test_file = tmp_file.name
-
-        try:
-            return _check_hdf5_snapshot(test_file, network)
-        finally:
-            # Cleanup
-            if os.path.exists(test_file):  # sourcery skip: no-conditionals-in-tests
-                os.remove(test_file)
-
-    except Exception as e:
-        print(f"✗ Test failed with error: {e}")
-        import traceback
-
-        traceback.print_exc()
-        return False
+        _check_hdf5_snapshot(test_file, network)
+    finally:
+        # Cleanup
+        if os.path.exists(test_file):  # sourcery skip: no-conditionals-in-tests
+            os.remove(test_file)
 
 
-def _check_hdf5_snapshot(test_file: str, network: CascadeCorrelationNetwork) -> bool:
+def _check_hdf5_snapshot(test_file: str, network: CascadeCorrelationNetwork) -> None:
     # Test saving
     print(f"Saving network to {test_file}...")
     success = network.save_to_hdf5(test_file, include_training_state=False)
 
-    if not success:  # sourcery skip: no-conditionals-in-tests
-        print("✗ Failed to save network")
-        return False
+    assert success, "Failed to save network"
 
     print("✓ Network saved successfully")
 
@@ -75,9 +65,7 @@ def _check_hdf5_snapshot(test_file: str, network: CascadeCorrelationNetwork) -> 
     print("Verifying saved file...")
     verification = network.verify_hdf5_file(test_file)
 
-    if not verification.get("valid", False):  # sourcery skip: no-conditionals-in-tests
-        print(f"✗ File verification failed: {verification.get('error', 'Unknown error')}")
-        return False
+    assert verification.get("valid", False), f"File verification failed: {verification.get('error', 'Unknown error')}"
 
     print("✓ File verification passed")
     print(f"  Format: {verification.get('format', 'unknown')} v{verification.get('format_version', 'unknown')}")
@@ -86,29 +74,16 @@ def _check_hdf5_snapshot(test_file: str, network: CascadeCorrelationNetwork) -> 
     print("Loading network from file...")
     loaded_network = CascadeCorrelationNetwork.load_from_hdf5(test_file)
 
-    if not loaded_network:  # sourcery skip: no-conditionals-in-tests
-        print("✗ Failed to load network")
-        return False
+    assert loaded_network, "Failed to load network"
 
     print("✓ Network loaded successfully")
     print(f"  Loaded UUID: {loaded_network.get_uuid()}")
 
     # Verify loaded network matches original
-    if str(network.get_uuid()) != str(loaded_network.get_uuid()):  # sourcery skip: no-conditionals-in-tests
-        print("✗ UUIDs don't match!")
-        return False
-
-    if network.input_size != loaded_network.input_size:  # sourcery skip: no-conditionals-in-tests
-        print("✗ Input sizes don't match!")
-        return False
-
-    if network.output_size != loaded_network.output_size:  # sourcery skip: no-conditionals-in-tests
-        print("✗ Output sizes don't match!")
-        return False
-
-    if network.activation_function_name != loaded_network.activation_function_name:  # sourcery skip: no-conditionals-in-tests
-        print("✗ Activation functions don't match!")
-        return False
+    assert str(network.get_uuid()) == str(loaded_network.get_uuid()), "UUIDs don't match!"
+    assert network.input_size == loaded_network.input_size, "Input sizes don't match!"
+    assert network.output_size == loaded_network.output_size, "Output sizes don't match!"
+    assert network.activation_function_name == loaded_network.activation_function_name, "Activation functions don't match!"
 
     print("✓ All network properties match")
 
@@ -116,23 +91,22 @@ def _check_hdf5_snapshot(test_file: str, network: CascadeCorrelationNetwork) -> 
     print("Testing HDF5 utilities...")
     file_info = HDF5Utils.get_file_info(test_file)
 
-    if not file_info.get("exists", False):  # sourcery skip: no-conditionals-in-tests
-        print("✗ File info failed")
-        return False
+    assert file_info.get("exists", False), "File info failed"
 
     print(f"✓ File info: {file_info.get('size_mb', 0):.2f} MB, {len(file_info.get('groups', []))} groups")
 
     # Test network summary
-    if summary := HDF5Utils.get_network_summary(test_file):  # sourcery skip: no-conditionals-in-tests
-        print(f"✓ Network summary: {summary['input_size']}→{summary['output_size']}, {summary['num_hidden_units']} hidden units")
-    else:
-        print("✗ Failed to get network summary")
-        return False
+    summary = HDF5Utils.get_network_summary(test_file)
+    assert summary, "Failed to get network summary"
+    print(f"✓ Network summary: {summary['input_size']}→{summary['output_size']}, {summary['num_hidden_units']} hidden units")
 
     print("\n✓ All tests passed!")
-    return True
 
 
 if __name__ == "__main__":
-    success = test_hdf5_serialization()
-    exit(0 if success else 1)
+    try:
+        test_hdf5_serialization()
+        exit(0)
+    except Exception as e:
+        print(f"✗ Test failed: {e}")
+        exit(1)

--- a/src/tests/unit/test_p1_fixes.py
+++ b/src/tests/unit/test_p1_fixes.py
@@ -26,14 +26,7 @@ print("=" * 70)
 def test_1_early_stopping():
     """Test that early stopping works in candidate training."""
     print("\n[Test 1] Early stopping implementation...")
-    try:
-        return _validate_candidate_early_stopping_helper(candidate=None)
-    except Exception as e:
-        print(f"❌ FAIL: {e}")
-        import traceback
-
-        traceback.print_exc()
-        return False
+    _validate_candidate_early_stopping_helper(candidate=None)
 
 
 def _validate_candidate_early_stopping_helper(candidate):
@@ -58,20 +51,12 @@ def _validate_candidate_early_stopping_helper(candidate):
     assert result.epochs_completed < 100, f"Should stop early, but ran {result.epochs_completed} epochs"  # trunk-ignore(bandit/B101)
     assert result.epochs_completed <= 10, f"Should stop within ~patience epochs, ran {result.epochs_completed}"  # trunk-ignore(bandit/B101)
     print(f"✅ PASS: Early stopping triggered at epoch {result.epochs_completed} (patience=3)")
-    return True
 
 
 def test_2_optimizer_serialization():
     """Test that optimizer state is saved and loaded."""
     print("\n[Test 2] Optimizer state serialization...")
-    try:
-        return _verify_optimizer_saved_to_hdf5_helper()
-    except Exception as e:
-        print(f"❌ FAIL: {e}")
-        import traceback
-
-        traceback.print_exc()
-        return False
+    _verify_optimizer_saved_to_hdf5_helper()
 
 
 def _verify_optimizer_saved_to_hdf5_helper():
@@ -98,7 +83,6 @@ def _verify_optimizer_saved_to_hdf5_helper():
     # Save to HDF5
     with tempfile.TemporaryDirectory() as tmpdir:
         _save_and_reload_network_hdf5_helper(tmpdir, network, CascadeCorrelationNetwork)
-    return True
 
 
 def _save_and_reload_network_hdf5_helper(tmpdir, network, CascadeCorrelationNetwork):
@@ -117,14 +101,7 @@ def _save_and_reload_network_hdf5_helper(tmpdir, network, CascadeCorrelationNetw
 def test_3_training_counters_persistence():
     """Test that training counters are persisted in HDF5."""
     print("\n[Test 3] Training counter persistence...")
-    try:
-        return _save_cascor_network_to_hdf5_helper()
-    except Exception as e:
-        print(f"❌ FAIL: {e}")
-        import traceback
-
-        traceback.print_exc()
-        return False
+    _save_cascor_network_to_hdf5_helper()
 
 
 def _save_cascor_network_to_hdf5_helper():
@@ -149,7 +126,6 @@ def _save_cascor_network_to_hdf5_helper():
     # Save to HDF5
     with tempfile.TemporaryDirectory() as tmpdir:
         _verify_saved_and_restored_cascor_network_helper(tmpdir, network, CascadeCorrelationNetwork)
-    return True
 
 
 # TODO Rename this here and in `test_3_training_counters_persistence`
@@ -172,35 +148,23 @@ def _verify_saved_and_restored_cascor_network_helper(tmpdir, network, CascadeCor
 def test_4_queue_timeout():
     """Test that queue operations have timeouts (structural test)."""
     print("\n[Test 4] Queue timeout implementation...")
-    try:
-        # Check that the code includes timeout parameter
-        # Use relative path instead of hardcoded absolute path (MED-003)
-        source_file = Path(__file__).parent.parent.parent / "cascade_correlation" / "cascade_correlation.py"
-        with open(source_file, "r") as f:
-            content = f.read()
+    # Check that the code includes timeout parameter
+    # Use relative path instead of hardcoded absolute path (MED-003)
+    source_file = Path(__file__).parent.parent.parent / "cascade_correlation" / "cascade_correlation.py"
+    with open(source_file, "r") as f:
+        content = f.read()
 
-        # Check for timeout in result_queue.put
-        assert "result_queue.put(result, timeout=" in content, "result_queue.put should have timeout parameter"  # trunk-ignore(bandit/B101)
-        assert "from queue import Full" in content, "Should import Full exception from queue"  # trunk-ignore(bandit/B101)
+    # Check for timeout in result_queue.put
+    assert "result_queue.put(result, timeout=" in content, "result_queue.put should have timeout parameter"  # trunk-ignore(bandit/B101)
+    assert "from queue import Full" in content, "Should import Full exception from queue"  # trunk-ignore(bandit/B101)
 
-        print("✅ PASS: Queue timeouts implemented correctly")
-        return True
-    except Exception as e:
-        print(f"❌ FAIL: {e}")
-        return False
+    print("✅ PASS: Queue timeouts implemented correctly")
 
 
 def test_5_optimizer_initialization():
     """Test optimizer is created as instance variable."""
     print("\n[Test 5] Optimizer initialization...")
-    try:
-        return _validate_cascor_network_optimizer_helper()
-    except Exception as e:
-        print(f"❌ FAIL: {e}")
-        import traceback
-
-        traceback.print_exc()
-        return False
+    _validate_cascor_network_optimizer_helper()
 
 
 def _validate_cascor_network_optimizer_helper():
@@ -225,7 +189,6 @@ def _validate_cascor_network_optimizer_helper():
     assert hasattr(network.output_optimizer, "state_dict"), "Optimizer should have state_dict method"  # trunk-ignore(bandit/B101)
 
     print("✅ PASS: Optimizer created and accessible as instance variable")
-    return True
 
 
 def _display_test_results_helper():
@@ -239,11 +202,22 @@ def _display_test_results_helper():
 
 def main():
     """Run all P1 validation tests."""
-    results = [("Early Stopping", test_1_early_stopping())]
-    results.append(("Optimizer Serialization", test_2_optimizer_serialization()))
-    results.append(("Training Counter Persistence", test_3_training_counters_persistence()))
-    results.append(("Queue Timeouts", test_4_queue_timeout()))
-    results.append(("Optimizer Initialization", test_5_optimizer_initialization()))
+    test_funcs = [
+        ("Early Stopping", test_1_early_stopping, {}),
+        ("Optimizer Serialization", test_2_optimizer_serialization, {}),
+        ("Training Counter Persistence", test_3_training_counters_persistence, {}),
+        ("Queue Timeouts", test_4_queue_timeout, {}),
+        ("Optimizer Initialization", test_5_optimizer_initialization, {}),
+    ]
+
+    results = []
+    for test_name, func, kwargs in test_funcs:
+        try:
+            func(**kwargs)
+            results.append((test_name, True))
+        except Exception as e:
+            print(f"❌ FAIL: {e}")
+            results.append((test_name, False))
 
     print("\n" + "=" * 70)
     print("P1 Test Results Summary")

--- a/src/tests/unit/test_remaining_coverage_deep.py
+++ b/src/tests/unit/test_remaining_coverage_deep.py
@@ -20,6 +20,7 @@ import pytest
 import torch
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
 
 from api.app import create_app
 from api.lifecycle.manager import TrainingLifecycleManager
@@ -146,7 +147,7 @@ class TestTrainingStreamWSManagerUnavailable:
         with TestClient(app) as client:
             # Remove ws_manager to simulate it being unavailable
             app.state.ws_manager = None
-            with pytest.raises(Exception):
+            with pytest.raises(WebSocketDisconnect):
                 # WebSocket connect should fail because ws_manager is None
                 with client.websocket_connect("/ws/training") as ws:
                     pass

--- a/src/tests/unit/test_snapshot_serializer_coverage_deep.py
+++ b/src/tests/unit/test_snapshot_serializer_coverage_deep.py
@@ -36,7 +36,6 @@ from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
 from cascade_correlation.cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
 from snapshots.snapshot_serializer import CascadeHDF5Serializer
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -205,7 +204,7 @@ class TestSaveLoadRoundTrips:
         assert len(loaded.hidden_units) == num_hidden_before
 
         # Verify hidden unit weights match
-        for i, (orig, loaded_unit) in enumerate(zip(trained_network.hidden_units, loaded.hidden_units)):
+        for _, (orig, loaded_unit) in enumerate(zip(trained_network.hidden_units, loaded.hidden_units)):
             if "weights" in orig and "weights" in loaded_unit:
                 torch.testing.assert_close(orig["weights"], loaded_unit["weights"])
             if "bias" in orig and "bias" in loaded_unit:
@@ -507,12 +506,14 @@ class TestSaveLoadBranches:
         """Lines 347-394: _save_hidden_units with populated units."""
         if len(trained_network.hidden_units) == 0:
             # Force at least one hidden unit for branch coverage
-            trained_network.hidden_units.append({
-                "weights": torch.randn(2),
-                "bias": torch.randn(1),
-                "correlation": 0.5,
-                "activation_fn": torch.tanh,
-            })
+            trained_network.hidden_units.append(
+                {
+                    "weights": torch.randn(2),
+                    "bias": torch.randn(1),
+                    "correlation": 0.5,
+                    "activation_fn": torch.tanh,
+                }
+            )
         serializer.save_network(trained_network, temp_hdf5_path)
 
         with h5py.File(temp_hdf5_path, "r") as f:

--- a/src/tests/unit/test_snapshot_serializer_coverage_final.py
+++ b/src/tests/unit/test_snapshot_serializer_coverage_final.py
@@ -21,17 +21,15 @@ import h5py
 import numpy as np
 import pytest
 import torch
+from helpers.utilities import set_deterministic_behavior
 
 from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
-from cascade_correlation.cascade_correlation_config.cascade_correlation_config import (
-    CascadeCorrelationConfig,
-)
-from helpers.utilities import set_deterministic_behavior
+from cascade_correlation.cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
 from snapshots.snapshot_serializer import CascadeHDF5Serializer
 
 
 def _make_config(**overrides):
-    defaults = dict(input_size=2, output_size=2, random_seed=42, candidate_pool_size=2, candidate_epochs=3, output_epochs=3, max_hidden_units=2, patience=1)
+    defaults = {"input_size": 2, "output_size": 2, "random_seed": 42, "candidate_pool_size": 2, "candidate_epochs": 3, "output_epochs": 3, "max_hidden_units": 2, "patience": 1}
     defaults.update(overrides)
     return CascadeCorrelationConfig(**defaults)
 
@@ -287,9 +285,7 @@ class TestValidateShapesMismatch:
         network = _make_network()
 
         # Add a hidden unit with wrong weight shape
-        network.hidden_units = [
-            {"weights": torch.randn(10), "bias": torch.randn(1)}  # Wrong: should be input_size=2
-        ]
+        network.hidden_units = [{"weights": torch.randn(10), "bias": torch.randn(1)}]  # Wrong: should be input_size=2
         # Expand output weights to match
         network.output_weights = torch.randn(3, 2)  # input_size + 1 hidden
 
@@ -303,9 +299,7 @@ class TestValidateShapesMismatch:
         network = _make_network()
 
         # Add a hidden unit with wrong bias shape
-        network.hidden_units = [
-            {"weights": torch.randn(2), "bias": torch.randn(5)}  # Wrong: should be (1,) or scalar
-        ]
+        network.hidden_units = [{"weights": torch.randn(2), "bias": torch.randn(5)}]  # Wrong: should be (1,) or scalar
         network.output_weights = torch.randn(3, 2)
 
         result = serializer._validate_shapes(network)

--- a/src/tests/unit/test_spiral_problem_coverage_deep.py
+++ b/src/tests/unit/test_spiral_problem_coverage_deep.py
@@ -37,10 +37,10 @@ from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
 from cascade_correlation.cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
 from spiral_problem.spiral_problem import SpiralProblem
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def sp():
@@ -117,6 +117,7 @@ def sp_three_spirals():
 # 1. __init__ error path (lines 437-439)
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.unit
 class TestInitErrorPath:
     """Test the __init__ error path when CascadeCorrelationNetwork returns None."""
@@ -138,6 +139,7 @@ class TestInitErrorPath:
 # 2. Deprecated data generation methods (lines 568-1208)
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.unit
 class TestInitializeSpiralProblemParams:
     """Tests for _initialize_spiral_problem_params."""
@@ -147,7 +149,8 @@ class TestInitializeSpiralProblemParams:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             sp._initialize_spiral_problem_params(
-                n_spirals=2, n_points=50,
+                n_spirals=2,
+                n_points=50,
             )
         assert sp.total_points == 100
 
@@ -159,11 +162,21 @@ class TestInitializeSpiralProblemParams:
             warnings.simplefilter("ignore", DeprecationWarning)
             # Pass None values so the fallback branch is exercised
             sp._initialize_spiral_problem_params(
-                min_new=None, max_new=None, min_orig=None, max_orig=None,
-                orig_points=None, train_ratio=None, test_ratio=None,
-                clockwise=None, n_spirals=None, n_rotations=None,
-                n_points=None, default_origin=None, default_radius=None,
-                noise_level=None, distribution=None,
+                min_new=None,
+                max_new=None,
+                min_orig=None,
+                max_orig=None,
+                orig_points=None,
+                train_ratio=None,
+                test_ratio=None,
+                clockwise=None,
+                n_spirals=None,
+                n_rotations=None,
+                n_points=None,
+                default_origin=None,
+                default_radius=None,
+                noise_level=None,
+                distribution=None,
             )
         # Should still have valid total_points
         assert sp.total_points == sp.n_spirals * sp.n_points
@@ -173,11 +186,21 @@ class TestInitializeSpiralProblemParams:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             sp._initialize_spiral_problem_params(
-                min_new=-2.0, max_new=2.0, min_orig=-1.0, max_orig=1.0,
-                orig_points=100, train_ratio=0.8, test_ratio=0.2,
-                clockwise=True, n_spirals=4, n_rotations=2,
-                n_points=25, default_origin=0.5, default_radius=2.0,
-                noise_level=0.2, distribution=0.5,
+                min_new=-2.0,
+                max_new=2.0,
+                min_orig=-1.0,
+                max_orig=1.0,
+                orig_points=100,
+                train_ratio=0.8,
+                test_ratio=0.2,
+                clockwise=True,
+                n_spirals=4,
+                n_rotations=2,
+                n_points=25,
+                default_origin=0.5,
+                default_radius=2.0,
+                noise_level=0.2,
+                distribution=0.5,
             )
         assert sp.n_spirals == 4
         assert sp.n_points == 25
@@ -279,7 +302,9 @@ class TestGenerateRawSpiralCoordinates:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             x_coords, y_coords = sp._generate_raw_spiral_coordinates(
-                n_distance=n_distance, direction=1, angular_offset=np.pi,
+                n_distance=n_distance,
+                direction=1,
+                angular_offset=np.pi,
             )
         assert isinstance(x_coords, np.ndarray)
         assert isinstance(y_coords, np.ndarray)
@@ -291,7 +316,9 @@ class TestGenerateRawSpiralCoordinates:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             x_coords, y_coords = sp._generate_raw_spiral_coordinates(
-                n_distance=n_distance, direction=1, angular_offset=np.pi,
+                n_distance=n_distance,
+                direction=1,
+                angular_offset=np.pi,
             )
         assert x_coords.shape[0] == sp.n_spirals
         assert y_coords.shape[0] == sp.n_spirals
@@ -303,7 +330,9 @@ class TestGenerateRawSpiralCoordinates:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             x_coords, y_coords = sp._generate_raw_spiral_coordinates(
-                n_distance=n_distance, direction=-1, angular_offset=np.pi,
+                n_distance=n_distance,
+                direction=-1,
+                angular_offset=np.pi,
             )
         assert x_coords.shape[0] == sp.n_spirals
 
@@ -314,7 +343,9 @@ class TestGenerateRawSpiralCoordinates:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             x_coords, y_coords = sp_three_spirals._generate_raw_spiral_coordinates(
-                n_distance=n_distance, direction=1, angular_offset=2 * np.pi / 3,
+                n_distance=n_distance,
+                direction=1,
+                angular_offset=2 * np.pi / 3,
             )
         assert x_coords.shape[0] == 3
         assert y_coords.shape[0] == 3
@@ -331,7 +362,10 @@ class TestGenerateXYCoordinates:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             x, y = sp._generate_xy_coordinates(
-                index=0, n_distance=n_distance, angular_offset=np.pi, direction=1,
+                index=0,
+                n_distance=n_distance,
+                angular_offset=np.pi,
+                direction=1,
             )
         assert isinstance(x, np.ndarray)
         assert isinstance(y, np.ndarray)
@@ -345,7 +379,10 @@ class TestGenerateXYCoordinates:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             x, y = sp._generate_xy_coordinates(
-                index=0, n_distance=n_distance, angular_offset=np.pi, direction=-1,
+                index=0,
+                n_distance=n_distance,
+                angular_offset=np.pi,
+                direction=-1,
             )
         assert x.shape == (sp.n_points,)
 
@@ -357,7 +394,10 @@ class TestGenerateXYCoordinates:
             warnings.simplefilter("ignore", DeprecationWarning)
             with pytest.raises(ValueError, match="Direction must be 1 or -1"):
                 sp._generate_xy_coordinates(
-                    index=0, n_distance=n_distance, angular_offset=np.pi, direction=0,
+                    index=0,
+                    n_distance=n_distance,
+                    angular_offset=np.pi,
+                    direction=0,
                 )
 
     def test_second_spiral_index(self, sp):
@@ -367,7 +407,10 @@ class TestGenerateXYCoordinates:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             x, y = sp._generate_xy_coordinates(
-                index=1, n_distance=n_distance, angular_offset=np.pi, direction=1,
+                index=1,
+                n_distance=n_distance,
+                angular_offset=np.pi,
+                direction=1,
             )
         assert x.shape == (sp.n_points,)
 
@@ -383,8 +426,11 @@ class TestMakeCoords:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             result = sp._make_coords(
-                index=0, n_distance=n_distance, angular_offset=np.pi,
-                direction=1, trig_function=np.cos,
+                index=0,
+                n_distance=n_distance,
+                angular_offset=np.pi,
+                direction=1,
+                trig_function=np.cos,
             )
         assert isinstance(result, np.ndarray)
         assert result.shape == (sp.n_points,)
@@ -396,8 +442,11 @@ class TestMakeCoords:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             result = sp._make_coords(
-                index=0, n_distance=n_distance, angular_offset=np.pi,
-                direction=1, trig_function=np.sin,
+                index=0,
+                n_distance=n_distance,
+                angular_offset=np.pi,
+                direction=1,
+                trig_function=np.sin,
             )
         assert isinstance(result, np.ndarray)
         assert result.shape == (sp.n_points,)
@@ -409,8 +458,11 @@ class TestMakeCoords:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             result = sp._make_coords(
-                index=0, n_distance=n_distance, angular_offset=np.pi,
-                direction=-1, trig_function=np.cos,
+                index=0,
+                n_distance=n_distance,
+                angular_offset=np.pi,
+                direction=-1,
+                trig_function=np.cos,
             )
         assert result.shape == (sp.n_points,)
 
@@ -422,8 +474,11 @@ class TestMakeCoords:
             warnings.simplefilter("ignore", DeprecationWarning)
             with pytest.raises(ValueError, match="trig_function must be provided"):
                 sp._make_coords(
-                    index=0, n_distance=n_distance, angular_offset=np.pi,
-                    direction=1, trig_function=None,
+                    index=0,
+                    n_distance=n_distance,
+                    angular_offset=np.pi,
+                    direction=1,
+                    trig_function=None,
                 )
 
     def test_raises_for_invalid_direction(self, sp):
@@ -434,8 +489,11 @@ class TestMakeCoords:
             warnings.simplefilter("ignore", DeprecationWarning)
             with pytest.raises(ValueError, match="Direction must be 1 or -1"):
                 sp._make_coords(
-                    index=0, n_distance=n_distance, angular_offset=np.pi,
-                    direction=2, trig_function=np.cos,
+                    index=0,
+                    n_distance=n_distance,
+                    angular_offset=np.pi,
+                    direction=2,
+                    trig_function=np.cos,
                 )
 
     def test_raises_for_negative_index(self, sp):
@@ -446,8 +504,11 @@ class TestMakeCoords:
             warnings.simplefilter("ignore", DeprecationWarning)
             with pytest.raises(ValueError, match="Index must be a non-negative integer"):
                 sp._make_coords(
-                    index=-1, n_distance=n_distance, angular_offset=np.pi,
-                    direction=1, trig_function=np.cos,
+                    index=-1,
+                    n_distance=n_distance,
+                    angular_offset=np.pi,
+                    direction=1,
+                    trig_function=np.cos,
                 )
 
     def test_raises_for_non_integer_index(self, sp):
@@ -458,8 +519,11 @@ class TestMakeCoords:
             warnings.simplefilter("ignore", DeprecationWarning)
             with pytest.raises(ValueError, match="Index must be a non-negative integer"):
                 sp._make_coords(
-                    index=1.5, n_distance=n_distance, angular_offset=np.pi,
-                    direction=1, trig_function=np.cos,
+                    index=1.5,
+                    n_distance=n_distance,
+                    angular_offset=np.pi,
+                    direction=1,
+                    trig_function=np.cos,
                 )
 
 
@@ -544,7 +608,9 @@ class TestCreateOneHotTargets:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             result = sp._create_one_hot_targets(
-                total_points=100, n_spirals=2, dtype=np.float32,
+                total_points=100,
+                n_spirals=2,
+                dtype=np.float32,
             )
         assert result.shape == (100, 2)
 
@@ -553,7 +619,9 @@ class TestCreateOneHotTargets:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             result = sp._create_one_hot_targets(
-                total_points=100, n_spirals=2, dtype=np.float32,
+                total_points=100,
+                n_spirals=2,
+                dtype=np.float32,
             )
         # First spiral: column 0 is 1
         assert np.all(result[:50, 0] == 1)
@@ -567,7 +635,9 @@ class TestCreateOneHotTargets:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             result = sp_three_spirals._create_one_hot_targets(
-                total_points=90, n_spirals=3, dtype=np.float32,
+                total_points=90,
+                n_spirals=3,
+                dtype=np.float32,
             )
         assert result.shape == (90, 3)
         # Each spiral block has its own column set to 1
@@ -584,7 +654,9 @@ class TestCreateOneHotTargets:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             result = sp._create_one_hot_targets(
-                total_points=100, n_spirals=2, dtype=np.float64,
+                total_points=100,
+                n_spirals=2,
+                dtype=np.float64,
             )
         assert result.dtype == np.float64
 
@@ -710,7 +782,10 @@ class TestPartitionDataset:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             train, test = sp._partition_dataset(
-                total_points=total, partitions=(0.7, 0.3), x=x, y=y,
+                total_points=total,
+                partitions=(0.7, 0.3),
+                x=x,
+                y=y,
             )
         x_train, y_train = train
         x_test, y_test = test
@@ -727,7 +802,10 @@ class TestPartitionDataset:
             warnings.simplefilter("ignore", DeprecationWarning)
             with pytest.raises(ValueError, match="Train and test ratios must sum to 1.0"):
                 sp._partition_dataset(
-                    total_points=total, partitions=(0.5, 0.3), x=x, y=y,
+                    total_points=total,
+                    partitions=(0.5, 0.3),
+                    x=x,
+                    y=y,
                 )
 
     def test_80_20_split(self, sp):
@@ -739,7 +817,10 @@ class TestPartitionDataset:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             train, test = sp._partition_dataset(
-                total_points=total, partitions=(0.8, 0.2), x=x, y=y,
+                total_points=total,
+                partitions=(0.8, 0.2),
+                x=x,
+                y=y,
             )
         x_train, _ = train
         x_test, _ = test
@@ -759,7 +840,10 @@ class TestSplitDataset:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             partitions = sp._split_dataset(
-                total_points=total, partitions=(0.7, 0.3), x=x, y=y,
+                total_points=total,
+                partitions=(0.7, 0.3),
+                x=x,
+                y=y,
             )
         assert len(partitions) == 2
         x_train, y_train = partitions[0]
@@ -865,7 +949,9 @@ class TestFindPartitionIndexEnd:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             result = sp._find_partition_index_end(
-                partition_start=0, total_points=100, partition=0.7,
+                partition_start=0,
+                total_points=100,
+                partition=0.7,
             )
         assert result == 70
 
@@ -874,7 +960,9 @@ class TestFindPartitionIndexEnd:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             result = sp._find_partition_index_end(
-                partition_start=70, total_points=100, partition=0.3,
+                partition_start=70,
+                total_points=100,
+                partition=0.3,
             )
         assert result == 100
 
@@ -883,7 +971,9 @@ class TestFindPartitionIndexEnd:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             result = sp._find_partition_index_end(
-                partition_start=0, total_points=100, partition=0.5,
+                partition_start=0,
+                total_points=100,
+                partition=0.5,
             )
         assert result == 50
 
@@ -965,6 +1055,7 @@ class TestGenerateSpiralCoordinates:
 # 3. solve_n_spiral_problem (lines 1240-1354)
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.unit
 class TestSolveNSpiralProblem:
     """Tests for solve_n_spiral_problem with mocked dependencies.
@@ -999,8 +1090,7 @@ class TestSolveNSpiralProblem:
         sp.network.fit.return_value = {"loss": [0.5, 0.3]}
         sp.network.summary.return_value = None
 
-        with patch.object(sp, "generate_n_spiral_dataset", return_value=mock_data), \
-             patch("spiral_problem.spiral_problem._SPIRAL_PROBLEM_GENERATE_PLOTS_DEFAULT", False):
+        with patch.object(sp, "generate_n_spiral_dataset", return_value=mock_data), patch("spiral_problem.spiral_problem._SPIRAL_PROBLEM_GENERATE_PLOTS_DEFAULT", False):
             sp.solve_n_spiral_problem(plot=False)
 
         sp.network.fit.assert_called_once()
@@ -1020,12 +1110,17 @@ class TestSolveNSpiralProblem:
         sp.network.fit.return_value = {"loss": [0.5]}
         sp.network.summary.return_value = None
 
-        with patch.object(sp, "generate_n_spiral_dataset", return_value=mock_data), \
-             patch("spiral_problem.spiral_problem._SPIRAL_PROBLEM_GENERATE_PLOTS_DEFAULT", False):
+        with patch.object(sp, "generate_n_spiral_dataset", return_value=mock_data), patch("spiral_problem.spiral_problem._SPIRAL_PROBLEM_GENERATE_PLOTS_DEFAULT", False):
             sp.solve_n_spiral_problem(
-                n_points=25, n_spirals=2, n_rotations=3,
-                clockwise=True, noise=0.2, distribution=0.5,
-                test_ratio=0.3, train_ratio=0.7, plot=False,
+                n_points=25,
+                n_spirals=2,
+                n_rotations=3,
+                clockwise=True,
+                noise=0.2,
+                distribution=0.5,
+                test_ratio=0.3,
+                train_ratio=0.7,
+                plot=False,
             )
 
         assert sp.n_points == 25
@@ -1039,8 +1134,7 @@ class TestSolveNSpiralProblem:
         sp.network.fit.return_value = {"loss": [0.1]}
         sp.network.summary.return_value = None
 
-        with patch.object(sp, "generate_n_spiral_dataset", return_value=mock_data), \
-             patch("spiral_problem.spiral_problem._SPIRAL_PROBLEM_GENERATE_PLOTS_DEFAULT", False):
+        with patch.object(sp, "generate_n_spiral_dataset", return_value=mock_data), patch("spiral_problem.spiral_problem._SPIRAL_PROBLEM_GENERATE_PLOTS_DEFAULT", False):
             sp.solve_n_spiral_problem(plot=False)
 
         call_args = sp.network.fit.call_args
@@ -1057,8 +1151,7 @@ class TestSolveNSpiralProblem:
         sp.network.summary.return_value = None
 
         original_n_points = sp.n_points
-        with patch.object(sp, "generate_n_spiral_dataset", return_value=mock_data), \
-             patch("spiral_problem.spiral_problem._SPIRAL_PROBLEM_GENERATE_PLOTS_DEFAULT", False):
+        with patch.object(sp, "generate_n_spiral_dataset", return_value=mock_data), patch("spiral_problem.spiral_problem._SPIRAL_PROBLEM_GENERATE_PLOTS_DEFAULT", False):
             sp.solve_n_spiral_problem()
 
         # n_points should remain unchanged (fallback to class attr)
@@ -1068,6 +1161,7 @@ class TestSolveNSpiralProblem:
 # ---------------------------------------------------------------------------
 # 4. evaluate (lines 1399-1476)
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.unit
 class TestEvaluate:
@@ -1097,8 +1191,7 @@ class TestEvaluate:
         sp.network.summary.return_value = None
         sp.network.calculate_accuracy.return_value = 0.85
 
-        with patch.object(sp, "generate_n_spiral_dataset", return_value=mock_data), \
-             patch("spiral_problem.spiral_problem._SPIRAL_PROBLEM_GENERATE_PLOTS_DEFAULT", False):
+        with patch.object(sp, "generate_n_spiral_dataset", return_value=mock_data), patch("spiral_problem.spiral_problem._SPIRAL_PROBLEM_GENERATE_PLOTS_DEFAULT", False):
             sp.evaluate(plot=False)
 
         assert hasattr(sp, "train_accuracy")
@@ -1118,13 +1211,19 @@ class TestEvaluate:
         sp.network.summary.return_value = None
         sp.network.calculate_accuracy.return_value = 0.9
 
-        with patch.object(sp, "generate_n_spiral_dataset", return_value=mock_data), \
-             patch("spiral_problem.spiral_problem._SPIRAL_PROBLEM_GENERATE_PLOTS_DEFAULT", False):
+        with patch.object(sp, "generate_n_spiral_dataset", return_value=mock_data), patch("spiral_problem.spiral_problem._SPIRAL_PROBLEM_GENERATE_PLOTS_DEFAULT", False):
             sp.evaluate(
-                n_points=25, n_spirals=2, n_rotations=3,
-                clockwise=True, noise=0.2, distribution=0.5,
-                plot=False, train_ratio=0.8, test_ratio=0.2,
-                random_value_scale=0.5, default_origin=1.0,
+                n_points=25,
+                n_spirals=2,
+                n_rotations=3,
+                clockwise=True,
+                noise=0.2,
+                distribution=0.5,
+                plot=False,
+                train_ratio=0.8,
+                test_ratio=0.2,
+                random_value_scale=0.5,
+                default_origin=1.0,
                 default_radius=2.0,
             )
 
@@ -1143,8 +1242,7 @@ class TestEvaluate:
         sp.network.summary.return_value = None
         sp.network.calculate_accuracy.side_effect = [0.85, 0.75]
 
-        with patch.object(sp, "generate_n_spiral_dataset", return_value=mock_data), \
-             patch("spiral_problem.spiral_problem._SPIRAL_PROBLEM_GENERATE_PLOTS_DEFAULT", False):
+        with patch.object(sp, "generate_n_spiral_dataset", return_value=mock_data), patch("spiral_problem.spiral_problem._SPIRAL_PROBLEM_GENERATE_PLOTS_DEFAULT", False):
             sp.evaluate(plot=False)
 
         assert sp.network.calculate_accuracy.call_count == 2
@@ -1161,8 +1259,7 @@ class TestEvaluate:
         sp.network.summary.return_value = None
         sp.network.calculate_accuracy.return_value = 0.9
 
-        with patch.object(sp, "generate_n_spiral_dataset", return_value=mock_data), \
-             patch("spiral_problem.spiral_problem._SPIRAL_PROBLEM_GENERATE_PLOTS_DEFAULT", False):
+        with patch.object(sp, "generate_n_spiral_dataset", return_value=mock_data), patch("spiral_problem.spiral_problem._SPIRAL_PROBLEM_GENERATE_PLOTS_DEFAULT", False):
             sp.evaluate(plot=False)
 
         # summary is called once in solve_n_spiral_problem and once in evaluate
@@ -1172,6 +1269,7 @@ class TestEvaluate:
 # ---------------------------------------------------------------------------
 # 5. UUID methods
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.unit
 class TestUUIDMethods:
@@ -1241,6 +1339,7 @@ class TestUUIDMethods:
 # 6. Setter/getter methods with edge cases
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.unit
 class TestSetDefaultRadius:
     """Tests for set_default_radius which has no None guard."""
@@ -1285,6 +1384,7 @@ class TestSetPlot:
 # 7. Full deprecated data-generation pipeline integration
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.unit
 class TestDeprecatedPipelineIntegration:
     """Test the full deprecated data generation pipeline end-to-end."""
@@ -1298,8 +1398,12 @@ class TestDeprecatedPipelineIntegration:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             sp._initialize_spiral_problem_params(
-                n_spirals=2, n_points=50, noise_level=0.1,
-                clockwise=True, train_ratio=0.7, test_ratio=0.3,
+                n_spirals=2,
+                n_points=50,
+                noise_level=0.1,
+                clockwise=True,
+                train_ratio=0.7,
+                test_ratio=0.3,
             )
 
         # Step 2: Generate spiral coordinates
@@ -1337,7 +1441,10 @@ class TestDeprecatedPipelineIntegration:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             train, test = sp._partition_dataset(
-                total_points=100, partitions=(0.7, 0.3), x=x_s, y=y_s,
+                total_points=100,
+                partitions=(0.7, 0.3),
+                x=x_s,
+                y=y_s,
             )
 
         x_train, y_train = train
@@ -1356,8 +1463,12 @@ class TestDeprecatedPipelineIntegration:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             sp._initialize_spiral_problem_params(
-                n_spirals=3, n_points=30, noise_level=0.05,
-                clockwise=False, train_ratio=0.8, test_ratio=0.2,
+                n_spirals=3,
+                n_points=30,
+                noise_level=0.05,
+                clockwise=False,
+                train_ratio=0.8,
+                test_ratio=0.2,
             )
             x_coords, y_coords = sp._generate_spiral_coordinates()
 
@@ -1369,7 +1480,10 @@ class TestDeprecatedPipelineIntegration:
             x_t, y_t = sp._convert_to_tensors(x, y)
             x_s, y_s = sp._shuffle_dataset(x_t, y_t)
             train, test = sp._partition_dataset(
-                total_points=90, partitions=(0.8, 0.2), x=x_s, y=y_s,
+                total_points=90,
+                partitions=(0.8, 0.2),
+                x=x_s,
+                y=y_s,
             )
 
         x_train, y_train = train
@@ -1382,6 +1496,7 @@ class TestDeprecatedPipelineIntegration:
 # ---------------------------------------------------------------------------
 # 8. Additional edge cases for maximum coverage
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.unit
 class TestDeprecationWarnings:
@@ -1538,6 +1653,7 @@ class TestSettersCoverage:
 
     def test_set_logger(self, sp):
         import logging
+
         new_logger = logging.getLogger("test")
         sp.set_logger(new_logger)
         assert sp.logger is new_logger


### PR DESCRIPTION
## Summary

Resolves all pytest warnings emitted when running the juniper-cascor test suite with warnings enabled. Adds batch size validation to `train_output_layer()` to catch mismatched input/target tensors before PyTorch silently broadcasts.

## Context / Motivation

Running `pytest -W default` (or without `-p no:warnings`) produced ~150 warnings across multiple categories. While all 2124 tests passed, the warnings indicated code quality issues and a latent production bug (silent tensor size mismatch in `train_output_layer()`). The blanket `-p no:warnings` in `pytest.ini` was hiding these.

## Changes

### Added
- Batch size validation in `CascadeCorrelationNetwork.train_output_layer()` — raises `ValueError` if `x.shape[0] != y.shape[0]`
- Registered missing `long` pytest marker in `pytest.ini`
- `notes/TEST_WARNING_FIXES_PLAN.md` — analysis and implementation plan

### Changed
- Replaced `-p no:warnings` in `pytest.ini` with targeted `filterwarnings` for unavoidable third-party warnings (starlette, sentry_sdk, matplotlib)
- Refactored 13 test functions across 4 files (`test_cascor_fix.py`, `test_critical_fixes.py`, `test_hdf5.py`, `test_p1_fixes.py`) to use assertions instead of `return True/False`
- Updated standalone `__main__` blocks to use try/except for pass/fail detection
- Fixed unawaited coroutine in `test_websocket_manager.py::test_broadcast_from_thread_with_loop` by closing captured coroutine

### Fixed
- **PytestReturnNotNoneWarning** (13 test functions) — tests no longer return values
- **RuntimeWarning: coroutine never awaited** — WebSocketManager.broadcast coroutine properly closed in test mock
- **UserWarning: mismatched tensor sizes** — caught at validation layer before reaching PyTorch MSELoss
- **PytestUnknownMarkWarning** — `long` marker now registered

## Impact & SemVer

- **SemVer impact:** PATCH
- **User-visible behavior change:** YES — `train_output_layer()` now raises `ValueError` on batch size mismatch (previously silently broadcast)
- **Breaking changes:** NO (silent broadcasting was a bug, not intentional behavior)
- **Performance impact:** NONE

## Testing & Results

### Test Summary

| Test Type   | Passed | Failed | Skipped | Notes                          |
| ----------- | ------ | ------ | ------- | ------------------------------ |
| Unit        | 2124   | 0      | 81      | All warnings resolved (0 remaining) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)