### PR TITLE
fix: thread-safe audit counters and stale-worker check (CR-027, CR-028)

### DIFF
--- a/src/api/workers/audit.py
+++ b/src/api/workers/audit.py
@@ -16,6 +16,7 @@ import json
 import logging
 import time
 from enum import StrEnum
+from threading import Lock
 from typing import Any
 
 logger = logging.getLogger("juniper_cascor.api.workers.audit")
@@ -53,6 +54,7 @@ class AuditLogger:
     def __init__(self, logger_name: str = "juniper_cascor.api.workers.audit") -> None:
         self._logger = logging.getLogger(logger_name)
         self._counter: dict[str, int] = {}
+        self._lock = Lock()
 
     def log(self, event_type: AuditEventType, **fields: Any) -> None:
         """Log a security audit event.
@@ -62,12 +64,14 @@ class AuditLogger:
             **fields: Key-value pairs to include in the structured log.
                 Common fields: worker_id, source_ip, task_id, details.
         """
-        self._counter[event_type] = self._counter.get(event_type, 0) + 1
+        with self._lock:
+            self._counter[event_type] = self._counter.get(event_type, 0) + 1
+            seq = self._counter[event_type]
 
         record = {
             "event": event_type.value,
             "timestamp": time.time(),
-            "seq": self._counter[event_type],
+            "seq": seq,
             **fields,
         }
 
@@ -76,11 +80,13 @@ class AuditLogger:
 
     def get_counts(self) -> dict[str, int]:
         """Return event counts by type."""
-        return dict(self._counter)
+        with self._lock:
+            return dict(self._counter)
 
     def reset_counts(self) -> None:
         """Reset event counters."""
-        self._counter.clear()
+        with self._lock:
+            self._counter.clear()
 
 
 class WorkerMetrics:
@@ -95,62 +101,70 @@ class WorkerMetrics:
 
     def __init__(self) -> None:
         self._workers: dict[str, _WorkerMetricData] = {}
+        self._lock = Lock()
 
     def on_register(self, worker_id: str, source_ip: str = "") -> None:
         """Record a worker registration."""
-        self._workers[worker_id] = _WorkerMetricData(
-            worker_id=worker_id,
-            source_ip=source_ip,
-            registered_at=time.time(),
-        )
+        with self._lock:
+            self._workers[worker_id] = _WorkerMetricData(
+                worker_id=worker_id,
+                source_ip=source_ip,
+                registered_at=time.time(),
+            )
 
     def on_deregister(self, worker_id: str) -> None:
         """Record a worker deregistration."""
-        data = self._workers.get(worker_id)
-        if data:
-            data.deregistered_at = time.time()
+        with self._lock:
+            data = self._workers.get(worker_id)
+            if data:
+                data.deregistered_at = time.time()
 
     def on_task_complete(self, worker_id: str, success: bool, duration: float) -> None:
         """Record a task completion."""
-        data = self._workers.get(worker_id)
-        if data is None:
-            return
-        data.tasks_completed += 1
-        if success:
-            data.tasks_succeeded += 1
-        else:
-            data.tasks_failed += 1
-        data.total_duration += duration
+        with self._lock:
+            data = self._workers.get(worker_id)
+            if data is None:
+                return
+            data.tasks_completed += 1
+            if success:
+                data.tasks_succeeded += 1
+            else:
+                data.tasks_failed += 1
+            data.total_duration += duration
 
     def on_anomaly(self, worker_id: str, anomaly_type: str) -> None:
         """Record an anomaly detection."""
-        data = self._workers.get(worker_id)
-        if data is None:
-            return
-        data.anomaly_count += 1
-        data.anomaly_types.append(anomaly_type)
+        with self._lock:
+            data = self._workers.get(worker_id)
+            if data is None:
+                return
+            data.anomaly_count += 1
+            data.anomaly_types.append(anomaly_type)
 
     def get_worker_metrics(self, worker_id: str) -> dict[str, Any] | None:
         """Get metrics for a specific worker."""
-        data = self._workers.get(worker_id)
-        if data is None:
-            return None
-        return {
-            "worker_id": data.worker_id,
-            "source_ip": data.source_ip,
-            "registered_at": data.registered_at,
-            "deregistered_at": data.deregistered_at,
-            "tasks_completed": data.tasks_completed,
-            "tasks_succeeded": data.tasks_succeeded,
-            "tasks_failed": data.tasks_failed,
-            "avg_duration": data.total_duration / max(1, data.tasks_completed),
-            "anomaly_count": data.anomaly_count,
-            "success_rate": data.tasks_succeeded / max(1, data.tasks_completed),
-        }
+        with self._lock:
+            data = self._workers.get(worker_id)
+            if data is None:
+                return None
+            return {
+                "worker_id": data.worker_id,
+                "source_ip": data.source_ip,
+                "registered_at": data.registered_at,
+                "deregistered_at": data.deregistered_at,
+                "tasks_completed": data.tasks_completed,
+                "tasks_succeeded": data.tasks_succeeded,
+                "tasks_failed": data.tasks_failed,
+                "avg_duration": data.total_duration / max(1, data.tasks_completed),
+                "anomaly_count": data.anomaly_count,
+                "success_rate": data.tasks_succeeded / max(1, data.tasks_completed),
+            }
 
     def get_all_metrics(self) -> list[dict[str, Any]]:
         """Get metrics for all workers."""
-        return [self.get_worker_metrics(wid) for wid in self._workers if self.get_worker_metrics(wid) is not None]
+        with self._lock:
+            worker_ids = list(self._workers.keys())
+        return [m for wid in worker_ids if (m := self.get_worker_metrics(wid)) is not None]
 
 
 class _WorkerMetricData:

--- a/src/api/workers/coordinator.py
+++ b/src/api/workers/coordinator.py
@@ -365,9 +365,24 @@ class WorkerCoordinator:
             self._check_task_timeouts()
 
     def _check_stale_workers(self) -> None:
-        """Deregister workers whose heartbeat has timed out."""
+        """Deregister workers whose heartbeat has timed out.
+
+        To close the TOCTOU gap between get_stale_workers() and deregister(),
+        each worker's staleness is re-checked via the registry before removal.
+        A worker that sent a heartbeat between the snapshot and the re-check
+        will be skipped.
+        """
         stale = self._registry.get_stale_workers()
         for worker in stale:
+            # Re-check: the worker may have sent a heartbeat since the snapshot
+            current = self._registry.get(worker.worker_id)
+            if current is None:
+                # Already deregistered by another path
+                continue
+            if current.is_alive(self._registry._heartbeat_timeout):
+                logger.debug("Worker %s recovered (heartbeat received since stale snapshot) — skipping deregister", worker.worker_id)
+                continue
+
             logger.warning("Worker %s heartbeat timeout — deregistering", worker.worker_id)
             # If worker had an active task, put it back in the unassigned queue
             if worker.active_task_id is not None:


### PR DESCRIPTION
## Summary
- **CR-027**: Add `threading.Lock` to `AuditLogger._counter` and `WorkerMetrics._workers` to prevent race conditions on compound read-modify-write operations
- **CR-028**: Re-check worker staleness before deregistration in `_check_stale_workers` to close TOCTOU gap where a worker could heartbeat between snapshot and removal

## Test plan
- [x] All 312 unit tests pass
- [ ] Verify lock contention doesn't impact worker throughput under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)