### PR TITLE
fix: Phase 1 interface verification — close CR-008 test gap and NEW-03/04 issues

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -172,7 +172,7 @@ class TrainingLifecycleManager:
                 status="Stopped",
                 phase="Idle",
                 learning_rate=kwargs.get("learning_rate", 0.01),
-                max_hidden_units=kwargs.get("max_hidden_units", 10),
+                max_hidden_units=kwargs.get("max_hidden_units", 1000),
                 max_epochs=kwargs.get("epochs_max", 200),
                 max_iterations=kwargs.get("max_iterations", 1000),
                 network_name=f"CasCor-{kwargs.get('input_size', 2)}x{kwargs.get('output_size', 2)}",
@@ -666,19 +666,28 @@ class TrainingLifecycleManager:
         return result
 
     def get_training_params(self) -> Dict[str, Any]:
-        """Get current training parameters."""
+        """Get current training parameters.
+
+        Returns every field listed in ``update_params``' ``updatable_keys`` so that
+        clients reconciling UI state after a reconnect observe the live network
+        values rather than falling back to stale defaults.
+        """
         if self.network is None:
             return {}
         return {
             "learning_rate": getattr(self.network, "learning_rate", 0.0),
+            "candidate_learning_rate": getattr(self.network, "candidate_learning_rate", 0.0),
             "max_hidden_units": getattr(self.network, "max_hidden_units", 0),
             "epochs_max": getattr(self.network, "epochs_max", 0),
+            "max_iterations": getattr(self.network, "max_iterations", 0),
             "patience": getattr(self.network, "patience", 0),
             "candidate_pool_size": getattr(self.network, "candidate_pool_size", 0),
             "correlation_threshold": getattr(self.network, "correlation_threshold", 0.0),
             "convergence_threshold": getattr(self.network, "convergence_threshold", 0.001),
             "candidate_patience": getattr(self.network, "candidate_patience", 30),
             "candidate_convergence_threshold": getattr(self.network, "candidate_convergence_threshold", 0.001),
+            "candidate_epochs": getattr(self.network, "candidate_epochs", 0),
+            "init_output_weights": getattr(self.network, "init_output_weights", "zero"),
         }
 
     def update_params(self, params: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/api/lifecycle/state_machine.py
+++ b/src/api/lifecycle/state_machine.py
@@ -214,7 +214,19 @@ class TrainingStateMachine:
         return False
 
     def get_state_summary(self) -> dict:
-        """Get current state as dictionary."""
+        """Get current state as dictionary.
+
+        Values for ``status``, ``phase``, and ``paused_phase`` are the UPPERCASE
+        Python enum ``.name`` attributes (e.g. ``"STOPPED"``, ``"OUTPUT"``). This
+        is intentional and asymmetric with ``TrainingState.get_state()`` which
+        emits title-case values (e.g. ``"Stopped"``, ``"Output"``) sourced from
+        string fields written by the lifecycle manager.
+
+        Both shapes are included in the ``get_status()`` response body (as
+        ``data.state_machine`` and ``data.training_state`` respectively). Downstream
+        consumers must normalize case-insensitively; canopy's
+        ``backend/state_sync.py::_normalize_status`` is the reference implementation.
+        """
         return {
             "status": self._status.name,
             "phase": self._phase.name,

--- a/src/api/models/network.py
+++ b/src/api/models/network.py
@@ -12,7 +12,7 @@ class NetworkCreateRequest(BaseModel):
     output_size: int = Field(2, ge=1, description="Number of output classes")
     learning_rate: float = Field(0.01, gt=0, description="Learning rate")
     candidate_learning_rate: float = Field(0.005, gt=0)
-    max_hidden_units: int = Field(10, ge=1)
+    max_hidden_units: int = Field(1000, ge=1, description="Maximum hidden units cap (aligned with _PROJECT_MODEL_MAX_HIDDEN_UNITS=1000 and canopy UI)")
     candidate_pool_size: int = Field(8, ge=1)
     correlation_threshold: float = Field(0.1, ge=0)
     patience: int = Field(5, ge=1)

--- a/src/tests/unit/api/test_lifecycle_manager.py
+++ b/src/tests/unit/api/test_lifecycle_manager.py
@@ -84,6 +84,31 @@ class TestLifecycleManagerNetwork:
         assert params["learning_rate"] == 0.01
         assert params["max_hidden_units"] == 10
 
+    def test_get_training_params_returns_all_updatable_keys(self):
+        """Every key in update_params' updatable_keys whitelist must be present in
+        the get_training_params response so clients reconciling after reconnect
+        observe live values instead of stale defaults (NEW-03)."""
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        params = mgr.get_training_params()
+        expected_keys = {
+            "learning_rate",
+            "candidate_learning_rate",
+            "correlation_threshold",
+            "candidate_pool_size",
+            "max_hidden_units",
+            "epochs_max",
+            "max_iterations",
+            "patience",
+            "convergence_threshold",
+            "candidate_convergence_threshold",
+            "candidate_patience",
+            "candidate_epochs",
+            "init_output_weights",
+        }
+        missing = expected_keys - params.keys()
+        assert not missing, f"get_training_params missing updatable keys: {missing}"
+
     def test_shutdown(self):
         """Shutdown cleans up resources."""
         mgr = TrainingLifecycleManager()

--- a/src/tests/unit/api/test_websocket_control.py
+++ b/src/tests/unit/api/test_websocket_control.py
@@ -18,6 +18,13 @@ def client():
         yield c
 
 
+@pytest.fixture
+def client_with_network(client):
+    """Test client with a network already created via POST /v1/network."""
+    client.post("/v1/network", json={"input_size": 2, "output_size": 2})
+    return client
+
+
 @pytest.mark.unit
 class TestControlStreamHandler:
     """Test /ws/control WebSocket handler."""
@@ -103,4 +110,52 @@ class TestControlStreamHandler:
             ws.send_text(json.dumps({"action": "start"}))
             response = ws.receive_json()
             assert response["type"] == "command_response"
+            assert response["data"]["status"] == "error"
+
+    def test_set_params_updates_live_network(self, client_with_network):
+        """set_params command applies whitelisted params to the live network (CR-008)."""
+        with client_with_network.websocket_connect("/ws/control") as ws:
+            ws.receive_json()  # connection_established
+            ws.send_text(
+                json.dumps(
+                    {
+                        "command": "set_params",
+                        "params": {"learning_rate": 0.007, "max_iterations": 23},
+                    }
+                )
+            )
+            response = ws.receive_json()
+            assert response["type"] == "command_response"
+            assert response["data"]["command"] == "set_params"
+            assert response["data"]["status"] == "success"
+
+        lifecycle = client_with_network.app.state.lifecycle
+        assert lifecycle.network.learning_rate == pytest.approx(0.007)
+        assert lifecycle.network.max_iterations == 23
+
+    def test_set_params_without_params_dict_errors(self, client_with_network):
+        """set_params without a 'params' dict returns error."""
+        with client_with_network.websocket_connect("/ws/control") as ws:
+            ws.receive_json()  # connection_established
+            ws.send_text(json.dumps({"command": "set_params"}))
+            response = ws.receive_json()
+            assert response["type"] == "command_response"
+            assert response["data"]["command"] == "set_params"
+            assert response["data"]["status"] == "error"
+
+    def test_set_params_without_network_errors(self, client):
+        """set_params without a network returns error (update_params raises)."""
+        with client.websocket_connect("/ws/control") as ws:
+            ws.receive_json()  # connection_established
+            ws.send_text(
+                json.dumps(
+                    {
+                        "command": "set_params",
+                        "params": {"learning_rate": 0.01},
+                    }
+                )
+            )
+            response = ws.receive_json()
+            assert response["type"] == "command_response"
+            assert response["data"]["command"] == "set_params"
             assert response["data"]["status"] == "error"


### PR DESCRIPTION
## Summary

- Verifies **CR-006** (`max_iterations` deconflation), **CR-007** (state machine auto-reset), and **CR-008** (`set_params` WebSocket) are fully resolved against live HEAD
- Closes the **CR-008 test gap**: adds 3 WebSocket `set_params` integration tests (happy path, missing params, no network)
- **Fixes NEW-03**: `get_training_params()` now returns every key in `updatable_keys` (adds `candidate_learning_rate`, `max_iterations`, `candidate_epochs`, `init_output_weights`) so UI clients see live values after reconnect
- **Documents NEW-04**: explicit docstring on `get_state_summary()` explaining the intentional UPPERCASE asymmetry and the canopy-side normalization contract
- **Aligns `max_hidden_units` default**: 10 → 1000 in both `NetworkCreateRequest` and `manager.py` kwargs fallback, to match the constant chain and canopy UI

## Context

Phase 1 of the Canopy-Cascor interface review roadmap. Prior analysis:

- `juniper-ml/notes/code-review/CANOPY_CASCOR_INTERFACE_ROADMAP_2026-04-08.md`
- `juniper-ml/notes/code-review/CANOPY_CASCOR_INTERFACE_ANALYSIS_2026-04-08.md`

All three Tier 0 issues (CR-006, CR-007, CR-008) were discovered already resolved during verification. This PR closes the remaining test gap (CR-008 had no WebSocket integration test coverage) and addresses four new issues surfaced during the verification pass. See the companion `juniper-ml` PR for the updated Phase 1 planning docs, and the companion `juniper-canopy` PR for the NEW-02 bridge documentation.

## Deferred items (see ROADMAP §3.5)

- **NEW-01** (_normalize_metric cleanup): canopy-only cosmetic refactor, separate PR
- **`epochs_max` default → 1,000,000**: 4 orders of magnitude behavior change, needs its own validation
- **Canopy integration test (UI → cascor round-trip)**: deferred to Phase 2/3 infrastructure work

## Test plan

- [x] `pytest tests/unit/api/` → 640/640 passed, exit=0, zero regressions
- [x] Specific regression tests pass: CR-006 (5 tests), CR-007 (2 tests), CR-008 (3 new tests), NEW-03 (1 new test)
- [ ] Verify canopy UI round-trip in demo mode (requires running both services)

🤖 Generated with [Claude Code](https://claude.com/claude-code)