### PR TITLE
fix(phase-2a): data-integrity bugs BUG-CC-03, BUG-CC-11, BUG-CC-18/ROBUST-01

### DIFF
--- a/src/cascade_correlation/cascade_correlation.py
+++ b/src/cascade_correlation/cascade_correlation.py
@@ -82,7 +82,7 @@ from candidate_unit.candidate_unit import CandidateTrainingResult, CandidateUnit
 #
 # Server-owned queues (live in Manager server process)
 from cascade_correlation.cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
-from cascade_correlation.cascade_correlation_exceptions.cascade_correlation_exceptions import ConfigurationError, TrainingError, ValidationError  # CascadeCorrelationError,; NetworkInitializationError,
+from cascade_correlation.cascade_correlation_exceptions.cascade_correlation_exceptions import CandidateTrainingError, ConfigurationError, TrainingError, ValidationError  # CascadeCorrelationError,; NetworkInitializationError,
 from cascor_constants.constants import (  # TODO: Commented out for F401 compliance - may be needed for future activation function selection; _CASCADE_CORRELATION_NETWORK_ACTIVATION_FUNCTION_NN_RELU,; _CASCADE_CORRELATION_NETWORK_ACTIVATION_FUNCTION_NN_SIGMOID,; _CASCADE_CORRELATION_NETWORK_ACTIVATION_FUNCTION_NN_TANH,; _CASCADE_CORRELATION_NETWORK_ACTIVATION_FUNCTION_RELU,; _CASCADE_CORRELATION_NETWORK_ACTIVATION_FUNCTION_SIGMOID,; _CASCADE_CORRELATION_NETWORK_ACTIVATION_FUNCTION_TANH,
     _CASCADE_CORRELATION_NETWORK_ACTIVATION_FUNCTION_DEFAULT,
     _CASCADE_CORRELATION_NETWORK_ACTIVATION_FUNCTION_NAME,
@@ -1714,6 +1714,15 @@ class CascadeCorrelationNetwork:
                 residual_error=residual_error,
             )
             self.logger.debug(f"CascadeCorrelationNetwork: train_candidates: Candidate training results: length: {len(results)}, value: {results}")
+        except CandidateTrainingError:
+            # BUG-CC-18 / ROBUST-01: propagate the specific candidate-training failure
+            # unchanged so callers can distinguish it from generic training errors and
+            # apply appropriate handling (abort, fail the run, surface via API, etc.).
+            import traceback
+
+            self.logger.error(f"CascadeCorrelationNetwork: train_candidates: Candidate training failed irrecoverably; aborting network growth")
+            self.logger.error(traceback.format_exc())
+            raise
         except Exception as e:
             self.logger.error(f"CascadeCorrelationNetwork: train_candidates: Error during candidate training: {e}")
             import traceback
@@ -1951,15 +1960,26 @@ class CascadeCorrelationNetwork:
                     results = self._execute_sequential_training(tasks)
                 self.logger.info("CascadeCorrelationNetwork: _execute_candidate_training: Sequential training completed successfully")
             except Exception as seq_error:
+                # BUG-CC-18 / ROBUST-01: Previously, both-paths-failed silently installed
+                # dummy zero-correlation results via ``_get_dummy_results``. That corrupted
+                # the network with meaningless candidate data while hiding the underlying
+                # failure. Raise an explicit error instead so the caller can abort training.
                 self.logger.error(f"CascadeCorrelationNetwork: _execute_candidate_training: Sequential training also failed: {seq_error}")
-                self.logger.warning("CascadeCorrelationNetwork: _execute_candidate_training: Creating dummy results for failed training")
-                results = self._get_dummy_results(len(tasks))
+                raise CandidateTrainingError(
+                    "Both parallel and sequential candidate training failed. "
+                    "Training cannot continue — network integrity would be compromised."
+                ) from seq_error
         self.logger.debug(f"CascadeCorrelationNetwork: _execute_candidate_training: Obtained {len(results)} results")
 
-        # Ensure we have some results:  For empty results list, create an intelligently empty dummy results
+        # BUG-CC-18 / ROBUST-01: Empty results after a non-exception return means every
+        # candidate silently produced nothing. Refuse to install zero-correlation dummies;
+        # surface the failure so the training loop can stop rather than corrupt the model.
         if not results:
             self.logger.error("CascadeCorrelationNetwork: _execute_candidate_training: No results obtained from either parallel or sequential processing")
-            results = self._get_dummy_results(len(tasks))
+            raise CandidateTrainingError(
+                "Candidate training produced no results after both parallel and sequential paths. "
+                "Refusing to install zero-correlation dummy candidates — network integrity would be compromised."
+            )
         return results
 
     def _drain_stale_results(self, result_queue) -> int:

--- a/src/cascade_correlation/cascade_correlation_exceptions/cascade_correlation_exceptions.py
+++ b/src/cascade_correlation/cascade_correlation_exceptions/cascade_correlation_exceptions.py
@@ -57,6 +57,19 @@ class TrainingError(CascadeCorrelationError):
     pass
 
 
+class CandidateTrainingError(TrainingError):
+    """Raised when candidate training fails irrecoverably.
+
+    BUG-CC-18 / ROBUST-01: Replaces the former silent installation of a dummy
+    zero-correlation candidate when both the parallel and sequential training
+    paths fail. Silent dummy installation corrupted the network with meaningless
+    data; raising this error instead fails loudly so callers can abort training
+    or apply their own retry policy.
+    """
+
+    pass
+
+
 class ValidationError(CascadeCorrelationError, ValueError):
     """Raised when input validation fails.
 

--- a/src/spiral_problem/spiral_problem.py
+++ b/src/spiral_problem/spiral_problem.py
@@ -572,64 +572,23 @@ class SpiralProblem(object):
             This method is called by the `generate_n_spiral_dataset` method to initialize the parameters for generating the spiral dataset.
         """
         self.logger.trace("SpiralProblem: _initialize_spiral_problem_params: Initializing Spiral Problem parameters")
