### PR TITLE
fix: test quality improvements and documentation (CR-061, CR-063, CR-073, CR-074, CR-076)

### DIFF
--- a/src/cascade_correlation/cascade_correlation.py
+++ b/src/cascade_correlation/cascade_correlation.py
@@ -1472,7 +1472,7 @@ class CascadeCorrelationNetwork:
             x_val=x_val,
             y_val=y_val,
         )
-        self.history["hidden_units_added"].append({"correlation": 0.0, "weights": [], "bias": []})
+        self.history["hidden_units_added"].append({"correlation": 0.0, "weight_shape": (), "unit_index": -1})
         self.logger.info("CascadeCorrelationNetwork: fit: Training completed.")
         self.logger.debug(f"CascadeCorrelationNetwork: fit: Final history: {len(self.history.get('train_loss', []))} epochs recorded")
         self.logger.trace("CascadeCorrelationNetwork: fit: Completed training of the network.")
@@ -1570,7 +1570,11 @@ class CascadeCorrelationNetwork:
             input_size += len(self.hidden_units)
         self.logger.debug(f"CascadeCorrelationNetwork: train_output_layer: Adjusted input size for output layer with hidden units: {input_size}")
 
-        # Create a temporary linear layer with the same weights as our current output layer
+        # INTENTIONAL: Recreate nn.Linear and optimizer on every call.
+        # In Cascade Correlation, the output layer's parameter space changes each time
+        # a hidden unit is added (input_size grows), so the previous nn.Linear and
+        # optimizer state are invalid.  Rebuilding from the current output_weights
+        # ensures the optimizer tracks the correct parameter tensors.
         output_layer = nn.Linear(input_size, self.output_size)
         with torch.no_grad():
             output_layer.weight.copy_(self.output_weights.t())  # Transpose because nn.Linear expects (out_features, in_features)
@@ -1579,7 +1583,7 @@ class CascadeCorrelationNetwork:
             self.logger.debug(f"CascadeCorrelationNetwork: train_output_layer: Output bias shape: {self.output_bias.shape}")
 
         # Use this layer for optimization (store as instance variable for HDF5 serialization)
-        # Create or recreate optimizer using factory method
+        # Create or recreate optimizer using factory method (see INTENTIONAL note above)
         self.output_optimizer = self._create_optimizer(output_layer.parameters())
         self.logger.debug(f"CascadeCorrelationNetwork: train_output_layer: Created optimizer: {type(self.output_optimizer).__name__}")
         optimizer = self.output_optimizer
@@ -3486,13 +3490,14 @@ class CascadeCorrelationNetwork:
         self.output_bias = old_output_bias
         self.logger.debug(f"CascadeCorrelationNetwork: add_unit: Updated output bias after copying old bias: {self.output_bias}")
 
-        # Add new unit to the history
+        # Add new unit to the history — metadata only; full weight tensors
+        # are already stored in self.hidden_units (see CR-063).
         self.logger.info(f"CascadeCorrelationNetwork: add_unit: Added hidden unit with correlation: {candidate.correlation:.6f}")
         self.history["hidden_units_added"].append(
             {
                 "correlation": candidate.correlation,
-                "weights": candidate.weights.clone().detach().numpy(),
-                "bias": candidate.bias.clone().detach().numpy(),
+                "weight_shape": tuple(candidate.weights.shape),
+                "unit_index": len(self.hidden_units) - 1,
             }
         )
         self.logger.info(f"CascadeCorrelationNetwork: add_unit: Current number of hidden units: {len(self.hidden_units)}")
@@ -3582,11 +3587,13 @@ class CascadeCorrelationNetwork:
                 self.hidden_units.append(new_unit)
                 added_count += 1
 
+                # Store metadata only; full weight tensors are already kept
+                # in self.hidden_units, so duplicating them here wastes memory.
                 self.history["hidden_units_added"].append(
                     {
                         "correlation": candidate.correlation,
-                        "weights": candidate.weights.clone().detach().numpy(),
-                        "bias": candidate.bias.clone().detach().numpy(),
+                        "weight_shape": tuple(candidate.weights.shape),
+                        "unit_index": len(self.hidden_units) - 1,
                     }
                 )
             else:

--- a/src/snapshots/snapshot_serializer.py
+++ b/src/snapshots/snapshot_serializer.py
@@ -542,7 +542,8 @@ class CascadeHDF5Serializer:
                 data = np.array(network.history[network_key])
                 save_numpy_array(history_group, save_key, data, compression, compression_opts)
 
-        # Save hidden units added history
+        # Save hidden units added history (metadata-only since CR-063;
+        # legacy weight/bias arrays are still handled for backward compat)
         if "hidden_units_added" in network.history:
             units_group = history_group.create_group("hidden_units_added")
             for i, unit_data in enumerate(network.history["hidden_units_added"]):
