### PR TITLE
feat(ws): Phase D per-command timeouts + unknown_command code (P11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Phase D (§S10) per-command timeouts on `/ws/control`: commands dispatched via `asyncio.to_thread` and bounded by `asyncio.wait_for` with `start=10s`, `stop/pause/resume/reset=2s`, `set_params=1s`. Timeouts emit `command_response{status:"error", error:"Command timed out after Ns"}` while the connection stays open.
+- Phase D (§S10.3) unknown-command envelope now includes `code:"unknown_command"` to let browser clients distinguish protocol errors from execution failures. `create_control_ack_message` gains an optional `code=` keyword argument.
+- Phase D (§S10.7) server-side observability counter `cascor_ws_control_command_received_total{command}` (lazy-registered so test suites without `prometheus_client` stay importable).
 - Hardcoded-values refactor (Wave 1): new `cascor_constants/constants_api/constants_api_defaults.py` module with 49 `_PROJECT_API_*` constants covering Pydantic field defaults for `NetworkCreateRequest` / `TrainingStartRequest`, lifecycle defaults, middleware body/rate-limit defaults, observability defaults, TLS minimum versions, decision-boundary resolution bounds, juniper-data integration timeouts, and inter-service URL templates. Existing constants modules (model, candidates, hdf5, logging) extended where needed.
 
 ### Changed

--- a/src/api/websocket/control_stream.py
+++ b/src/api/websocket/control_stream.py
@@ -14,6 +14,11 @@ has no replay buffer.
 Phase B-pre-b: Origin validation, per-connection leaky bucket (10 cmd/s),
 idle timeout (120s bidirectional), per-origin handshake cooldown.
 
+Phase D: Per-command execution timeouts via ``asyncio.wait_for``. Commands
+are dispatched to the thread pool (``asyncio.to_thread``) to avoid blocking
+the event loop, then bounded: start=10s, stop/pause/resume=2s, set_params=1s,
+reset=2s. Timeout → ``command_response{status:"error", error:"...timed out..."}``.
+
 Phase F: Application-level heartbeat. Server sends ``{"type":"ping","ts":<float>}``
 every ``ws_heartbeat_interval_sec`` (30s). Client must reply
 ``{"type":"pong"}`` within ``ws_heartbeat_pong_timeout_sec`` (10s) or
@@ -36,6 +41,37 @@ logger = logging.getLogger("juniper_cascor.api.websocket.control")
 
 _VALID_COMMANDS = {"start", "stop", "pause", "resume", "reset", "set_params"}
 _MAX_MESSAGE_SIZE = 65536  # 64KB
+
+# Phase D: per-command execution timeouts (§S10)
+_COMMAND_TIMEOUTS: dict[str, float] = {
+    "start": 10.0,
+    "stop": 2.0,
+    "pause": 2.0,
+    "resume": 2.0,
+    "reset": 2.0,
+    "set_params": 1.0,
+}
+
+# Observability: lazy-initialized Prometheus counter (§S10.7)
+_command_received_counter = None
+
+
+def _get_command_counter():
+    """Lazily create the command received counter when metrics are available."""
+    global _command_received_counter
+    if _command_received_counter is None:
+        try:
+            from prometheus_client import Counter
+
+            _command_received_counter = Counter(
+                "cascor_ws_control_command_received_total",
+                "WebSocket control commands received",
+                ["command"],
+            )
+        except ImportError:
+            _command_received_counter = False  # sentinel: prometheus not available
+    return _command_received_counter
+
 
 # Module-level handshake cooldown (shared across connections, cleared on restart)
 _handshake_cooldown = None
@@ -195,16 +231,37 @@ async def control_stream_handler(websocket: WebSocket) -> None:
                 continue
 
             if command not in _VALID_COMMANDS:
-                await websocket.send_json(create_control_ack_message(command, "error", error=f"Unknown command: {command}", command_id=command_id))
+                await websocket.send_json(
+                    create_control_ack_message(
+                        command,
+                        "error",
+                        error=f"Unknown command: {command}",
+                        command_id=command_id,
+                        code="unknown_command",
+                    )
+                )
                 continue
 
             if lifecycle is None:
                 await websocket.send_json(create_control_ack_message(command, "error", error="Lifecycle manager not available", command_id=command_id))
                 continue
 
+            # Observability: count command receipt (§S10.7)
+            counter = _get_command_counter()
+            if counter:
+                counter.labels(command=command).inc()
+
+            # Phase D: per-command timeout (§S10)
+            timeout = _COMMAND_TIMEOUTS.get(command, 2.0)
             try:
-                result = _execute_command(lifecycle, command, msg.get("params"))
+                result = await asyncio.wait_for(
+                    asyncio.to_thread(_execute_command, lifecycle, command, msg.get("params")),
+                    timeout=timeout,
+                )
                 await websocket.send_json(create_control_ack_message(command, "success", data=result, command_id=command_id))
+            except asyncio.TimeoutError:
+                logger.error("Command '%s' timed out after %ss", command, timeout)
+                await websocket.send_json(create_control_ack_message(command, "error", error=f"Command timed out after {timeout}s", command_id=command_id))
             except Exception as e:
                 logger.error("Command '%s' failed: %s", command, e)
                 await websocket.send_json(create_control_ack_message(command, "error", error="Command execution failed", command_id=command_id))

--- a/src/api/websocket/messages.py
+++ b/src/api/websocket/messages.py
@@ -116,6 +116,7 @@ def create_control_ack_message(
     error: Optional[str] = None,
     *,
     command_id: Optional[str] = None,
+    code: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Create a control command acknowledgment message.
 
@@ -136,4 +137,6 @@ def create_control_ack_message(
         msg["data"]["result"] = data
     if error:
         msg["data"]["error"] = error
+    if code is not None:
+        msg["data"]["code"] = code
     return msg

--- a/src/tests/unit/api/test_control_stream_timeouts.py
+++ b/src/tests/unit/api/test_control_stream_timeouts.py
@@ -1,0 +1,239 @@
+"""Phase D: Per-command timeout tests for /ws/control (§S10).
+
+Tests that _execute_command is bounded by per-command timeouts:
+start=10s, stop/pause/resume=2s, set_params=1s, reset=2s.
+Timeout → command_response{status:"error", error:"...timed out..."}.
+"""
+
+import asyncio
+import json
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import WebSocketDisconnect
+
+from api.websocket.control_stream import _COMMAND_TIMEOUTS, _execute_command, control_stream_handler
+
+
+def _make_ws(lifecycle=None):
+    """Create a mock WebSocket with standard test setup."""
+    ws = AsyncMock()
+    ws.headers = {"origin": "http://localhost:8050"}
+    ws.client = ("127.0.0.1", 12345)
+    app_state = MagicMock()
+    app_state.api_key_auth = None
+    app_state.lifecycle = lifecycle if lifecycle is not None else MagicMock()
+    app_state.settings = None
+    ws.app.state = app_state
+    return ws
+
+
+def _blocking_lifecycle(hang_seconds: float = 0.5):
+    """Create a lifecycle whose methods block for ``hang_seconds`` seconds.
+
+    The sleep must be longer than the patched ``_COMMAND_TIMEOUTS`` (0.1s) so
+    that ``asyncio.wait_for`` trips, but short enough to keep the test fast:
+    ``asyncio.to_thread`` futures can't be forcibly cancelled, so the wait_for
+    waits for the thread to finish before raising TimeoutError.
+    """
+    lifecycle = MagicMock()
+
+    def hang(*args, **kwargs):
+        time.sleep(hang_seconds)
+
+    lifecycle.start_training.side_effect = hang
+    lifecycle.stop_training.side_effect = hang
+    lifecycle.pause_training.side_effect = hang
+    lifecycle.resume_training.side_effect = hang
+    lifecycle.reset.side_effect = hang
+    lifecycle.update_params.side_effect = hang
+    return lifecycle
+
+
+# ===================================================================
+# §S10 timeout value tests
+# ===================================================================
+
+
+@pytest.mark.unit
+class TestCommandTimeoutValues:
+    """Verify the per-command timeout constants match the §S10 spec."""
+
+    def test_start_timeout_10s(self):
+        assert _COMMAND_TIMEOUTS["start"] == 10.0
+
+    def test_stop_timeout_2s(self):
+        assert _COMMAND_TIMEOUTS["stop"] == 2.0
+
+    def test_pause_timeout_2s(self):
+        assert _COMMAND_TIMEOUTS["pause"] == 2.0
+
+    def test_resume_timeout_2s(self):
+        assert _COMMAND_TIMEOUTS["resume"] == 2.0
+
+    def test_reset_timeout_2s(self):
+        assert _COMMAND_TIMEOUTS["reset"] == 2.0
+
+    def test_set_params_timeout_1s(self):
+        assert _COMMAND_TIMEOUTS["set_params"] == 1.0
+
+    def test_all_valid_commands_have_timeouts(self):
+        from api.websocket.control_stream import _VALID_COMMANDS
+
+        for cmd in _VALID_COMMANDS:
+            assert cmd in _COMMAND_TIMEOUTS, f"Missing timeout for '{cmd}'"
+
+
+# ===================================================================
+# §S10 timeout behavior tests
+# ===================================================================
+
+
+@pytest.mark.unit
+class TestCommandTimeoutBehavior:
+    """Verify that timed-out commands produce the correct error response."""
+
+    @pytest.mark.asyncio
+    async def test_stop_command_timeout_returns_error(self):
+        """A hanging stop command produces a timeout error response."""
+        lifecycle = _blocking_lifecycle()
+        ws = _make_ws(lifecycle)
+
+        ws.receive_text.side_effect = [
+            json.dumps({"command": "stop", "command_id": "timeout-test-1"}),
+            WebSocketDisconnect(code=1000),
+        ]
+
+        with patch("api.websocket.control_stream._COMMAND_TIMEOUTS", {"stop": 0.1, "start": 0.1, "pause": 0.1, "resume": 0.1, "reset": 0.1, "set_params": 0.1}):
+            await control_stream_handler(ws)
+
+        # Find the timeout error response (skip connection_established)
+        responses = [call.args[0] for call in ws.send_json.call_args_list if isinstance(call.args[0], dict) and call.args[0].get("type") == "command_response"]
+        assert len(responses) == 1
+        resp = responses[0]
+        assert resp["data"]["command"] == "stop"
+        assert resp["data"]["status"] == "error"
+        assert "timed out" in resp["data"]["error"].lower()
+        assert resp["data"]["command_id"] == "timeout-test-1"
+
+    @pytest.mark.asyncio
+    async def test_start_command_timeout_returns_error(self):
+        """A hanging start command produces a timeout error response."""
+        lifecycle = _blocking_lifecycle()
+        ws = _make_ws(lifecycle)
+
+        ws.receive_text.side_effect = [
+            json.dumps({"command": "start", "command_id": "timeout-start"}),
+            WebSocketDisconnect(code=1000),
+        ]
+
+        with patch("api.websocket.control_stream._COMMAND_TIMEOUTS", {k: 0.1 for k in _COMMAND_TIMEOUTS}):
+            await control_stream_handler(ws)
+
+        responses = [call.args[0] for call in ws.send_json.call_args_list if isinstance(call.args[0], dict) and call.args[0].get("type") == "command_response"]
+        assert len(responses) == 1
+        assert responses[0]["data"]["status"] == "error"
+        assert "timed out" in responses[0]["data"]["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_successful_command_within_timeout(self):
+        """A fast command completes normally within its timeout window."""
+        lifecycle = MagicMock()
+        lifecycle.stop_training.return_value = {"state": "idle"}
+        ws = _make_ws(lifecycle)
+
+        ws.receive_text.side_effect = [
+            json.dumps({"command": "stop", "command_id": "fast-1"}),
+            WebSocketDisconnect(code=1000),
+        ]
+
+        await control_stream_handler(ws)
+
+        responses = [call.args[0] for call in ws.send_json.call_args_list if isinstance(call.args[0], dict) and call.args[0].get("type") == "command_response"]
+        assert len(responses) == 1
+        assert responses[0]["data"]["status"] == "success"
+        assert responses[0]["data"]["command_id"] == "fast-1"
+
+    @pytest.mark.asyncio
+    async def test_timeout_error_does_not_close_connection(self):
+        """After a timeout error, the connection stays open for more commands."""
+        lifecycle = _blocking_lifecycle()
+        # Make reset block but stop succeed
+        lifecycle.stop_training.side_effect = None
+        lifecycle.stop_training.return_value = {"state": "idle"}
+
+        ws = _make_ws(lifecycle)
+
+        ws.receive_text.side_effect = [
+            json.dumps({"command": "reset", "command_id": "hang-1"}),
+            json.dumps({"command": "stop", "command_id": "ok-2"}),
+            WebSocketDisconnect(code=1000),
+        ]
+
+        with patch("api.websocket.control_stream._COMMAND_TIMEOUTS", {k: 0.1 for k in _COMMAND_TIMEOUTS}):
+            await control_stream_handler(ws)
+
+        responses = [call.args[0] for call in ws.send_json.call_args_list if isinstance(call.args[0], dict) and call.args[0].get("type") == "command_response"]
+        assert len(responses) == 2
+        assert responses[0]["data"]["status"] == "error"  # reset timed out
+        assert responses[1]["data"]["status"] == "success"  # stop succeeded
+
+
+# ===================================================================
+# _execute_command dispatch tests
+# ===================================================================
+
+
+@pytest.mark.unit
+class TestExecuteCommandDispatch:
+    """Verify _execute_command routes to correct lifecycle methods."""
+
+    def test_start_calls_start_training(self):
+        lifecycle = MagicMock()
+        lifecycle.start_training.return_value = {"started": True}
+        result = _execute_command(lifecycle, "start", {"epochs": 100})
+        lifecycle.start_training.assert_called_once()
+        assert result == {"started": True}
+
+    def test_set_params_passes_params(self):
+        lifecycle = MagicMock()
+        lifecycle.update_params.return_value = {"updated": True}
+        result = _execute_command(lifecycle, "set_params", {"learning_rate": 0.01})
+        lifecycle.update_params.assert_called_once_with({"learning_rate": 0.01})
+        assert result == {"updated": True}
+
+    def test_set_params_no_params_raises(self):
+        lifecycle = MagicMock()
+        with pytest.raises(ValueError, match="set_params requires"):
+            _execute_command(lifecycle, "set_params", None)
+
+
+# ===================================================================
+# §S10.3 unknown command rejection (test_unknown_command_rejected)
+# ===================================================================
+
+
+@pytest.mark.unit
+class TestUnknownCommandRejection:
+    """§S10.3: unknown command → command_response{status:"error", code:"unknown_command"}."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_command_rejected(self):
+        """Unknown command yields error envelope with code=unknown_command."""
+        ws = _make_ws()
+
+        ws.receive_text.side_effect = [
+            json.dumps({"command": "explode", "command_id": "reject-1"}),
+            WebSocketDisconnect(code=1000),
+        ]
+
+        await control_stream_handler(ws)
+
+        responses = [call.args[0] for call in ws.send_json.call_args_list if isinstance(call.args[0], dict) and call.args[0].get("type") == "command_response"]
+        assert len(responses) == 1
+        resp = responses[0]
+        assert resp["data"]["command"] == "explode"
+        assert resp["data"]["status"] == "error"
+        assert resp["data"]["code"] == "unknown_command"
+        assert resp["data"]["command_id"] == "reject-1"


### PR DESCRIPTION
## Summary

Implements the cascor half of Phase D (§S10) from the R5-01 canonical interface plan.

- **Per-command timeouts**: `/ws/control` commands are now dispatched via `asyncio.to_thread` and bounded by `asyncio.wait_for` with per-command ceilings — `start=10s`, `stop/pause/resume/reset=2s`, `set_params=1s`. Timeouts emit `command_response{status:"error", error:"Command timed out after Ns", command_id}` while the connection stays open.
- **Unknown command code**: unknown-command error envelope now includes `code:"unknown_command"` so browser clients can distinguish protocol errors from execution failures. `create_control_ack_message` gains an optional `code=` keyword argument.
- **Observability**: new lazy Prometheus counter `cascor_ws_control_command_received_total{command}` per §S10.7; lazy init keeps test suites without `prometheus_client` importable.
- **Tests**: 15 new unit tests in `test_control_stream_timeouts.py` covering timeout constants, timeout behavior (stop/start/reset), connection survival after timeout, `_execute_command` dispatch, and `test_unknown_command_rejected` per §S10.4.

## Test plan

- [x] `python -m pytest src/tests/unit/api/test_control_stream_timeouts.py -v` — 15 passed
- [x] Regression: `test_websocket_control.py` (15), `test_websocket_messages.py` (11), `test_control_stream_coverage.py` (5) — all green
- [x] Pre-commit hooks pass on touched files (flake8, bandit relaxed, shellcheck, markdownlint)
- [ ] CI: wait for `pre-commit`, `tests`, `build`, `docs`, `security`, `required-checks`
- [ ] Manual staging soak after merge: verify timeout error does not kill the connection
- [ ] Confirm `cascor_ws_control_command_received_total{command}` appears under `/metrics` when training runs against a browser client

## Notes

- This is the first half of Phase D. P12 (canopy `phase-d-canopy-button-ws-routing`) builds on this to route buttons through the WS with REST fallback.
- Two pre-existing unit failures in `test_api_middleware.test_invalid_content_length_rejected` and `test_lifecycle_manager.test_create_network_training_limit_defaults_aligned_with_canopy` exist on main and are unrelated to this PR.
- D-49 feature flag `enable_ws_control_buttons` is on the canopy side (next PR). This PR ships the server-side contract only.

Refs: R5-01 §S10.3, §S10.4, §S10.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)