-        # Set the parameters to the provided values or use the class attributes if the parameters are None
-        self.min_new = min_new or self.min_new or _SPIRAL_PROBLEM_MIN_NEW  # Use class attribute if min_new is None
-        # Original corrupted line:
-        # self.max_new = max_new or self.max_new or _SPIRAL_PROBLEM_MAX_NEW\ \ \#\ Use class attribute if max_new is None
-        # Fixed line:
-        self.max_new = max_new or self.max_new or _SPIRAL_PROBLEM_MAX_NEW  # Use class attribute if max_new is None
-        # Original corrupted line:
-        # self.min_orig = min_orig or self.min_orig or _SPIRAL_PROBLEM_MIN_ORIG\ \ \#\ Use class attribute if min_orig is None
-        # Fixed line:
-        self.min_orig = min_orig or self.min_orig or _SPIRAL_PROBLEM_MIN_ORIG  # Use class attribute if min_orig is None
-        # Original corrupted line:
-        # self.max_orig = max_orig or self.max_orig or _SPIRAL_PROBLEM_MAX_ORIG\ \ \#\ Use class attribute if max_orig is None
-        # Fixed line:
-        self.max_orig = max_orig or self.max_orig or _SPIRAL_PROBLEM_MAX_ORIG  # Use class attribute if max_orig is None
-        # Original corrupted line:
-        # self.orig_points = orig_points or self.orig_points or _SPIRAL_PROBLEM_ORIG_POINTS\ \ \#\ Use class attribute if orig_points is None
-        # Fixed line:
-        self.orig_points = orig_points or self.orig_points or _SPIRAL_PROBLEM_ORIG_POINTS  # Use class attribute if orig_points is None
-        # Original corrupted line:
-        # self.train_ratio = train_ratio or self.train_ratio or _SPIRAL_PROBLEM_TRAIN_RATIO\ \ \#\ Use class attribute if train_ratio is None
-        # Fixed line:
-        self.train_ratio = train_ratio or self.train_ratio or _SPIRAL_PROBLEM_TRAIN_RATIO  # Use class attribute if train_ratio is None
-        # Original corrupted line:
-        # self.test_ratio = test_ratio or self.test_ratio or _SPIRAL_PROBLEM_TEST_RATIO\ \ \#\ Use class attribute if test_ratio is None
-        # Fixed line:
-        self.test_ratio = test_ratio or self.test_ratio or _SPIRAL_PROBLEM_TEST_RATIO  # Use class attribute if test_ratio is None
-        # Original corrupted line:
-        # self.clockwise = clockwise or self.clockwise or _SPIRAL_PROBLEM_CLOCKWISE\ \ \#\ Use class attribute if clockwise is None
-        # Fixed line:
-        self.clockwise = clockwise or self.clockwise or _SPIRAL_PROBLEM_CLOCKWISE  # Use class attribute if clockwise is None
-        # Original corrupted line:
-        # self.n_spirals = n_spirals or self.n_spirals or _SPIRAL_PROBLEM_NUM_SPIRALS\ \ \#\ Use class attribute if n_spirals is None
-        # Fixed line:
-        self.n_spirals = n_spirals or self.n_spirals or _SPIRAL_PROBLEM_NUM_SPIRALS  # Use class attribute if n_spirals is None
-        # Original corrupted line:
-        # self.n_rotations = n_rotations or self.n_rotations or _SPIRAL_PROBLEM_NUM_ROTATIONS\ \ \#\ Use class attribute if n_rotations is None
-        # Fixed line:
-        self.n_rotations = n_rotations or self.n_rotations or _SPIRAL_PROBLEM_NUM_ROTATIONS  # Use class attribute if n_rotations is None
-        # Original corrupted line:
-        # self.n_points = n_points or self.n_points or _SPIRAL_PROBLEM_NUMBER_POINTS_PER_SPIRAL\ \ \#\ Use class attribute if n_points is None
-        # Fixed line:
-        self.n_points = n_points or self.n_points or _SPIRAL_PROBLEM_NUMBER_POINTS_PER_SPIRAL  # Use class attribute if n_points is None
-        # Original corrupted line:
-        # self.default_origin = default_origin or self.default_origin or _SPIRAL_PROBLEM_DEFAULT_ORIGIN\ \ \#\ Use class attribute if default_origin is None
-        # Fixed line:
-        self.default_origin = default_origin or self.default_origin or _SPIRAL_PROBLEM_DEFAULT_ORIGIN  # Use class attribute if default_origin is None
-        # Original corrupted line:
-        # self.default_radius = default_radius or self.default_radius or _SPIRAL_PROBLEM_DEFAULT_RADIUS\ \ \#\ Use class attribute if default_radius is None
-        # Fixed line:
-        self.default_radius = default_radius or self.default_radius or _SPIRAL_PROBLEM_DEFAULT_RADIUS  # Use class attribute if default_radius is None
-        # Original corrupted line:
-        # self.noise = noise_level or self.noise or _SPIRAL_PROBLEM_NOISE_FACTOR_DEFAULT\ \ \#\ Use class attribute if noise is None
-        # Fixed line:
-        self.noise = noise_level or self.noise or _SPIRAL_PROBLEM_NOISE_FACTOR_DEFAULT  # Use class attribute if noise is None
-        # Original corrupted line:
-        # self.distribution = distribution or self.distribution or _SPIRAL_PROBLEM_DISTRIBUTION_FACTOR\ \ \#\ Use class attribute if distribution is None
-        # Fixed line:
-        self.distribution = distribution or self.distribution or _SPIRAL_PROBLEM_DISTRIBUTION_FACTOR  # Use class attribute if distribution is None
+        # BUG-CC-03: Use explicit `is not None` checks instead of `or` fallback chains so that
+        # valid falsy values (False, 0, 0.0, "") are not silently overridden by class attributes/defaults.
+        self.min_new = min_new if min_new is not None else (self.min_new if self.min_new is not None else _SPIRAL_PROBLEM_MIN_NEW)
+        self.max_new = max_new if max_new is not None else (self.max_new if self.max_new is not None else _SPIRAL_PROBLEM_MAX_NEW)
+        self.min_orig = min_orig if min_orig is not None else (self.min_orig if self.min_orig is not None else _SPIRAL_PROBLEM_MIN_ORIG)
+        self.max_orig = max_orig if max_orig is not None else (self.max_orig if self.max_orig is not None else _SPIRAL_PROBLEM_MAX_ORIG)
+        self.orig_points = orig_points if orig_points is not None else (self.orig_points if self.orig_points is not None else _SPIRAL_PROBLEM_ORIG_POINTS)
+        self.train_ratio = train_ratio if train_ratio is not None else (self.train_ratio if self.train_ratio is not None else _SPIRAL_PROBLEM_TRAIN_RATIO)
+        self.test_ratio = test_ratio if test_ratio is not None else (self.test_ratio if self.test_ratio is not None else _SPIRAL_PROBLEM_TEST_RATIO)
+        self.clockwise = clockwise if clockwise is not None else (self.clockwise if self.clockwise is not None else _SPIRAL_PROBLEM_CLOCKWISE)
+        self.n_spirals = n_spirals if n_spirals is not None else (self.n_spirals if self.n_spirals is not None else _SPIRAL_PROBLEM_NUM_SPIRALS)
+        self.n_rotations = n_rotations if n_rotations is not None else (self.n_rotations if self.n_rotations is not None else _SPIRAL_PROBLEM_NUM_ROTATIONS)
+        self.n_points = n_points if n_points is not None else (self.n_points if self.n_points is not None else _SPIRAL_PROBLEM_NUMBER_POINTS_PER_SPIRAL)
+        self.default_origin = default_origin if default_origin is not None else (self.default_origin if self.default_origin is not None else _SPIRAL_PROBLEM_DEFAULT_ORIGIN)
+        self.default_radius = default_radius if default_radius is not None else (self.default_radius if self.default_radius is not None else _SPIRAL_PROBLEM_DEFAULT_RADIUS)
+        self.noise = noise_level if noise_level is not None else (self.noise if self.noise is not None else _SPIRAL_PROBLEM_NOISE_FACTOR_DEFAULT)
+        self.distribution = distribution if distribution is not None else (self.distribution if self.distribution is not None else _SPIRAL_PROBLEM_DISTRIBUTION_FACTOR)
         self.total_points = self.n_spirals * self.n_points
         self.logger.trace("SpiralProblem: _initialize_spiral_problem_params: Completed initialization")
 
