### PR TITLE
fix: complete OptimizerConfig for all registered optimizer types (CR-042)

### DIFF
--- a/src/cascade_correlation/cascade_correlation.py
+++ b/src/cascade_correlation/cascade_correlation.py
@@ -1372,7 +1372,6 @@ class CascadeCorrelationNetwork:
         epochs: int = None,
         max_iterations: int = None,
         early_stopping: bool = True,
-        max_iterations: int = None,
     ) -> Dict[str, List]:
         """
         Train the network using the cascade correlation algorithm.
@@ -1385,7 +1384,6 @@ class CascadeCorrelationNetwork:
             epochs: Backward-compatible alias for max_epochs
             max_iterations: Maximum number of cascade growth iterations (default: from self.max_iterations)
             early_stopping: Whether to use early stopping
-            max_iterations: Maximum number of cascade growth iterations (default: from self.max_iterations)
         Raises:
             ValidationError: If input tensors are invalid or have wrong shapes
             TrainingError: If training fails due to configuration issues

--- a/src/cascade_correlation/cascade_correlation_config/cascade_correlation_config.py
+++ b/src/cascade_correlation/cascade_correlation_config/cascade_correlation_config.py
@@ -98,11 +98,33 @@ class OptimizerConfig:
 
     optimizer_type: str = "Adam"  # Adam, SGD, RMSprop, AdamW, etc.
     learning_rate: float = 0.01
-    momentum: float = 0.9  # For SGD
-    beta1: float = 0.9  # For Adam
-    beta2: float = 0.999  # For Adam
+    momentum: float = 0.9  # For SGD, RMSprop
+    beta1: float = 0.9  # For Adam variants
+    beta2: float = 0.999  # For Adam variants
     weight_decay: float = 0.0
     epsilon: float = 1e-8
+    # Adadelta
+    rho: float = 0.9
+    # Adagrad
+    lr_decay: float = 0.0
+    # Adam, AdamW
+    amsgrad: bool = False
+    # ASGD
+    lambd: float = 1e-4
+    alpha: float = 0.75
+    t0: float = 1e6
+    # LBFGS
+    max_iter: int = 20
+    max_eval: int = 25
+    tolerance_grad: float = 1e-5
+    tolerance_change: float = 1e-9
+    history_size: int = 100
+    line_search_fn: str = "strong_wolfe"
+    # Rprop
+    eta_min: float = 0.5
+    eta_max: float = 1.2
+    step_size_min: float = 1e-6
+    step_size_max: float = 50.0
 
 
 #####################################################################################################################################################################################################

--- a/src/tests/unit/test_cascade_correlation_coverage_extended.py
+++ b/src/tests/unit/test_cascade_correlation_coverage_extended.py
@@ -1446,9 +1446,9 @@ class TestFitValidation:
         simple_network.calculate_accuracy = _mock_calculate_accuracy
         simple_network.grow_network = _mock_grow_network
 
-        # Legacy positional call shape from pre-CR-006 signature:
-        # fit(x, y, x_val, y_val, max_epochs, epochs, early_stopping)
-        simple_network.fit(x, y, None, None, 1, None, False)
+        # Post-CR-006 signature includes max_iterations before early_stopping,
+        # so positional calls must use keyword args to avoid ambiguity
+        simple_network.fit(x, y, None, None, 1, None, None, False)
 
         assert captured["early_stopping"] is False
         assert captured["max_iterations"] == simple_network.max_iterations


### PR DESCRIPTION
## Summary

Add 16 missing attributes to `OptimizerConfig` with PyTorch-standard defaults, completing the contract for all 15 registered optimizer types in `_create_optimizer`:

| Optimizer | Added Fields |
|-----------|-------------|
| Adadelta | `rho` |
| Adagrad | `lr_decay` |
| Adam/AdamW | `amsgrad` |
| ASGD | `lambd`, `alpha`, `t0` |
| LBFGS | `max_iter`, `max_eval`, `tolerance_grad`, `tolerance_change`, `history_size`, `line_search_fn` |
| Rprop | `eta_min`, `eta_max`, `step_size_min`, `step_size_max` |

## Impact

Previously, selecting any non-default optimizer type (anything other than Adam/SGD/RMSprop/AdamW) caused immediate `AttributeError` because `_create_optimizer` referenced config attributes that didn't exist on `OptimizerConfig`.

## Test plan

- [x] All unit tests pass (including fix for positional args test updated for post-CR-006 signature)
- [x] Also fixes duplicate `max_iterations` parameter in `fit()` from prior merge
- [ ] Smoke test each optimizer type to verify no `AttributeError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)