### PR TITLE
refactor: remove dead metrics_queue from TrainingMonitor

### DIFF
--- a/src/api/lifecycle/monitor.py
+++ b/src/api/lifecycle/monitor.py
@@ -7,7 +7,6 @@ DataAdapter dependency — metrics are stored as plain dicts.
 
 import json
 import logging
-import queue
 import threading
 import time
 from collections import deque
@@ -147,7 +146,6 @@ class TrainingMonitor:
             "candidate_progress": [],
         }
 
-        self.metrics_queue: queue.Queue = queue.Queue()
         self._lock = threading.Lock()
         self.logger.info("TrainingMonitor initialized")
 
@@ -205,7 +203,6 @@ class TrainingMonitor:
             self.current_epoch = epoch
             self.metrics_buffer.append(metrics)
 
-        self.metrics_queue.put(metrics)
         self._trigger_callbacks("epoch_end", metrics=metrics, epoch=epoch, loss=loss, accuracy=accuracy)
 
     def on_cascade_add(self, hidden_unit_index: int, correlation: float) -> None:
@@ -249,8 +246,3 @@ class TrainingMonitor:
             self.metrics_buffer.clear()
         self.logger.info("Metrics buffer cleared")
 
-    def poll_metrics_queue(self, timeout: float = 0.1) -> Optional[Dict[str, Any]]:
-        try:
-            return self.metrics_queue.get(timeout=timeout)
-        except queue.Empty:
-            return None

--- a/src/tests/unit/api/test_lifecycle_monitor.py
+++ b/src/tests/unit/api/test_lifecycle_monitor.py
@@ -265,26 +265,6 @@ class TestTrainingMonitor:
             )
         assert monitor.get_current_state()["total_metrics"] == 10000
 
-    def test_poll_metrics_queue(self):
-        """Metrics queue receives epoch data."""
-        monitor = TrainingMonitor()
-        monitor.on_epoch_end(
-            epoch=1,
-            loss=0.5,
-            accuracy=0.75,
-            learning_rate=0.01,
-            hidden_units=0,
-        )
-        metric = monitor.poll_metrics_queue(timeout=0.1)
-        assert metric is not None
-        assert metric["epoch"] == 1
-
-    def test_poll_metrics_queue_empty(self):
-        """Empty queue returns None."""
-        monitor = TrainingMonitor()
-        result = monitor.poll_metrics_queue(timeout=0.01)
-        assert result is None
-
     def test_training_start_clears_buffer(self):
         """Starting training clears existing metrics."""
         monitor = TrainingMonitor()


### PR DESCRIPTION
## Summary

- **Item 10**: Remove `metrics_queue` and `poll_metrics_queue()` from `TrainingMonitor` — the queue was populated on every epoch end but never consumed by any production code. Metrics flow through the callback pipeline and `metrics_buffer` instead.
- Remove unused `import queue`
- Remove 2 unit tests that tested the removed queue functionality

## Test plan

- [x] All 109 lifecycle/monitoring unit tests pass
- [x] TrainingMonitor verified: `metrics_queue` attribute removed, `metrics_buffer` works correctly
- [x] No production code referenced `metrics_queue` or `poll_metrics_queue()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)