### PR TITLE
security: Phase 1C — cascor per-IP/typed-params/pickle/PII/snapshot-id (SEC-03/07/11/15/17)

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -51,6 +51,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         max_connections=settings.ws_max_connections,
         max_replay_buffer_size=settings.ws_replay_buffer_size,
         send_timeout_seconds=settings.ws_send_timeout_seconds,
+        max_connections_per_ip=settings.ws_max_connections_per_ip,  # SEC-03
     )
     ws_manager.set_event_loop(asyncio.get_running_loop())
     app.state.ws_manager = ws_manager

--- a/src/api/models/training.py
+++ b/src/api/models/training.py
@@ -29,13 +29,44 @@ class InlineDataset(BaseModel):
     val_y: Optional[List[List[float]]] = Field(None, max_length=_PROJECT_API_MAX_DATASET_TARGETS, description="Validation targets")
 
 
+class TrainingParams(BaseModel):
+    """Validated training parameter overrides for ``POST /training/start`` (SEC-07).
+
+    Each field has the same type + range constraints as the runtime-modifiable
+    ``TrainingParamUpdateRequest`` so the start-of-training validation cannot
+    diverge from the patch validation. ``extra="forbid"`` ensures unknown
+    keys raise 422 instead of being silently dropped — closing the gap that
+    the previous ``Dict[str, Any]`` + whitelist-in-handler pattern left open
+    (values were never range-checked and allow-listed keys were only
+    enforced server-side).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    max_epochs: Optional[int] = Field(None, ge=1, description="Max epochs override")
+    max_iterations: Optional[int] = Field(None, ge=1, description="Maximum cascade growth iterations")
+    early_stopping: Optional[bool] = Field(None, description="Whether early stopping is enabled")
+    learning_rate: Optional[float] = Field(None, gt=0, le=10.0, description="Output layer learning rate")
+    candidate_learning_rate: Optional[float] = Field(None, gt=0, le=10.0, description="Candidate training learning rate")
+    correlation_threshold: Optional[float] = Field(None, gt=0, le=1.0, description="Minimum correlation to accept candidate")
+    candidate_pool_size: Optional[int] = Field(None, ge=1, le=256, description="Number of candidate units per round")
+    max_hidden_units: Optional[int] = Field(None, ge=1, le=10_000, description="Maximum hidden units")
+    epochs_max: Optional[int] = Field(None, ge=1, le=1_000_000, description="Global maximum training epochs")
+    patience: Optional[int] = Field(None, ge=1, le=100_000, description="Early stopping patience epochs")
+    convergence_threshold: Optional[float] = Field(None, gt=0, description="Minimum loss improvement to reset patience counter")
+    candidate_convergence_threshold: Optional[float] = Field(None, gt=0, description="Minimum loss improvement for candidate training patience")
+    candidate_patience: Optional[int] = Field(None, ge=1, le=100_000, description="Candidate training patience epochs")
+    candidate_epochs: Optional[int] = Field(None, ge=1, le=1_000_000, description="Number of epochs for candidate training")
+    init_output_weights: Optional[Literal["zero", "random"]] = Field(None, description="Initialization mode for new hidden unit output weights")
+
+
 class TrainingStartRequest(BaseModel):
     """Request to start training."""
 
     epochs: Optional[int] = Field(None, ge=1, description="Max epochs override")
     dataset: Optional[DatasetSource] = Field(None, description="Dataset source specification")
     inline_data: Optional[InlineDataset] = Field(None, description="Inline dataset")
-    params: Optional[Dict[str, Any]] = Field(None, description="Training params (learning_rate, patience, etc.)")
+    params: Optional[TrainingParams] = Field(None, description="Training params (learning_rate, patience, etc.)")
 
 
 class TrainingStatus(BaseModel):

--- a/src/api/models/training.py
+++ b/src/api/models/training.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from cascor_constants.constants_api import _PROJECT_API_DATASET_SOURCE_DEFAULT, _PROJECT_API_MAX_DATASET_SAMPLES, _PROJECT_API_MAX_DATASET_TARGETS
 

--- a/src/api/observability.py
+++ b/src/api/observability.py
@@ -158,6 +158,31 @@ def configure_logging(log_level: str, log_format: str, service_name: str = _SERV
     root.addHandler(file_handler)
 
 
+# SEC-15: Header names that may carry secrets. We always strip them from
+# Sentry events regardless of ``send_default_pii``; the default is now
+# ``False`` so request headers are not uploaded at all, but the filter
+# remains as a second line of defense if any future integration re-enables
+# per-event header capture (e.g. a custom logging integration).
+_SENTRY_SENSITIVE_HEADERS = frozenset({"x-api-key", "authorization", "cookie"})
+
+
+def _strip_sensitive_headers(event, hint):  # noqa: ARG001 — Sentry hook signature
+    """Replace any sensitive request headers in a Sentry event with ``[Filtered]``.
+
+    Sentry calls this via ``before_send`` for every outbound event. The
+    filter walks the request headers dict and only rewrites keys that
+    match the sensitive set, so non-sensitive diagnostic headers still
+    reach Sentry unchanged.
+    """
+    request_data = event.get("request", {}) if isinstance(event, dict) else {}
+    headers = request_data.get("headers", {}) if isinstance(request_data, dict) else {}
+    if isinstance(headers, dict):
+        for key in list(headers.keys()):
+            if key.lower() in _SENTRY_SENSITIVE_HEADERS:
+                headers[key] = "[Filtered]"
+    return event
+
+
 def configure_sentry(dsn: str | None, service_name: str, version: str) -> None:
     """Initialize Sentry with FastAPI integration. No-op when dsn is None or empty.
 
