### PR TITLE
refactor: extract shared WebSocket auth utility (CR-010)

### DIFF
--- a/src/api/websocket/control_stream.py
+++ b/src/api/websocket/control_stream.py
@@ -14,6 +14,7 @@ import logging
 
 from fastapi import WebSocket, WebSocketDisconnect
 
+from api.websocket.manager import ws_authenticate
 from api.websocket.messages import create_control_ack_message
 
 logger = logging.getLogger("juniper_cascor.api.websocket.control")
@@ -24,13 +25,8 @@ _MAX_MESSAGE_SIZE = 65536  # 64KB
 
 async def control_stream_handler(websocket: WebSocket) -> None:
     """Handle /ws/control WebSocket connections."""
-    # Authenticate WebSocket connection (BaseHTTPMiddleware does not intercept WS)
-    auth = getattr(websocket.app.state, "api_key_auth", None)
-    if auth is not None and auth.enabled:
-        api_key = websocket.headers.get("X-API-Key")
-        if not auth.validate(api_key):
-            await websocket.close(code=4001, reason="Authentication required")
-            return
+    if not await ws_authenticate(websocket):
+        return
 
     lifecycle = getattr(websocket.app.state, "lifecycle", None)
 

--- a/src/api/websocket/manager.py
+++ b/src/api/websocket/manager.py
@@ -18,6 +18,26 @@ from fastapi import WebSocket
 logger = logging.getLogger("juniper_cascor.api.websocket")
 
 
+async def ws_authenticate(websocket: WebSocket) -> bool:
+    """Authenticate a WebSocket connection via X-API-Key header.
+
+    Shared utility replacing inline auth boilerplate in each stream handler.
+    BaseHTTPMiddleware cannot intercept WebSocket upgrades, so each WS
+    endpoint must authenticate independently.
+
+    Returns:
+        True if authenticated (or auth disabled). False if auth failed
+        (connection is closed with 4001).
+    """
+    auth = getattr(websocket.app.state, "api_key_auth", None)
+    if auth is not None and auth.enabled:
+        api_key = websocket.headers.get("X-API-Key")
+        if not auth.validate(api_key):
+            await websocket.close(code=4001, reason="Authentication required")
+            return False
+    return True
+
+
 class WebSocketManager:
     """Manages WebSocket connections and message broadcasting.
 

--- a/src/api/websocket/training_stream.py
+++ b/src/api/websocket/training_stream.py
@@ -12,6 +12,7 @@ import logging
 
 from fastapi import WebSocket, WebSocketDisconnect
 
+from api.websocket.manager import ws_authenticate
 from api.websocket.messages import create_state_message
 
 logger = logging.getLogger("juniper_cascor.api.websocket.training")
@@ -19,13 +20,8 @@ logger = logging.getLogger("juniper_cascor.api.websocket.training")
 
 async def training_stream_handler(websocket: WebSocket) -> None:
     """Handle /ws/training WebSocket connections."""
-    # Authenticate WebSocket connection (BaseHTTPMiddleware does not intercept WS)
-    auth = getattr(websocket.app.state, "api_key_auth", None)
-    if auth is not None and auth.enabled:
-        api_key = websocket.headers.get("X-API-Key")
-        if not auth.validate(api_key):
-            await websocket.close(code=4001, reason="Authentication required")
-            return
+    if not await ws_authenticate(websocket):
+        return
 
     ws_manager = getattr(websocket.app.state, "ws_manager", None)
     lifecycle = getattr(websocket.app.state, "lifecycle", None)

--- a/src/api/websocket/worker_stream.py
+++ b/src/api/websocket/worker_stream.py
@@ -17,6 +17,7 @@ import logging
 
 from fastapi import WebSocket, WebSocketDisconnect
 
+from api.websocket.manager import ws_authenticate
 from api.workers.coordinator import WorkerCoordinator
 from api.workers.protocol import BinaryFrame, MessageType, WorkerProtocol
 from api.workers.registry import WorkerRegistry
@@ -42,13 +43,8 @@ async def worker_stream_handler(websocket: WebSocket) -> None:
         await websocket.close(code=4003, reason="Origin header not allowed on worker endpoint")
         return
 
-    # Authenticate (same pattern as control_stream.py)
-    auth = getattr(websocket.app.state, "api_key_auth", None)
-    if auth is not None and auth.enabled:
-        api_key = websocket.headers.get("X-API-Key")
-        if not auth.validate(api_key):
-            await websocket.close(code=4001, reason="Authentication required")
-            return
+    if not await ws_authenticate(websocket):
+        return
 
     # Get coordinator and registry from app state
     coordinator: WorkerCoordinator | None = getattr(websocket.app.state, "worker_coordinator", None)


### PR DESCRIPTION
## Summary

Extract `ws_authenticate(websocket)` helper from identical inline auth boilerplate duplicated in `control_stream.py`, `training_stream.py`, and `worker_stream.py`. Ensures auth logic consistency across all WebSocket endpoints.

## Test plan

- [x] 68 WebSocket tests pass (control, training, worker streams + auth + manager)

🤖 Generated with [Claude Code](https://claude.com/claude-code)