@@ -1247,23 +1206,24 @@ class SpiralProblem(object):
 
         # Initialize Spiral Problem input parameters
         self.logger.trace("SpiralProblem: solve_n_spiral_problem: Initializing Spiral Problem input parameters")
-        self.n_points = n_points or self.n_points or _SPIRAL_PROBLEM_NUMBER_POINTS_PER_SPIRAL  # Use class attribute if n_points is None
+        # BUG-CC-03: Explicit `is not None` fallbacks preserve valid falsy overrides (False, 0, 0.0).
+        self.n_points = n_points if n_points is not None else (self.n_points if self.n_points is not None else _SPIRAL_PROBLEM_NUMBER_POINTS_PER_SPIRAL)
         self.logger.verbose(f"SpiralProblem: solve_n_spiral_problem: Number of points per spiral: {self.n_points}")
-        self.n_spirals = n_spirals or self.n_spirals or _SPIRAL_PROBLEM_NUM_SPIRALS  # Use class attribute if n_spirals is None
+        self.n_spirals = n_spirals if n_spirals is not None else (self.n_spirals if self.n_spirals is not None else _SPIRAL_PROBLEM_NUM_SPIRALS)
         self.logger.verbose(f"SpiralProblem: solve_n_spiral_problem: Number of spirals to generate: {self.n_spirals}")
-        self.n_rotations = n_rotations or self.n_rotations or _SPIRAL_PROBLEM_NUM_ROTATIONS  # Use class attribute if n_rotations is None
+        self.n_rotations = n_rotations if n_rotations is not None else (self.n_rotations if self.n_rotations is not None else _SPIRAL_PROBLEM_NUM_ROTATIONS)
         self.logger.verbose(f"SpiralProblem: solve_n_spiral_problem: Number of rotations for each spiral: {self.n_rotations}")
-        self.clockwise = clockwise or self.clockwise or _SPIRAL_PROBLEM_CLOCKWISE  # Use class attribute if clockwise is None
+        self.clockwise = clockwise if clockwise is not None else (self.clockwise if self.clockwise is not None else _SPIRAL_PROBLEM_CLOCKWISE)
         self.logger.verbose(f"SpiralProblem: solve_n_spiral_problem: Clockwise spirals: {'Yes' if self.clockwise else 'No'}")
-        self.noise = noise or self.noise or _SPIRAL_PROBLEM_NOISE_FACTOR_DEFAULT  # Use class attribute if noise is None
+        self.noise = noise if noise is not None else (self.noise if self.noise is not None else _SPIRAL_PROBLEM_NOISE_FACTOR_DEFAULT)
         self.logger.verbose(f"SpiralProblem: solve_n_spiral_problem: Noise level: {self.noise}")
