### PR TITLE
fix: snapshot round-trip fidelity for activation functions (CR-048, CR-044)

### DIFF
--- a/src/cascade_correlation/cascade_correlation.py
+++ b/src/cascade_correlation/cascade_correlation.py
@@ -1372,7 +1372,6 @@ class CascadeCorrelationNetwork:
         epochs: int = None,
         max_iterations: int = None,
         early_stopping: bool = True,
-        max_iterations: int = None,
     ) -> Dict[str, List]:
         """
         Train the network using the cascade correlation algorithm.
@@ -1385,7 +1384,6 @@ class CascadeCorrelationNetwork:
             epochs: Backward-compatible alias for max_epochs
             max_iterations: Maximum number of cascade growth iterations (default: from self.max_iterations)
             early_stopping: Whether to use early stopping
-            max_iterations: Maximum number of cascade growth iterations (default: from self.max_iterations)
         Raises:
             ValidationError: If input tensors are invalid or have wrong shapes
             TrainingError: If training fails due to configuration issues

--- a/src/snapshots/snapshot_serializer.py
+++ b/src/snapshots/snapshot_serializer.py
@@ -23,6 +23,7 @@ import torch
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from log_config.logger.logger import Logger
+from utils.activation import ActivationWithDerivative
 
 from .snapshot_common import calculate_tensor_checksum, load_numpy_array, load_tensor, read_str_attr, read_str_dataset, save_numpy_array, save_tensor, verify_tensor_checksum, write_str_attr, write_str_dataset
 
@@ -382,7 +383,7 @@ class CascadeHDF5Serializer:
 
             # Save activation function name (per unit, in case they differ)
             if "activation_fn" in unit:
-                af_name = getattr(unit["activation_fn"], "__name__", network.activation_function_name)
+                af_name = getattr(unit["activation_fn"], "_activation_name", network.activation_function_name)
                 write_str_attr(unit_group, "activation_function_name", af_name)
             else:
                 write_str_attr(
@@ -783,12 +784,12 @@ class CascadeHDF5Serializer:
             if "correlation" in unit_group.attrs:
                 unit["correlation"] = float(unit_group.attrs["correlation"])
 
-            # Load activation function (per unit)
+            # Load activation function (per unit), wrapped in ActivationWithDerivative for consistency with runtime-created units
             af_name = read_str_attr(unit_group, "activation_function_name", network.activation_function_name)
             if hasattr(network, "activation_functions_dict") and af_name in network.activation_functions_dict:
-                unit["activation_fn"] = network.activation_functions_dict[af_name]
+                unit["activation_fn"] = ActivationWithDerivative(network.activation_functions_dict[af_name])
             else:
-                unit["activation_fn"] = network.activation_fn
+                unit["activation_fn"] = ActivationWithDerivative(network.activation_fn) if not isinstance(network.activation_fn, ActivationWithDerivative) else network.activation_fn
 
             network.hidden_units.append(unit)
 


### PR DESCRIPTION
## Summary

- **CR-048**: Fix activation name extraction in `_save_hidden_units` — use `_activation_name` attribute instead of `__name__` which doesn't exist on `ActivationWithDerivative` wrappers. Per-unit activation identity was silently lost on save when units had heterogeneous activations.
- **CR-044**: Wrap deserialized activation functions in `ActivationWithDerivative` during HDF5 load, matching runtime-created units. Previously loaded units got bare `torch.nn` modules while runtime units got wrapped versions.
- Also fixes duplicate `max_iterations` parameter in `fit()` signature introduced during prior merge.

## Test plan

- [x] Full unit test suite passes (0 failures)
- [ ] Round-trip test: save network with heterogeneous per-unit activations → load → verify `_activation_name` preserved and derivatives work

🤖 Generated with [Claude Code](https://claude.com/claude-code)