@@ -173,10 +198,14 @@ def configure_sentry(dsn: str | None, service_name: str, version: str) -> None:
 
     sentry_sdk.init(
         dsn=dsn,
-        send_default_pii=True,
+        # SEC-15: never upload default PII (IP, cookies, user identifiers,
+        # request headers). The before_send filter scrubs any headers that
+        # slip through via other integrations.
+        send_default_pii=False,
         enable_logs=True,
         traces_sample_rate=_LOGGER_SENTRY_TRACES_SAMPLE_RATE,
         release=f"{service_name}@{version}",
+        before_send=_strip_sensitive_headers,
     )
 
 

--- a/src/api/routes/snapshots.py
+++ b/src/api/routes/snapshots.py
@@ -1,6 +1,7 @@
 """Snapshot management routes."""
 
 import logging
+import re
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
@@ -10,6 +11,31 @@ from api.models.common import success_response
 logger = logging.getLogger("juniper_cascor.api.routes.snapshots")
 
 router = APIRouter(prefix="/snapshots", tags=["snapshots"])
+
+# SEC-17: allowlist for snapshot identifiers. The lifecycle manager already
+# matches on file stems via ``glob("*.h5")`` so a crafted path with ``..``
+# or a slash cannot escape the snapshots directory today, but we enforce a
+# strict regex at the route boundary so (a) attempts are rejected with 400
+# before reaching the lifecycle layer, (b) any future code path that uses
+# ``snapshot_id`` to build a path directly inherits the defense, and
+# (c) traversal attempts are audit-logged.
+_SNAPSHOT_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
+
+
+def _validate_snapshot_id(snapshot_id: str, client: str | None = None) -> None:
+    """Reject ``snapshot_id`` values that are not pure alphanumerics/_/-.
+
+    Raises ``HTTPException(400)`` with a fixed detail. Also logs the bad
+    identifier at WARNING so operators can spot traversal probing in the
+    access logs.
+    """
+    if not _SNAPSHOT_ID_PATTERN.fullmatch(snapshot_id or ""):
+        logger.warning(
+            "Rejected snapshot_id (invalid format): %r client=%s",
+            snapshot_id,
+            client or "unknown",
+        )
+        raise HTTPException(status_code=400, detail="Invalid snapshot_id format")
 
 
 class SnapshotCreateRequest(BaseModel):
@@ -48,6 +74,7 @@ async def list_snapshots(request: Request) -> dict:
 @router.get("/{snapshot_id}")
 async def get_snapshot(request: Request, snapshot_id: str) -> dict:
     """Get metadata for a specific snapshot."""
+    _validate_snapshot_id(snapshot_id, client=request.client.host if request.client else None)
     lifecycle = _get_lifecycle(request)
     result = lifecycle.get_snapshot(snapshot_id)
     if result is None:
@@ -58,6 +85,7 @@ async def get_snapshot(request: Request, snapshot_id: str) -> dict:
 @router.post("/{snapshot_id}/restore")
 async def restore_snapshot(request: Request, snapshot_id: str) -> dict:
     """Restore a network from a snapshot."""
+    _validate_snapshot_id(snapshot_id, client=request.client.host if request.client else None)
     lifecycle = _get_lifecycle(request)
     success = lifecycle.load_snapshot(snapshot_id)
     if not success:

