### PR TITLE
feat(ws): Phase F heartbeat ping/pong (P14)

### DIFF
--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -30,6 +30,9 @@ _JUNIPER_CASCOR_API_WS_MAX_CONNECTIONS_DEFAULT: int = _JUNIPER_CASCOR_API_WS_MAX
 _JUNIPER_CASCOR_API_WS_HEARTBEAT_INTERVAL_SEC: int = 30
 _JUNIPER_CASCOR_API_WS_HEARTBEAT_INTERVAL_SEC_DEFAULT: int = _JUNIPER_CASCOR_API_WS_HEARTBEAT_INTERVAL_SEC
 
+_JUNIPER_CASCOR_API_WS_HEARTBEAT_PONG_TIMEOUT_SEC: int = 10
+_JUNIPER_CASCOR_API_WS_HEARTBEAT_PONG_TIMEOUT_SEC_DEFAULT: int = _JUNIPER_CASCOR_API_WS_HEARTBEAT_PONG_TIMEOUT_SEC
+
 # Phase 0-cascor: WebSocket sequencing, replay, and resume settings
 # Env vars match canonical plan kill switch names (JUNIPER_WS_* prefix)
 _JUNIPER_CASCOR_API_WS_REPLAY_BUFFER_SIZE: int = 1024
@@ -124,6 +127,7 @@ class Settings(BaseSettings):
 
     ws_max_connections: int = _JUNIPER_CASCOR_API_WS_MAX_CONNECTIONS_DEFAULT
     ws_heartbeat_interval_sec: int = _JUNIPER_CASCOR_API_WS_HEARTBEAT_INTERVAL_SEC_DEFAULT
+    ws_heartbeat_pong_timeout_sec: int = _JUNIPER_CASCOR_API_WS_HEARTBEAT_PONG_TIMEOUT_SEC_DEFAULT
 
     # Phase 0-cascor: WebSocket sequencing, replay, and resume
     # Kill-switch env vars use JUNIPER_WS_* prefix per canonical plan §3.1

--- a/src/api/websocket/control_stream.py
+++ b/src/api/websocket/control_stream.py
@@ -13,11 +13,17 @@ has no replay buffer.
 
 Phase B-pre-b: Origin validation, per-connection leaky bucket (10 cmd/s),
 idle timeout (120s bidirectional), per-origin handshake cooldown.
+
+Phase F: Application-level heartbeat. Server sends ``{"type":"ping","ts":<float>}``
+every ``ws_heartbeat_interval_sec`` (30s). Client must reply
+``{"type":"pong"}`` within ``ws_heartbeat_pong_timeout_sec`` (10s) or
+connection is closed with 1006. Pong receipt resets the idle timeout timer.
 """
 
 import asyncio
 import json
 import logging
+import time
 
 from fastapi import WebSocket, WebSocketDisconnect
 
@@ -113,6 +119,35 @@ async def control_stream_handler(websocket: WebSocket) -> None:
 
     idle_timeout = settings.ws_control_idle_timeout_sec
 
+    # Phase F: heartbeat settings from app.state.settings (testable)
+    app_settings = getattr(websocket.app.state, "settings", None)
+    hb_interval = getattr(app_settings, "ws_heartbeat_interval_sec", 30) if app_settings else 30
+    hb_timeout = getattr(app_settings, "ws_heartbeat_pong_timeout_sec", 10) if app_settings else 10
+
+    # Phase F: heartbeat ping/pong for dead-connection detection
+    pong_received = asyncio.Event()
+    pong_received.set()  # No outstanding ping at start
+
+    async def _ping_loop():
+        while True:
+            await asyncio.sleep(hb_interval)
+            pong_received.clear()
+            try:
+                await websocket.send_json({"type": "ping", "ts": time.time()})
+            except Exception:
+                return
+            try:
+                await asyncio.wait_for(pong_received.wait(), timeout=hb_timeout)
+            except asyncio.TimeoutError:
+                logger.info("Control WS: heartbeat timeout, closing: %s", client_ip)
+                try:
+                    await websocket.close(code=1006, reason="Heartbeat timeout")
+                except Exception:
+                    pass
+                return
+
+    ping_task = asyncio.create_task(_ping_loop())
+
     try:
         while True:
             # Gate 6: Bidirectional idle timeout
@@ -136,6 +171,11 @@ async def control_stream_handler(websocket: WebSocket) -> None:
                 await websocket.send_json(create_control_ack_message("unknown", "error", error="Invalid JSON"))
                 await websocket.close(code=1003, reason="Malformed JSON")
                 return
+
+            # Phase F: pong handling — resets idle timeout (receive_text returned)
+            if msg.get("type") == "pong":
+                pong_received.set()
+                continue
 
             command = msg.get("command", "")
             command_id = msg.get("command_id")
@@ -171,6 +211,12 @@ async def control_stream_handler(websocket: WebSocket) -> None:
 
     except WebSocketDisconnect:
         pass
+    finally:
+        ping_task.cancel()
+        try:
+            await ping_task
+        except asyncio.CancelledError:
+            pass
 
 
 def _execute_command(lifecycle, command: str, params: dict = None) -> dict:

--- a/src/api/websocket/training_stream.py
+++ b/src/api/websocket/training_stream.py
@@ -7,8 +7,10 @@ Server-to-client streaming endpoint with optional resume support. On connect:
 4. If fresh connect: initial_status + state + promote to active
 5. Ongoing metrics/state/topology broadcasts during training
 
-The client sends only the optional resume frame during the handshake window.
-After promotion, the recv loop detects disconnection only.
+After promotion, the server sends application-level ``{"type":"ping","ts":<float>}``
+heartbeats every ``ws_heartbeat_interval_sec`` (default 30s). Client must reply
+with ``{"type":"pong"}`` within ``ws_heartbeat_pong_timeout_sec`` (default 10s)
+or the connection is closed with 1006 (heartbeat timeout).
 """
 
 import asyncio
