### PR TITLE
feat(ws): control-path security — origin, rate limit, cooldown (P8)

### DIFF
--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -211,6 +211,20 @@ class Settings(BaseSettings):
     worker_audit_logging_enabled: bool = _JUNIPER_CASCOR_API_WORKER_AUDIT_LOGGING_ENABLED_DEFAULT
     worker_metrics_enabled: bool = _JUNIPER_CASCOR_API_WORKER_METRICS_ENABLED_DEFAULT
 
+    # Phase B-pre-b: Control-path security (§S8)
+    ws_control_allowed_origins: list[str] = [
+        "http://localhost:8050",
+        "http://127.0.0.1:8050",
+        "https://localhost:8050",
+        "https://127.0.0.1:8050",
+    ]
+    ws_control_rate_limit_per_sec: int = 10  # leaky bucket: 10 tokens, 10/s refill
+    ws_control_idle_timeout_sec: int = 120  # bidirectional idle timeout
+    ws_control_cooldown_rejections: int = 10  # rejections in cooldown window before IP block
+    ws_control_cooldown_window_sec: int = 60  # cooldown window in seconds
+    ws_control_cooldown_block_sec: int = 300  # 5-minute IP block after cooldown triggers
+    disable_ws_control_endpoint: bool = False  # emergency kill switch (CSWSH hard-disable)
+
 
 @lru_cache
 def get_settings() -> Settings:

--- a/src/api/websocket/control_security.py
+++ b/src/api/websocket/control_security.py
@@ -1,0 +1,128 @@
+"""Phase B-pre-b: Control-path security primitives.
+
+Provides:
+- Origin validation for /ws/control (reuses allowlist pattern from worker_stream)
+- Per-connection leaky bucket rate limiter (10 tokens, 10/s refill)
+- Per-origin handshake cooldown (10 rejections in 60s → 5-min IP block)
+"""
+
+import logging
+import threading
+import time
+from collections import defaultdict
+from typing import Optional
+
+from fastapi import WebSocket
+
+logger = logging.getLogger("juniper_cascor.api.websocket.control_security")
+
+
+def validate_control_origin(websocket: WebSocket, allowed_origins: list[str]) -> bool:
+    """Validate Origin header against allowlist for /ws/control.
+
+    Unlike worker endpoints (which reject ALL Origins), the control endpoint
+    accepts connections from allowed browser origins.
+
+    Returns True if origin is allowed, False otherwise.
+    """
+    origin = websocket.headers.get("origin", "").rstrip("/").lower()
+    if not origin:
+        logger.info("Control WS: no Origin header — rejecting (fail-closed)")
+        return False
+    normalized_allowed = [o.rstrip("/").lower() for o in allowed_origins]
+    if origin in normalized_allowed:
+        return True
+    logger.info("Control WS: origin %r not in allowlist — rejecting", origin)
+    return False
+
+
+class LeakyBucket:
+    """Per-connection leaky bucket rate limiter.
+
+    Allows `capacity` commands, refills at `refill_rate` per second.
+    Thread-safe for use from async context.
+    """
+
+    def __init__(self, capacity: int = 10, refill_rate: float = 10.0):
+        self._capacity = capacity
+        self._refill_rate = refill_rate
+        self._tokens = float(capacity)
+        self._last_refill = time.monotonic()
+        self._lock = threading.Lock()
+
+    def try_acquire(self) -> bool:
+        """Try to consume one token. Returns True if allowed, False if rate-limited."""
+        with self._lock:
+            now = time.monotonic()
+            elapsed = now - self._last_refill
+            self._tokens = min(self._capacity, self._tokens + elapsed * self._refill_rate)
+            self._last_refill = now
+
+            if self._tokens >= 1.0:
+                self._tokens -= 1.0
+                return True
+            return False
+
+    @property
+    def retry_after(self) -> float:
+        """Estimated seconds until a token is available."""
+        with self._lock:
+            if self._tokens >= 1.0:
+                return 0.0
+            deficit = 1.0 - self._tokens
+            return round(deficit / self._refill_rate, 1)
+
+
+class HandshakeCooldown:
+    """Per-origin handshake cooldown tracker.
+
+    Tracks rejected handshakes per client IP. When `max_rejections` are
+    exceeded within `window_sec`, the IP is blocked for `block_sec`.
+    Cleared on server restart (NAT-hostile escape hatch).
+    """
+
+    def __init__(self, max_rejections: int = 10, window_sec: int = 60, block_sec: int = 300):
+        self._max_rejections = max_rejections
+        self._window_sec = window_sec
+        self._block_sec = block_sec
+        self._rejections: dict[str, list[float]] = defaultdict(list)
+        self._blocked_until: dict[str, float] = {}
+        self._lock = threading.Lock()
+
+    def is_blocked(self, client_ip: str) -> bool:
+        """Check if an IP is currently blocked."""
+        with self._lock:
+            blocked_until = self._blocked_until.get(client_ip)
+            if blocked_until is not None:
+                if time.monotonic() < blocked_until:
+                    return True
+                del self._blocked_until[client_ip]
+            return False
+
+    def record_rejection(self, client_ip: str) -> bool:
+        """Record a handshake rejection. Returns True if IP is now blocked."""
+        with self._lock:
+            now = time.monotonic()
+            cutoff = now - self._window_sec
+            timestamps = self._rejections[client_ip]
+            # Prune old entries
+            self._rejections[client_ip] = [t for t in timestamps if t > cutoff]
+            self._rejections[client_ip].append(now)
+
+            if len(self._rejections[client_ip]) >= self._max_rejections:
+                self._blocked_until[client_ip] = now + self._block_sec
+                self._rejections[client_ip] = []
+                logger.warning("Control WS: IP %s blocked for %ds (cooldown triggered)", client_ip, self._block_sec)
+                return True
+            return False
+
+    def get_block_remaining(self, client_ip: str) -> Optional[float]:
+        """Get remaining block time in seconds, or None if not blocked."""
+        with self._lock:
+            blocked_until = self._blocked_until.get(client_ip)
+            if blocked_until is not None:
+                remaining = blocked_until - time.monotonic()
+                if remaining > 0:
+                    return round(remaining, 1)
+                del self._blocked_until[client_ip]
+            return None