--- a/src/api/routes/training.py
+++ b/src/api/routes/training.py
@@ -32,25 +32,11 @@ async def start_training(request: Request, body: TrainingStartRequest = None) ->
     """
     lifecycle = _get_lifecycle(request)
 
-    # Whitelist of allowed training parameter keys (matches update_params in lifecycle manager)
-    _ALLOWED_TRAINING_PARAMS = {
-        "max_epochs",
-        "max_iterations",
-        "early_stopping",
-        "learning_rate",
-        "candidate_learning_rate",
-        "correlation_threshold",
-        "candidate_pool_size",
-        "max_hidden_units",
-        "epochs_max",
-        "patience",
-        "convergence_threshold",
-        "candidate_convergence_threshold",
-        "candidate_patience",
-        "candidate_epochs",
-        "init_output_weights",
-    }
-
+    # SEC-07: the ``params`` field is now a typed ``TrainingParams`` model
+    # with ``extra="forbid"``; Pydantic rejects unknown keys with 422 at
+    # the request boundary, and per-field validators enforce numeric
+    # ranges. The old hand-maintained ``_ALLOWED_TRAINING_PARAMS`` set and
+    # silent-drop behavior are gone because they left values unchecked.
     kwargs = {}
     x = None
     y = None
@@ -70,13 +56,10 @@ async def start_training(request: Request, body: TrainingStartRequest = None) ->
         if body.dataset is not None and body.dataset.generator == "spiral":
             x, y = _generate_spiral_data(body.dataset.params or {})
 
-        # Handle training params — only allow whitelisted keys
-        if body.params:
-            for key, value in body.params.items():
-                if key in _ALLOWED_TRAINING_PARAMS:
-                    kwargs[key] = value
-                else:
-                    logger.warning("Ignoring unrecognized training param: %s", key)
+        # Handle training params — typed TrainingParams model rejects
+        # unknown keys via Pydantic; forward only explicitly-set fields.
+        if body.params is not None:
+            kwargs.update(body.params.model_dump(exclude_none=True))
 
         if body.epochs is not None:
             kwargs["max_epochs"] = body.epochs

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -126,6 +126,11 @@ class Settings(BaseSettings):
     cors_origins: list[str] = _JUNIPER_CASCOR_API_CORS_ORIGINS_DEFAULT
 
     ws_max_connections: int = _JUNIPER_CASCOR_API_WS_MAX_CONNECTIONS_DEFAULT
+    # SEC-03: per-IP cap on concurrent WebSocket connections. Mirrors the
+    # canopy ``max_connections_per_ip`` pattern so a single hostile client
+    # cannot monopolize the global ``ws_max_connections`` pool. Applies to
+    # every endpoint routed through ``WebSocketManager.connect*``.
+    ws_max_connections_per_ip: int = 5
     ws_heartbeat_interval_sec: int = _JUNIPER_CASCOR_API_WS_HEARTBEAT_INTERVAL_SEC_DEFAULT
     ws_heartbeat_pong_timeout_sec: int = _JUNIPER_CASCOR_API_WS_HEARTBEAT_PONG_TIMEOUT_SEC_DEFAULT
 

--- a/src/api/websocket/manager.py
+++ b/src/api/websocket/manager.py
@@ -62,11 +62,19 @@ class WebSocketManager:
         max_connections: int = 50,
         max_replay_buffer_size: int = 1024,
         send_timeout_seconds: float = 0.5,
+        max_connections_per_ip: int = 5,
     ):
         # Connection tracking
         self._active_connections: Set[WebSocket] = set()
         self._pending_connections: Set[WebSocket] = set()
         self._max_connections = max_connections
+        # SEC-03: per-IP cap. Stored as ``ip -> count`` and updated under
+        # ``self._lock`` alongside the connection sets. Unknown clients
+        # (no ``websocket.client``) all share the sentinel key "unknown",
+        # which is intentional — if the reverse proxy strips the client
+        # address we cannot distinguish attackers anyway.
+        self._max_connections_per_ip = max_connections_per_ip
+        self._per_ip_counts: Dict[str, int] = {}
         self._event_loop: Optional[asyncio.AbstractEventLoop] = None
         self._connection_meta: Dict[WebSocket, Dict[str, Any]] = {}
         self._lock = asyncio.Lock()
@@ -127,6 +135,38 @@ class WebSocketManager:
             },
         }
 
+    def _source_ip(self, websocket: WebSocket) -> str:
+        """Best-effort source-IP for per-IP accounting (SEC-03)."""
+        client = getattr(websocket, "client", None)
+        if client is not None:
+            try:
+                return client[0] or "unknown"
+            except (IndexError, TypeError):
+                return "unknown"
+        return "unknown"
+
+    def _check_and_reserve_per_ip_slot(self, source_ip: str) -> bool:
+        """Reserve a per-IP slot; returns False if the cap would be exceeded.
+
+        Must be called with ``self._lock`` held. On success the caller is
+        responsible for invoking ``_release_per_ip_slot`` on disconnect.
+        """
+        current = self._per_ip_counts.get(source_ip, 0)
+        if current >= self._max_connections_per_ip:
+            return False
+        self._per_ip_counts[source_ip] = current + 1
+        return True
+
+    def _release_per_ip_slot(self, source_ip: Optional[str]) -> None:
+        """Release a per-IP slot previously reserved by _check_and_reserve_per_ip_slot."""
+        if not source_ip:
+            return
+        current = self._per_ip_counts.get(source_ip, 0)
+        if current <= 1:
+            self._per_ip_counts.pop(source_ip, None)
+        else:
+            self._per_ip_counts[source_ip] = current - 1
+
     async def connect(self, websocket: WebSocket) -> bool:
         """Accept and register a WebSocket connection as immediately active.
 
