### PR TITLE
fix(phase-2c): juniper-cascor memory leaks and body-limit bypass (BUG-CC-13/14/15)

### DIFF
--- a/src/api/middleware.py
+++ b/src/api/middleware.py
@@ -88,9 +88,16 @@ class RequestBodyLimitMiddleware(BaseHTTPMiddleware):
             if declared_length > self._max_bytes:
                 return JSONResponse(status_code=_PROJECT_API_HTTP_413_PAYLOAD_TOO_LARGE, content={"detail": "Request body too large"})
         if content_length is None and request.method in ("POST", "PUT", "PATCH"):
-            body = await request.body()
-            if len(body) > self._max_bytes:
-                return JSONResponse(status_code=_PROJECT_API_HTTP_413_PAYLOAD_TOO_LARGE, content={"detail": "Request body too large"})
+            # BUG-CC-15: stream-read with early abort to avoid buffering full body before size check.
+            chunks: list[bytes] = []
+            size = 0
+            async for chunk in request.stream():
+                size += len(chunk)
+                if size > self._max_bytes:
+                    return JSONResponse(status_code=_PROJECT_API_HTTP_413_PAYLOAD_TOO_LARGE, content={"detail": "Request body too large"})
+                chunks.append(chunk)
+            # Cache body for downstream handlers (Starlette convention).
+            request._body = b"".join(chunks)
         return await call_next(request)
 
 

--- a/src/api/security.py
+++ b/src/api/security.py
@@ -1,6 +1,7 @@
 """API security: authentication and rate limiting middleware."""
 
 import hmac
+import logging
 import time
 from collections import defaultdict
 from threading import Lock
@@ -9,6 +10,8 @@ from fastapi import HTTPException, Request, status
 from fastapi.security import APIKeyHeader
 
 from .settings import get_settings
+
+logger = logging.getLogger(__name__)
 
 api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
 
@@ -88,6 +91,10 @@ class RateLimiter:
     implementation suitable for single-process deployments.
     """
 
+    # BUG-CC-13: bounded periodic cleanup to prevent unbounded counter growth.
+    _CLEANUP_INTERVAL = 100  # Run cleanup every N check() calls.
+    _MAX_ENTRIES = 10_000  # Hard cap on _counters entries.
+
     def __init__(
         self,
         requests_per_minute: int = 60,
@@ -106,6 +113,22 @@ class RateLimiter:
         self._enabled = enabled
         self._counters: dict[str, tuple[int, float]] = defaultdict(lambda: (0, 0.0))
         self._lock = Lock()
+        self._request_count_since_cleanup = 0  # BUG-CC-13: tracks calls between prunes.
+
+    def _maybe_cleanup(self) -> None:
+        """BUG-CC-13: lazy-prune expired counter buckets. Caller must hold ``_lock``."""
+        now = time.time()
+        cutoff = now - (2 * self._window)
+        expired_keys = [k for k, (_, ts) in self._counters.items() if ts < cutoff]
+        for k in expired_keys:
+            del self._counters[k]
+        if expired_keys:
+            logger.debug("RateLimiter: pruned %d expired entries", len(expired_keys))
+        if len(self._counters) > self._MAX_ENTRIES:
+            # Hard cap: drop oldest entries by window_start timestamp.
+            sorted_keys = sorted(self._counters, key=lambda k: self._counters[k][1])
+            for k in sorted_keys[: len(self._counters) - self._MAX_ENTRIES]:
+                del self._counters[k]
 
     @property
     def enabled(self) -> bool:
@@ -154,6 +177,12 @@ class RateLimiter:
         now = time.time()
 
         with self._lock:
+            # BUG-CC-13: trigger periodic cleanup to bound memory.
+            self._request_count_since_cleanup += 1
+            if self._request_count_since_cleanup >= self._CLEANUP_INTERVAL:
+                self._maybe_cleanup()
+                self._request_count_since_cleanup = 0
+
             count, window_start = self._counters[key]
 
             if now - window_start >= self._window:
@@ -202,6 +231,7 @@ class RateLimiter:
         """Reset all rate limit counters. Useful for testing."""
         with self._lock:
             self._counters.clear()
+            self._request_count_since_cleanup = 0
 
 
 _api_key_auth: APIKeyAuth | None = None

--- a/src/api/websocket/control_security.py
+++ b/src/api/websocket/control_security.py
@@ -81,6 +81,9 @@ class HandshakeCooldown:
     Cleared on server restart (NAT-hostile escape hatch).
     """
 
+    # BUG-CC-14: prune stale rejection histories every N record_rejection calls.
+    _CLEANUP_EVERY_N = 50
+
     def __init__(self, max_rejections: int = 10, window_sec: int = 60, block_sec: int = 300):
         self._max_rejections = max_rejections
         self._window_sec = window_sec
