### PR TITLE
feat: candidate training progress queue and real-time visibility

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -94,7 +94,7 @@ class TrainingLifecycleManager:
         if self._ws_manager is None:
             return
 
-        from api.websocket.messages import create_cascade_add_message, create_event_message, create_metrics_message, create_state_message
+        from api.websocket.messages import create_candidate_progress_message, create_cascade_add_message, create_event_message, create_metrics_message, create_state_message
 
         ws = self._ws_manager
 
@@ -113,6 +113,10 @@ class TrainingLifecycleManager:
         self.training_monitor.register_callback(
             "training_end",
             lambda **kw: ws.broadcast_from_thread(create_event_message({"event": "training_complete"})),
+        )
+        self.training_monitor.register_callback(
+            "candidate_progress",
+            lambda progress, **kw: ws.broadcast_from_thread(create_candidate_progress_message(progress)),
         )
 
         self.logger.info("WebSocket broadcast callbacks registered")
@@ -288,6 +292,25 @@ class TrainingLifecycleManager:
                     phase_detail=phase_detail,
                 )
 
+            def _drain_progress_queue(progress_queue, stop_event):
+                """Background thread that reads candidate progress from workers."""
+                import queue as _queue_mod
+
+                while not stop_event.is_set():
+                    try:
+                        progress = progress_queue.get(timeout=0.25)
+                    except _queue_mod.Empty:
+                        continue
+                    except Exception:
+                        break
+                    state.update_state(
+                        phase_detail="training_candidates",
+                        candidate_epoch=progress.get("epoch", 0),
+                        candidate_total_epochs=progress.get("total_epochs", 0),
+                        best_correlation=progress.get("correlation", 0.0),
+                    )
+                    monitor.on_candidate_progress(progress)
+
             def monitored_grow(*args, **kwargs):
                 # Pre-call: capture initial output training metrics
                 # (appended by fit() between train_output_layer() and grow_network())
@@ -301,7 +324,27 @@ class TrainingLifecycleManager:
                 # Inject grow iteration callback (Approach B — attribute fallback)
                 manager_ref.network._grow_iteration_callback = _grow_iteration_callback
 
-                result = original_grow(*args, **kwargs)
+                # Start drain thread for candidate progress from worker pool
+                _drain_stop = threading.Event()
+                _drain_thread = None
+                _pq = getattr(manager_ref.network, "_persistent_progress_queue", None)
+                if _pq is not None:
+                    _drain_thread = threading.Thread(
+                        target=_drain_progress_queue,
+                        args=(_pq, _drain_stop),
+                        daemon=True,
+                        name="candidate-progress-drain",
+                    )
+                    _drain_thread.start()
+
+                try:
+                    result = original_grow(*args, **kwargs)
+                finally:
+                    # Stop drain thread
+                    _drain_stop.set()
+                    if _drain_thread is not None:
+                        _drain_thread.join(timeout=2.0)
+
                 new_hidden = len(manager_ref.network.hidden_units)
 
                 if new_hidden > prev_hidden:
@@ -314,7 +357,7 @@ class TrainingLifecycleManager:
                 # Post-call: return to output phase after grow completes
                 monitor.current_phase = "output"
                 sm.set_phase(TrainingPhase.OUTPUT)
-                state.update_state(phase="Output", phase_detail="")
+                state.update_state(phase="Output", phase_detail="", candidate_epoch=0, candidate_total_epochs=0)
                 # Catch-all for any remaining metrics
                 manager_ref._extract_and_record_metrics()
                 return result

--- a/src/api/lifecycle/monitor.py
+++ b/src/api/lifecycle/monitor.py
@@ -41,6 +41,8 @@ class TrainingState:
         "candidates_trained",
         "candidates_total",
         "phase_started_at",
+        "candidate_epoch",
+        "candidate_total_epochs",
     }
 
     def __init__(self):
@@ -64,6 +66,8 @@ class TrainingState:
         self._candidates_trained: int = 0
         self._candidates_total: int = 0
         self._phase_started_at: str = ""
+        self._candidate_epoch: int = 0
+        self._candidate_total_epochs: int = 0
 
     def get_state(self) -> Dict[str, Any]:
         """Get current state as dictionary."""
@@ -88,6 +92,8 @@ class TrainingState:
                 "candidates_trained": self._candidates_trained,
                 "candidates_total": self._candidates_total,
                 "phase_started_at": self._phase_started_at,
+                "candidate_epoch": self._candidate_epoch,
+                "candidate_total_epochs": self._candidate_total_epochs,
             }
 
     def update_state(self, **kwargs) -> None:
@@ -138,6 +144,7 @@ class TrainingMonitor:
             "training_start": [],
             "training_end": [],
             "topology_change": [],
+            "candidate_progress": [],
         }
 
         self.metrics_queue: queue.Queue = queue.Queue()