-        self.distribution = distribution or self.distribution or _SPIRAL_PROBLEM_DISTRIBUTION_FACTOR  # Use class attribute if distribution is None
+        self.distribution = distribution if distribution is not None else (self.distribution if self.distribution is not None else _SPIRAL_PROBLEM_DISTRIBUTION_FACTOR)
         self.logger.verbose(f"SpiralProblem: solve_n_spiral_problem: Distribution factor: {self.distribution}")
-        self.test_ratio = test_ratio or self.test_ratio or _SPIRAL_PROBLEM_TEST_RATIO  # Use class attribute if test_ratio is None
+        self.test_ratio = test_ratio if test_ratio is not None else (self.test_ratio if self.test_ratio is not None else _SPIRAL_PROBLEM_TEST_RATIO)
         self.logger.verbose(f"SpiralProblem: solve_n_spiral_problem: Test Ratio: {self.test_ratio}")
-        self.train_ratio = train_ratio or self.train_ratio or _SPIRAL_PROBLEM_TRAIN_RATIO  # Use class attribute if train_ratio is None
+        self.train_ratio = train_ratio if train_ratio is not None else (self.train_ratio if self.train_ratio is not None else _SPIRAL_PROBLEM_TRAIN_RATIO)
         self.logger.verbose(f"SpiralProblem: solve_n_spiral_problem: Train Ratio: {self.train_ratio}")
-        self.plot = plot or self.plot or _SPIRAL_PROBLEM_GENERATE_PLOTS_DEFAULT  # Use class attribute if plot is None
+        self.plot = plot if plot is not None else (self.plot if self.plot is not None else _SPIRAL_PROBLEM_GENERATE_PLOTS_DEFAULT)
         self.logger.verbose(f"SpiralProblem: solve_n_spiral_problem: Plotting results: {'Enabled' if self.plot else 'Disabled'}")
 
         # Generate the n spiral dataset
@@ -1406,29 +1366,30 @@ class SpiralProblem(object):
 
         # Set parameters for the two spiral problem
         self.logger.trace("SpiralProblem: evaluate: Setting parameters for the two spiral problem")
-        self.n_points = n_points or self.n_points or _SPIRAL_PROBLEM_NUMBER_POINTS_PER_SPIRAL
+        # BUG-CC-03: Explicit `is not None` fallbacks preserve valid falsy overrides (False, 0, 0.0).
+        self.n_points = n_points if n_points is not None else (self.n_points if self.n_points is not None else _SPIRAL_PROBLEM_NUMBER_POINTS_PER_SPIRAL)
         self.logger.verbose(f"SpiralProblem: evaluate: Number of points per spiral: {self.n_points}")
-        self.n_spirals = n_spirals or self.n_spirals or _SPIRAL_PROBLEM_NUM_SPIRALS
+        self.n_spirals = n_spirals if n_spirals is not None else (self.n_spirals if self.n_spirals is not None else _SPIRAL_PROBLEM_NUM_SPIRALS)
         self.logger.verbose(f"SpiralProblem: evaluate: Number of spirals to generate: {self.n_spirals}")
-        self.n_rotations = n_rotations or self.n_rotations or _SPIRAL_PROBLEM_NUM_ROTATIONS
+        self.n_rotations = n_rotations if n_rotations is not None else (self.n_rotations if self.n_rotations is not None else _SPIRAL_PROBLEM_NUM_ROTATIONS)
         self.logger.verbose(f"SpiralProblem: evaluate: Number of rotations for each spiral: {self.n_rotations}")
-        self.clockwise = clockwise or self.clockwise or _SPIRAL_PROBLEM_CLOCKWISE
+        self.clockwise = clockwise if clockwise is not None else (self.clockwise if self.clockwise is not None else _SPIRAL_PROBLEM_CLOCKWISE)
         self.logger.verbose(f"SpiralProblem: evaluate: Clockwise spirals: {'Yes' if self.clockwise else 'No'}")
-        self.noise = noise or self.noise or _SPIRAL_PROBLEM_NOISE_FACTOR_DEFAULT
+        self.noise = noise if noise is not None else (self.noise if self.noise is not None else _SPIRAL_PROBLEM_NOISE_FACTOR_DEFAULT)
         self.logger.verbose(f"SpiralProblem: evaluate: Noise level: {self.noise}")
-        self.distribution = distribution or self.distribution or _SPIRAL_PROBLEM_DISTRIBUTION_FACTOR
+        self.distribution = distribution if distribution is not None else (self.distribution if self.distribution is not None else _SPIRAL_PROBLEM_DISTRIBUTION_FACTOR)
         self.logger.verbose(f"SpiralProblem: evaluate: Distribution factor: {self.distribution}")
-        self.plot = plot or self.plot or _SPIRAL_PROBLEM_GENERATE_PLOTS_DEFAULT
+        self.plot = plot if plot is not None else (self.plot if self.plot is not None else _SPIRAL_PROBLEM_GENERATE_PLOTS_DEFAULT)
         self.logger.verbose(f"SpiralProblem: evaluate: Plotting results: {'Enabled' if self.plot else 'Disabled'}")
-        self.train_ratio = train_ratio or self.train_ratio or _SPIRAL_PROBLEM_TRAIN_RATIO
+        self.train_ratio = train_ratio if train_ratio is not None else (self.train_ratio if self.train_ratio is not None else _SPIRAL_PROBLEM_TRAIN_RATIO)
         self.logger.verbose(f"SpiralProblem: evaluate: Training data ratio: {self.train_ratio}")