@@ -88,6 +91,17 @@ class HandshakeCooldown:
         self._rejections: dict[str, list[float]] = defaultdict(list)
         self._blocked_until: dict[str, float] = {}
         self._lock = threading.Lock()
+        self._total_rejections_since_cleanup = 0  # BUG-CC-14: cleanup tick counter.
+
+    def _maybe_full_cleanup(self) -> None:
+        """BUG-CC-14: prune ALL stale rejection entries across all IPs. Caller must hold ``_lock``."""
+        now = time.monotonic()
+        cutoff = now - (2 * self._window_sec)
+        stale_ips = [ip for ip, timestamps in self._rejections.items() if not timestamps or all(t < cutoff for t in timestamps)]
+        for ip in stale_ips:
+            del self._rejections[ip]
+        if stale_ips:
+            logger.debug("HandshakeCooldown: pruned rejection history for %d stale IPs", len(stale_ips))
 
     def is_blocked(self, client_ip: str) -> bool:
         """Check if an IP is currently blocked."""
@@ -108,6 +122,12 @@ class HandshakeCooldown:
             # Prune old entries
             self._rejections[client_ip] = [t for t in timestamps if t > cutoff]
             self._rejections[client_ip].append(now)
+
+            # BUG-CC-14: periodically prune stale histories for non-blocked IPs.
+            self._total_rejections_since_cleanup += 1
+            if self._total_rejections_since_cleanup >= self._CLEANUP_EVERY_N:
+                self._maybe_full_cleanup()
+                self._total_rejections_since_cleanup = 0
 
             if len(self._rejections[client_ip]) >= self._max_rejections:
                 self._blocked_until[client_ip] = now + self._block_sec

--- a/src/tests/unit/api/test_api_middleware.py
+++ b/src/tests/unit/api/test_api_middleware.py
@@ -172,3 +172,52 @@ class TestRequestBodyLimitMiddleware:
 
         response = client.post("/echo", content=body_gen())
         assert response.status_code == 413
+
+    @pytest.mark.asyncio
+    async def test_bug_cc_15_chunked_body_aborts_before_full_buffer(self):
+        """BUG-CC-15: middleware must abort streaming read before consuming the full body.
+
+        Verified at the dispatch level by counting how many chunks ``request.stream()``
+        yields before the middleware aborts. With max_bytes=1024 and 20 x 512-byte
+        chunks (total 10240 bytes), the middleware must return 413 after reading
+        at most ~1024 + 1 chunk, not 10240 bytes.
+        """
+        from unittest.mock import MagicMock
+
+        bytes_yielded = 0
+
+        async def stream_gen():
+            nonlocal bytes_yielded
+            for _ in range(20):
+                chunk = b"A" * 512
+                bytes_yielded += len(chunk)
+                yield chunk
+
+        request = MagicMock()
+        request.headers = {}
+        request.method = "POST"
+        request.stream = stream_gen
+
+        async def call_next(_req):  # pragma: no cover — should not be reached.
+            raise AssertionError("call_next should not run after 413 abort")
+
+        middleware = RequestBodyLimitMiddleware(app=MagicMock(), max_bytes=1024)
+        response = await middleware.dispatch(request, call_next)
+
+        assert response.status_code == 413
+        # Streaming early-abort: should abort within a single chunk past the limit.
+        assert bytes_yielded <= 1024 + 512, f"Streaming read consumed {bytes_yielded} bytes — should abort near the 1024 byte limit"
+
+    def test_bug_cc_15_body_cached_for_downstream_handlers(self, body_limit_app):
+        """BUG-CC-15: after streaming read, body must remain readable by downstream handlers."""
+        client = TestClient(body_limit_app)
+
+        # Send a chunked body under the limit; handler must still be able to parse JSON.
+        def body_gen():
+            yield b'{"a":"b'
+            yield b'","c":"d"}'
+
+        response = client.post("/echo", content=body_gen())
+        assert response.status_code == 200
+        # Handler echoes received_bytes; presence + 200 confirm body was readable downstream.
+        assert "received_bytes" in response.json()

--- a/src/tests/unit/api/test_api_security.py
+++ b/src/tests/unit/api/test_api_security.py
@@ -251,6 +251,66 @@ class TestRateLimiter:
 
 
 @pytest.mark.unit
