### PR TITLE
fix: whitelist training start params and bound inline dataset arrays (CR-023, CR-029)

### DIFF
--- a/src/api/models/training.py
+++ b/src/api/models/training.py
@@ -15,12 +15,16 @@ class DatasetSource(BaseModel):
 
 
 class InlineDataset(BaseModel):
-    """Inline dataset provided directly in the request body."""
+    """Inline dataset provided directly in the request body.
 
-    train_x: List[List[float]] = Field(..., description="Training features (2D array)")
-    train_y: List[List[float]] = Field(..., description="Training targets (2D array)")
-    val_x: Optional[List[List[float]]] = Field(None, description="Validation features")
-    val_y: Optional[List[List[float]]] = Field(None, description="Validation targets")
+    Size limits enforce that inline data is for small ad-hoc datasets only.
+    For large datasets, use the juniper-data service.
+    """
+
+    train_x: List[List[float]] = Field(..., max_length=100000, description="Training features (2D array)")
+    train_y: List[List[float]] = Field(..., max_length=100000, description="Training targets (2D array)")
+    val_x: Optional[List[List[float]]] = Field(None, max_length=100000, description="Validation features")
+    val_y: Optional[List[List[float]]] = Field(None, max_length=100000, description="Validation targets")
 
 
 class TrainingStartRequest(BaseModel):

--- a/src/api/routes/training.py
+++ b/src/api/routes/training.py
@@ -32,6 +32,15 @@ async def start_training(request: Request, body: TrainingStartRequest = None) ->
     """
     lifecycle = _get_lifecycle(request)
 
+    # Whitelist of allowed training parameter keys (matches update_params in lifecycle manager)
+    _ALLOWED_TRAINING_PARAMS = {
+        "max_epochs", "max_iterations", "early_stopping",
+        "learning_rate", "candidate_learning_rate", "correlation_threshold",
+        "candidate_pool_size", "max_hidden_units", "epochs_max",
+        "patience", "convergence_threshold", "candidate_convergence_threshold",
+        "candidate_patience", "candidate_epochs", "init_output_weights",
+    }
+
     kwargs = {}
     x = None
     y = None
@@ -51,9 +60,13 @@ async def start_training(request: Request, body: TrainingStartRequest = None) ->
         if body.dataset is not None and body.dataset.generator == "spiral":
             x, y = _generate_spiral_data(body.dataset.params or {})
 
-        # Handle training params
+        # Handle training params — only allow whitelisted keys
         if body.params:
-            kwargs.update(body.params)
+            for key, value in body.params.items():
+                if key in _ALLOWED_TRAINING_PARAMS:
+                    kwargs[key] = value
+                else:
+                    logger.warning("Ignoring unrecognized training param: %s", key)
 
         if body.epochs is not None:
             kwargs["max_epochs"] = body.epochs

--- a/src/cascade_correlation/cascade_correlation.py
+++ b/src/cascade_correlation/cascade_correlation.py
@@ -1372,7 +1372,6 @@ class CascadeCorrelationNetwork:
         epochs: int = None,
         max_iterations: int = None,
         early_stopping: bool = True,
-        max_iterations: int = None,
     ) -> Dict[str, List]:
         """
         Train the network using the cascade correlation algorithm.
@@ -1385,7 +1384,6 @@ class CascadeCorrelationNetwork:
             epochs: Backward-compatible alias for max_epochs
             max_iterations: Maximum number of cascade growth iterations (default: from self.max_iterations)
             early_stopping: Whether to use early stopping
-            max_iterations: Maximum number of cascade growth iterations (default: from self.max_iterations)
         Raises:
             ValidationError: If input tensors are invalid or have wrong shapes
             TrainingError: If training fails due to configuration issues


### PR DESCRIPTION
## Summary

- **CR-023**: Add parameter whitelist in `start_training` route — only allowed keys from `body.params` are forwarded as `**kwargs`. Unrecognized keys are logged and dropped, preventing information disclosure from unexpected kwargs leaking internal function signatures.
- **CR-029**: Add `max_length=100000` to `InlineDataset` array fields. Inline data is for small ad-hoc datasets; large datasets should use the juniper-data service.

## Test plan

- [x] 610 API unit tests pass
- [x] Also fixes duplicate `max_iterations` parameter in `fit()` from prior merge
- [ ] Test with request containing unrecognized params key → verify it's logged and dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)