-        self.test_ratio = test_ratio or self.test_ratio or _SPIRAL_PROBLEM_TEST_RATIO
+        self.test_ratio = test_ratio if test_ratio is not None else (self.test_ratio if self.test_ratio is not None else _SPIRAL_PROBLEM_TEST_RATIO)
         self.logger.verbose(f"SpiralProblem: evaluate: Test data ratio: {self.test_ratio}")
-        self.random_value_scale = random_value_scale or self.random_value_scale or _SPIRAL_PROBLEM_RANDOM_VALUE_SCALE
+        self.random_value_scale = random_value_scale if random_value_scale is not None else (self.random_value_scale if self.random_value_scale is not None else _SPIRAL_PROBLEM_RANDOM_VALUE_SCALE)
         self.logger.verbose(f"SpiralProblem: evaluate: Random value scale: {self.random_value_scale}")
-        self.default_origin = default_origin or self.default_origin or _SPIRAL_PROBLEM_DEFAULT_ORIGIN
+        self.default_origin = default_origin if default_origin is not None else (self.default_origin if self.default_origin is not None else _SPIRAL_PROBLEM_DEFAULT_ORIGIN)
         self.logger.verbose(f"SpiralProblem: evaluate: Default origin for spirals: {self.default_origin}")
-        self.default_radius = default_radius or self.default_radius or _SPIRAL_PROBLEM_DEFAULT_RADIUS
+        self.default_radius = default_radius if default_radius is not None else (self.default_radius if self.default_radius is not None else _SPIRAL_PROBLEM_DEFAULT_RADIUS)
         self.logger.verbose(f"SpiralProblem: evaluate: Default radius for spirals: {self.default_radius}")
 
         # Solve the two spiral problem

--- a/src/tests/unit/test_cascade_correlation_coverage_deep.py
+++ b/src/tests/unit/test_cascade_correlation_coverage_deep.py
@@ -207,8 +207,19 @@ class TestExecuteCandidateTraining:
                 assert len(results) == 1
 
     @pytest.mark.unit
-    def test_both_parallel_and_sequential_fail_returns_dummy(self):
-        """When both distributed and sequential fail, returns dummy results."""
+    def test_both_parallel_and_sequential_fail_raises_candidate_training_error(self):
+        """BUG-CC-18 / ROBUST-01: double failure must raise, not silently install dummies.
+
+        Previously, when both distributed and sequential paths failed,
+        ``_execute_candidate_training`` returned zero-correlation dummy results
+        via ``_get_dummy_results``, corrupting the network with meaningless data.
+        The fix surfaces the failure as ``CandidateTrainingError`` so the caller
+        can abort training.
+        """
+        from cascade_correlation.cascade_correlation_exceptions.cascade_correlation_exceptions import (
+            CandidateTrainingError,
+        )
+
         network = _make_network()
         x = torch.randn(4, 2)
         y = torch.randn(4, 2)
@@ -219,11 +230,8 @@ class TestExecuteCandidateTraining:
 
         with patch.object(network._task_distributor, "distribute_and_collect", side_effect=RuntimeError("dist fail")):
             with patch.object(network, "_execute_sequential_training", side_effect=RuntimeError("seq fail")):
-                results = network._execute_candidate_training(tasks=tasks, process_count=2)
-                # Should get dummy results
-                assert len(results) == 2
-                for r in results:
-                    assert r.success is False
+                with pytest.raises(CandidateTrainingError):
+                    network._execute_candidate_training(tasks=tasks, process_count=2)
 
     @pytest.mark.unit
     def test_sequential_fallback_after_parallel_exception(self):

