### PR TITLE
fix: restore early stopping and raise on unrecognized activation (CR-040, CR-043, CR-046)

### DIFF
--- a/src/cascade_correlation/cascade_correlation.py
+++ b/src/cascade_correlation/cascade_correlation.py
@@ -3746,16 +3746,9 @@ class CascadeCorrelationNetwork:
                 traceback.print_exc()
                 raise TrainingError from e
 
-            # # Update loop state from validation results (critical for early stopping convergence)
-            # patience_counter = validate_training_results.patience_counter
-            # best_value_loss = validate_training_results.best_value_loss
-            # self.logger.debug(f"CascadeCorrelationNetwork: grow_network: Growth Iteration {growth_iteration}, Early Stop: {validate_training_results.early_stop}, Patience Counter: {patience_counter}, Best Value Loss: {best_value_loss:.6f}, Value Output: {validate_training_results.value_output} Value Loss: {validate_training_results.value_loss:.6f}, Value Accuracy: {validate_training_results.value_accuracy:.4f}")
-            # if validate_training_results.early_stop:
-            #     self.logger.info(f"CascadeCorrelationNetwork: grow_network: Early stopping triggered at growth iteration {growth_iteration}.")
-            #     break
-            # self.logger.info(f"CascadeCorrelationNetwork: grow_network: Growth Iteration {growth_iteration} - Train Loss: {train_loss:.6f}, Train Accuracy: {train_accuracy:.4f}, Early stop: {validate_training_results.early_stop}")
-            # epochs_completed = growth_iteration + 1
-            # Update variables from validation results
+            # Update loop state from validation results (critical for early stopping convergence)
+            patience_counter = validate_training_results.patience_counter
+            best_value_loss = validate_training_results.best_value_loss
             self.logger.debug(f"CascadeCorrelationNetwork: grow_network: Iteration {iteration}, Early Stop: {validate_training_results.early_stop}, Patience Counter: {validate_training_results.patience_counter}, Best Value Loss: {validate_training_results.best_value_loss:.6f}, Value Output: {validate_training_results.value_output} Value Loss: {validate_training_results.value_loss:.6f}, Value Accuracy: {validate_training_results.value_accuracy:.4f}")
             if validate_training_results.early_stop:
                 self.logger.info(f"CascadeCorrelationNetwork: grow_network: Early stopping triggered at iteration {iteration}.")
@@ -4399,29 +4392,27 @@ class CascadeCorrelationNetwork:
             self.logger.info(f"CascadeCorrelationNetwork: validate_training: Early Stopping: {early_stop_flag}, Patience Counter: {patience_counter}, Best Val Loss: {best_value_loss:.6f}")
             self.logger.verbose(f"CascadeCorrelationNetwork: validate_training: Value Output: {value_output}, Value Loss: {value_loss:.6f}, Value Accuracy: {value_accuracy:.4f}")
 
-        # else:
-        #     # No validation data — use training loss for early stopping
-        #     if early_stopping:
-        #         if train_loss < best_value_loss - self.convergence_threshold:
-        #             best_value_loss = train_loss
-        #             patience_counter = 0
-        #         else:
-        #             patience_counter += 1
-        #         patience_exhausted = patience_counter >= self.patience
-        #         max_units_reached = self.check_hidden_units_max()
-        #         train_accuracy_reached = self.check_training_accuracy(
-        #             train_accuracy=train_accuracy,
-        #             accuracy_target=self.target_accuracy,
-        #         )
-        #         early_stop_flag = patience_exhausted or max_units_reached or train_accuracy_reached
-        #         self.logger.info(
-        #             f"CascadeCorrelationNetwork: validate_training: "
-        #             f"Epoch {epoch} (no val data) - Train Loss: {train_loss:.6f}, "
-        #             f"Train Acc: {train_accuracy:.4f}, Patience: {patience_counter}/{self.patience}, "
-        #             f"Early Stop: {early_stop_flag}"
-        #         )
-        #
-        # self.logger.verbose(f"CascadeCorrelationNetwork: validate_training: Epoch {epoch}, Early Stop: {early_stop_flag}, Patience Counter: {patience_counter}, Best Value Loss: {best_value_loss:.6f}, Value Output: {value_output}, Value Loss: {value_loss:.6f}, Value Accuracy: {value_accuracy:.4f}")
+        else:
+            # No validation data — use training loss for early stopping
+            if early_stopping:
+                if train_loss < best_value_loss - self.convergence_threshold:
+                    best_value_loss = train_loss
+                    patience_counter = 0
+                else:
+                    patience_counter += 1
+                patience_exhausted = patience_counter >= self.patience
+                max_units_reached = self.check_hidden_units_max()
+                train_accuracy_reached = self.check_training_accuracy(
+                    train_accuracy=train_accuracy,
+                    accuracy_target=self.target_accuracy,
+                )
+                early_stop_flag = patience_exhausted or max_units_reached or train_accuracy_reached
+                self.logger.info(
+                    f"CascadeCorrelationNetwork: validate_training: "
+                    f"Iteration {iteration} (no val data) - Train Loss: {train_loss:.6f}, "
+                    f"Train Acc: {train_accuracy:.4f}, Patience: {patience_counter}/{self.patience}, "
+                    f"Early Stop: {early_stop_flag}"
+                )
         self.logger.verbose(f"CascadeCorrelationNetwork: validate_training: Iteration {iteration}, Early Stop: {early_stop_flag}, Patience Counter: {patience_counter}, Best Value Loss: {best_value_loss:.6f}, Value Output: {value_output}, Value Loss: {value_loss:.6f}, Value Accuracy: {value_accuracy:.4f}")
         self.logger.trace("CascadeCorrelationNetwork: validate_training: Completed validation of the training process.")
 