@@ -550,6 +551,12 @@ class CascadeHDF5Serializer:
                 if isinstance(unit_data, dict):
                     if "correlation" in unit_data:
                         unit_group.attrs["correlation"] = float(unit_data["correlation"])
+                    # New metadata-only fields (CR-063)
+                    if "weight_shape" in unit_data:
+                        unit_group.attrs["weight_shape"] = list(unit_data["weight_shape"])
+                    if "unit_index" in unit_data:
+                        unit_group.attrs["unit_index"] = int(unit_data["unit_index"])
+                    # Legacy weight/bias arrays (kept for backward compat with old snapshots)
                     if "weights" in unit_data:
                         save_numpy_array(
                             unit_group,
@@ -897,7 +904,7 @@ class CascadeHDF5Serializer:
                 # self.logger.debug(f"CascadeHDF5Serializer: Loaded history key '{save_key}' as '{network_key}'")  # B907
                 self.logger.debug(f"CascadeHDF5Serializer: Loaded history key {save_key!r} as {network_key!r}")
 
-        # Load hidden units history
+        # Load hidden units history (supports both metadata-only and legacy weight/bias formats)
         if "hidden_units_added" in history_group:
             units_group = history_group["hidden_units_added"]
             for unit_name in sorted(units_group.keys()):
@@ -906,6 +913,12 @@ class CascadeHDF5Serializer:
 
                 if "correlation" in unit_group.attrs:
                     unit_data["correlation"] = float(unit_group.attrs["correlation"])
+                # New metadata-only fields (CR-063)
+                if "weight_shape" in unit_group.attrs:
+                    unit_data["weight_shape"] = tuple(unit_group.attrs["weight_shape"])
+                if "unit_index" in unit_group.attrs:
+                    unit_data["unit_index"] = int(unit_group.attrs["unit_index"])
+                # Legacy weight/bias arrays (from old snapshots)
                 if "weights" in unit_group:
                     unit_data["weights"] = load_numpy_array(unit_group["weights"])
                 if "bias" in unit_group:

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -225,7 +225,7 @@ def fast_training_params(fast_slow_mode):
 @pytest.fixture
 def simple_2d_data(fast_training_params) -> Tuple[torch.Tensor, torch.Tensor]:
     """Generate simple 2D classification data."""
-    torch.manual_seed(42)
+    # Seed is already set by the autouse reset_random_seeds fixture (CR-076)
     n_samples = fast_training_params["n_samples"]
     # Create two classes in 2D space
 
@@ -241,7 +241,7 @@ def simple_2d_data(fast_training_params) -> Tuple[torch.Tensor, torch.Tensor]:
 @pytest.fixture
 def spiral_2d_data() -> Tuple[torch.Tensor, torch.Tensor]:
     """Generate 2-spiral problem data."""
-    torch.manual_seed(42)
+    # Seed is already set by the autouse reset_random_seeds fixture (CR-076)
     n_per_spiral = 100
 
     # Generate spiral data
@@ -266,7 +266,7 @@ def n_spiral_data() -> callable:
     """Generate N-spiral problem data (parameterized)."""
 
     def _generate_n_spiral(n_spirals: int = 3, n_per_spiral: int = 50) -> Tuple[torch.Tensor, torch.Tensor]:
-        torch.manual_seed(42)
+        # Seed is already set by the autouse reset_random_seeds fixture (CR-076)
 
         x_data = []
         y_data = []
@@ -296,7 +296,7 @@ def n_spiral_data() -> callable:
 @pytest.fixture
 def regression_data() -> Tuple[torch.Tensor, torch.Tensor]:
     """Generate regression data for testing."""
-    torch.manual_seed(42)
+    # Seed is already set by the autouse reset_random_seeds fixture (CR-076)
     n_samples = 200
 
     x = torch.randn(n_samples, 2)
@@ -466,14 +466,14 @@ def mock_config():
 @pytest.fixture
 def valid_tensor_2d() -> torch.Tensor:
     """Valid 2D tensor for testing."""
-    torch.manual_seed(42)
+    # Seed is already set by the autouse reset_random_seeds fixture (CR-076)
     return torch.randn(10, 2)
 
 
 @pytest.fixture
 def valid_target_2d() -> torch.Tensor:
     """Valid 2D target tensor (one-hot)."""
-    torch.manual_seed(42)
+    # Seed is already set by the autouse reset_random_seeds fixture (CR-076)
     targets = torch.zeros(10, 2)
     targets[torch.arange(10), torch.randint(0, 2, (10,))] = 1
     return targets

--- a/src/tests/integration/test_comprehensive_serialization.py
+++ b/src/tests/integration/test_comprehensive_serialization.py
@@ -357,13 +357,13 @@ class TestHistoryPreservation(unittest.TestCase):
             "hidden_units_added": [
                 {
                     "correlation": 0.6,
-                    "weights": np.array([0.1, 0.2]),
-                    "bias": np.array([0.05]),
+                    "weight_shape": (2,),
+                    "unit_index": 0,
                 },
                 {
                     "correlation": 0.7,
-                    "weights": np.array([0.3, 0.4, 0.5]),
-                    "bias": np.array([0.06]),
+                    "weight_shape": (3,),
+                    "unit_index": 1,
                 },
             ],
         }