--- a/src/tests/unit/test_phase_2a_data_integrity.py
+++ b/src/tests/unit/test_phase_2a_data_integrity.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python
+"""
+Regression tests for Phase 2A (Track 2) data-integrity bug fixes in juniper-cascor.
+
+Covers:
+- BUG-CC-11: walrus operator precedence in utils._object_attributes_to_table
+- BUG-CC-03: falsy-safe parameter fallbacks in SpiralProblem parameter init methods
+- BUG-CC-18 / ROBUST-01: CandidateTrainingError raised on double candidate-training failure
+  instead of silently installing dummy zero-correlation candidates.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# Ensure `src/` is on sys.path so the top-level packages (utils, spiral_problem, ...) resolve.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# BUG-CC-11: walrus operator precedence in utils._object_attributes_to_table
+# ---------------------------------------------------------------------------
+class TestBugCC11WalrusPrecedence:
+    """`content := _init_content_list(...)` must receive the list, not a bool.
+
+    Before the fix, `if content := _init_content_list(...) is not None:` bound
+    ``content`` to the result of `is not None` (True/False), then attempted to
+    call `.append` on a boolean inside the loop body.
+    """
+
+    def test_attributes_table_returns_string_for_valid_input(self):
+        """With the walrus fix, a dict with public keys produces a non-None table."""
+        from utils.utils import _object_attributes_to_table
+
+        obj_dict = {"alpha": 1, "beta": 2}
+        keys = list(obj_dict.keys())
+
+        result = _object_attributes_to_table(
+            obj_dict=obj_dict,
+            keys=keys,
+            private_attrs=False,
+        )
+
+        # Before fix: `content` was a bool, calling .append() would AttributeError.
+        # After fix: we get a rendered string (columnar or fallback) containing both keys.
+        assert result is not None
+        assert isinstance(result, str)
+        assert "alpha" in result
+        assert "beta" in result
+
+    def test_attributes_table_handles_only_private_attrs(self):
+        """Private-only input with ``private_attrs=False`` still renders (empty) without crashing."""
+        from utils.utils import _object_attributes_to_table
+
+        obj_dict = {"_hidden": 1}
+        keys = list(obj_dict.keys())
+
+        # Would AttributeError pre-fix; post-fix returns either None or an empty-rendered string.
+        result = _object_attributes_to_table(
+            obj_dict=obj_dict,
+            keys=keys,
+            private_attrs=False,
+        )
+        # No crash is the assertion of interest; accept either empty-string/None.
+        assert result is None or isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# BUG-CC-03: falsy-safe parameter fallbacks in SpiralProblem
+# ---------------------------------------------------------------------------
+def _make_spiral_problem_shell():
+    """Create an un-__init__'d SpiralProblem shell with a no-op logger.
+
+    Avoids the heavy constructor (Logger/LogConfig/network wiring) while still
+    allowing direct exercise of private parameter-initialization methods.
+    """
+    from spiral_problem.spiral_problem import SpiralProblem
+
+    sp = SpiralProblem.__new__(SpiralProblem)
+    sp.logger = MagicMock()
+    return sp
+
+
+class TestBugCC03FalsyFallbacks:
+    """`param if param is not None else ...` must preserve valid falsy values.
+
+    Before the fix, `param or self.param or DEFAULT` silently replaced ``False``,
+    ``0``, and ``0.0`` with class attributes or module defaults.
+    """
+
+    def test_initialize_preserves_boolean_false_clockwise(self):
+        from spiral_problem import spiral_problem as sp_mod
+
+        sp = _make_spiral_problem_shell()
+        # Seed attributes so the fallback chain can be exercised.
+        sp.min_new = sp.max_new = 0
+        sp.min_orig = sp.max_orig = 0
+        sp.orig_points = None
+        sp.train_ratio = sp.test_ratio = 0.5
+        sp.clockwise = True  # class default truthy — explicit False must override.
+        sp.n_spirals = sp.n_rotations = sp.n_points = 1
+        sp.default_origin = sp.default_radius = 0
+        sp.noise = sp.distribution = 0.0
+
+        sp._initialize_spiral_problem_params(clockwise=False)
+
+        # Pre-fix this would silently become True (because `False or True or DEFAULT == True`).
+        assert sp.clockwise is False
+
+    def test_initialize_preserves_zero_noise(self):
+        sp = _make_spiral_problem_shell()
+        sp.min_new = sp.max_new = sp.min_orig = sp.max_orig = 0
+        sp.orig_points = None
+        sp.train_ratio = sp.test_ratio = 0.5
+        sp.clockwise = False
+        sp.n_spirals = sp.n_rotations = sp.n_points = 1
+        sp.default_origin = sp.default_radius = 0
+        sp.noise = 0.25  # non-zero prior value
+        sp.distribution = 1.0
+
+        sp._initialize_spiral_problem_params(noise_level=0.0)
+
+        # Pre-fix: `0.0 or 0.25 or DEFAULT` -> 0.25. Post-fix: caller's 0.0 wins.
+        assert sp.noise == 0.0
+
+    def test_initialize_preserves_zero_integer_params(self):
+        sp = _make_spiral_problem_shell()
+        sp.min_new = sp.max_new = sp.min_orig = sp.max_orig = 0
+        sp.orig_points = 10  # non-zero prior value
+        sp.train_ratio = sp.test_ratio = 0.5
+        sp.clockwise = False
+        sp.n_spirals = sp.n_rotations = sp.n_points = 1
+        sp.default_origin = sp.default_radius = 0
+        sp.noise = sp.distribution = 0.0
+
+        sp._initialize_spiral_problem_params(orig_points=0)
+
+        # Pre-fix: `0 or 10 or DEFAULT` -> 10. Post-fix: caller's 0 wins.
+        assert sp.orig_points == 0
+
+    def test_none_still_falls_back_to_class_attribute(self):
+        """Regression for the non-None fallback path: None should fall through to self.X."""
+        sp = _make_spiral_problem_shell()
+        sp.min_new = sp.max_new = sp.min_orig = sp.max_orig = 0
+        sp.orig_points = None
+        sp.train_ratio = 0.8
+        sp.test_ratio = 0.2
+        sp.clockwise = True
+        sp.n_spirals = 3
+        sp.n_rotations = sp.n_points = 1
+        sp.default_origin = sp.default_radius = 0
+        sp.noise = 0.05
+        sp.distribution = 1.0
+
+        sp._initialize_spiral_problem_params(n_spirals=None, noise_level=None)
+
+        # None caller -> class attribute (not module default).
+        assert sp.n_spirals == 3
+        assert sp.noise == 0.05
+
+
+# ---------------------------------------------------------------------------
+# BUG-CC-18 / ROBUST-01: CandidateTrainingError on double failure
+# ---------------------------------------------------------------------------
+class TestBugCC18CandidateTrainingError:
+    """Double failure in _execute_candidate_training must raise, not install dummies.
+
+    Pre-fix: on sequential-fallback failure OR empty-result return, the code
+    silently installed zero-correlation dummy candidates via
+    ``_get_dummy_results``, corrupting the network with meaningless data.
+    Post-fix: an explicit ``CandidateTrainingError`` propagates to the caller.
+    """
+
+    def test_candidate_training_error_is_subclass_of_training_error(self):
+        """CandidateTrainingError must be a TrainingError so existing catch blocks still work."""
+        from cascade_correlation.cascade_correlation_exceptions.cascade_correlation_exceptions import (
+            CandidateTrainingError,
+            TrainingError,
+        )
+
+        assert issubclass(CandidateTrainingError, TrainingError)
+
+    def test_execute_raises_when_sequential_fallback_fails(self):
+        """Both-paths-failed path must raise CandidateTrainingError instead of returning dummies."""
+        from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
+        from cascade_correlation.cascade_correlation_exceptions.cascade_correlation_exceptions import (
+            CandidateTrainingError,
+        )
+
+        net = CascadeCorrelationNetwork.__new__(CascadeCorrelationNetwork)
+        net.logger = MagicMock()
+        # Steer _execute_candidate_training down the sequential-only path.
+        task_distributor = MagicMock()
+        task_distributor.remote_worker_count = 0
+        net._task_distributor = task_distributor
+        net._execute_sequential_training = MagicMock(side_effect=RuntimeError("sequential boom"))
+        # Non-dict, length-1 task list: sequential is attempted first, then the except
+        # branch retries sequential, which also raises -> CandidateTrainingError.
+        tasks = [(0, "uuid-0", [None, None, None, None])]
+
+        with pytest.raises(CandidateTrainingError) as excinfo:
+            net._execute_candidate_training(tasks, process_count=1)
+
+        assert "sequential" in str(excinfo.value).lower() or "parallel" in str(excinfo.value).lower()
+
+    def test_execute_raises_when_sequential_returns_empty(self):
+        """Empty-results branch must also raise rather than synthesize dummies."""
+        from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
+        from cascade_correlation.cascade_correlation_exceptions.cascade_correlation_exceptions import (
+            CandidateTrainingError,
+        )
+
+        net = CascadeCorrelationNetwork.__new__(CascadeCorrelationNetwork)
+        net.logger = MagicMock()
+        task_distributor = MagicMock()
+        task_distributor.remote_worker_count = 0
+        net._task_distributor = task_distributor
+        # Single-process sequential path returns no results — this is the empty-results branch.
+        net._execute_sequential_training = MagicMock(return_value=[])
+        tasks = [(0, "uuid-0", [None, None, None, None])]
+
+        with pytest.raises(CandidateTrainingError):
+            net._execute_candidate_training(tasks, process_count=1)

--- a/src/tests/unit/test_remaining_coverage_deep.py
+++ b/src/tests/unit/test_remaining_coverage_deep.py
@@ -99,28 +99,38 @@ class TestUtilsColumnarImportFallback:
 
 
 class TestObjectAttributesToTableColumnar:
-    """Test _object_attributes_to_table columnar formatting paths."""
+    """Test _object_attributes_to_table columnar formatting paths.
+
+    BUG-CC-11 (fixed): the walrus-operator precedence bug on line 208 of
+    ``utils/utils.py`` previously bound ``content`` to a bool, so every call
+    with valid inputs raised ``AttributeError`` inside the loop. These tests
+    now lock in the post-fix rendering behavior.
+    """
 
     def test_table_formatting_fallback_without_columnar(self):
-        """When HAS_COLUMNAR is False, fallback string formatting is used (lines 220-222)."""
+        """When HAS_COLUMNAR is False, fallback string formatting renders a string."""
+        from unittest.mock import patch
+
         from utils.utils import _object_attributes_to_table
 
-        # Due to walrus operator precedence bug in line 208, calling with valid
-        # params triggers AttributeError. Document the behavior.
         obj_dict = {"name": "test", "value": 42}
         keys = ["name", "value"]
-        with pytest.raises(AttributeError):
-            _object_attributes_to_table(obj_dict, keys, False)
+        with patch("utils.utils.HAS_COLUMNAR", False), patch("utils.utils.col", None):
+            result = _object_attributes_to_table(obj_dict, keys, False)
+        assert isinstance(result, str)
+        assert "name" in result and "value" in result
 
     def test_table_with_private_attrs_false_skips_underscore(self):
-        """Private attrs starting with _ are skipped when private_attrs=False."""
+        """Private attrs starting with ``_`` are skipped when private_attrs=False."""
         from utils.utils import _object_attributes_to_table
 
         obj_dict = {"_private": "hidden", "public": "visible"}
         keys = ["_private", "public"]
-        # Walrus operator bug prevents reaching the filtering logic
-        with pytest.raises(AttributeError):
-            _object_attributes_to_table(obj_dict, keys, False)
+        result = _object_attributes_to_table(obj_dict, keys, False)
+        assert isinstance(result, str)
+        # Only the public key should appear in the rendered table.
+        assert "public" in result
+        assert "_private" not in result
 
     def test_table_with_private_attrs_true_includes_underscore(self):
         """Private attrs are included when private_attrs=True."""
@@ -128,8 +138,9 @@ class TestObjectAttributesToTableColumnar:
 
         obj_dict = {"_private": "hidden", "public": "visible"}
         keys = ["_private", "public"]
-        with pytest.raises(AttributeError):
-            _object_attributes_to_table(obj_dict, keys, True)
+        result = _object_attributes_to_table(obj_dict, keys, True)
+        assert isinstance(result, str)
+        assert "_private" in result and "public" in result
 
 
 # ======================================================================

--- a/src/tests/unit/test_utils_coverage.py
+++ b/src/tests/unit/test_utils_coverage.py
@@ -445,46 +445,55 @@ class TestCheckObjectPickleabilityExtended:
 class TestDisplayObjectAttributesModulePath:
     """Tests for display_object_attributes with real modules (lines 191-194).
 