+class TestRateLimiterBugCC13Cleanup:
+    """BUG-CC-13: RateLimiter._counters must be pruned to prevent unbounded growth."""
+
+    def test_expired_entries_pruned_after_cleanup_interval(self) -> None:
+        """After CLEANUP_INTERVAL calls, expired entries (older than 2*window) are removed."""
+        limiter = RateLimiter(requests_per_minute=1000, window_seconds=1, enabled=True)
+        # Seed many distinct keys; each will create a counter entry.
+        for i in range(50):
+            limiter.check(f"key-{i}")
+        # Force timestamps into the past so they are eligible for eviction.
+        with limiter._lock:
+            for k in list(limiter._counters):
+                count, _ts = limiter._counters[k]
+                limiter._counters[k] = (count, time.time() - (2 * limiter._window) - 1)
+        # Drive cleanup by reaching CLEANUP_INTERVAL across one fresh key.
+        for _ in range(limiter._CLEANUP_INTERVAL):
+            limiter.check("driver-key")
+        # Only the driver key should remain; expired keys pruned.
+        with limiter._lock:
+            assert "driver-key" in limiter._counters
+            for i in range(50):
+                assert f"key-{i}" not in limiter._counters
+
+    def test_unbounded_growth_prevented_by_max_entries_cap(self) -> None:
+        """Hard cap _MAX_ENTRIES prevents unbounded counter growth even with fresh keys."""
+        limiter = RateLimiter(requests_per_minute=10, window_seconds=60, enabled=True)
+        # Override cap and interval to keep test fast.
+        limiter._MAX_ENTRIES = 100
+        limiter._CLEANUP_INTERVAL = 50
+        # Insert many more keys than the cap; each is fresh so not "expired".
+        for i in range(500):
+            limiter.check(f"key-{i}")
+        # After cleanup runs, dict size must be bounded near _MAX_ENTRIES
+        # (allow +1 for the current request's freshly-inserted key after the
+        # cleanup pass that ran at the start of this same check() call).
+        assert len(limiter._counters) <= limiter._MAX_ENTRIES + 1
+        # And critically: it must not approach the unbounded-growth scale (500).
+        assert len(limiter._counters) < 200
+
+    def test_cleanup_does_not_evict_fresh_entries_under_cap(self) -> None:
+        """Entries within the active window must not be pruned by periodic cleanup."""
+        limiter = RateLimiter(requests_per_minute=10, window_seconds=60, enabled=True)
+        limiter._CLEANUP_INTERVAL = 5
+        for i in range(20):
+            limiter.check(f"fresh-{i}")
+        # All 20 fresh keys should still be present.
+        for i in range(20):
+            assert f"fresh-{i}" in limiter._counters
+
+    def test_reset_clears_cleanup_counter(self) -> None:
+        """reset() should also reset the cleanup tick counter."""
+        limiter = RateLimiter(requests_per_minute=5, enabled=True)
+        for _ in range(5):
+            limiter.check("key")
+        assert limiter._request_count_since_cleanup > 0
+        limiter.reset()
+        assert limiter._request_count_since_cleanup == 0
+
+
+@pytest.mark.unit
 class TestSecurityModuleFunctions:
     """Tests for module-level security functions."""
 

--- a/src/tests/unit/api/test_control_security.py
+++ b/src/tests/unit/api/test_control_security.py
@@ -151,6 +151,53 @@ class TestHandshakeCooldown:
 
 
 @pytest.mark.unit
+class TestHandshakeCooldownBugCC14Cleanup:
+    """BUG-CC-14: HandshakeCooldown._rejections must be pruned for non-blocked IPs."""
+
+    def test_stale_non_blocked_ips_pruned_after_threshold(self):
+        """After CLEANUP_EVERY_N record_rejection calls, stale non-blocked IPs are dropped."""
+        cd = HandshakeCooldown(max_rejections=1000, window_sec=60, block_sec=300)
+        cd._CLEANUP_EVERY_N = 10
+        # Seed 50 non-blocked IPs each with a single rejection.
+        for i in range(50):
+            cd.record_rejection(f"10.0.0.{i}")
+        # All present so far (cleanup not yet triggered to prune them since they are fresh).
+        assert len(cd._rejections) == 50
+
+        # Push their timestamps far into the past (beyond 2 * window_sec).
+        with cd._lock:
+            for ip in list(cd._rejections):
+                cd._rejections[ip] = [time.monotonic() - (2 * cd._window_sec) - 5]
+
+        # Drive cleanup using a single different IP so its history stays fresh.
+        for _ in range(cd._CLEANUP_EVERY_N):
+            cd.record_rejection("9.9.9.9")
+
+        # The 50 stale non-blocked IPs should have been pruned.
+        for i in range(50):
+            assert f"10.0.0.{i}" not in cd._rejections
+        assert "9.9.9.9" in cd._rejections
+
+    def test_blocked_ips_not_in_rejections_after_block(self):
+        """Sanity: a blocked IP's rejection list is cleared by record_rejection itself."""
+        cd = HandshakeCooldown(max_rejections=2, window_sec=60, block_sec=300)
+        cd.record_rejection("1.1.1.1")
+        cd.record_rejection("1.1.1.1")  # triggers block, clears list.
+        assert cd._rejections.get("1.1.1.1", []) == []
+        assert cd.is_blocked("1.1.1.1") is True
+
+    def test_fresh_non_blocked_ips_preserved(self):
+        """Cleanup must not remove IPs whose timestamps are within the active window."""
+        cd = HandshakeCooldown(max_rejections=100, window_sec=60, block_sec=300)
+        cd._CLEANUP_EVERY_N = 5
+        for i in range(20):
+            cd.record_rejection(f"172.16.0.{i}")
+        # All entries are fresh, so even after cleanup runs they remain.
+        for i in range(20):
+            assert f"172.16.0.{i}" in cd._rejections
+
+
+@pytest.mark.unit
 class TestControlSecuritySettings:
     """Test Phase B-pre-b settings."""
 