--- a/src/tests/integration/test_serialization.py
+++ b/src/tests/integration/test_serialization.py
@@ -245,13 +245,13 @@ class TestHistoryPreservation:
 
     def test_hidden_units_history_preserved(self, network_with_hidden_units, temp_snapshot_file):
         """Test that hidden units added history is preserved."""
-        # Add history of added units
-        for unit in network_with_hidden_units.hidden_units:
+        # Add metadata-only history of added units (CR-063)
+        for idx, unit in enumerate(network_with_hidden_units.hidden_units):
             network_with_hidden_units.history["hidden_units_added"].append(
                 {
-                    "weights": unit["weights"].numpy(),
-                    "bias": unit["bias"].numpy(),
                     "correlation": unit["correlation"],
+                    "weight_shape": tuple(unit["weights"].shape),
+                    "unit_index": idx,
                 }
             )
 
@@ -264,11 +264,11 @@ class TestHistoryPreservation:
         loaded_network = serializer.load_network(temp_snapshot_file)
         assert loaded_network is not None  # trunk-ignore(bandit/B101)
 
-        # Verify hidden units history
+        # Verify hidden units history (metadata-only format)
         assert len(loaded_network.history["hidden_units_added"]) == 3  # trunk-ignore(bandit/B101)
         for unit_data in loaded_network.history["hidden_units_added"]:
-            assert "weights" in unit_data  # trunk-ignore(bandit/B101)
-            assert "bias" in unit_data  # trunk-ignore(bandit/B101)
+            assert "weight_shape" in unit_data  # trunk-ignore(bandit/B101)
+            assert "unit_index" in unit_data  # trunk-ignore(bandit/B101)
             assert "correlation" in unit_data  # trunk-ignore(bandit/B101)
 
 

--- a/src/tests/unit/test_cascade_correlation_coverage.py
+++ b/src/tests/unit/test_cascade_correlation_coverage.py
@@ -132,19 +132,36 @@ class TestNetworkGrowth:
     """Tests for network growth functionality."""
 
     @pytest.mark.unit
-    @pytest.mark.timeout(10)
+    @pytest.mark.timeout(30)
     def test_grow_network_adds_hidden_unit(self, simple_network, simple_2d_data):
-        """Test that grow_network adds hidden units."""
+        """Test that grow_network actually adds a hidden unit (CR-074).
+
+        Previously this test faked the growth by manually appending a dict.
+        Now it calls grow_network() with ultra-minimal parameters so the
+        real candidate-training and unit-installation paths are exercised.
+        """
         set_deterministic_behavior()
         x, y = simple_2d_data
 
-        initial_hidden = len(simple_network.hidden_units)
-        # Use candidate approach instead of full grow_network to avoid timeout
-        candidate = simple_network._create_candidate_unit(0)
-        hidden_unit = {"weights": candidate.weights.clone(), "bias": candidate.bias.clone(), "activation_fn": candidate.activation_fn, "correlation": 0.5}
-        simple_network.hidden_units.append(hidden_unit)
+        # Train the output layer first so there is a meaningful residual error
+        simple_network.train_output_layer(x, y, epochs=3)
 
-        assert len(simple_network.hidden_units) > initial_hidden
+        initial_hidden = len(simple_network.hidden_units)
+
+        # Call the real grow_network with minimal work
+        simple_network.grow_network(
+            x_train=x,
+            y_train=y,
+            max_iterations=1,
+            early_stopping=False,
+        )
+
+        assert len(simple_network.hidden_units) == initial_hidden + 1
+        new_unit = simple_network.hidden_units[-1]
+        assert "weights" in new_unit
+        assert "bias" in new_unit
+        assert "activation_fn" in new_unit
+        assert "correlation" in new_unit
 
     @pytest.mark.unit
     @pytest.mark.timeout(10)
@@ -399,6 +416,57 @@ class TestCandidateCreation:
 
         if len(indices) > 1:
             assert len(set(indices)) > 1  # Should have 0, 1, 2