-    Note: Due to walrus operator precedence bug in _object_attributes_to_table line 208,
-    valid inputs cause AttributeError because content gets assigned False instead of [].
-    These tests exercise the code paths and document the bug.
+    BUG-CC-11 (fixed): the walrus-operator precedence bug on line 208 previously
+    bound ``content`` to a bool, so every call with valid inputs raised
+    ``AttributeError: 'bool' object has no attribute 'append'``. With the
+    parenthesized walrus, ``content`` now receives the list and the function
+    renders a table instead of crashing. These tests lock in the fixed behavior.
     """
 
-    def test_display_object_attributes_with_os_module(self):
-        """Test with 'os' module - exercises import path, triggers known bug."""
-        with pytest.raises(AttributeError, match="'bool' object has no attribute 'append'"):
-            display_object_attributes("os", private_attrs=False)
-
     def test_display_object_attributes_with_json_module(self):
-        """Test with 'json' module - exercises module import path, triggers known bug."""
-        with pytest.raises(AttributeError, match="'bool' object has no attribute 'append'"):
-            display_object_attributes("json", private_attrs=False)
+        """'json' module has a small, bounded __dict__ so columnar formatting is fast."""
+        result = display_object_attributes("json", private_attrs=False)
+        assert result is not None
+        assert isinstance(result, str)
+        # ``dumps`` is a public attribute of the json module and must appear in the table.
+        assert "dumps" in result
 
-    def test_display_object_attributes_with_private_true(self):
-        """Test with private_attrs=True - exercises private attr path, triggers known bug."""
-        with pytest.raises(AttributeError, match="'bool' object has no attribute 'append'"):
-            display_object_attributes("sys", private_attrs=True)
+    def test_display_object_attributes_private_true_renders_small_module(self):
+        """With private_attrs=True, private keys are included in the rendered table."""
+        # Avoid ``sys`` here: its __dict__ is large enough that columnar formatting
+        # can exceed the 60s default pytest timeout on slow runners.
+        result = display_object_attributes("json", private_attrs=True)
+        assert result is not None
+        assert isinstance(result, str)
 
 
 class TestObjectAttributesTableColumnarPath:
     """Tests for _object_attributes_to_table columnar formatting (lines 217-222).
 