--- a/src/api/websocket/control_stream.py
+++ b/src/api/websocket/control_stream.py
@@ -10,13 +10,19 @@ Client-to-server command endpoint. Accepts JSON commands:
 Responds with command_response acknowledgments. Note: command_response
 messages have NO ``seq`` field (D-03 canonical). The /ws/control channel
 has no replay buffer.
+
+Phase B-pre-b: Origin validation, per-connection leaky bucket (10 cmd/s),
+idle timeout (120s bidirectional), per-origin handshake cooldown.
 """
 
+import asyncio
 import json
 import logging
 
 from fastapi import WebSocket, WebSocketDisconnect
 
+from api.settings import get_settings
+from api.websocket.control_security import HandshakeCooldown, LeakyBucket, validate_control_origin
 from api.websocket.manager import ws_authenticate
 from api.websocket.messages import create_control_ack_message
 
@@ -25,11 +31,69 @@ logger = logging.getLogger("juniper_cascor.api.websocket.control")
 _VALID_COMMANDS = {"start", "stop", "pause", "resume", "reset", "set_params"}
 _MAX_MESSAGE_SIZE = 65536  # 64KB
 
+# Module-level handshake cooldown (shared across connections, cleared on restart)
+_handshake_cooldown = None
+
+
+def _get_cooldown() -> HandshakeCooldown:
+    """Lazily initialize the handshake cooldown from settings."""
+    global _handshake_cooldown
+    if _handshake_cooldown is None:
+        settings = get_settings()
+        _handshake_cooldown = HandshakeCooldown(
+            max_rejections=settings.ws_control_cooldown_rejections,
+            window_sec=settings.ws_control_cooldown_window_sec,
+            block_sec=settings.ws_control_cooldown_block_sec,
+        )
+    return _handshake_cooldown
+
+
+def _get_client_ip(websocket: WebSocket) -> str:
+    """Extract client IP from WebSocket connection."""
+    if websocket.client:
+        return websocket.client[0]
+    return "unknown"
+
 
 async def control_stream_handler(websocket: WebSocket) -> None:
-    """Handle /ws/control WebSocket connections."""
-    if not await ws_authenticate(websocket):
+    """Handle /ws/control WebSocket connections.
+
+    Security gates (Phase B-pre-b):
+    1. Kill switch check
+    2. Per-origin handshake cooldown (IP block)
+    3. API key authentication
+    4. Origin header validation
+    5. Per-connection leaky bucket rate limiting on commands
+    6. Bidirectional idle timeout
+    """
+    settings = get_settings()
+
+    # Gate 1: Kill switch (CSWSH emergency hard-disable)
+    if settings.disable_ws_control_endpoint:
+        await websocket.close(code=1013, reason="Control endpoint disabled")
         return
+
+    client_ip = _get_client_ip(websocket)
+
+    # Gate 2: Per-origin handshake cooldown — blocked IPs get 429-equivalent
+    cooldown = _get_cooldown()
+    if cooldown.is_blocked(client_ip):
+        remaining = cooldown.get_block_remaining(client_ip)
+        logger.warning("Control WS: IP %s blocked (cooldown), remaining=%ss", client_ip, remaining)
+        await websocket.close(code=4029, reason="Too many rejected handshakes")
+        return
+
+    # Gate 3: API key authentication
+    if not await ws_authenticate(websocket):
+        cooldown.record_rejection(client_ip)
+        return
+
+    # Gate 4: Origin validation
+    if settings.ws_control_allowed_origins:
+        if not validate_control_origin(websocket, settings.ws_control_allowed_origins):
+            cooldown.record_rejection(client_ip)
+            await websocket.close(code=4003, reason="Origin not allowed")
+            return
 
     lifecycle = getattr(websocket.app.state, "lifecycle", None)
 
@@ -41,9 +105,26 @@ async def control_stream_handler(websocket: WebSocket) -> None:
         }
     )
 
+    # Per-connection leaky bucket rate limiter
+    bucket = LeakyBucket(
+        capacity=settings.ws_control_rate_limit_per_sec,
+        refill_rate=float(settings.ws_control_rate_limit_per_sec),
+    )
+
+    idle_timeout = settings.ws_control_idle_timeout_sec
+
     try:
         while True:
-            raw = await websocket.receive_text()
+            # Gate 6: Bidirectional idle timeout
+            try:
+                if idle_timeout and idle_timeout > 0:
+                    raw = await asyncio.wait_for(websocket.receive_text(), timeout=idle_timeout)
+                else:
+                    raw = await websocket.receive_text()
+            except asyncio.TimeoutError:
+                logger.info("Control WS: idle timeout (%ds), closing: %s", idle_timeout, client_ip)
+                await websocket.close(code=1000, reason="Idle timeout")
+                return
 
             if len(raw) > _MAX_MESSAGE_SIZE:
                 await websocket.send_json(create_control_ack_message("unknown", "error", error="Message too large"))
@@ -58,6 +139,20 @@ async def control_stream_handler(websocket: WebSocket) -> None:
 
             command = msg.get("command", "")
             command_id = msg.get("command_id")
+
+            # Gate 5: Per-connection rate limiting
+            if not bucket.try_acquire():
+                retry_after = bucket.retry_after
+                await websocket.send_json(
+                    {
+                        "type": "command_response",
+                        "command": command,
+                        "status": "rate_limited",
+                        "retry_after": retry_after,
+                        **({"command_id": command_id} if command_id else {}),
+                    }
+                )
+                continue
 
             if command not in _VALID_COMMANDS:
                 await websocket.send_json(create_control_ack_message(command, "error", error=f"Unknown command: {command}", command_id=command_id))

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -166,6 +166,34 @@ def pytest_collection_modifyitems(config, items):
 
 
 # ===================================================================
+# WEBSOCKET ORIGIN HEADER INJECTION
+# ===================================================================
+# Phase B-pre-b: Control-path origin validation requires all WS test
+# connections to include an allowed Origin header. Monkeypatch globally.
+_WS_TEST_ORIGIN = "http://localhost:8050"
+_original_ws_connect = None
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _inject_ws_origin_header():
+    """Inject Origin header into all TestClient.websocket_connect calls."""
+    from starlette.testclient import TestClient
+
+    global _original_ws_connect
+    _original_ws_connect = TestClient.websocket_connect
+
+    def _patched_ws_connect(self, url, subprotocols=None, **kwargs):
+        headers = kwargs.get("headers", {})
+        headers.setdefault("origin", _WS_TEST_ORIGIN)
+        kwargs["headers"] = headers
+        return _original_ws_connect(self, url, subprotocols=subprotocols, **kwargs)
+
+    TestClient.websocket_connect = _patched_ws_connect
+    yield
+    TestClient.websocket_connect = _original_ws_connect
+
+
+# ===================================================================
 # FAST-SLOW MODE CONFIGURATION
 # ===================================================================
 

--- a/src/tests/unit/api/test_control_security.py
+++ b/src/tests/unit/api/test_control_security.py
@@ -1,0 +1,178 @@
+"""Tests for Phase B-pre-b control-path security: origin validation, rate limiting, cooldown."""
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from api.websocket.control_security import HandshakeCooldown, LeakyBucket, validate_control_origin
+
+
+@pytest.mark.unit
+class TestControlOriginValidation:
+    """Test origin validation for /ws/control (§S8)."""
+
+    def _make_ws(self, origin=None):
+        ws = AsyncMock()
+        headers = {}
+        if origin is not None:
+            headers["origin"] = origin
+        ws.headers = headers
+        return ws
+
+    def test_allowed_origin_accepted(self):
+        ws = self._make_ws("http://localhost:8050")
+        assert validate_control_origin(ws, ["http://localhost:8050"]) is True
+
+    def test_disallowed_origin_rejected(self):
+        ws = self._make_ws("http://evil.example.com")
+        assert validate_control_origin(ws, ["http://localhost:8050"]) is False
+
+    def test_missing_origin_rejected_fail_closed(self):
+        ws = self._make_ws(origin=None)
+        assert validate_control_origin(ws, ["http://localhost:8050"]) is False
+
+    def test_empty_allowlist_rejects_all(self):
+        ws = self._make_ws("http://localhost:8050")
+        assert validate_control_origin(ws, []) is False
+
+    def test_case_insensitive(self):
+        ws = self._make_ws("HTTP://LOCALHOST:8050")
+        assert validate_control_origin(ws, ["http://localhost:8050"]) is True
+
+    def test_trailing_slash_ignored(self):
+        ws = self._make_ws("http://localhost:8050/")
+        assert validate_control_origin(ws, ["http://localhost:8050"]) is True
+
+    def test_port_significant(self):
+        ws = self._make_ws("http://localhost:9999")
+        assert validate_control_origin(ws, ["http://localhost:8050"]) is False
+
+
+@pytest.mark.unit
+class TestLeakyBucket:
+    """Test per-connection leaky bucket rate limiter."""
+
+    def test_allows_up_to_capacity(self):
+        bucket = LeakyBucket(capacity=3, refill_rate=3.0)
+        assert bucket.try_acquire() is True
+        assert bucket.try_acquire() is True
+        assert bucket.try_acquire() is True
+
+    def test_rejects_after_capacity_exhausted(self):
+        bucket = LeakyBucket(capacity=2, refill_rate=2.0)
+        bucket.try_acquire()
+        bucket.try_acquire()
+        assert bucket.try_acquire() is False
+
+    def test_refills_over_time(self):
+        bucket = LeakyBucket(capacity=1, refill_rate=100.0)
+        bucket.try_acquire()  # exhaust
+        assert bucket.try_acquire() is False
+        time.sleep(0.02)  # 20ms → should refill at 100/s
+        assert bucket.try_acquire() is True
+
+    def test_retry_after_positive_when_empty(self):
+        bucket = LeakyBucket(capacity=1, refill_rate=10.0)
+        bucket.try_acquire()
+        retry = bucket.retry_after
+        assert retry > 0
+
+    def test_retry_after_zero_when_tokens_available(self):
+        bucket = LeakyBucket(capacity=5, refill_rate=5.0)
+        assert bucket.retry_after == 0.0
+
+    def test_response_not_close_connection(self):
+        """Rate limit sends response but does NOT close the connection (§S8)."""
+        bucket = LeakyBucket(capacity=1, refill_rate=1.0)
+        bucket.try_acquire()
+        # After exhaustion, try_acquire returns False but bucket still exists
+        assert bucket.try_acquire() is False
+        # Connection stays up — we just need to verify the bucket doesn't raise
+        time.sleep(1.1)
+        assert bucket.try_acquire() is True
+
+
+@pytest.mark.unit
+class TestHandshakeCooldown:
+    """Test per-origin handshake cooldown."""
+
+    def test_not_blocked_initially(self):
+        cd = HandshakeCooldown(max_rejections=3, window_sec=60, block_sec=10)
+        assert cd.is_blocked("1.2.3.4") is False
+
+    def test_not_blocked_below_threshold(self):
+        cd = HandshakeCooldown(max_rejections=3, window_sec=60, block_sec=10)
+        cd.record_rejection("1.2.3.4")
+        cd.record_rejection("1.2.3.4")
+        assert cd.is_blocked("1.2.3.4") is False
+
+    def test_blocked_at_threshold(self):
+        cd = HandshakeCooldown(max_rejections=3, window_sec=60, block_sec=10)
+        cd.record_rejection("1.2.3.4")
+        cd.record_rejection("1.2.3.4")
+        blocked = cd.record_rejection("1.2.3.4")  # 3rd rejection
+        assert blocked is True
+        assert cd.is_blocked("1.2.3.4") is True
+
+    def test_block_expires(self):
+        cd = HandshakeCooldown(max_rejections=1, window_sec=60, block_sec=0.05)
+        cd.record_rejection("1.2.3.4")
+        assert cd.is_blocked("1.2.3.4") is True
+        time.sleep(0.06)
+        assert cd.is_blocked("1.2.3.4") is False
+
+    def test_different_ips_independent(self):
+        cd = HandshakeCooldown(max_rejections=2, window_sec=60, block_sec=10)
+        cd.record_rejection("1.1.1.1")
+        cd.record_rejection("1.1.1.1")  # blocked
+        assert cd.is_blocked("1.1.1.1") is True
+        assert cd.is_blocked("2.2.2.2") is False
+
+    def test_get_block_remaining_when_blocked(self):
+        cd = HandshakeCooldown(max_rejections=1, window_sec=60, block_sec=300)
+        cd.record_rejection("1.2.3.4")
+        remaining = cd.get_block_remaining("1.2.3.4")
+        assert remaining is not None
+        assert remaining > 290  # ~300 seconds remaining
+
+    def test_get_block_remaining_when_not_blocked(self):
+        cd = HandshakeCooldown(max_rejections=10, window_sec=60, block_sec=300)
+        assert cd.get_block_remaining("1.2.3.4") is None
+
+    def test_old_rejections_pruned(self):
+        cd = HandshakeCooldown(max_rejections=3, window_sec=0.05, block_sec=10)
+        cd.record_rejection("1.2.3.4")
+        cd.record_rejection("1.2.3.4")
+        time.sleep(0.06)  # window expires
+        # Third rejection is now the first in a fresh window
+        blocked = cd.record_rejection("1.2.3.4")
+        assert blocked is False
+
+
+@pytest.mark.unit
+class TestControlSecuritySettings:
+    """Test Phase B-pre-b settings."""
+
+    def test_control_settings_defaults(self):
+        from api.settings import Settings
+
+        s = Settings(auto_start=False)
+        assert s.ws_control_rate_limit_per_sec == 10
+        assert s.ws_control_idle_timeout_sec == 120
+        assert s.ws_control_cooldown_rejections == 10
+        assert s.ws_control_cooldown_window_sec == 60
+        assert s.ws_control_cooldown_block_sec == 300
+        assert s.disable_ws_control_endpoint is False
+
+    def test_kill_switch_default_off(self):
+        from api.settings import Settings
+
+        s = Settings(auto_start=False)
+        assert s.disable_ws_control_endpoint is False
+
+    def test_control_allowed_origins_has_localhost(self):
+        from api.settings import Settings
+
+        s = Settings(auto_start=False)
+        assert "http://localhost:8050" in s.ws_control_allowed_origins

--- a/src/tests/unit/api/test_control_stream_coverage.py
+++ b/src/tests/unit/api/test_control_stream_coverage.py
@@ -25,7 +25,8 @@ class TestControlStreamAuth:
     async def test_auth_enabled_invalid_key_closes_connection(self):
         """WebSocket closed with 4001 when auth enabled and key invalid."""
         ws = AsyncMock()
-        ws.headers = {"X-API-Key": "bad-key"}
+        ws.headers = {"X-API-Key": "bad-key", "origin": "http://localhost:8050"}
+        ws.client = ("127.0.0.1", 12345)
 
         auth = MagicMock()
         auth.enabled = True
@@ -46,7 +47,8 @@ class TestControlStreamAuth:
     async def test_auth_enabled_missing_key_closes_connection(self):
         """WebSocket closed when auth enabled and no key provided."""
         ws = AsyncMock()
-        ws.headers = {}
+        ws.headers = {"origin": "http://localhost:8050"}
+        ws.client = ("127.0.0.1", 12345)
 
         auth = MagicMock()
         auth.enabled = True
@@ -71,6 +73,8 @@ class TestControlStreamMessageSize:
         from fastapi import WebSocketDisconnect
 
         ws = AsyncMock()
+        ws.headers = {"origin": "http://localhost:8050"}
+        ws.client = ("127.0.0.1", 12345)
         app_state = MagicMock()
         app_state.api_key_auth = None
         app_state.lifecycle = MagicMock()
@@ -103,6 +107,8 @@ class TestControlStreamLifecycleUnavailable:
         from fastapi import WebSocketDisconnect
 
         ws = AsyncMock()
+        ws.headers = {"origin": "http://localhost:8050"}
+        ws.client = ("127.0.0.1", 12345)
         app_state = MagicMock()
         app_state.api_key_auth = None
         app_state.lifecycle = None


### PR DESCRIPTION
## Summary

Phase B-pre-b (§S8 cascor-side, PR P8): hardens /ws/control with layered security gates for the control command channel.

### Security gates (applied in order)

1. **Kill switch** — \`disable_ws_control_endpoint=True\` closes with 1013 (CSWSH emergency)
2. **Per-origin handshake cooldown** — 10 rejections in 60s → 5-min IP block (cleared on restart, NAT escape hatch)
3. **API key authentication** (existing, reordered after cooldown)
4. **Origin header validation** — configurable allowlist, fail-closed (no origin → reject)
5. **Per-connection leaky bucket** — 10 cmd/s; 11th → \`{status: "rate_limited", retry_after: 0.3}\`, connection stays up
6. **Bidirectional idle timeout** — 120s default, closes with 1000

### New settings (JUNIPER_CASCOR_ prefix)

| Setting | Default | Purpose |
|---------|---------|---------|
| \`ws_control_allowed_origins\` | localhost:8050 variants | Origin allowlist |
| \`ws_control_rate_limit_per_sec\` | 10 | Leaky bucket capacity + refill rate |
| \`ws_control_idle_timeout_sec\` | 120 | Bidirectional idle timeout |
| \`ws_control_cooldown_rejections\` | 10 | Threshold before IP block |
| \`ws_control_cooldown_window_sec\` | 60 | Rolling window |
| \`ws_control_cooldown_block_sec\` | 300 | IP block duration |
| \`disable_ws_control_endpoint\` | False | Kill switch |

### Files changed

- **control_security.py** (new): \`LeakyBucket\`, \`HandshakeCooldown\`, \`validate_control_origin\`
- **control_stream.py**: Integrated all 6 security gates into handler
- **settings.py**: 7 new settings
- **conftest.py**: WS Origin header injection for test compatibility
- **test_control_security.py** (new): 24 unit tests
- **test_control_stream_coverage.py**: Added Origin headers to mock WebSockets

## Test plan

- [x] 24 new control security tests pass (origin, rate limit, cooldown, settings)
- [x] All existing control stream tests pass (15 in test_websocket_control + 5 in coverage)
- [x] Full API unit suite: 0 regressions (2 pre-existing failures in middleware + lifecycle unrelated)
- [ ] P9 (canopy CSRF) follows after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)