### PR TITLE
chore: raise training limit constants per canopy requirements

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -172,11 +172,12 @@ class TrainingLifecycleManager:
                 status="Stopped",
                 phase="Idle",
                 learning_rate=kwargs.get("learning_rate", 0.01),
-                max_hidden_units=kwargs.get("max_hidden_units", 1000),
-                # epochs_max default aligned with canopy nn_max_total_epochs (1,000,000) — see
+                max_hidden_units=kwargs.get("max_hidden_units", 10000),
+                # Training-limit defaults raised per canopy requirements (2026-04-10):
+                # epochs_max=1e11, max_iterations=1e6, max_hidden_units=1e4. See
                 # juniper-ml/notes/code-review/CANOPY_CASCOR_INTERFACE_ROADMAP_2026-04-08.md §3.5
-                max_epochs=kwargs.get("epochs_max", 1000000),
-                max_iterations=kwargs.get("max_iterations", 1000),
+                max_epochs=kwargs.get("epochs_max", 100000000000),
+                max_iterations=kwargs.get("max_iterations", 1000000),
                 network_name=f"CasCor-{kwargs.get('input_size', 2)}x{kwargs.get('output_size', 2)}",
             )
 

--- a/src/api/models/network.py
+++ b/src/api/models/network.py
@@ -12,14 +12,14 @@ class NetworkCreateRequest(BaseModel):
     output_size: int = Field(2, ge=1, description="Number of output classes")
     learning_rate: float = Field(0.01, gt=0, description="Learning rate")
     candidate_learning_rate: float = Field(0.005, gt=0)
-    max_hidden_units: int = Field(1000, ge=1, description="Maximum hidden units cap (aligned with _PROJECT_MODEL_MAX_HIDDEN_UNITS=1000 and canopy UI)")
+    max_hidden_units: int = Field(10000, ge=1, description="Maximum hidden units cap (raised to 10,000 per canopy requirements 2026-04-10)")
     candidate_pool_size: int = Field(8, ge=1)
     correlation_threshold: float = Field(0.1, ge=0)
     patience: int = Field(5, ge=1)
     candidate_epochs: int = Field(50, ge=1)
     output_epochs: int = Field(25, ge=1)
-    epochs_max: int = Field(1000000, ge=1, description="Global maximum training epochs (aligned with canopy nn_max_total_epochs default of 1,000,000)")
-    max_iterations: int = Field(1000, ge=1, description="Maximum cascade growth iterations")
+    epochs_max: int = Field(100000000000, ge=1, description="Global maximum training epochs (raised to 100,000,000,000 per canopy requirements 2026-04-10)")
+    max_iterations: int = Field(1000000, ge=1, description="Maximum cascade growth iterations (raised to 1,000,000 per canopy requirements 2026-04-10)")
     init_output_weights: Literal["zero", "random"] = Field("zero", description="Initialization mode for new hidden unit output weights")
 
 

--- a/src/cascor_constants/constants_model/constants_model.py
+++ b/src/cascor_constants/constants_model/constants_model.py
@@ -203,8 +203,10 @@ _PROJECT_MODEL_LEARNING_RATE = 0.05
 #####################################################################################################################################################################################################
 # Define constants for the Cascade Correlation Network training parameters, Output Epochs
 # _PROJECT_MODEL_EPOCHS_MAX = 10000
-_PROJECT_MODEL_EPOCHS_MAX = 1000000000
-_PROJECT_MODEL_MAX_ITERATIONS = 1000
+# _PROJECT_MODEL_EPOCHS_MAX = 1000000000
+_PROJECT_MODEL_EPOCHS_MAX = 100000000000
+# _PROJECT_MODEL_MAX_ITERATIONS = 1000
+_PROJECT_MODEL_MAX_ITERATIONS = 1000000
 
 #####################################################################################################################################################################################################
 # Define constants for the Cascade Correlation Network training parameters, Output Weight Initialization
@@ -338,7 +340,7 @@ _PROJECT_MODEL_OUTPUT_EPOCHS = 10000
 # _PROJECT_MODEL_MAX_HIDDEN_UNITS = 85
 # _PROJECT_MODEL_MAX_HIDDEN_UNITS = 90
 # _PROJECT_MODEL_MAX_HIDDEN_UNITS = 95
