### PR TITLE
fix: validate SharedTrainingMemory ndim and fix binary accuracy (CR-047, CR-049)

### DIFF
--- a/src/cascade_correlation/cascade_correlation.py
+++ b/src/cascade_correlation/cascade_correlation.py
@@ -257,6 +257,12 @@ class SharedTrainingMemory:
             dtype_code = self.DTYPE_MAP.get(ct.dtype)
             if dtype_code is None:
                 raise ValueError(f"Unsupported tensor dtype: {ct.dtype}")
+            if ct.ndim > 2:
+                raise ValueError(
+                    f"SharedTrainingMemory only supports tensors up to 2 dimensions, "
+                    f"got tensor with {ct.ndim} dimensions (shape: {tuple(ct.shape)}). "
+                    f"Higher-dimensional tensor support is planned for a future release."
+                )
             self._tensors_info.append(
                 {
                     "nbytes": ct.nbytes,
@@ -287,6 +293,9 @@ class SharedTrainingMemory:
             shape_0 = info["shape"][0] if info["ndim"] >= 1 else 0
             shape_1 = info["shape"][1] if info["ndim"] >= 2 else 0
             # Descriptor: offset(Q) + nbytes(Q) + ndim(B) + dtype_code(B) + shape0(I) + shape1(I) + reserved(6x) = 32 bytes
+            # NOTE: Struct format only stores shape_0 and shape_1, limiting support to
+            # tensors with ndim <= 2. Validated in __init__. Higher-dimensional support
+            # would require a format change (e.g., variable-length shape encoding).
             struct.pack_into(
                 "<QQBBII6x",
                 buf,
@@ -4706,7 +4715,8 @@ class CascadeCorrelationNetwork:
             target: Target output
             output: Raw output from the network
         Notes:
-            - This method assumes that the target and output tensors are one-hot encoded.
+            - For multi-class (output_size > 1), assumes one-hot encoded tensors and uses argmax.
+            - For binary classification (output_size == 1), uses a 0.5 threshold.
             - The accuracy is calculated as the percentage of correct predictions over the total number of predictions.
             - If either the target or output tensor is missing, an error is raised.
         Returns:
@@ -4734,13 +4744,24 @@ class CascadeCorrelationNetwork:
             return float("nan")
 
         # Find predicted and target values
-        predicted = torch.argmax(output, dim=1)
-        self.logger.verbose(f"CascadeCorrelationNetwork: _accuracy: Predicted shape: {predicted.shape}")
-        target = torch.argmax(y, dim=1)
-        self.logger.verbose(f"CascadeCorrelationNetwork: _accuracy: Target shape: {target.shape}")
-        correct = (predicted == target).sum().item()
-        self.logger.verbose(f"CascadeCorrelationNetwork: _accuracy: Number of correct predictions: {correct}, Total samples: {len(target)}")
-        accuracy = correct / len(target)
+        if output.shape[1] == 1:
+            # Binary classification with single output: threshold at 0.5
+            predicted = (output.squeeze(1) > 0.5).long()
+            self.logger.verbose(f"CascadeCorrelationNetwork: _accuracy: Predicted shape (binary): {predicted.shape}")
+            target_binary = (y.squeeze(1) > 0.5).long()
+            self.logger.verbose(f"CascadeCorrelationNetwork: _accuracy: Target shape (binary): {target_binary.shape}")
+            correct = (predicted == target_binary).sum().item()
+            self.logger.verbose(f"CascadeCorrelationNetwork: _accuracy: Number of correct predictions: {correct}, Total samples: {len(target_binary)}")
+            accuracy = correct / len(target_binary)
+        else:
+            # Multi-class classification: use argmax on one-hot encoded tensors
+            predicted = torch.argmax(output, dim=1)
+            self.logger.verbose(f"CascadeCorrelationNetwork: _accuracy: Predicted shape: {predicted.shape}")
+            target = torch.argmax(y, dim=1)
+            self.logger.verbose(f"CascadeCorrelationNetwork: _accuracy: Target shape: {target.shape}")
+            correct = (predicted == target).sum().item()
+            self.logger.verbose(f"CascadeCorrelationNetwork: _accuracy: Number of correct predictions: {correct}, Total samples: {len(target)}")
+            accuracy = correct / len(target)
         self.logger.info(f"CascadeCorrelationNetwork: _accuracy: Calculated accuracy: {accuracy:.4f}, Percentage: {accuracy * 100:.4f}%")
         self.logger.trace("CascadeCorrelationNetwork: _accuracy: Completed calculating accuracy.")
         return accuracy

--- a/src/tests/unit/test_accuracy.py
+++ b/src/tests/unit/test_accuracy.py
@@ -406,3 +406,104 @@ class TestAccuracyMulticlass:
         assert 0.0 <= accuracy <= 1.0  # trunk-ignore(bandit/B101)
 
         print(f"Imbalanced accuracy: {accuracy}, type: {type(accuracy)}, Data: x={len(x)}, y={y.sum(dim=0)}, n_class0={n_class0}, n_class1={n_class1}")
+
+
+class TestBinaryAccuracySingleOutput:
+    """Test accuracy calculation with output_size=1 binary classification (CR-049)."""
+
+    @pytest.mark.unit
+    @pytest.mark.accuracy
+    def test_binary_perfect_accuracy(self):
+        """Test binary accuracy with perfect predictions (output_size=1)."""
+        from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
+
+        set_deterministic_behavior()
+        network = CascadeCorrelationNetwork.create_simple_network(input_size=2, output_size=1)
+
+        # Targets above 0.5 -> class 1, outputs match perfectly
+        targets = torch.tensor([[1.0], [0.0], [1.0], [0.0]])
+        outputs = torch.tensor([[0.9], [0.1], [0.8], [0.2]])
+
+        accuracy = network._accuracy(y=targets, output=outputs)
+        assert_approximately_equal(accuracy, 1.0, atol=1e-10)
+
+    @pytest.mark.unit
+    @pytest.mark.accuracy
+    def test_binary_zero_accuracy(self):
+        """Test binary accuracy with completely wrong predictions (output_size=1)."""
+        from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
+
+        set_deterministic_behavior()
+        network = CascadeCorrelationNetwork.create_simple_network(input_size=2, output_size=1)
+
+        # Targets and outputs are perfectly inverted
+        targets = torch.tensor([[1.0], [0.0], [1.0], [0.0]])
+        outputs = torch.tensor([[0.1], [0.9], [0.2], [0.8]])
+
+        accuracy = network._accuracy(y=targets, output=outputs)
+        assert_approximately_equal(accuracy, 0.0, atol=1e-10)
+
+    @pytest.mark.unit
+    @pytest.mark.accuracy
+    def test_binary_partial_accuracy(self):
+        """Test binary accuracy with 50% correct predictions (output_size=1)."""
+        from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
+
+        set_deterministic_behavior()
+        network = CascadeCorrelationNetwork.create_simple_network(input_size=2, output_size=1)
+
+        # 2 correct, 2 wrong
+        targets = torch.tensor([[1.0], [0.0], [1.0], [0.0]])
+        outputs = torch.tensor([[0.9], [0.1], [0.2], [0.8]])  # first two correct, last two wrong
+
+        accuracy = network._accuracy(y=targets, output=outputs)
+        assert_approximately_equal(accuracy, 0.5, atol=1e-10)
+
+    @pytest.mark.unit
+    @pytest.mark.accuracy
+    def test_binary_threshold_boundary(self):
+        """Test binary accuracy at the 0.5 threshold boundary (output_size=1)."""
+        from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
+
+        set_deterministic_behavior()
+        network = CascadeCorrelationNetwork.create_simple_network(input_size=2, output_size=1)
+
+        # Values exactly at 0.5 should be classified as 0 (> 0.5 is True, == 0.5 is False)
+        targets = torch.tensor([[0.0], [1.0]])
+        outputs = torch.tensor([[0.5], [0.5]])  # Both at boundary -> predicted as 0
+
+        accuracy = network._accuracy(y=targets, output=outputs)
+        # target[0]=0 matches predicted=0, target[1]=1 does not match predicted=0
+        assert_approximately_equal(accuracy, 0.5, atol=1e-10)
+
+    @pytest.mark.unit
+    @pytest.mark.accuracy
+    def test_binary_does_not_always_return_100(self):
+        """Regression: output_size=1 must NOT always return 100% accuracy (CR-049)."""
+        from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
+
+        set_deterministic_behavior()
+        network = CascadeCorrelationNetwork.create_simple_network(input_size=2, output_size=1)
+
+        # Deliberately wrong predictions
+        targets = torch.tensor([[1.0], [1.0], [1.0], [1.0]])
+        outputs = torch.tensor([[0.1], [0.2], [0.3], [0.4]])
+
+        accuracy = network._accuracy(y=targets, output=outputs)
+        # All predictions are below 0.5, targets are all 1.0 -> 0% accuracy
+        assert_approximately_equal(accuracy, 0.0, atol=1e-10)
+
+    @pytest.mark.unit
+    @pytest.mark.accuracy
+    def test_multiclass_still_uses_argmax(self):
+        """Verify that multi-class accuracy still uses argmax (not threshold)."""
+        from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
+
+        set_deterministic_behavior()
+        network = CascadeCorrelationNetwork.create_simple_network(input_size=2, output_size=3)
+
+        targets = torch.tensor([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+        outputs = torch.tensor([[0.9, 0.05, 0.05], [0.1, 0.8, 0.1], [0.1, 0.1, 0.8]])
+
+        accuracy = network._accuracy(y=targets, output=outputs)
+        assert_approximately_equal(accuracy, 1.0, atol=1e-10)

--- a/src/tests/unit/test_shared_memory_validation.py
+++ b/src/tests/unit/test_shared_memory_validation.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+"""
+Project:       Juniper
+Prototype:     Cascade Correlation Neural Network
+File Name:     test_shared_memory_validation.py
+Author:        Paul Calnon
+Version:       0.1.0
+
+Date:          2026-04-05
+Last Modified: 2026-04-05
+
+License:       MIT License
+Copyright:     Copyright (c) 2024-2026 Paul Calnon
+
+Description:
+    Unit tests for SharedTrainingMemory ndim validation (CR-047).
+    Verifies that tensors with ndim > 2 are rejected with a clear error message,
+    and that 0D, 1D, and 2D tensors continue to work correctly.
+"""
+
+import pytest
+import torch
+
+from cascade_correlation.cascade_correlation import SharedTrainingMemory
+
+
+class TestSharedTrainingMemoryNdimValidation:
+    """Test ndim validation in SharedTrainingMemory (CR-047)."""
+
+    @pytest.mark.unit
+    @pytest.mark.validation
+    def test_rejects_3d_tensor(self):
+        """SharedTrainingMemory should reject 3D tensors with ValueError."""
+        tensor_3d = torch.randn(2, 3, 4)
+        with pytest.raises(ValueError, match=r"only supports tensors up to 2 dimensions.*got tensor with 3 dimensions"):
+            SharedTrainingMemory([tensor_3d], name_suffix="test_3d")
+
+    @pytest.mark.unit
+    @pytest.mark.validation
+    def test_rejects_4d_tensor(self):
+        """SharedTrainingMemory should reject 4D tensors with ValueError."""
+        tensor_4d = torch.randn(2, 3, 4, 5)
+        with pytest.raises(ValueError, match=r"only supports tensors up to 2 dimensions.*got tensor with 4 dimensions"):
+            SharedTrainingMemory([tensor_4d], name_suffix="test_4d")
+
+    @pytest.mark.unit
+    @pytest.mark.validation
+    def test_rejects_5d_tensor(self):
+        """SharedTrainingMemory should reject 5D tensors with ValueError."""
+        tensor_5d = torch.randn(2, 3, 4, 5, 6)
+        with pytest.raises(ValueError, match=r"only supports tensors up to 2 dimensions.*got tensor with 5 dimensions"):
+            SharedTrainingMemory([tensor_5d], name_suffix="test_5d")
+
+    @pytest.mark.unit
+    @pytest.mark.validation
+    def test_error_message_includes_shape(self):
+        """Error message should include the actual tensor shape."""
+        tensor_3d = torch.randn(8, 16, 32)
+        with pytest.raises(ValueError, match=r"\(8, 16, 32\)"):
+            SharedTrainingMemory([tensor_3d], name_suffix="test_shape_msg")
+
+    @pytest.mark.unit
+    @pytest.mark.validation
+    def test_rejects_3d_tensor_in_mixed_list(self):
+        """A 3D tensor among valid tensors should still be rejected."""
+        tensor_2d = torch.randn(4, 5)
+        tensor_3d = torch.randn(2, 3, 4)
+        with pytest.raises(ValueError, match=r"only supports tensors up to 2 dimensions"):
+            SharedTrainingMemory([tensor_2d, tensor_3d], name_suffix="test_mixed")
+
+    @pytest.mark.unit
+    @pytest.mark.validation
+    def test_accepts_1d_tensor(self):
+        """SharedTrainingMemory should accept 1D tensors."""
+        tensor_1d = torch.randn(10)
+        shm = SharedTrainingMemory([tensor_1d], name_suffix="test_1d_ok")
+        try:
+            tensors, handle = SharedTrainingMemory.reconstruct_tensors(shm.get_metadata())
+            assert len(tensors) == 1  # trunk-ignore(bandit/B101)
+            assert tensors[0].shape == (10,)  # trunk-ignore(bandit/B101)
+            handle.close()
+        finally:
+            shm.close()
+            shm.unlink()
+
+    @pytest.mark.unit
+    @pytest.mark.validation
+    def test_accepts_2d_tensor(self):
+        """SharedTrainingMemory should accept 2D tensors."""
+        tensor_2d = torch.randn(4, 5)
+        shm = SharedTrainingMemory([tensor_2d], name_suffix="test_2d_ok")
+        try:
+            tensors, handle = SharedTrainingMemory.reconstruct_tensors(shm.get_metadata())
+            assert len(tensors) == 1  # trunk-ignore(bandit/B101)
+            assert tensors[0].shape == (4, 5)  # trunk-ignore(bandit/B101)
+            handle.close()
+        finally:
+            shm.close()
+            shm.unlink()


### PR DESCRIPTION
## Summary
- **CR-047**: Reject tensors with `ndim > 2` in `SharedTrainingMemory` with clear error message documenting the struct format limitation
- **CR-049**: Support `output_size=1` in `_accuracy` using threshold-based binary classification instead of `argmax`, which always returns 0 for single-column tensors

## Test plan
- [x] 7 new tests for SharedTrainingMemory validation (3D/4D/5D rejection, 1D/2D acceptance with roundtrip)
- [x] 6 new tests for binary accuracy (perfect/zero/partial, threshold boundary, argmax regression)
- [x] Full unit suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)