@@ -87,12 +89,50 @@ async def training_stream_handler(websocket: WebSocket) -> None:
                     create_state_message(state_data),
                 )
 
-        # Keep connection alive — broadcasts come from training thread
-        # via ws_manager.broadcast_from_thread()
-        while True:
-            await websocket.receive_text()
-    except WebSocketDisconnect:
-        pass
+        # Heartbeat + keep-alive: broadcasts come from training thread
+        # via ws_manager.broadcast_from_thread(). The recv loop also
+        # handles pong responses for dead-connection detection.
+        hb_interval = getattr(settings, "ws_heartbeat_interval_sec", 30) if settings else 30
+        hb_timeout = getattr(settings, "ws_heartbeat_pong_timeout_sec", 10) if settings else 10
+        pong_received = asyncio.Event()
+        pong_received.set()  # No outstanding ping at start
+
+        async def _ping_loop():
+            while True:
+                await asyncio.sleep(hb_interval)
+                pong_received.clear()
+                try:
+                    await websocket.send_json({"type": "ping", "ts": time.time()})
+                except Exception:
+                    return  # Connection already closed
+                try:
+                    await asyncio.wait_for(pong_received.wait(), timeout=hb_timeout)
+                except asyncio.TimeoutError:
+                    logger.info("Training WS: heartbeat timeout, closing connection")
+                    try:
+                        await websocket.close(code=1006, reason="Heartbeat timeout")
+                    except Exception:
+                        pass
+                    return
+
+        ping_task = asyncio.create_task(_ping_loop())
+        try:
+            while True:
+                raw = await websocket.receive_text()
+                try:
+                    msg = json.loads(raw)
+                    if msg.get("type") == "pong":
+                        pong_received.set()
+                except (json.JSONDecodeError, AttributeError):
+                    pass  # Non-JSON keep-alive frames are fine
+        except WebSocketDisconnect:
+            pass
+        finally:
+            ping_task.cancel()
+            try:
+                await ping_task
+            except asyncio.CancelledError:
+                pass
     finally:
         await ws_manager.disconnect(websocket)
 