-_PROJECT_MODEL_MAX_HIDDEN_UNITS = 100
+# _PROJECT_MODEL_MAX_HIDDEN_UNITS = 100
 # _PROJECT_MODEL_MAX_HIDDEN_UNITS = 105
 # _PROJECT_MODEL_MAX_HIDDEN_UNITS = 110
 # _PROJECT_MODEL_MAX_HIDDEN_UNITS = 115
@@ -403,6 +405,7 @@ _PROJECT_MODEL_MAX_HIDDEN_UNITS = 100
 # _PROJECT_MODEL_MAX_HIDDEN_UNITS = 2000
 # _PROJECT_MODEL_MAX_HIDDEN_UNITS = 2500
 # _PROJECT_MODEL_MAX_HIDDEN_UNITS = 3000
+_PROJECT_MODEL_MAX_HIDDEN_UNITS = 10000
 
 
 #####################################################################################################################################################################################################

--- a/src/tests/unit/api/test_lifecycle_manager.py
+++ b/src/tests/unit/api/test_lifecycle_manager.py
@@ -66,20 +66,24 @@ class TestLifecycleManagerNetwork:
         assert state["max_epochs"] == 11
         assert state["max_iterations"] == 4
 
-    def test_create_network_epochs_max_default_aligned_with_canopy(self):
-        """Phase 1 deferred item: epochs_max default must be 1,000,000 to match
-        canopy's nn_max_total_epochs default. Aligning the API model with the
-        canopy UI prevents the silent 200-epoch cap that surprised users when
-        they didn't pass epochs_max explicitly. See juniper-ml/notes/code-review/
-        CANOPY_CASCOR_INTERFACE_ROADMAP_2026-04-08.md §3.5 for the deferral
-        rationale.
+    def test_create_network_training_limit_defaults_aligned_with_canopy(self):
+        """Phase 1 deferred item (revised 2026-04-10): training-limit defaults
+        must match the canopy / requirements-spec values:
+
+        - epochs_max          = 100,000,000,000  (1e11, raised from 1e6)
+        - max_iterations      =       1,000,000  (1e6, raised from 1e3)
+        - max_hidden_units    =          10,000  (1e4, raised from 1e3)
+
+        These caps are intentionally large so the user, not the API model,
+        chooses when to stop. See juniper-ml/notes/code-review/
+        CANOPY_CASCOR_INTERFACE_ROADMAP_2026-04-08.md §3.5.
         """
         mgr = TrainingLifecycleManager()
         mgr.create_network(input_size=2, output_size=2)
         state = mgr.training_state.get_state()
-        assert state["max_epochs"] == 1000000, (
-            f"epochs_max default should be 1,000,000 to match canopy; got {state['max_epochs']}"
-        )
+        assert state["max_epochs"] == 100000000000, f"epochs_max default should be 1e11; got {state['max_epochs']}"
+        assert state["max_iterations"] == 1000000, f"max_iterations default should be 1e6; got {state['max_iterations']}"
+        assert state["max_hidden_units"] == 10000, f"max_hidden_units default should be 1e4; got {state['max_hidden_units']}"
 
     def test_get_training_params_no_network(self):
         """Training params returns empty dict without network."""


### PR DESCRIPTION
## Summary

Raises the cascor training-limit defaults per 2026-04-10 canopy requirements:

| Constant | Old | New |
|---|---|---|
| \`epochs_max\` | 1,000,000 (1e6) | 100,000,000,000 (1e11) |
| \`max_iterations\` | 1,000 (1e3) | 1,000,000 (1e6) |
| \`max_hidden_units\` | 1,000 (1e3) | 10,000 (1e4) |

Touches:
- \`src/cascor_constants/constants_model/constants_model.py\` (active values in the menu format)
- \`src/api/models/network.py\` (NetworkCreateRequest field defaults)
- \`src/api/lifecycle/manager.py\` (kwargs.get fallbacks)
- \`src/tests/unit/api/test_lifecycle_manager.py\` (regression test renamed and expanded)

## Behavior change

Cascor API clients that don't pass these fields explicitly will now train up to 100 billion epochs / 1 million growth iterations / 10,000 hidden units instead of the previous lower caps. The intent is that the user, not the API model, decides when to stop. Convergence-based stopping criteria still apply.

## Test plan

- [x] All cascor src/tests/unit/api tests pass (exit 0)
- [x] Regression test \`test_create_network_training_limit_defaults_aligned_with_canopy\` asserts all three new defaults

Companion PR: pcalnon/juniper-canopy with the same constants update on the canopy side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)