-    Note: Due to walrus operator precedence bug in line 208, valid params trigger
-    AttributeError because content := (expr) is not None evaluates to the bool result,
-    not the list. Tests document actual behavior.
+    BUG-CC-11 (fixed): the walrus-operator precedence bug on line 208 previously
+    caused ``_object_attributes_to_table`` to crash on valid input and to return
+    ``False`` when ``private_attrs`` was ``None`` (because the boolean walrus
+    result propagated through). After the fix, valid inputs render a string and
+    a ``None`` validity input short-circuits to ``None``.
     """
 
     def test_table_with_none_private_attrs(self):
-        """Test table generation with None private_attrs parameter returns False."""
+        """None validity input short-circuits to a None table (no content list)."""
+        # _init_content_list(False) -> None, so `(content := None) is not None` is False
+        # and the function returns None without entering the loop.
         result = _object_attributes_to_table({"name": "test"}, ["name"], None)
-        assert result is False
+        assert result is None
 
-    def test_table_all_params_valid_triggers_bug(self):
-        """Test that valid params trigger AttributeError due to walrus operator bug."""
+    def test_table_all_params_valid_renders_string(self):
+        """With valid inputs, the post-fix walrus binds ``content`` to a list and renders a string."""
         obj_dict = {"a": 1, "b": 2}
         keys = ["a", "b"]
-        with pytest.raises(AttributeError, match="'bool' object has no attribute 'append'"):
-            _object_attributes_to_table(obj_dict, keys, False)
+        result = _object_attributes_to_table(obj_dict, keys, False)
+        assert result is not None
+        assert isinstance(result, str)
+        assert "a" in result and "b" in result
 
 
 class TestCheckPickleabilityLogging:

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -205,7 +205,8 @@ def _object_attributes_to_table(obj_dict: dict = None, keys: [str] = None, priva
     Returns:
         String representing the object's attributes and their values in a columnar format.
     """
-    if content := _init_content_list(obj_dict is not None and keys is not None and private_attrs is not None) is not None:
+    # BUG-CC-11: parenthesize walrus so `content` receives the list, not the truthiness of the `is not None` comparison.
+    if (content := _init_content_list(obj_dict is not None and keys is not None and private_attrs is not None)) is not None:
         for key in keys:  # parse attributes from target object
             if key.startswith("_") and not private_attrs:  # Ignore private attributes
                 continue


### PR DESCRIPTION
## Summary

Implements **Track 2 / Phase 2A** of the V7 roadmap — three correctness fixes that together eliminate silent data-corruption paths in juniper-cascor.

- **BUG-CC-11 (P0)** — Parenthesize walrus in `utils._object_attributes_to_table` so `content` receives the list, not a bool.
- **BUG-CC-03 (P1)** — Replace `param or self.param or DEFAULT` chains with explicit `is not None` checks in `SpiralProblem` parameter-init methods so valid falsy overrides (`False`, `0`, `0.0`) are preserved.
- **BUG-CC-18 / ROBUST-01 (P0, Critical)** — Introduce `CandidateTrainingError` and raise it from `_execute_candidate_training` on double-failure / empty-results paths instead of silently installing zero-correlation dummy candidates. `train_candidates` now re-raises the specific error unchanged.

## Test plan

- [x] New `tests/unit/test_phase_2a_data_integrity.py` (9 regression tests) all pass.
- [x] Updated `test_utils_coverage.py`, `test_remaining_coverage_deep.py`, and `test_cascade_correlation_coverage_deep.py` now lock in post-fix behavior.
- [x] Broader unit-test runs covering affected files (`utils`, `spiral_problem`, `cascade_correlation` coverage/extended/deep, `candidate_training_manager`, `candidate_unit_coverage`, `config_and_exceptions`) pass without regressions.
- [ ] CI is the source of truth — confirm on the PR.

Notes:
- Pre-existing stale test files referencing modules removed in commit cbcf9bd (`test_spiral_check_coverage.py`, `test_remote_client_0_extended.py`) continue to collect-error — out of scope for Phase 2A; tracked separately.
- `_get_dummy_results` is retained for the defensive path in `_process_training_results`; only the two silent-corruption callsites are removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)