@@ -140,9 +180,22 @@ class WebSocketManager:
                 logger.warning("Connection rejected: limit of %d reached", self._max_connections)
                 return False
 
+            source_ip = self._source_ip(websocket)
+            if not self._check_and_reserve_per_ip_slot(source_ip):
+                # SEC-03: per-IP cap exceeded. Close with the same 1013
+                # used for the global cap so clients see a single "too
+                # many connections" signal.
+                await websocket.close(code=1013, reason="Per-IP connection limit reached")
+                logger.warning(
+                    "Connection rejected: per-IP limit of %d reached for %s",
+                    self._max_connections_per_ip,
+                    source_ip,
+                )
+                return False
+
             await websocket.accept()
             self._active_connections.add(websocket)
-            self._connection_meta[websocket] = {"connected_at": time.time()}
+            self._connection_meta[websocket] = {"connected_at": time.time(), "source_ip": source_ip}
             logger.info("WebSocket connected (%d active)", self.connection_count)
 
         await self._send_json(websocket, self._build_connection_established())
@@ -165,9 +218,19 @@ class WebSocketManager:
                 logger.warning("Connection rejected: limit of %d reached", self._max_connections)
                 return False
 
+            source_ip = self._source_ip(websocket)
+            if not self._check_and_reserve_per_ip_slot(source_ip):
+                await websocket.close(code=1013, reason="Per-IP connection limit reached")
+                logger.warning(
+                    "Pending connection rejected: per-IP limit of %d reached for %s",
+                    self._max_connections_per_ip,
+                    source_ip,
+                )
+                return False
+
             await websocket.accept()
             self._pending_connections.add(websocket)
-            self._connection_meta[websocket] = {"connected_at": time.time(), "pending": True}
+            self._connection_meta[websocket] = {"connected_at": time.time(), "pending": True, "source_ip": source_ip}
             logger.info("WebSocket connected as pending (%d pending)", len(self._pending_connections))
 
         await self._send_json(websocket, self._build_connection_established())
@@ -194,7 +257,12 @@ class WebSocketManager:
         async with self._lock:
             self._active_connections.discard(websocket)
             self._pending_connections.discard(websocket)