+
+
+class TestRealLoggerSmoke:
+    """Smoke test exercising fit() with a real logger (CR-073).
+
+    The _NoOpLogger session fixture replaces the entire logging system with
+    no-ops for speed.  This single test verifies that the real logging
+    code-paths (format strings, level checks, etc.) do not raise exceptions
+    when a standard-library logger at WARNING level is attached.
+    """
+
+    @pytest.mark.unit
+    @pytest.mark.timeout(30)
+    def test_fit_with_real_logger_no_exceptions(self):
+        """Run fit() with a real Python logger at WARNING — expect no errors."""
+        import logging
+
+        from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
+        from cascade_correlation.cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
+
+        config = CascadeCorrelationConfig.create_simple_config(
+            input_size=2,
+            output_size=2,
+            learning_rate=0.1,
+            candidate_learning_rate=0.1,
+            max_hidden_units=1,
+            candidate_pool_size=2,
+            candidate_epochs=3,
+            output_epochs=3,
+            epochs_max=3,
+            patience=1,
+            correlation_threshold=0.01,
+        )
+        network = CascadeCorrelationNetwork(config=config)
+
+        # Replace the no-op logger with a real stdlib logger at WARNING
+        real_logger = logging.getLogger("cascor_smoke_test")
+        real_logger.setLevel(logging.WARNING)
+        # Add custom methods expected by CascadeCorrelationNetwork
+        real_logger.trace = lambda msg, *a, **kw: None
+        real_logger.verbose = lambda msg, *a, **kw: None
+        network.logger = real_logger
+
+        # Minimal XOR-like dataset (4 samples)
+        x = torch.tensor([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]])
+        y = torch.tensor([[1.0, 0.0], [0.0, 1.0], [0.0, 1.0], [1.0, 0.0]])
+
+        # This should complete without any logging-related exceptions
+        history = network.fit(x, y, max_epochs=3)
+        assert isinstance(history, dict)
+        assert "train_loss" in history
 
 
 class TestOptimalProcessCount:

--- a/src/tests/unit/test_snapshot_serializer_coverage_deep.py
+++ b/src/tests/unit/test_snapshot_serializer_coverage_deep.py
@@ -589,7 +589,7 @@ class TestSaveLoadBranches:
             "train_accuracy": [0.6, 0.7],
             "value_accuracy": [0.5, 0.6],
             "hidden_units_added": [
-                {"correlation": 0.8, "weights": np.array([0.1, 0.2]), "bias": np.array([0.01])},
+                {"correlation": 0.8, "weight_shape": (2,), "unit_index": 0},
             ],
         }
         serializer.save_network(simple_network, temp_hdf5_path, include_training_state=True)

--- a/src/tests/unit/test_snapshot_serializer_coverage_final.py
+++ b/src/tests/unit/test_snapshot_serializer_coverage_final.py
@@ -133,8 +133,8 @@ class TestHiddenUnitsHistory:
 
         # Add hidden units history
         network.history["hidden_units_added"] = [
-            {"correlation": 0.85, "weights": np.array([0.1, 0.2], dtype=np.float32), "bias": np.array([0.05], dtype=np.float32)},
-            {"correlation": 0.92, "weights": np.array([0.3, 0.4], dtype=np.float32), "bias": np.array([0.1], dtype=np.float32)},
+            {"correlation": 0.85, "weight_shape": (2,), "unit_index": 0},
+            {"correlation": 0.92, "weight_shape": (2,), "unit_index": 1},
         ]
 
         with tempfile.NamedTemporaryFile(suffix=".h5", delete=False) as f:

--- a/src/tests/unit/test_snapshot_serializer_extended.py
+++ b/src/tests/unit/test_snapshot_serializer_extended.py
@@ -226,7 +226,7 @@ class TestTrainingHistorySave:
             "train_accuracy": [0.7, 0.8, 0.9],
             "value_accuracy": [0.65, 0.75, 0.85],
             "hidden_units_added": [
-                {"correlation": 0.8, "weights": np.array([0.1, 0.2]), "bias": np.array([0.05])},
+                {"correlation": 0.8, "weight_shape": (2,), "unit_index": 0},
                 {"correlation": 0.9},
             ],
         }


### PR DESCRIPTION
## Summary
- **CR-061**: Document intentional optimizer reset in `train_output_layer` (parameter space changes when hidden units are added)
- **CR-063**: Store metadata only (shape, correlation, unit index) in unit history instead of weight copies — reduces memory duplication. Backward-compatible deserialization for legacy snapshots.
- **CR-073**: Add smoke test running `fit()` with real logger at WARNING level to catch logging attribute errors
- **CR-074**: Rewrite `test_grow_network_adds_hidden_unit` to actually call `grow_network()` with minimal parameters
- **CR-076**: Remove 6 redundant per-fixture `torch.manual_seed(42)` calls; `reset_random_seeds` autouse fixture is single source of truth

## Test plan
- [x] All modified tests pass (28 passed, 2 skipped)
- [x] All 102 snapshot serializer tests pass (backward compatibility verified)
- [x] Full unit suite passes (1 pre-existing failure in `test_api_observability.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)