### PR TITLE
fix: resolve pre-commit bandit and test failures

### DIFF
--- a/notes/PRE_COMMIT_FIX_PLAN_2026-03-14.md
+++ b/notes/PRE_COMMIT_FIX_PLAN_2026-03-14.md
@@ -1,0 +1,117 @@
+# Pre-Commit Fix Plan — 2026-03-14
+
+**Date**: 2026-03-14
+**Branch**: `fix/pre-commit-errors`
+**Status**: Complete
+**Prior Fix Plans**: `PRE_COMMIT_FIX_PLAN.md` (2026-03-11), `FIX_PLAN_flake8_test_lint_2026-03-13.md`
+
+---
+
+## Overview
+
+Running `pre-commit run --all-files` on juniper-cascor produces **2 failing hooks** (bandit source scan, pytest-unit) out of 23 total hooks. All other hooks pass (including shellcheck, yamllint, markdownlint, flake8, mypy, black, isort, coverage gate).
+
+## Passing Hooks (21/23)
+
+- check-yaml, check-toml, check-json, end-of-file-fixer, trailing-whitespace
+- check-merge-conflict, check-added-large-files, check-case-conflict, check-ast
+- debug-statements, detect-private-key
+- black, isort, flake8 (source), flake8 (tests)
+- mypy, bandit (tests), markdownlint, shellcheck, yamllint
+- coverage-gate (80% threshold met — 93.79%)
+
+---
+
+## Issue 1: Bandit Source Scan — 7 Findings in `api/service_launcher.py` and `api/app.py`
+
+### Findings
+
+| # | Check | File | Line | Description |
+|---|-------|------|------|-------------|
+| 1 | B104 | `api/app.py` | 69 | `"0.0.0.0"` in env_overrides dict |
+| 2 | B404 | `api/service_launcher.py` | 17 | `import subprocess` |
+| 3 | B110 | `api/service_launcher.py` | 63 | try/except/pass in `_close_log()` |
+| 4 | B110 | `api/service_launcher.py` | 73 | try/except/pass in `_cleanup_at_exit()` |
+| 5 | B110 | `api/service_launcher.py` | 105 | try/except/pass in `wait_for_health()` |
+| 6 | B310 | `api/service_launcher.py` | 102 | `urllib.request.urlopen()` call |
+| 7 | B603 | `api/service_launcher.py` | 155 | `subprocess.Popen()` call |
+
+### Root Cause
+
+`api/service_launcher.py` is a new file (companion service subprocess launcher for local dev) that was added after the previous bandit fixes. Its patterns are all intentional:
+
+- **B104**: `"0.0.0.0"` is passed as an environment variable override for juniper-data's listen address in local dev mode, not a socket bind.
+- **B404/B603**: `subprocess` is the core purpose of this module — it manages child processes.
+- **B110**: try/except/pass in cleanup/teardown is standard defensive code — failure during cleanup should not propagate.
+- **B310**: `urllib.request.urlopen` is used for health polling an internal service URL constructed from configuration, not user input.
+
+### Fix
+
+Add inline `# nosec` annotations to each finding with explanatory comments:
+
+| File | Line | Annotation |
+|------|------|------------|
+| `api/app.py` | 69 | `# nosec B104 — env override for local dev, not a socket bind` |
+| `api/service_launcher.py` | 17 | `# nosec B404 — subprocess is the core purpose of this module` |
+| `api/service_launcher.py` | 63-64 | `# nosec B110 — cleanup must not propagate exceptions` |
+| `api/service_launcher.py` | 73-74 | `# nosec B110 — cleanup must not propagate exceptions` |
+| `api/service_launcher.py` | 102 | `# nosec B310 — internal health check URL from configuration` |
+| `api/service_launcher.py` | 105-106 | `# nosec B110 — health poll retries on any exception` |
+| `api/service_launcher.py` | 155 | `# nosec B603 — command is from settings, not user input` |
+
+### Files Modified
+
+- `src/api/app.py` (line 69)
+- `src/api/service_launcher.py` (lines 17, 63, 73, 102, 105, 155)
+
+---
+
+## Issue 2: pytest-unit — 2 Test Failures (UUID Double-Set Tests)
+
+### Failing Tests
+
+1. `test_candidate_unit_coverage_deep.py::TestUUIDMethods::test_set_uuid_double_set_error`
+2. `test_spiral_problem_coverage_deep.py::TestUUIDMethods::test_set_uuid_double_set_calls_exit`
+
+### Root Cause
+
+Both tests mock `os._exit` expecting the `set_uuid()` method to call `os._exit(1)` on double-set. However, the production code was previously changed from `os._exit(1)` to `sys.exit(1)`. The `sys.exit(1)` call raises `SystemExit`, which is not caught by the `os._exit` mock, causing the test to fail with an uncaught `SystemExit` exception.
+
+### Fix
+
+Update both tests to use `pytest.raises(SystemExit)` instead of mocking `os._exit`:
+
+**Before:**
+```python
+with patch("os._exit") as mock_exit:
+    candidate.set_uuid("new-uuid")
+    mock_exit.assert_called_once_with(1)
+```
+
+**After:**
+```python
+with pytest.raises(SystemExit) as exc_info:
+    candidate.set_uuid("new-uuid")
+assert exc_info.value.code == 1
+```
+
+### Files Modified
+
+- `src/tests/unit/test_candidate_unit_coverage_deep.py` (lines 669-671)
+- `src/tests/unit/test_spiral_problem_coverage_deep.py` (lines 1312-1314)
+
+---
+
+## Implementation Order
+
+1. Fix bandit nosec annotations (config/annotation changes, no behavioral risk)
+2. Fix UUID double-set tests (test changes, no production code changes)
+3. Verify all hooks pass with `pre-commit run --all-files`
+
+## Verification
+
+```bash
+cd /path/to/worktree
+pre-commit run --all-files
+# Expected: All 23 hooks pass (including Skipped)
+```

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -66,7 +66,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             name="juniper-data",
             command=settings.auto_start_data_service_command,
             health_url=f"{data_url.rstrip('/')}/v1/health",
