### PR TITLE
fix: thread-safe singletons, Prometheus labels, async boundary (CR-021, CR-022, CR-064)

### DIFF
--- a/src/api/observability.py
+++ b/src/api/observability.py
@@ -87,7 +87,8 @@ class PrometheusMiddleware(BaseHTTPMiddleware):
         response = await call_next(request)
         duration = time.perf_counter() - start
 
-        endpoint = request.url.path
+        route = request.scope.get("route")
+        endpoint = route.path if route else "unmatched"
         method = request.method
         status = str(response.status_code)
 

--- a/src/api/routes/decision_boundary.py
+++ b/src/api/routes/decision_boundary.py
@@ -1,5 +1,7 @@
 """Decision boundary routes for 2D visualization."""
 
+import asyncio
+
 from fastapi import APIRouter, HTTPException, Query, Request
 
 from api.models.common import success_response
@@ -23,13 +25,14 @@ async def get_decision_boundary(
 
     Computes a grid of network predictions over the input space.
     Requires a network with 2D input and loaded training data.
+    Computation is offloaded to a thread to avoid blocking the event loop.
     """
     lifecycle = _get_lifecycle(request)
     if not lifecycle.has_network():
         raise HTTPException(status_code=404, detail="No network created")
     if not lifecycle.has_training_data():
         raise HTTPException(status_code=404, detail="No training data loaded")
-    boundary = lifecycle.get_decision_boundary(resolution=resolution)
+    boundary = await asyncio.to_thread(lifecycle.get_decision_boundary, resolution=resolution)
     if boundary is None:
         raise HTTPException(status_code=500, detail="Failed to compute decision boundary")
     return success_response(boundary)

--- a/src/api/security.py
+++ b/src/api/security.py
@@ -206,29 +206,34 @@ class RateLimiter:
 
 _api_key_auth: APIKeyAuth | None = None
 _rate_limiter: RateLimiter | None = None
+_singleton_lock = Lock()
 
 
 def get_api_key_auth() -> APIKeyAuth:
-    """Get the global API key auth handler, creating if needed."""
+    """Get the global API key auth handler, creating if needed (thread-safe)."""
     global _api_key_auth
     if _api_key_auth is None:
-        settings = get_settings()
-        api_keys = getattr(settings, "api_keys", None)
-        _api_key_auth = APIKeyAuth(api_keys)
+        with _singleton_lock:
+            if _api_key_auth is None:
+                settings = get_settings()
+                api_keys = getattr(settings, "api_keys", None)
+                _api_key_auth = APIKeyAuth(api_keys)
     return _api_key_auth
 
 
 def get_rate_limiter() -> RateLimiter:
-    """Get the global rate limiter, creating if needed."""
+    """Get the global rate limiter, creating if needed (thread-safe)."""
     global _rate_limiter
     if _rate_limiter is None:
-        settings = get_settings()
-        enabled = getattr(settings, "rate_limit_enabled", False)
-        requests_per_minute = getattr(settings, "rate_limit_requests_per_minute", 60)
-        _rate_limiter = RateLimiter(
-            requests_per_minute=requests_per_minute,
-            enabled=enabled,
-        )
+        with _singleton_lock:
+            if _rate_limiter is None:
+                settings = get_settings()
+                enabled = getattr(settings, "rate_limit_enabled", False)
+                requests_per_minute = getattr(settings, "rate_limit_requests_per_minute", 60)
+                _rate_limiter = RateLimiter(
+                    requests_per_minute=requests_per_minute,
+                    enabled=enabled,
+                )
     return _rate_limiter
 
 


### PR DESCRIPTION
## Summary

Three Tier 3 quick wins from the comprehensive code review:

- **CR-021 (S3, concurrency)**: Add double-checked locking to `get_api_key_auth()` and `get_rate_limiter()` — prerequisite for CR-009/CR-010 security integration
- **CR-022 (S2, observability)**: Normalize Prometheus endpoint labels from raw URL paths to route templates (`request.scope["route"].path`), preventing unbounded label cardinality
- **CR-064 (S2, performance)**: Offload `get_decision_boundary()` to a thread via `asyncio.to_thread()`, preventing meshgrid + forward pass from blocking the event loop

## Test plan

- [x] 610 API unit tests pass
- [ ] Verify Prometheus labels use route templates (e.g. `/v1/snapshots/{snapshot_id}`) not actual paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)