-            self._connection_meta.pop(websocket, None)
+            meta = self._connection_meta.pop(websocket, None)
+            # SEC-03: release the per-IP slot reserved at connect time so
+            # a client who reconnects cleanly does not accrue phantom
+            # counts against the cap.
+            if meta is not None:
+                self._release_per_ip_slot(meta.get("source_ip"))
             logger.info(
                 "WebSocket disconnected (%d active, %d pending)",
                 self.connection_count,

--- a/src/main.py
+++ b/src/main.py
@@ -122,22 +122,22 @@ from spiral_problem.spiral_problem import SpiralProblem
 load_dotenv()
 _sentry_dsn = os.getenv("SENTRY_SDK_DSN")
 if _sentry_dsn:
+    # Match configure_sentry()'s behavior at the application-bootstrap
+    # site as well: default PII off (SEC-15) and scrub any residual
+    # sensitive headers via before_send.
+    from api.observability import _strip_sensitive_headers as _sentry_strip_sensitive_headers
+
     sentry_sdk.init(
         dsn=_sentry_dsn,
-        # Add data like request headers and IP for users,
-        # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-        send_default_pii=True,
-        # Enable sending logs to Sentry
+        # SEC-15: do not upload default PII (request headers, IP addresses,
+        # user identifiers). The before_send hook strips any sensitive
+        # headers that other integrations may still attach to events.
+        send_default_pii=False,
         enable_logs=True,
-        # Set traces_sample_rate to 1.0 to capture 100%
-        # of transactions for tracing.
         traces_sample_rate=1.0,
-        # Set profile_session_sample_rate to 1.0 to profile 100%
-        # of profile sessions.
         profile_session_sample_rate=1.0,
-        # Set profile_lifecycle to "trace" to automatically
-        # run the profiler on when there is an active transaction
         profile_lifecycle="trace",
+        before_send=_sentry_strip_sensitive_headers,
     )
 # app = FastAPI()
 

--- a/src/snapshots/snapshot_serializer.py
+++ b/src/snapshots/snapshot_serializer.py
@@ -5,6 +5,7 @@ Provides comprehensive state capture and restoration with full multiprocessing s
 """
 
 import datetime
+import io
 import json
 import multiprocessing as mp
 import os
@@ -14,6 +15,68 @@ import random
 import sys
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
+
+# SEC-11: allowlist for the snapshot RNG-state unpickler. Only modules we
+# know Python's ``random.getstate()`` payloads reference (plus their pickle
+# helpers) and a tight set of builtin container types are permitted. Any
+# other ``find_class`` lookup — including torch, numpy, or user code — is
+# rejected so a crafted HDF5 file cannot smuggle an RCE-capable pickle
+# payload into the snapshot restore path.
+_SNAPSHOT_UNPICKLER_ALLOWED_MODULES = frozenset(
+    {
+        "random",
+        "_random",
+        "collections",
+        "collections.abc",
+        "_codecs",
+        "copyreg",
+    }
+)
+_SNAPSHOT_UNPICKLER_ALLOWED_BUILTINS = frozenset(
+    {
+        "dict",
+        "list",
+        "tuple",
+        "set",
+        "frozenset",
+        "int",
+        "float",
+        "str",
+        "bool",
+        "bytes",
+        "complex",
+        "slice",
+        "range",
+        "type",
+    }
+)
+
+
+class SnapshotUnpicklingError(pickle.UnpicklingError):
+    """Raised when a snapshot pickle references a class outside the allowlist."""
+
+
+class _SnapshotRestrictedUnpickler(pickle.Unpickler):
+    """Unpickler used to restore Python RNG state from HDF5 snapshots.
+
+    Overrides ``find_class`` to fail closed on anything outside the
+    allowlists above. This is the last line of defense for snapshot
+    integrity: even a legitimately-signed snapshot file must still pass
+    this check, so a compromised signing key or a file swapped on disk
+    cannot escalate to arbitrary code execution.
+    """
+
+    def find_class(self, module: str, name: str):  # type: ignore[override]
+        if module in _SNAPSHOT_UNPICKLER_ALLOWED_MODULES:
+            return super().find_class(module, name)
+        if module == "builtins" and name in _SNAPSHOT_UNPICKLER_ALLOWED_BUILTINS:
+            return super().find_class(module, name)
+        raise SnapshotUnpicklingError(f"Blocked unpickling of {module}.{name} — not in snapshot allowlist")
+
+
+def _snapshot_restricted_loads(data: bytes):
+    """Run ``pickle.loads`` equivalent against ``_SnapshotRestrictedUnpickler``."""
+    return _SnapshotRestrictedUnpickler(io.BytesIO(data)).load()
 
 import h5py
 import numpy as np
@@ -822,10 +885,13 @@ class CascadeHDF5Serializer:
             if "python_state" in random_group:
                 python_state_array = load_numpy_array(random_group["python_state"])
                 python_state_bytes = python_state_array.tobytes()
-                # SECURITY: pickle.loads is used here to restore Python random state from
-                # HDF5 snapshots. These snapshots are trusted-origin-only artifacts created
-                # by this application. Do NOT load untrusted/third-party snapshot files.
-                python_state = pickle.loads(python_state_bytes)  # trunk-ignore(bandit/B301)
+                # SEC-11: route RNG-state deserialization through the
+                # restricted unpickler so even a tampered snapshot cannot
+                # escalate to arbitrary code execution. ``find_class`` is
+                # locked to the ``random``/``_random`` modules and a small
+                # set of builtin container types; anything else raises
+                # ``SnapshotUnpicklingError`` and aborts the restore.
+                python_state = _snapshot_restricted_loads(python_state_bytes)
                 random.setstate(python_state)
                 self.logger.debug("CascadeHDF5Serializer: Restored Python random state")
 

--- a/src/tests/unit/api/test_phase1c_security.py
+++ b/src/tests/unit/api/test_phase1c_security.py
@@ -1,0 +1,221 @@
+"""Phase 1C Track 1 security remediation tests (SEC-03/11/15/17)."""
+
+import pickle  # nosec B403 — needed to hand-craft a hostile payload for SEC-11
+
+import pytest
+from unittest.mock import AsyncMock
+
+
+# =============================================================================
+# SEC-03: per-IP WebSocket connection cap
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestSEC03PerIPLimit:
+    """WebSocketManager must enforce a per-IP cap in addition to the global one."""
+
+    @pytest.mark.asyncio
+    async def test_per_ip_cap_rejects_overflow(self) -> None:
+        from api.websocket.manager import WebSocketManager
+
+        mgr = WebSocketManager(max_connections=50, max_connections_per_ip=2)
+        connections = []
+        for _ in range(2):
+            ws = AsyncMock()
+            ws.client = ("10.0.0.1", 12345)
+            ok = await mgr.connect(ws)
+            assert ok is True
+            connections.append(ws)
+
+        overflow = AsyncMock()
+        overflow.client = ("10.0.0.1", 23456)
+        result = await mgr.connect(overflow)
+        assert result is False
+        overflow.close.assert_awaited_once()
+        args, kwargs = overflow.close.call_args
+        assert kwargs.get("code") == 1013
+        assert "per-ip" in kwargs.get("reason", "").lower()
+
+    @pytest.mark.asyncio
+    async def test_per_ip_cap_isolated_per_source(self) -> None:
+        from api.websocket.manager import WebSocketManager
+
+        mgr = WebSocketManager(max_connections=50, max_connections_per_ip=1)
+
+        ws_a = AsyncMock()
+        ws_a.client = ("10.0.0.1", 1)
+        ws_b = AsyncMock()
+        ws_b.client = ("10.0.0.2", 1)
+
+        assert await mgr.connect(ws_a) is True
+        assert await mgr.connect(ws_b) is True
+
+    @pytest.mark.asyncio
+    async def test_disconnect_releases_per_ip_slot(self) -> None:
+        from api.websocket.manager import WebSocketManager
+
+        mgr = WebSocketManager(max_connections=50, max_connections_per_ip=1)
+
+        ws1 = AsyncMock()
+        ws1.client = ("10.0.0.5", 1)
+        assert await mgr.connect(ws1) is True
+
+        await mgr.disconnect(ws1)
+
+        ws2 = AsyncMock()
+        ws2.client = ("10.0.0.5", 2)
+        assert await mgr.connect(ws2) is True
+
+
+# =============================================================================
+# SEC-11: snapshot RestrictedUnpickler
+# =============================================================================
+
+
+class TestSEC11SnapshotRestrictedUnpickler:
+    """Snapshot deserialization must reject classes outside the allowlist."""
+
+    def test_accepts_python_random_state(self) -> None:
+        import random as _random
+
+        from snapshots.snapshot_serializer import _snapshot_restricted_loads
+
+        ref = _random.Random()
+        ref.seed(1234)
+        state_bytes = pickle.dumps(ref.getstate())
+        restored = _snapshot_restricted_loads(state_bytes)
+        assert isinstance(restored, tuple)
+        rng = _random.Random()
+        rng.setstate(restored)
+        assert rng.random() == ref.random()
+
+    def test_rejects_os_system_gadget(self) -> None:
+        from snapshots.snapshot_serializer import (
+            SnapshotUnpicklingError,
+            _snapshot_restricted_loads,
+        )
+
+        class _Gadget:
+            def __reduce__(self):
+                import os  # noqa: PLC0415
+
+                return (os.system, ("true",))
+
+        payload = pickle.dumps(_Gadget())
+        # Python serializes os.system under the platform-specific module name
+        # (posix on Linux, nt on Windows). Match the common ``.system`` suffix.
+        with pytest.raises(SnapshotUnpicklingError, match=r"\.system"):
+            _snapshot_restricted_loads(payload)
+
+    def test_rejects_arbitrary_module(self) -> None:
+        from snapshots.snapshot_serializer import (
+            SnapshotUnpicklingError,
+            _snapshot_restricted_loads,
+        )
+
+        class _Unknown:
+            def __reduce__(self):
+                import subprocess  # noqa: PLC0415
+
+                return (subprocess.run, (["true"],))
+
+        payload = pickle.dumps(_Unknown())
+        with pytest.raises(SnapshotUnpicklingError, match="subprocess"):
+            _snapshot_restricted_loads(payload)
+
+
+# =============================================================================
+# SEC-15: Sentry send_default_pii=False + before_send filter
+# =============================================================================
+
+
+class TestSEC15SentryPII:
+    def test_before_send_filter_redacts_sensitive_headers(self) -> None:
+        from api.observability import _strip_sensitive_headers
+
+        event = {
+            "request": {
+                "headers": {
+                    "X-API-Key": "super-secret-key",
+                    "authorization": "Bearer super-secret-token",
+                    "cookie": "session=abc",
+                    "User-Agent": "juniper-canopy/0.1",
+                }
+            }
+        }
+        filtered = _strip_sensitive_headers(event, hint={})
+        assert filtered is event
+        assert filtered["request"]["headers"]["X-API-Key"] == "[Filtered]"
+        assert filtered["request"]["headers"]["authorization"] == "[Filtered]"
+        assert filtered["request"]["headers"]["cookie"] == "[Filtered]"
+        assert filtered["request"]["headers"]["User-Agent"] == "juniper-canopy/0.1"
+
+    def test_before_send_filter_handles_missing_request(self) -> None:
+        from api.observability import _strip_sensitive_headers
+
+        filtered = _strip_sensitive_headers({}, hint={})
+        assert filtered == {}
+
+    def test_configure_sentry_sets_pii_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict = {}
+
+        class _FakeSentry:
+            @staticmethod
+            def init(**kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr("api.observability.sentry_sdk", _FakeSentry, raising=False)
+        # Inject the fake into the function-local import by patching sys.modules
+        import sys
+
+        monkeypatch.setitem(sys.modules, "sentry_sdk", _FakeSentry)
+
+        from api.observability import configure_sentry
+
+        configure_sentry("https://public@example.com/1", "juniper-cascor", "0.0.0")
+        assert captured.get("send_default_pii") is False
+        assert callable(captured.get("before_send"))
+
+
+# =============================================================================
+# SEC-17: snapshot_id traversal validation
+# =============================================================================
+
+
+class TestSEC17SnapshotIDValidation:
+    @pytest.mark.parametrize(
+        "snapshot_id",
+        [
+            "snapshot_20260101_120000",
+            "my-snapshot-v2",
+            "abc",
+            "A" + "b" * 127,
+        ],
+    )
+    def test_valid_snapshot_id_accepted(self, snapshot_id: str) -> None:
+        from api.routes.snapshots import _validate_snapshot_id
+
+        _validate_snapshot_id(snapshot_id)
+
+    @pytest.mark.parametrize(
+        "snapshot_id",
+        [
+            "",
+            "..",
+            "../etc/passwd",
+            "snap/sub",
+            "snap\x00",
+            "snap.h5",
+            "snap with space",
+            "a" * 129,
+        ],
+    )
+    def test_invalid_snapshot_id_rejected(self, snapshot_id: str) -> None:
+        from fastapi import HTTPException
+
+        from api.routes.snapshots import _validate_snapshot_id
+
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_snapshot_id(snapshot_id)
+        assert exc_info.value.status_code == 400

--- a/src/tests/unit/api/test_training_route_coverage.py
+++ b/src/tests/unit/api/test_training_route_coverage.py
@@ -170,12 +170,31 @@ class TestStartTraining:
         assert response.status_code == 409
         assert "cannot be started" in response.json()["detail"].lower()
 
-    def test_start_training_filters_unwhitelisted_params(self, client_with_network):
-        """CR-023 regression: params outside the _ALLOWED_TRAINING_PARAMS
-        whitelist are filtered out (ignored with a warning) rather than
-        forwarded to lifecycle.start_training() as kwargs where they could
-        inject arbitrary behavior. Verifies by patching the lifecycle's
-        start_training and inspecting the forwarded kwargs directly."""
+    def test_start_training_rejects_unknown_params(self, client_with_network):
+        """SEC-07 regression (supersedes CR-023): unknown keys in ``params``
+        are now rejected by Pydantic at the request boundary (422) instead
+        of silently dropped. A whitelisted key plus any unknown key must
+        fail-closed so callers learn about the typo / attack attempt."""
+        response = client_with_network.post(
+            "/v1/training/start",
+            json={
+                "inline_data": {
+                    "train_x": [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6], [0.7, 0.8]],
+                    "train_y": [[1.0, 0.0], [0.0, 1.0], [1.0, 0.0], [0.0, 1.0]],
+                },
+                "params": {
+                    "learning_rate": 0.01,  # allowed
+                    "evil_injection_key": "pwned",  # rejected
+                },
+                "epochs": 1,
+            },
+        )
+        assert response.status_code == 422
+        body = response.json()
+        assert any("evil_injection_key" in str(err) for err in body.get("detail", [])), body
+
+    def test_start_training_accepts_all_known_params(self, client_with_network):
+        """SEC-07: TrainingParams model forwards every known key unchanged."""
         lifecycle = client_with_network.app.state.lifecycle
         with patch.object(lifecycle, "start_training", wraps=lifecycle.start_training) as spy:
             response = client_with_network.post(
@@ -185,22 +204,14 @@ class TestStartTraining:
                         "train_x": [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6], [0.7, 0.8]],
                         "train_y": [[1.0, 0.0], [0.0, 1.0], [1.0, 0.0], [0.0, 1.0]],
                     },
-                    "params": {
-                        "learning_rate": 0.01,  # whitelisted
-                        "evil_injection_key": "pwned",  # NOT whitelisted
-                        "__class__": "hack",  # NOT whitelisted
-                    },
+                    "params": {"learning_rate": 0.01, "patience": 5},
                     "epochs": 1,
                 },
             )
         assert response.status_code == 200
-        spy.assert_called_once()
         forwarded_kwargs = spy.call_args.kwargs
-        # Whitelisted param made it through
         assert forwarded_kwargs.get("learning_rate") == 0.01
-        # Non-whitelisted params are NOT forwarded to lifecycle.start_training()
-        assert "evil_injection_key" not in forwarded_kwargs
-        assert "__class__" not in forwarded_kwargs
+        assert forwarded_kwargs.get("patience") == 5
 
 
 class TestPauseTraining:


### PR DESCRIPTION
## Summary

Phase 1C of Track 1 (Security Hardening) from the V7 Outstanding Items roadmap. Closes five security items in \`juniper-cascor\`:

- **SEC-03** — new setting \`JUNIPER_CASCOR_WS_MAX_CONNECTIONS_PER_IP\` (default 5). \`WebSocketManager\` enforces the cap alongside the global \`ws_max_connections\`, rejects excess with code 1013 \"Per-IP connection limit reached\", and releases the slot on disconnect. Unknown clients all share the sentinel \`"unknown"\` key.
- **SEC-07** — \`params\` on \`TrainingStartRequest\` replaced with a typed \`TrainingParams\` Pydantic model (\`extra=\"forbid\"\`, per-field range constraints mirroring \`TrainingParamUpdateRequest\`). The old hand-maintained whitelist + silent-drop behavior is gone; unknown keys produce 422.
- **SEC-11** — \`_SnapshotRestrictedUnpickler\` locks \`find_class\` to \`{random, _random, collections, collections.abc, _codecs, copyreg}\` plus a small set of builtin container types. RNG-state restore in \`CascadeHDF5Serializer\` now routes through \`_snapshot_restricted_loads\`; anything else raises \`SnapshotUnpicklingError\`.
- **SEC-15** — both Sentry init sites (\`api/observability.py::configure_sentry\` and \`main.py\`) set \`send_default_pii=False\` and register \`_strip_sensitive_headers\` as \`before_send\` (scrubs X-API-Key / Authorization / Cookie).
- **SEC-17** — \`_validate_snapshot_id\` (allowlist \`^[A-Za-z0-9_-]{1,128}$\`) runs before \`GET /snapshots/{snapshot_id}\` and \`POST /snapshots/{snapshot_id}/restore\` hit the lifecycle manager. Invalid IDs return 400 and are audit-logged.

## Test plan

- [x] \`src/tests/unit/api/test_phase1c_security.py\` — 21 new tests across SEC-03 / SEC-11 / SEC-15 / SEC-17
- [x] Updated \`test_training_route_coverage.py\`: old CR-023 silent-drop test superseded by SEC-07 422-rejection test plus a new \"every known key forwards unchanged\" test
- [x] \`src/tests/unit/api/test_phase1c_security.py\` alone: 21 passed (conda \`JuniperCascor\`, Python 3.14.3)
- [x] Related tests (\`test_websocket_manager.py\` + \`test_training_route_coverage.py\`): 34 passed, exit 0
- [ ] Full cascor unit suite validation noted as in-progress; the earlier parallel SEC-18 + stale \`remote_client_0\` tests surface pre-existing collection errors unrelated to this PR.

## Implementation notes

- \`WebsocketManager.__init__\` gained \`max_connections_per_ip=5\`; \`app.py\` wires \`settings.ws_max_connections_per_ip\` through. Per-IP counts live in \`self._per_ip_counts\` under the existing \`self._lock\`.
- \`TrainingParams.extra=\"forbid\"\` is a *breaking* contract change for clients that were sending unknown keys and relying on the old silent-drop behavior. The roadmap calls this out explicitly.
- The snapshot pickle allowlist intentionally rejects \`torch\` and \`numpy\` modules — the HDF5 serializer only pickles Python RNG state; tensor data goes through \`save_tensor\`/\`load_tensor\` which do not use pickle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)