### PR TITLE
security: Phase 1a concurrency hardening

### DIFF
--- a/src/api/security.py
+++ b/src/api/security.py
@@ -1,5 +1,6 @@
 """API security: authentication and rate limiting middleware."""
 
+import hmac
 import time
 from collections import defaultdict
 from threading import Lock
@@ -46,7 +47,7 @@ class APIKeyAuth:
             return True
         if api_key is None:
             return False
-        return api_key in self._api_keys
+        return any(hmac.compare_digest(api_key, k) for k in self._api_keys)
 
     async def __call__(self, request: Request) -> str | None:
         """FastAPI dependency for API key validation.

--- a/src/cascade_correlation/cascade_correlation.py
+++ b/src/cascade_correlation/cascade_correlation.py
@@ -36,12 +36,14 @@
 #####################################################################################################################################################################################################
 import datetime
 import datetime as pd
+import io
 
 # import logging
 import logging.config
 import multiprocessing as mp
 import os
 import pathlib as pl
+import pickle
 import random
 import sys
 import time
@@ -193,7 +195,7 @@ def _create_task_queue():
     """
     global _task_queue
     if _task_queue is None:
-        _task_queue = Queue()
+        _task_queue = Queue(maxsize=1000)
     return _task_queue
 
 
@@ -204,8 +206,70 @@ def _create_result_queue():
     """
     global _result_queue
     if _result_queue is None:
-        _result_queue = Queue()
+        _result_queue = Queue(maxsize=1000)
     return _result_queue
+
+
+#####################################################################################################################################################################################################
+# Security: Restricted unpickler for deserialization defense-in-depth
+#####################################################################################################################################################################################################
+class RestrictedUnpickler(pickle.Unpickler):
+    """Restricts unpickling to known-safe types for CandidateTrainingResult deserialization.
+
+    This class provides defense-in-depth against pickle-based deserialization attacks.
+    It is used for any manual deserialization paths (e.g., network I/O). Note that
+    multiprocessing.Queue uses its own internal unpickler that cannot be overridden;
+    for that path, post-deserialization validation via _validate_training_result() is
+    the primary defense.
+    """
+
+    ALLOWED_CLASSES = {
+        # Application types
+        ("candidate_unit.candidate_unit", "CandidateTrainingResult"),
+        ("candidate_unit.candidate_unit", "CandidateUnit"),
+        ("candidate_unit.candidate_unit", "ActivationWithDerivative"),
+        # Python builtins
+        ("builtins", "list"),
+        ("builtins", "dict"),
+        ("builtins", "set"),
+        ("builtins", "tuple"),
+        ("builtins", "float"),
+        ("builtins", "int"),
+        ("builtins", "bool"),
+        ("builtins", "str"),
+        ("builtins", "bytes"),
+        # PyTorch tensor reconstruction
+        ("torch._utils", "_rebuild_tensor_v2"),
+        ("torch", "Tensor"),
+        ("torch", "Size"),
+        ("torch.storage", "TypedStorage"),
+        ("torch.storage", "UntypedStorage"),
+        ("torch.storage", "_load_from_bytes"),
+        ("torch", "float32"),
+        ("torch", "float64"),
+        ("torch", "int64"),
+        # PyTorch activation modules (used by CandidateUnit.activation_fn_base)
+        ("torch.nn.modules.activation", "Tanh"),
+        ("torch.nn.modules.activation", "Sigmoid"),
+        ("torch.nn.modules.activation", "ReLU"),
+        # Collections and codecs
+        ("collections", "OrderedDict"),
+        ("_codecs", "encode"),
+        # Numpy
+        ("numpy", "ndarray"),
+        ("numpy", "dtype"),
+        ("numpy.core.multiarray", "_reconstruct"),
+    }
+
+    def find_class(self, module, name):
+        if (module, name) in self.ALLOWED_CLASSES:
+            return super().find_class(module, name)
+        raise pickle.UnpicklingError(f"Blocked unpickling of {module}.{name}")
+
+    @classmethod
+    def loads(cls, data: bytes):
+        """Deserialize bytes using the restricted unpickler."""
+        return cls(io.BytesIO(data)).load()
 
 
 # Define CandidateTrainingManager Class and global functions
@@ -1683,6 +1747,34 @@ class CascadeCorrelationNetwork:
                 results.append((task[0], task[1][4] if len(task[1]) > 4 else None, 0.0, None))
         return results
 
+    def _validate_training_result(self, result) -> bool:
+        """Validate a CandidateTrainingResult from the result queue.
+
+        Checks type, field types, and bounds to detect corrupted or malicious results.
+        Returns True if the result is valid, False otherwise.
+        """
+        if not isinstance(result, CandidateTrainingResult):
+            self.logger.error(f"SECURITY: Result queue returned unexpected type: {type(result).__name__}")
+            return False
+        if not isinstance(result.correlation, (int, float)):
+            self.logger.error(f"SECURITY: Invalid correlation type: {type(result.correlation)}")
+            return False
+        if not (0.0 <= result.correlation <= 1.0):
+            self.logger.warning(f"CascadeCorrelationNetwork: _validate_training_result: correlation {result.correlation} out of bounds [0, 1]")
+            return False
+        if result.candidate is not None and not isinstance(result.candidate, CandidateUnit):
+            self.logger.error(f"SECURITY: Invalid candidate type: {type(result.candidate).__name__}")
+            return False
+        if result.norm_output is not None and isinstance(result.norm_output, torch.Tensor):
+            if torch.isnan(result.norm_output).any() or torch.isinf(result.norm_output).any():
+                self.logger.warning("CascadeCorrelationNetwork: _validate_training_result: norm_output contains NaN or Inf")
+                return False
+        if result.norm_error is not None and isinstance(result.norm_error, torch.Tensor):
+            if torch.isnan(result.norm_error).any() or torch.isinf(result.norm_error).any():
+                self.logger.warning("CascadeCorrelationNetwork: _validate_training_result: norm_error contains NaN or Inf")
+                return False
+        return True
+
     def _collect_training_results(
         self,
         result_queue: Queue,
@@ -1719,6 +1811,9 @@ class CascadeCorrelationNetwork:
             try:
                 result = result_queue.get(timeout=request_timeout)
                 self.logger.debug(f"CascadeCorrelationNetwork: _collect_training_results: Retrieved result: {result}")
+                if not self._validate_training_result(result):
+                    self.logger.error("CascadeCorrelationNetwork: _collect_training_results: Discarding invalid training result")
+                    continue
                 results.append(result)
                 collected_results += 1
                 self.logger.verbose(f"CascadeCorrelationNetwork: _collect_training_results: Collected {collected_results}/{num_tasks}")
@@ -2490,8 +2585,8 @@ class CascadeCorrelationNetwork:
             self._shutdown_worker_pool()
 
         # Create fresh queues and workers
-        self._persistent_task_queue = self._mp_ctx.Queue()
-        self._persistent_result_queue = self._mp_ctx.Queue()
+        self._persistent_task_queue = self._mp_ctx.Queue(maxsize=1000)
+        self._persistent_result_queue = self._mp_ctx.Queue(maxsize=1000)
         self._persistent_pool_size = num_workers
         _worker_thread_count = getattr(self.config, "worker_thread_count", 1)
 

--- a/src/cascade_correlation/cascade_correlation_config/cascade_correlation_config.py
+++ b/src/cascade_correlation/cascade_correlation_config/cascade_correlation_config.py
@@ -149,7 +149,7 @@ class CascadeCorrelationConfig:
         log_level_numbers_dict: dict = _CASCADE_CORRELATION_NETWORK_LOG_LEVEL_NUMBERS_DICT,
         log_level_numbers_list: list = _CASCADE_CORRELATION_NETWORK_LOG_LEVEL_NUMBERS_LIST,
         # Multiprocessing configuration
-        candidate_training_queue_authkey: str = _CASCADE_CORRELATION_NETWORK_AUTHKEY,
+        candidate_training_queue_authkey: str | None = _CASCADE_CORRELATION_NETWORK_AUTHKEY,
         candidate_training_queue_address: tuple = _CASCADE_CORRELATION_NETWORK_BASE_MANAGER_ADDRESS,
         candidate_training_worker_standby_sleepytime: float = _CASCADE_CORRELATION_NETWORK_WORKER_STANDBY_SLEEPYTIME,
         candidate_training_task_queue_timeout: float = _CASCADE_CORRELATION_NETWORK_TASK_QUEUE_TIMEOUT,
@@ -216,6 +216,9 @@ class CascadeCorrelationConfig:
         self.log_level_numbers_list = log_level_numbers_list
 
         # Multiprocessing configuration
+        if candidate_training_queue_authkey is None:
+            import secrets
+            candidate_training_queue_authkey = secrets.token_hex(32)
         self.candidate_training_queue_authkey = candidate_training_queue_authkey
         self.candidate_training_queue_address = candidate_training_queue_address
         self.candidate_training_worker_standby_sleepytime = candidate_training_worker_standby_sleepytime

--- a/src/cascor_constants/constants_model/constants_model.py
+++ b/src/cascor_constants/constants_model/constants_model.py
@@ -41,10 +41,9 @@
 # Define constants to support multiprocessing of candidate unit training
 
 # Define authkey for multiprocessing shared queues
-# _PROJECT_MODEL_AUTHKEY = b"Juniper_Cascade_Correlation_Multiprocessing_Authkey"
-# _PROJECT_MODEL_AUTHKEY = b'Juniper_Cascade_Correlation_Multiprocessing_Authkey'
-# _PROJECT_MODEL_AUTHKEY = 'Juniper_Cascade_Correlation_Multiprocessing_Authkey'
-_PROJECT_MODEL_AUTHKEY = "Juniper_Cascade_Correlation_Multiprocessing_Authkey"
+# SECURITY: No default authkey — must be explicitly configured at runtime.
+# A random authkey will be generated if not provided (see cascade_correlation_config.py).
+_PROJECT_MODEL_AUTHKEY = None
 
 # Multiprocessing context for candidate training
 # NOTE: 'forkserver' is the preferred context for parallel candidate training:

--- a/src/tests/unit/api/test_api_security.py
+++ b/src/tests/unit/api/test_api_security.py
@@ -43,6 +43,24 @@ class TestAPIKeyAuth:
         assert not auth.validate("invalid-key")
         assert not auth.validate(None)
 
+    def test_validate_uses_timing_safe_comparison(self) -> None:
+        """Validate should use hmac.compare_digest for timing-safe comparison."""
+        import hmac
+        from unittest.mock import patch
+
+        auth = APIKeyAuth(["valid-key"])
+        with patch.object(hmac, "compare_digest", wraps=hmac.compare_digest) as mock_compare:
+            auth.validate("valid-key")
+            mock_compare.assert_called()
+
+    def test_validate_with_multiple_keys(self) -> None:
+        """Validate should work correctly with multiple configured keys."""
+        auth = APIKeyAuth(["key1", "key2", "key3"])
+        assert auth.validate("key1")
+        assert auth.validate("key2")
+        assert auth.validate("key3")
+        assert not auth.validate("key4")
+
     @pytest.mark.asyncio
     async def test_call_returns_none_when_disabled(self) -> None:
         """Dependency should return None when auth is disabled."""

--- a/src/tests/unit/test_cascade_correlation_security.py
+++ b/src/tests/unit/test_cascade_correlation_security.py
@@ -1,0 +1,329 @@
+"""Unit tests for Phase 1a security hardening of CasCor concurrency.
+
+Tests cover:
+- RestrictedUnpickler allowlist enforcement
+- _validate_training_result bounds and type checking
+- Queue maxsize limits
+- Random authkey generation when no default is configured
+"""
+
+import io
+import pickle
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from candidate_unit.candidate_unit import CandidateTrainingResult, CandidateUnit
+from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork, RestrictedUnpickler
+from cascade_correlation.cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
+
+
+# ===================================================================
+# RestrictedUnpickler Tests
+# ===================================================================
+
+
+@pytest.mark.unit
+class TestRestrictedUnpickler:
+    """Tests for RestrictedUnpickler allowlist enforcement."""
+
+    def test_allows_builtins(self) -> None:
+        """RestrictedUnpickler should allow standard builtins."""
+        data = pickle.dumps([1, 2.0, "hello", True, (3, 4)])
+        result = RestrictedUnpickler.loads(data)
+        assert result == [1, 2.0, "hello", True, (3, 4)]
+
+    def test_allows_dict(self) -> None:
+        """RestrictedUnpickler should allow dict."""
+        data = pickle.dumps({"key": "value", "num": 42})
+        result = RestrictedUnpickler.loads(data)
+        assert result == {"key": "value", "num": 42}
+
+    def test_blocks_os_system(self) -> None:
+        """RestrictedUnpickler should block os.system and similar dangerous calls."""
+        import os
+
+        # Use pickle's __reduce__ mechanism to create a payload that would call os.system
+        class MaliciousOS:
+            def __reduce__(self):
+                return (os.system, ("echo pwned",))
+
+        payload = pickle.dumps(MaliciousOS())
+        with pytest.raises(pickle.UnpicklingError, match="Blocked unpickling of"):
+            RestrictedUnpickler.loads(payload)
+
+    def test_blocks_subprocess(self) -> None:
+        """RestrictedUnpickler should block subprocess module."""
+        import subprocess
+
+        class MaliciousSubprocess:
+            def __reduce__(self):
+                return (subprocess.call, (["echo", "hi"],))
+
+        payload = pickle.dumps(MaliciousSubprocess())
+        with pytest.raises(pickle.UnpicklingError, match="Blocked unpickling of"):
+            RestrictedUnpickler.loads(payload)
+
+    def test_allows_candidate_training_result(self) -> None:
+        """RestrictedUnpickler should allow CandidateTrainingResult."""
+        result = CandidateTrainingResult(candidate_id=0, correlation=0.5, success=True)
+        data = pickle.dumps(result)
+        restored = RestrictedUnpickler.loads(data)
+        assert isinstance(restored, CandidateTrainingResult)
+        assert restored.candidate_id == 0
+        assert restored.correlation == 0.5
+
+    def test_allows_torch_tensor(self) -> None:
+        """RestrictedUnpickler should allow torch.Tensor."""
+        tensor = torch.tensor([1.0, 2.0, 3.0])
+        data = pickle.dumps(tensor)
+        restored = RestrictedUnpickler.loads(data)
+        assert isinstance(restored, torch.Tensor)
+        assert torch.equal(restored, tensor)
+
+    def test_allowlist_completeness_for_training_result_with_candidate(self) -> None:
+        """RestrictedUnpickler should handle a full CandidateTrainingResult with a CandidateUnit."""
+        candidate = CandidateUnit(
+            _CandidateUnit__input_size=2,
+            _CandidateUnit__learning_rate=0.01,
+            _CandidateUnit__epochs=10,
+            _CandidateUnit__log_level_name="ERROR",
+        )
+        result = CandidateTrainingResult(
+            candidate_id=0,
+            correlation=0.75,
+            candidate=candidate,
+            norm_output=torch.randn(10),
+            norm_error=torch.randn(10),
+            success=True,
+            epochs_completed=10,
+        )
+        data = pickle.dumps(result)
+        restored = RestrictedUnpickler.loads(data)
+        assert isinstance(restored, CandidateTrainingResult)
+        assert isinstance(restored.candidate, CandidateUnit)
+        assert restored.correlation == 0.75
+
+
+# ===================================================================
+# _validate_training_result Tests
+# ===================================================================
+
+
+@pytest.mark.unit
+class TestValidateTrainingResult:
+    """Tests for CascadeCorrelationNetwork._validate_training_result."""
+
+    @pytest.fixture
+    def network(self) -> CascadeCorrelationNetwork:
+        """Create a minimal network for testing validation."""
+        config = CascadeCorrelationConfig.create_simple_config(
+            input_size=2,
+            output_size=1,
+            max_hidden_units=2,
+            candidate_pool_size=2,
+            candidate_epochs=3,
+            output_epochs=3,
+            epochs_max=5,
+        )
+        return CascadeCorrelationNetwork(config=config)
+
+    def test_valid_result(self, network) -> None:
+        """Valid CandidateTrainingResult should pass validation."""
+        result = CandidateTrainingResult(
+            candidate_id=0,
+            correlation=0.85,
+            success=True,
+            epochs_completed=100,
+            norm_output=torch.randn(10),
+            norm_error=torch.randn(10),
+        )
+        assert network._validate_training_result(result) is True
+
+    def test_valid_result_with_candidate(self, network) -> None:
+        """Valid result with CandidateUnit should pass validation."""
+        candidate = CandidateUnit(
+            _CandidateUnit__input_size=2,
+            _CandidateUnit__learning_rate=0.01,
+            _CandidateUnit__epochs=10,
+            _CandidateUnit__log_level_name="ERROR",
+        )
+        result = CandidateTrainingResult(
+            candidate_id=0,
+            correlation=0.5,
+            candidate=candidate,
+            success=True,
+        )
+        assert network._validate_training_result(result) is True
+
+    def test_wrong_type(self, network) -> None:
+        """Non-CandidateTrainingResult should fail validation."""
+        assert network._validate_training_result("not a result") is False
+        assert network._validate_training_result(42) is False
+        assert network._validate_training_result(None) is False
+
+    def test_correlation_out_of_bounds_high(self, network) -> None:
+        """Correlation > 1.0 should fail validation."""
+        result = CandidateTrainingResult(correlation=1.5)
+        assert network._validate_training_result(result) is False
+
+    def test_correlation_out_of_bounds_negative(self, network) -> None:
+        """Negative correlation should fail validation."""
+        result = CandidateTrainingResult(correlation=-0.1)
+        assert network._validate_training_result(result) is False
+
+    def test_correlation_boundary_zero(self, network) -> None:
+        """Correlation of exactly 0.0 should pass."""
+        result = CandidateTrainingResult(correlation=0.0)
+        assert network._validate_training_result(result) is True
+
+    def test_correlation_boundary_one(self, network) -> None:
+        """Correlation of exactly 1.0 should pass."""
+        result = CandidateTrainingResult(correlation=1.0)
+        assert network._validate_training_result(result) is True
+
+    def test_invalid_candidate_type(self, network) -> None:
+        """Non-CandidateUnit candidate should fail validation."""
+        result = CandidateTrainingResult(
+            correlation=0.5,
+            candidate="not a candidate unit",
+        )
+        assert network._validate_training_result(result) is False
+
+    def test_norm_output_nan(self, network) -> None:
+        """norm_output with NaN should fail validation."""
+        result = CandidateTrainingResult(
+            correlation=0.5,
+            norm_output=torch.tensor([1.0, float("nan"), 3.0]),
+        )
+        assert network._validate_training_result(result) is False
+
+    def test_norm_output_inf(self, network) -> None:
+        """norm_output with Inf should fail validation."""
+        result = CandidateTrainingResult(
+            correlation=0.5,
+            norm_output=torch.tensor([1.0, float("inf"), 3.0]),
+        )
+        assert network._validate_training_result(result) is False
+
+    def test_norm_error_nan(self, network) -> None:
+        """norm_error with NaN should fail validation."""
+        result = CandidateTrainingResult(
+            correlation=0.5,
+            norm_error=torch.tensor([1.0, float("nan")]),
+        )
+        assert network._validate_training_result(result) is False
+
+    def test_norm_error_inf(self, network) -> None:
+        """norm_error with Inf should fail validation."""
+        result = CandidateTrainingResult(
+            correlation=0.5,
+            norm_error=torch.tensor([float("-inf"), 1.0]),
+        )
+        assert network._validate_training_result(result) is False
+
+    def test_none_tensors_pass(self, network) -> None:
+        """None norm_output and norm_error should pass validation."""
+        result = CandidateTrainingResult(
+            correlation=0.5,
+            norm_output=None,
+            norm_error=None,
+        )
+        assert network._validate_training_result(result) is True
+
+    def test_none_candidate_passes(self, network) -> None:
+        """None candidate should pass validation (failure results have candidate=None)."""
+        result = CandidateTrainingResult(
+            correlation=0.0,
+            candidate=None,
+            success=False,
+            error_message="Training failed",
+        )
+        assert network._validate_training_result(result) is True
+
+
+# ===================================================================
+# Queue Size Limit Tests
+# ===================================================================
+
+
+@pytest.mark.unit
+class TestQueueSizeLimits:
+    """Tests for queue maxsize enforcement."""
+
+    def test_manager_task_queue_has_maxsize(self) -> None:
+        """Manager-hosted task queue should have maxsize=1000."""
+        from cascade_correlation.cascade_correlation import _create_task_queue, _task_queue
+
+        import cascade_correlation.cascade_correlation as cc_module
+
+        # Reset module-level queue to force recreation
+        original = cc_module._task_queue
+        cc_module._task_queue = None
+        try:
+            q = _create_task_queue()
+            assert q.maxsize == 1000
+        finally:
+            cc_module._task_queue = original
+
+    def test_manager_result_queue_has_maxsize(self) -> None:
+        """Manager-hosted result queue should have maxsize=1000."""
+        from cascade_correlation.cascade_correlation import _create_result_queue
+
+        import cascade_correlation.cascade_correlation as cc_module
+
+        original = cc_module._result_queue
+        cc_module._result_queue = None
+        try:
+            q = _create_result_queue()
+            assert q.maxsize == 1000
+        finally:
+            cc_module._result_queue = original
+
+
+# ===================================================================
+# Authkey Generation Tests
+# ===================================================================
+
+
+@pytest.mark.unit
+class TestAuthkeyGeneration:
+    """Tests for random authkey generation when no default is configured."""
+
+    def test_none_authkey_generates_random(self) -> None:
+        """Config with None authkey should auto-generate a random hex string."""
+        config = CascadeCorrelationConfig.create_simple_config(
+            input_size=2,
+            output_size=1,
+        )
+        assert config.candidate_training_queue_authkey is not None
+        assert isinstance(config.candidate_training_queue_authkey, str)
+        assert len(config.candidate_training_queue_authkey) == 64  # 32 bytes = 64 hex chars
+
+    def test_two_configs_get_different_authkeys(self) -> None:
+        """Two configs should get different random authkeys."""
+        config1 = CascadeCorrelationConfig.create_simple_config(
+            input_size=2,
+            output_size=1,
+        )
+        config2 = CascadeCorrelationConfig.create_simple_config(
+            input_size=2,
+            output_size=1,
+        )
+        assert config1.candidate_training_queue_authkey != config2.candidate_training_queue_authkey
+
+    def test_explicit_authkey_preserved(self) -> None:
+        """Explicitly provided authkey should not be overridden."""
+        config = CascadeCorrelationConfig.create_simple_config(
+            input_size=2,
+            output_size=1,
+            candidate_training_queue_authkey="my-explicit-key",
+        )
+        assert config.candidate_training_queue_authkey == "my-explicit-key"
+
+    def test_default_constant_is_none(self) -> None:
+        """The default authkey constant should be None (no hardcoded value)."""
+        from cascor_constants.constants_model.constants_model import _PROJECT_MODEL_AUTHKEY
+
+        assert _PROJECT_MODEL_AUTHKEY is None


### PR DESCRIPTION
## Summary

- **Timing-safe API key comparison**: Replace `api_key in self._api_keys` with `hmac.compare_digest()` to prevent timing side-channel attacks on API key validation
- **Remove hardcoded multiprocessing authkey**: Replace static `"Juniper_Cascade_Correlation_Multiprocessing_Authkey"` default with `None`; config now auto-generates a random 32-byte hex token via `secrets.token_hex()`
- **Restricted unpickler**: Add `RestrictedUnpickler` class with empirically validated allowlist (CandidateTrainingResult, CandidateUnit, torch tensors, builtins) for defense-in-depth against pickle deserialization attacks
- **Result validation**: Add `_validate_training_result()` method with type checking, correlation bounds `[0, 1]`, candidate type verification, and NaN/Inf tensor detection; integrated into `_collect_training_results()` loop to discard invalid results
- **Queue size limits**: Add `maxsize=1000` to all `Queue()` and `mp.Queue()` creations to prevent unbounded memory growth from bugs or attacks

## Context

Implements Phase 1a of the [CasCor Concurrency Architecture Plan](https://github.com/pcalnon/juniper-ml/blob/worktree-harmonic-crafting-castle/notes/CASCOR_CONCURRENCY_PLAN.md) — security fixes for the existing multiprocessing path, prior to Phase 1b (WebSocket remote workers).

## Test plan

- [x] 27 new security tests pass (`test_cascade_correlation_security.py`)
- [x] 2 new API key tests pass (`test_api_security.py`)
- [x] Full unit test suite: 2159 passed, 15 skipped, 0 failed
- [x] RestrictedUnpickler blocks `os.system` and `subprocess` payloads
- [x] RestrictedUnpickler allows full CandidateTrainingResult with CandidateUnit + tensors
- [x] Allowlist empirically validated via `pickletools.dis()` on real training results

🤖 Generated with [Claude Code](https://claude.com/claude-code)