### PR TITLE
fix: auto-reset state machine from terminal states on start (CR-007)

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -531,23 +531,13 @@ class TrainingLifecycleManager:
         return {"status": "training_started", "timestamp": time.time()}
 
     def _run_training(self, x, y, x_val, y_val, **kwargs) -> None:
-        """Execute training in background thread."""
-        try:
-            self.network.fit(x, y, x_val=x_val, y_val=y_val, **kwargs)
-        except Exception as e:
-            self.logger.error(f"Training failed: {e}", exc_info=True)
-            self.state_machine.handle_command(Command.STOP)
-            self.training_state.update_state(status="Failed", phase="Idle")
-            if self._ws_manager:
-                try:
-                    self._ws_manager.broadcast_from_thread(
-                        {
-                            "type": "training_failed",
-                            "data": {"error": str(e), "phase": str(self.training_state.phase)},
-                        }
-                    )
-                except Exception:  # nosec B110 — broadcast failure must not prevent state update
-                    pass
+        """Execute training in background thread.
+
+        Note: Exception handling (state transitions, status updates, broadcasts)
+        is performed by monitored_fit() which wraps network.fit(). This method
+        intentionally does not duplicate that handling (CR-007 Option C).
+        """
+        self.network.fit(x, y, x_val=x_val, y_val=y_val, **kwargs)
 
     def stop_training(self) -> Dict[str, Any]:
         """Request training stop."""

--- a/src/api/lifecycle/state_machine.py
+++ b/src/api/lifecycle/state_machine.py
@@ -111,6 +111,9 @@ class TrainingStateMachine:
         return handler()
 
     def _handle_start(self) -> bool:
+        if self._status in (TrainingStatus.FAILED, TrainingStatus.COMPLETED):
+            self.logger.info(f"Auto-resetting from terminal state {self._status.name} before start")
+            self._reset_to_stopped()
         if self._status == TrainingStatus.STOPPED:
             self._status = TrainingStatus.STARTED
             self._phase = TrainingPhase.OUTPUT

--- a/src/tests/unit/api/test_lifecycle_state_machine.py
+++ b/src/tests/unit/api/test_lifecycle_state_machine.py
@@ -181,3 +181,23 @@ class TestTrainingStateMachine:
         sm.save_candidate_state({"epoch": 5})
         sm.handle_command(Command.RESET)
         assert sm.get_candidate_state() is None
+
+    def test_start_auto_resets_from_failed(self):
+        """Start command auto-resets from FAILED terminal state (CR-007)."""
+        sm = TrainingStateMachine()
+        sm.handle_command(Command.START)
+        sm.mark_failed("test error")
+        assert sm.is_failed()
+        result = sm.handle_command(Command.START)
+        assert result is True
+        assert sm.is_started()
+
+    def test_start_auto_resets_from_completed(self):
+        """Start command auto-resets from COMPLETED terminal state (CR-007)."""
+        sm = TrainingStateMachine()
+        sm.handle_command(Command.START)
+        sm.mark_completed()
+        assert sm.is_completed()
+        result = sm.handle_command(Command.START)
+        assert result is True
+        assert sm.is_started()

--- a/src/tests/unit/test_remaining_coverage_deep.py
+++ b/src/tests/unit/test_remaining_coverage_deep.py
@@ -705,8 +705,8 @@ class TestLifecycleManagerShutdownDeep:
 class TestRunTrainingExceptionPath:
     """Test _run_training error handling."""
 
-    def test_run_training_logs_exception(self):
-        """_run_training catches and logs exceptions from network.fit (line 354-355)."""
+    def test_run_training_propagates_exception(self):
+        """_run_training lets exceptions propagate — error handling is in monitored_fit (CR-007)."""
         mgr = TrainingLifecycleManager()
         mgr.create_network(input_size=2, output_size=2)
 
@@ -718,6 +718,6 @@ class TestRunTrainingExceptionPath:
         # Make fit raise an exception
         mgr.network.fit = MagicMock(side_effect=ValueError("bad data"))
 
-        # _run_training should catch the exception, not propagate it
-        mgr._run_training(x, y, None, None)
-        # No exception raised — the error was caught and logged
+        # _run_training no longer catches exceptions — monitored_fit handles them
+        with pytest.raises(ValueError, match="bad data"):
+            mgr._run_training(x, y, None, None)


### PR DESCRIPTION
## Summary

- **Option A**: `_handle_start` now auto-resets from FAILED/COMPLETED terminal states before proceeding with the start transition, preventing permanent state machine desynchronization
- **Option C**: Removed duplicate error handler in `_run_training` that redundantly attempted `Command.STOP` from FAILED state (producing spurious "Invalid transition" warnings) — exception handling is performed by `monitored_fit()`

## Impact

After training fails or completes, the state machine previously entered an irrecoverable terminal state. Calling `start_training` again would bypass the guard (it only checks `is_started()`), submit new work, but `monitored_fit`'s `Command.START` would silently fail. The state machine would report stale data while training actually executed.

## Test plan

- [x] Added `test_start_auto_resets_from_failed` — verifies start succeeds from FAILED state
- [x] Added `test_start_auto_resets_from_completed` — verifies start succeeds from COMPLETED state
- [x] Updated `test_run_training_propagates_exception` to reflect new contract
- [x] Full test suite passes (2703 passed, 234 skipped, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)