### PR TITLE
feat: implement set_params command in WebSocket control stream (CR-008)

### DIFF
--- a/src/api/websocket/control_stream.py
+++ b/src/api/websocket/control_stream.py
@@ -18,7 +18,7 @@ from api.websocket.messages import create_control_ack_message
 
 logger = logging.getLogger("juniper_cascor.api.websocket.control")
 
-_VALID_COMMANDS = {"start", "stop", "pause", "resume", "reset"}
+_VALID_COMMANDS = {"start", "stop", "pause", "resume", "reset", "set_params"}
 _MAX_MESSAGE_SIZE = 65536  # 64KB
 
 
@@ -98,5 +98,9 @@ def _execute_command(lifecycle, command: str, params: dict = None) -> dict:
         return lifecycle.resume_training()
     elif command == "reset":
         return lifecycle.reset()
+    elif command == "set_params":
+        if not params:
+            raise ValueError("set_params requires a 'params' dict")
+        return lifecycle.update_params(params)
     else:
         raise ValueError(f"Unhandled command: {command}")

--- a/src/cascade_correlation/cascade_correlation.py
+++ b/src/cascade_correlation/cascade_correlation.py
@@ -1372,7 +1372,6 @@ class CascadeCorrelationNetwork:
         epochs: int = None,
         max_iterations: int = None,
         early_stopping: bool = True,
-        max_iterations: int = None,
     ) -> Dict[str, List]:
         """
         Train the network using the cascade correlation algorithm.
@@ -1385,7 +1384,6 @@ class CascadeCorrelationNetwork:
             epochs: Backward-compatible alias for max_epochs
             max_iterations: Maximum number of cascade growth iterations (default: from self.max_iterations)
             early_stopping: Whether to use early stopping
-            max_iterations: Maximum number of cascade growth iterations (default: from self.max_iterations)
         Raises:
             ValidationError: If input tensors are invalid or have wrong shapes
             TrainingError: If training fails due to configuration issues


### PR DESCRIPTION
## Summary

- Add `set_params` to `_VALID_COMMANDS` and `_execute_command` in `control_stream.py`
- Calls `lifecycle.update_params(params)` with the same validation as the REST `PATCH /v1/training/params` endpoint
- Fulfills the documented contract — module docstring already listed `set_params` as a valid command but it was not implemented

## Impact

This is critical functionality for juniper-canopy integration. Previously, clients sending `set_params` via WebSocket received "Unknown command" errors and had to fall back to the REST endpoint.

## Test plan

- [x] All 14 WebSocket control tests pass
- [x] Also fixes duplicate `max_iterations` parameter in `fit()` from prior merge
- [ ] Integration test: canopy sends `set_params` via WebSocket → verify params update on cascor side

🤖 Generated with [Claude Code](https://claude.com/claude-code)