-            env_overrides={"JUNIPER_DATA_HOST": "0.0.0.0"},
+            env_overrides={"JUNIPER_DATA_HOST": "0.0.0.0"},  # nosec B104 — env override for local dev, not a socket bind
         )
         if svc:
             managed_services.append(svc)

--- a/src/api/service_launcher.py
+++ b/src/api/service_launcher.py
@@ -14,7 +14,7 @@ import atexit
 import logging
 import os
 import shlex
-import subprocess
+import subprocess  # nosec B404 — subprocess is the core purpose of this module
 import urllib.request
 from pathlib import Path
 
@@ -60,7 +60,7 @@ class ManagedService:
         if self._log_handle is not None:
             try:
                 self._log_handle.close()
-            except Exception:
+            except Exception:  # nosec B110 — cleanup must not propagate exceptions
                 pass
             self._log_handle = None
 
@@ -70,7 +70,7 @@ def _cleanup_at_exit() -> None:
     for svc in _active_services:
         try:
             svc.terminate(timeout=5)
-        except Exception:
+        except Exception:  # nosec B110 — cleanup must not propagate exceptions
             pass
 
 
@@ -99,10 +99,10 @@ async def wait_for_health(
     while time.monotonic() < deadline:
         try:
             req = urllib.request.Request(url, method="GET")
-            with urllib.request.urlopen(req, timeout=5) as resp:
+            with urllib.request.urlopen(req, timeout=5) as resp:  # nosec B310 — internal health check URL from configuration
                 if resp.status == 200:
                     return True
-        except Exception:
+        except Exception:  # nosec B110 — health poll retries on any exception
             pass
         await asyncio.sleep(interval)
     return False
@@ -152,7 +152,7 @@ async def start_service(
         logger.warning(f"Could not open log file {log_file}, using /dev/null")
 
     try:
-        process = subprocess.Popen(
+        process = subprocess.Popen(  # nosec B603 — command is from settings, not user input
             cmd_parts,
             env=env,
             stdout=stdout_target,

--- a/src/tests/unit/test_candidate_unit_coverage_deep.py
+++ b/src/tests/unit/test_candidate_unit_coverage_deep.py
@@ -663,12 +663,12 @@ class TestUUIDMethods:
 
     @pytest.mark.unit
     def test_set_uuid_double_set_error(self, candidate):
-        """Lines 1473-1475: Double-set UUID triggers fatal and os._exit."""
+        """Lines 1473-1476: Double-set UUID triggers fatal and sys.exit(1)."""
         # candidate already has a UUID set during __init__
         assert candidate.uuid is not None
-        with patch("os._exit") as mock_exit:
+        with pytest.raises(SystemExit) as exc_info:
             candidate.set_uuid("new-uuid")
-            mock_exit.assert_called_once_with(1)
+        assert exc_info.value.code == 1
 
     @pytest.mark.unit
     def test_get_uuid_lazy_initialization(self):

--- a/src/tests/unit/test_spiral_problem_coverage_deep.py
+++ b/src/tests/unit/test_spiral_problem_coverage_deep.py
@@ -1305,13 +1305,13 @@ class TestUUIDMethods:
         assert len(sp.uuid) == 36
 
     def test_set_uuid_double_set_calls_exit(self, sp):
-        """Setting UUID when already set should call os._exit(1)."""
+        """Setting UUID when already set should call sys.exit(1)."""
         # Ensure uuid is already set from __init__
         assert hasattr(sp, "uuid")
         assert sp.uuid is not None
-        with patch("os._exit") as mock_exit:
+        with pytest.raises(SystemExit) as exc_info:
             sp.set_uuid("another-uuid")
-            mock_exit.assert_called_once_with(1)
+        assert exc_info.value.code == 1
 
     def test_get_uuid_returns_existing(self, sp):
         """get_uuid should return the existing UUID."""


### PR DESCRIPTION
## Summary

- Add `nosec` annotations to 7 intentional security patterns in `api/service_launcher.py` and `api/app.py` (B104, B110, B310, B404, B603) that were flagged by bandit 1.9.4
- Fix 2 UUID double-set tests that mocked `os._exit` but source code was previously changed to `sys.exit` — now use `pytest.raises(SystemExit)` instead
- Add fix plan document `notes/PRE_COMMIT_FIX_PLAN_2026-03-14.md`

All 23 pre-commit hooks now pass (+ 1 skipped). Coverage at 93.79%.

## Test plan

- [x] Both previously-failing tests pass: `test_set_uuid_double_set_error`, `test_set_uuid_double_set_calls_exit`
- [x] Full `pre-commit run --all-files` passes (23/23 hooks)
- [x] Coverage gate passes (93.79% >= 80%)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)