--- a/src/tests/unit/test_activation_with_derivative.py
+++ b/src/tests/unit/test_activation_with_derivative.py
@@ -246,8 +246,8 @@ class TestActivationMapCoverage:
         assert activation_name in CandidateActivationWithDerivative.ACTIVATION_MAP
 
     @pytest.mark.unit
-    def test_unknown_activation_fallback(self):
-        """Test that unknown activation falls back to ReLU."""
+    def test_unknown_activation_raises_value_error(self):
+        """Test that unknown activation raises ValueError on deserialization (CR-046)."""
 
         class CustomActivation:
             def __call__(self, x):
@@ -255,11 +255,7 @@ class TestActivationMapCoverage:
 
         wrapper = CandidateActivationWithDerivative(CustomActivation())
         pickled = pickle.dumps(wrapper)
-        restored = pickle.loads(pickled)
 
-        # Should fall back to ReLU after unpickling
-        x = torch.tensor([0.5, -0.5])
-        output = restored(x)
-        # ReLU: max(0, x)
-        expected = torch.relu(x)
-        assert torch.allclose(output, expected)
+        # Should raise ValueError instead of silently falling back to ReLU
+        with pytest.raises(ValueError, match="Unrecognized activation function name"):
+            pickle.loads(pickled)

--- a/src/utils/activation.py
+++ b/src/utils/activation.py
@@ -133,8 +133,10 @@ class ActivationWithDerivative:
     def __setstate__(self, state):
         """Reconstruct activation function from name after unpickling."""
         self._activation_name = state["_activation_name"]
-        # Try to reconstruct from map, fall back to ReLU as default
-        self.activation_fn = self.ACTIVATION_MAP.get(self._activation_name, self.ACTIVATION_MAP.get(self._activation_name.lower(), torch.nn.ReLU()))
+        activation = self.ACTIVATION_MAP.get(self._activation_name) or self.ACTIVATION_MAP.get(self._activation_name.lower())
+        if activation is None:
+            raise ValueError(f"Unrecognized activation function name during deserialization: '{self._activation_name}'. Known activations: {list(self.ACTIVATION_MAP.keys())}")
+        self.activation_fn = activation
 
     def __repr__(self):
         """String representation for debugging."""


### PR DESCRIPTION
## Summary

- **CR-040**: Restore `patience_counter` and `best_value_loss` propagation between `grow_network` iterations — early stopping patience was completely non-functional because validation results were never read back into loop variables (2-line fix)
- **CR-043**: Uncomment training-loss early stopping path when no validation data is provided — the `else`-block in `validate_training` was entirely commented out, making early stopping impossible without validation data
- **CR-046**: Raise `ValueError` instead of silently falling back to ReLU when `ActivationWithDerivative` encounters an unrecognized activation name during deserialization

## Impact

These three findings from the comprehensive code review are the highest-priority core ML correctness fixes:
- **CR-040 (S1)** is the single highest-impact fix — patience-based early stopping was completely broken
- **CR-043 (S2)** completes the early stopping fix by enabling training-loss-based stopping when no validation data is available
- **CR-046 (S2)** prevents silent behavior changes from corrupting training results during multiprocessing

## Test plan

- [x] Updated `test_unknown_activation_fallback` → `test_unknown_activation_raises_value_error` to assert `ValueError` on unrecognized activation deserialization
- [x] Full test suite passes (2701 passed, 234 skipped, 0 failed)
- [ ] Verify early stopping triggers correctly in integration training run with patience < max_iterations

🤖 Generated with [Claude Code](https://claude.com/claude-code)