--- a/src/tests/unit/api/test_ws_heartbeat.py
+++ b/src/tests/unit/api/test_ws_heartbeat.py
@@ -1,0 +1,231 @@
+"""Phase F: Unit tests for WebSocket heartbeat ping/pong.
+
+§S12 — Tests for application-level heartbeat on /ws/training and /ws/control.
+Validates ping cadence, pong cancellation, dead-connection detection, and
+the full 1006 close cycle.
+"""
+
+import json
+import time
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from api.app import create_app
+from api.settings import Settings
+
+
+# ===================================================================
+# Fixtures
+# ===================================================================
+
+
+@pytest.fixture
+def client_fast_heartbeat():
+    """Test client with short heartbeat interval for fast tests.
+
+    Uses 0.3s interval + 0.5s pong timeout to avoid slow tests while
+    exercising the full heartbeat cycle.
+    """
+    settings = Settings(
+        auto_start=False,
+        ws_heartbeat_interval_sec=1,
+        ws_heartbeat_pong_timeout_sec=1,
+    )
+    app = create_app(settings)
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def client_fast_heartbeat_with_network(client_fast_heartbeat):
+    """Fast-heartbeat client with network created."""
+    client_fast_heartbeat.post("/v1/network", json={"input_size": 2, "output_size": 2})
+    return client_fast_heartbeat
+
+
+# ===================================================================
+# Tests — Phase F (§S12)
+# ===================================================================
+
+
+@pytest.mark.unit
+class TestWsHeartbeat:
+    """Unit tests for WebSocket heartbeat ping/pong."""
+
+    # ------------------------------------------------------------------
+    # 1. Ping sent at configured interval
+    # ------------------------------------------------------------------
+
+    def test_ping_sent_every_30_seconds(self, client_fast_heartbeat):
+        """Server sends ping at configured heartbeat interval.
+
+        Uses short interval (1s) for test speed. Verifies the ping
+        message format: {"type": "ping", "ts": <float>}.
+        """
+        with client_fast_heartbeat.websocket_connect("/ws/training") as ws:
+            # Drain connection_established + initial_status + state
+            for _ in range(3):
+                ws.receive_json()
+
+            # Wait for the first heartbeat ping (interval = 1s)
+            ping = ws.receive_json()
+            assert ping["type"] == "ping"
+            assert isinstance(ping["ts"], float)
+            assert ping["ts"] > 0
+
+            # Reply with pong to keep connection alive
+            ws.send_text(json.dumps({"type": "pong"}))
+
+        # Also verify on /ws/control
+        with client_fast_heartbeat.websocket_connect("/ws/control") as ws:
+            ws.receive_json()  # connection_established
+
+            ping = ws.receive_json()
+            assert ping["type"] == "ping"
+            assert isinstance(ping["ts"], float)
+
+            ws.send_text(json.dumps({"type": "pong"}))
+
+    # ------------------------------------------------------------------
+    # 2. Pong received cancels close
+    # ------------------------------------------------------------------
+
+    def test_pong_received_cancels_close(self, client_fast_heartbeat):
+        """Replying with pong prevents heartbeat timeout close.
+
+        Survives two full ping/pong cycles — connection stays open.
+        """
+        with client_fast_heartbeat.websocket_connect("/ws/training") as ws:
+            # Drain connect sequence
+            for _ in range(3):
+                ws.receive_json()
+
+            # Survive two ping/pong cycles
+            for _ in range(2):
+                ping = ws.receive_json()
+                assert ping["type"] == "ping"
+                ws.send_text(json.dumps({"type": "pong"}))
+
+            # Connection still alive — no disconnect
+
+    # ------------------------------------------------------------------
+    # 3. Dead connection detected via missing pong
+    # ------------------------------------------------------------------
+
+    def test_dead_connection_detected_via_missing_pong(self, client_fast_heartbeat):
+        """Not replying with pong triggers 1006 close after timeout.
+
+        With 1s interval + 1s timeout, the connection should close
+        within ~2s of the ping being sent (1s interval + 1s timeout).
+        """
+        with pytest.raises(WebSocketDisconnect) as exc_info:
+            with client_fast_heartbeat.websocket_connect("/ws/training") as ws:
+                # Drain connect sequence
+                for _ in range(3):
+                    ws.receive_json()
+
+                # Receive ping but do NOT send pong
+                ping = ws.receive_json()
+                assert ping["type"] == "ping"
+
+                # Wait for server to close — next receive triggers disconnect
+                ws.receive_json()
+
+        assert exc_info.value.code == 1006
+
+    # ------------------------------------------------------------------
+    # 4. Full cycle: 1006 → heartbeat detection → reconnect trigger
+    # ------------------------------------------------------------------
+
+    def test_broken_connection_1006_triggers_heartbeat_detection_and_reconnect(
+        self, client_fast_heartbeat
+    ):
+        """Full heartbeat failure cycle on /ws/control.
+
+        1. Connect to /ws/control
+        2. Receive ping
+        3. Do NOT reply with pong
+        4. Server closes with 1006
+        5. Client reconnects successfully (new connection accepted)
+        """
+        # Phase 1: Connect and let heartbeat timeout
+        with pytest.raises(WebSocketDisconnect) as exc_info:
+            with client_fast_heartbeat.websocket_connect("/ws/control") as ws:
+                ws.receive_json()  # connection_established
+
+                # Receive ping, don't reply
+                ping = ws.receive_json()
+                assert ping["type"] == "ping"
+
+                # Wait for close
+                ws.receive_json()
+
+        assert exc_info.value.code == 1006
+
+        # Phase 2: Reconnect — fresh connection works
+        with client_fast_heartbeat.websocket_connect("/ws/control") as ws:
+            msg = ws.receive_json()
+            assert msg["type"] == "connection_established"
+            assert msg["data"]["channel"] == "control"
+
+            # Respond to ping to keep alive
+            ping = ws.receive_json()
+            assert ping["type"] == "ping"
+            ws.send_text(json.dumps({"type": "pong"}))
+
+    # ------------------------------------------------------------------
+    # 5. Pong on /ws/control doesn't count as a command (no rate limit)
+    # ------------------------------------------------------------------
+
+    def test_pong_not_counted_as_command(self, client_fast_heartbeat):
+        """Pong messages bypass the rate limiter (not a command)."""
+        with client_fast_heartbeat.websocket_connect("/ws/control") as ws:
+            ws.receive_json()  # connection_established
+
+            # Receive ping and reply
+            ping = ws.receive_json()
+            assert ping["type"] == "ping"
+            ws.send_text(json.dumps({"type": "pong"}))
+
+            # Send a real command — should still succeed (pong didn't consume a token)
+            ws.send_text(json.dumps({"command": "stop"}))
+            response = ws.receive_json()
+            assert response["data"]["status"] == "success"
+
+    # ------------------------------------------------------------------
+    # 6. Pong resets idle timeout on /ws/control
+    # ------------------------------------------------------------------
+
+    def test_heartbeat_resets_idle_timeout(self):
+        """Pong responses reset the idle timeout timer.
+
+        Uses a 2s idle timeout with 1s heartbeat interval. Without
+        heartbeat resetting idle, the connection would close at 2s.
+        With heartbeat, it survives past 2s.
+        """
+        settings = Settings(
+            auto_start=False,
+            ws_heartbeat_interval_sec=1,
+            ws_heartbeat_pong_timeout_sec=1,
+            ws_control_idle_timeout_sec=2,
+        )
+        app = create_app(settings)
+        with TestClient(app) as tc:
+            with tc.websocket_connect("/ws/control") as ws:
+                ws.receive_json()  # connection_established
+
+                # First ping at ~1s
+                ping1 = ws.receive_json()
+                assert ping1["type"] == "ping"
+                ws.send_text(json.dumps({"type": "pong"}))
+
+                # Second ping at ~2s — if idle timeout weren't reset,
+                # connection would close here
+                ping2 = ws.receive_json()
+                assert ping2["type"] == "ping"
+                ws.send_text(json.dumps({"type": "pong"}))
+
+                # Still alive past the 2s idle timeout


### PR DESCRIPTION
## Summary

- Add application-level heartbeat to `/ws/training` and `/ws/control`: server sends `{"type":"ping","ts":<float>}` every 30s, closes with 1006 if no pong within 10s
- New setting: `ws_heartbeat_pong_timeout_sec` (default 10)
- Pong receipt on `/ws/control` resets idle timeout timer
- 6 unit tests covering ping cadence, pong cancellation, dead-conn detection, full 1006 cycle, rate limiter bypass, and idle timeout reset

**Cross-repo**: paired with juniper-canopy phase-f-heartbeat-jitter (pong response + jitter formula)

## Test plan

- [x] 6 new heartbeat tests pass
- [x] 46 existing WS tests pass (no regressions)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)