@@ -213,6 +220,10 @@ class TrainingMonitor:
         }
         self.logger.info(f"Cascade unit {hidden_unit_index} added (correlation={correlation:.4f})")
         self._trigger_callbacks("cascade_add", event=event)
+
+    def on_candidate_progress(self, progress: Dict[str, Any]) -> None:
+        """Handle candidate training progress update from worker pool."""
+        self._trigger_callbacks("candidate_progress", progress=progress)
 
     def get_recent_metrics(self, count: int = 100) -> List[Dict[str, Any]]:
         with self._lock:

--- a/src/api/websocket/messages.py
+++ b/src/api/websocket/messages.py
@@ -59,6 +59,15 @@ def create_cascade_add_message(data: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def create_candidate_progress_message(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Create a candidate training progress message."""
+    return {
+        "type": "candidate_progress",
+        "timestamp": time.time(),
+        "data": data,
+    }
+
+
 def create_control_ack_message(
     command: str,
     status: str,

--- a/src/candidate_unit/candidate_unit.py
+++ b/src/candidate_unit/candidate_unit.py
@@ -621,6 +621,7 @@ class CandidateUnit:
         residual_error: torch.Tensor = None,
         learning_rate: float = _CANDIDATE_UNIT_LEARNING_RATE,
         display_frequency: int = _CANDIDATE_UNIT_DISPLAY_FREQUENCY,
+        progress_callback=None,
     ) -> CandidateTrainingResult:
         """
         Description:
@@ -718,6 +719,17 @@ class CandidateUnit:
                     self.logger.info(f"CandidateUnit: train: Early stopping at epoch {epoch + 1} - no improvement for {self.patience} epochs")
                     early_stopped = True
                     break
+
+            # Throttled progress emission for real-time monitoring
+            _pcb = progress_callback or getattr(self, "_progress_callback", None)
+            if _pcb is not None and (epoch % 50 == 0 or epoch == epochs - 1):
+                _pcb(
+                    candidate_id=getattr(self, "candidate_index", 0),
+                    candidate_uuid=str(getattr(self, "uuid", "")),
+                    epoch=epoch + 1,
+                    total_epochs=epochs,
+                    correlation=float(self.correlation),
+                )
 
             # Display training progress at specified frequency
             self.logger.debug("CandidateUnit: train: Display training progress at specified frequency")

--- a/src/cascade_correlation/cascade_correlation.py
+++ b/src/cascade_correlation/cascade_correlation.py
@@ -684,6 +684,7 @@ class CascadeCorrelationNetwork:
         self._persistent_workers = []
         self._persistent_task_queue = None
         self._persistent_result_queue = None
+        self._persistent_progress_queue = None
         self._persistent_pool_size = 0
 
         # Phase 1b: Remote worker coordinator reference (set via set_worker_coordinator)
@@ -2493,7 +2494,7 @@ class CascadeCorrelationNetwork:
         return optimizer
 
     @staticmethod
-    def train_candidate_worker(task_data_input: tuple = None, parallel: bool = True) -> None:
+    def train_candidate_worker(task_data_input: tuple = None, parallel: bool = True, progress_callback=None) -> None:
         logger = Logger
         logger.info("CascadeCorrelationNetwork: train_candidate_worker: Starting training of Candidate Units in Pool.")
         try:  # Get task data for process worker
@@ -2562,6 +2563,7 @@ class CascadeCorrelationNetwork:
                 candidate_display_frequency=candidate_inputs.get("candidate_display_frequency"),
                 worker_id=worker_id,
                 worker_uuid=worker_uuid,
+                progress_callback=progress_callback,
             )
             # PARALLEL-FIX (RC-5): Tag result with round_id for cross-round contamination detection
             result.round_id = candidate_inputs.get("round_id")
@@ -2677,6 +2679,7 @@ class CascadeCorrelationNetwork:
         candidate_display_frequency: int = 0,
         worker_id: int = 0,
         worker_uuid: str = "None",
+        progress_callback=None,
     ) -> CandidateTrainingResult:
         # Train the candidate unit
         global shared_object_dict
@@ -2691,6 +2694,7 @@ class CascadeCorrelationNetwork:
                 residual_error=residual_error,
                 learning_rate=candidate_learning_rate,
                 display_frequency=candidate_display_frequency,
+                progress_callback=progress_callback,
             )
             logger.info(f"CascadeCorrelationNetwork: _train_candidate_unit: Completed Training CandidateUnit object: Worker ID: {worker_id}, Worker UUID: {worker_uuid}, Candidate Index: {candidate_index}, Candidate UUID: {candidate_uuid}, Correlation: {float(training_result.correlation):.6f}")
             logger.debug(f"CascadeCorrelationNetwork: _train_candidate_unit: Clearing Display Progress and Display Status for Candidate Unit: Worker ID: {worker_id}, Worker UUID: {worker_uuid}, Candidate Index: {candidate_index}, Candidate UUID: {candidate_uuid}")
