### PR TITLE
fix: align epochs_max default to canopy's 1,000,000

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -173,7 +173,9 @@ class TrainingLifecycleManager:
                 phase="Idle",
                 learning_rate=kwargs.get("learning_rate", 0.01),
                 max_hidden_units=kwargs.get("max_hidden_units", 1000),
-                max_epochs=kwargs.get("epochs_max", 200),
+                # epochs_max default aligned with canopy nn_max_total_epochs (1,000,000) — see
+                # juniper-ml/notes/code-review/CANOPY_CASCOR_INTERFACE_ROADMAP_2026-04-08.md §3.5
+                max_epochs=kwargs.get("epochs_max", 1000000),
                 max_iterations=kwargs.get("max_iterations", 1000),
                 network_name=f"CasCor-{kwargs.get('input_size', 2)}x{kwargs.get('output_size', 2)}",
             )

--- a/src/api/models/network.py
+++ b/src/api/models/network.py
@@ -18,7 +18,7 @@ class NetworkCreateRequest(BaseModel):
     patience: int = Field(5, ge=1)
     candidate_epochs: int = Field(50, ge=1)
     output_epochs: int = Field(25, ge=1)
-    epochs_max: int = Field(200, ge=1)
+    epochs_max: int = Field(1000000, ge=1, description="Global maximum training epochs (aligned with canopy nn_max_total_epochs default of 1,000,000)")
     max_iterations: int = Field(1000, ge=1, description="Maximum cascade growth iterations")
     init_output_weights: Literal["zero", "random"] = Field("zero", description="Initialization mode for new hidden unit output weights")
 

--- a/src/tests/unit/api/test_lifecycle_manager.py
+++ b/src/tests/unit/api/test_lifecycle_manager.py
@@ -66,6 +66,21 @@ class TestLifecycleManagerNetwork:
         assert state["max_epochs"] == 11
         assert state["max_iterations"] == 4
 
+    def test_create_network_epochs_max_default_aligned_with_canopy(self):
+        """Phase 1 deferred item: epochs_max default must be 1,000,000 to match
+        canopy's nn_max_total_epochs default. Aligning the API model with the
+        canopy UI prevents the silent 200-epoch cap that surprised users when
+        they didn't pass epochs_max explicitly. See juniper-ml/notes/code-review/
+        CANOPY_CASCOR_INTERFACE_ROADMAP_2026-04-08.md §3.5 for the deferral
+        rationale.
+        """
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        state = mgr.training_state.get_state()
+        assert state["max_epochs"] == 1000000, (
+            f"epochs_max default should be 1,000,000 to match canopy; got {state['max_epochs']}"
+        )
+
     def test_get_training_params_no_network(self):
         """Training params returns empty dict without network."""
         mgr = TrainingLifecycleManager()


### PR DESCRIPTION
## Summary

- Aligns the cascor API model \`epochs_max\` default from 200 to 1,000,000 to match canopy's \`nn_max_total_epochs\` default
- Touches \`api/models/network.py:21\` (NetworkCreateRequest field default) and \`api/lifecycle/manager.py:176\` (kwargs fallback)
- Adds regression test \`test_create_network_epochs_max_default_aligned_with_canopy\`
- Resolves Phase 1 deferred item from the Canopy-Cascor interface roadmap

## Behavior change

This is an intentional behavior change for cascor API clients that don't pass \`epochs_max\` explicitly: they will now train up to 1M epochs instead of 200. Prior 200 default silently capped training at a level vastly below the canopy slider range (10 to 10,000,000, default 1,000,000), surprising users who edited other params via the canopy UI.

## Test plan

- [x] All cascor api unit tests pass (exit 0)
- [x] New regression test locks in the 1M default

🤖 Generated with [Claude Code](https://claude.com/claude-code)