### PR DESCRIPTION
## Summary

Phase 2C of the Juniper outstanding-items roadmap. Three independent fixes in `juniper-cascor`:

- **BUG-CC-13** (MEDIUM, `src/api/security.py`): `RateLimiter._counters` had no eviction mechanism, leading to unbounded memory growth (one entry per unique key/IP forever). Added `_maybe_cleanup()` mirroring the existing `ConnectionRateLimiter` pattern: runs every 100 `check()` calls, evicts buckets older than `2 * window_seconds`, and hard-caps at 10,000 entries (oldest by window_start dropped first).
- **BUG-CC-14** (LOW, `src/api/websocket/control_security.py`): `HandshakeCooldown._rejections` only pruned the *current* IP per-call, leaving stale histories for non-blocked IPs forever. Added `_maybe_full_cleanup()` that runs every 50 `record_rejection()` calls and removes IPs whose timestamps are all older than `2 * window_sec`.
- **BUG-CC-15** (HIGH, `src/api/middleware.py`): `RequestBodyLimitMiddleware` called `await request.body()` on the no-Content-Length path, allocating the full body before the size check (SEC-08 partial reopening; the docstring claimed streaming, but the implementation did not). Replaced with `async for chunk in request.stream()` plus an early 413 abort when cumulative bytes exceed `max_bytes`. Body is cached on `request._body` so downstream FastAPI handlers can still read it.

All changes follow the recommended approaches from the roadmap (notes/JUNIPER_OUTSTANDING_DEVELOPMENT_ITEMS_V7_IMPLEMENTATION_ROADMAP.md sections 2053+, 2132+, 2201+).

## Test coverage added

- `src/tests/unit/api/test_api_security.py::TestRateLimiterBugCC13Cleanup` (4 tests)
  - Expired entries pruned after CLEANUP_INTERVAL
  - Hard cap (`_MAX_ENTRIES`) prevents unbounded growth even with all-fresh keys
  - Fresh entries within active window are not evicted
  - `reset()` clears the cleanup tick counter
- `src/tests/unit/api/test_control_security.py::TestHandshakeCooldownBugCC14Cleanup` (3 tests)
  - Stale non-blocked IPs pruned after CLEANUP_EVERY_N rejections
  - Blocked IPs cleared from `_rejections` (existing behavior preserved)
  - Fresh non-blocked IPs preserved across cleanup
- `src/tests/unit/api/test_api_middleware.py` (2 tests)
  - `test_bug_cc_15_chunked_body_aborts_before_full_buffer` — counts bytes consumed via mocked `request.stream()` and asserts the middleware aborts within one chunk past the limit
  - `test_bug_cc_15_body_cached_for_downstream_handlers` — verifies cached body remains readable by downstream handlers via TestClient

Total: 9 new tests. All 75 existing+new tests in `test_api_security.py`, `test_control_security.py`, and `test_api_middleware.py` pass. Full `src/tests/unit/api/` suite passes (rc=0).

## Test plan

- [ ] CI pre-commit hooks green
- [ ] CI unit tests green
- [ ] CI integration tests green
- [ ] Manual review of memory bounds (`_MAX_ENTRIES=10000`, `CLEANUP_INTERVAL=100`, `CLEANUP_EVERY_N=50`)

## Notes

- No backwards-compat shims; behavior is purely additive (eviction of stale entries / earlier 413 on oversized streamed bodies).
- One inline comment per fix site tagged with the bug ID for traceability.
- No deviations from the roadmap's recommended approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)