@@ -2816,6 +2820,7 @@ class CascadeCorrelationNetwork:
         # Create fresh queues and workers
         self._persistent_task_queue = self._mp_ctx.Queue(maxsize=_QUEUE_MAXSIZE)
         self._persistent_result_queue = self._mp_ctx.Queue(maxsize=_QUEUE_MAXSIZE)
+        self._persistent_progress_queue = self._mp_ctx.Queue(maxsize=_QUEUE_MAXSIZE)
         self._persistent_pool_size = num_workers
         _worker_thread_count = getattr(self.config, "worker_thread_count", 1)
 
@@ -2830,6 +2835,7 @@ class CascadeCorrelationNetwork:
                     _CASCADE_CORRELATION_NETWORK_TASK_QUEUE_TIMEOUT,
                     _worker_thread_count,
                     shared_training_inputs,
+                    self._persistent_progress_queue,
                 ),
                 daemon=True,
                 name=f"CandidateWorker-{i}",
@@ -2882,6 +2888,7 @@ class CascadeCorrelationNetwork:
         self._persistent_workers = []
         self._persistent_task_queue = None
         self._persistent_result_queue = None
+        self._persistent_progress_queue = None
         self._persistent_pool_size = 0
         self.logger.debug("CascadeCorrelationNetwork: _shutdown_worker_pool: Persistent pool shut down")
 
@@ -2898,6 +2905,7 @@ class CascadeCorrelationNetwork:
         # being duplicated in every task through the queue. None for backward compatibility
         # with sequential training path or legacy callers.
         shared_training_inputs: tuple = None,
+        progress_queue: Queue = None,
     ):
         """
         Description:
@@ -2976,10 +2984,20 @@ class CascadeCorrelationNetwork:
                     # Legacy format: task already contains training_inputs
                     full_task = task
 
+                # Build progress callback from progress_queue if available
+                _progress_cb = None
+                if progress_queue is not None:
+                    from queue import Full as _FullQ
+
+                    def _progress_cb(**kwargs):
+                        try:
+                            progress_queue.put_nowait(kwargs)
+                        except _FullQ:
+                            pass
+
                 # Process the task
                 logger.debug(f"CascadeCorrelationNetwork: _worker_loop: Processing task: {full_task[0] if full_task else 'None'}")
-                # Original call: result = CascadeCorrelationNetwork.train_candidate_worker(task_data_input=task, parallel=parallel)
-                result = CascadeCorrelationNetwork.train_candidate_worker(task_data_input=full_task, parallel=parallel)
+                result = CascadeCorrelationNetwork.train_candidate_worker(task_data_input=full_task, parallel=parallel, progress_callback=_progress_cb)
                 logger.debug("CascadeCorrelationNetwork: _worker_loop: Task processed, putting result in queue")
 
                 # Add timeout to prevent deadlock if queue is full

--- a/src/tests/unit/api/test_lifecycle_manager_coverage.py
+++ b/src/tests/unit/api/test_lifecycle_manager_coverage.py
@@ -221,12 +221,13 @@ class TestSetWsManager:
         with patch.object(mgr.training_monitor, "register_callback") as mock_register:
             mgr._register_ws_callbacks()
 
-            assert mock_register.call_count == 4
+            assert mock_register.call_count == 5
             event_names = [call.args[0] for call in mock_register.call_args_list]
             assert "epoch_end" in event_names
             assert "cascade_add" in event_names
             assert "training_start" in event_names
             assert "training_end" in event_names
+            assert "candidate_progress" in event_names
 
 
 class TestMonitoringHooks:


### PR DESCRIPTION
## Summary

- **Item 5**: Add multiprocessing `progress_queue` alongside existing task/result queues in persistent worker pool. Thread `progress_callback` through `_worker_loop()` → `train_candidate_worker()` → `_train_candidate_unit()` → `CandidateUnit.train_detailed()`. Emit throttled progress every 50 epochs (candidate_id, epoch, total_epochs, correlation).
- **Item 5 (drain)**: Add background drain thread in `monitored_grow()` that reads the progress queue and updates `TrainingState` + triggers `on_candidate_progress()` callbacks in real-time during candidate training.
- **Item 5 (WS)**: Add `create_candidate_progress_message()` builder and register `candidate_progress` WS broadcast callback.
- **Item 6**: Add `candidate_epoch` and `candidate_total_epochs` fields to `TrainingState` for per-candidate epoch tracking (field count 19 → 21).

Implements Appendix G Tier 1 Items 5-6 from `FINAL_CANOPY_CASCOR_CONNECTION_ANALYSIS.md`.

## Test plan

- [x] All 107 lifecycle/monitoring/WS unit tests pass
- [x] TrainingState verified: 21 fields, candidate_epoch/candidate_total_epochs populate correctly
- [x] TrainingMonitor has `candidate_progress` callback registered
- [x] WS callback count test updated (4 → 5)
- [x] Syntax check passes on all 6 modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)