### PR TITLE
fix(observability): bound Prometheus middleware label cardinality (R1.1 / seed-01)

### DIFF
--- a/src/api/observability.py
+++ b/src/api/observability.py
@@ -61,6 +61,14 @@ class RequestIdMiddleware(BaseHTTPMiddleware):
             request_id_var.reset(token)
 
 
+# METRICS-MON seed-01 / R1.1: bound cardinality. Restrict the ``endpoint``
+# label to the resolved Starlette route template; collapse unmatched
+# requests into ``UNMATCHED_ENDPOINT_LABEL`` and increment a separate
+# counter so unmatched volume stays observable without polluting the
+# histogram. Aligned with the same fix in juniper-data and juniper-canopy.
+UNMATCHED_ENDPOINT_LABEL = "_unmatched"
+
+
 class PrometheusMiddleware(BaseHTTPMiddleware):
     """Tracks http_requests_total and http_request_duration_seconds with namespace prefix."""
 
@@ -79,6 +87,11 @@ class PrometheusMiddleware(BaseHTTPMiddleware):
             "HTTP request duration in seconds",
             ["method", "endpoint"],
         )
+        self._unmatched_count = Counter(
+            f"{prefix}http_unmatched_requests_total",
+            "HTTP requests not matching any registered route template",
+            ["method"],
+        )
 
     async def dispatch(
         self,
@@ -90,8 +103,14 @@ class PrometheusMiddleware(BaseHTTPMiddleware):
         duration = time.perf_counter() - start
 
         route = request.scope.get("route")
-        endpoint = route.path if route else "unmatched"
+        template = getattr(route, "path", None) if route is not None else None
         method = request.method
+        if template:
+            endpoint = template
+        else:
+            endpoint = UNMATCHED_ENDPOINT_LABEL
+            self._unmatched_count.labels(method=method).inc()
+
         status = str(response.status_code)
 
         self._request_count.labels(method=method, endpoint=endpoint, status=status).inc()

--- a/src/tests/unit/test_api_observability.py
+++ b/src/tests/unit/test_api_observability.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from api.observability import JuniperJsonFormatter, PrometheusMiddleware, RequestIdMiddleware, configure_logging, configure_sentry, get_prometheus_app, record_training_epoch, request_id_var, set_build_info, set_training_loss
+from api.observability import UNMATCHED_ENDPOINT_LABEL, JuniperJsonFormatter, PrometheusMiddleware, RequestIdMiddleware, configure_logging, configure_sentry, get_prometheus_app, record_training_epoch, request_id_var, set_build_info, set_training_loss
 
 
 @pytest.mark.unit
@@ -173,12 +173,27 @@ class TestRequestIdMiddleware:
 class TestPrometheusMiddleware:
     """Tests for PrometheusMiddleware."""
 
+    @staticmethod
+    def _build_request(*, method: str, url_path: str, route_template: str | None) -> MagicMock:
+        request = MagicMock()
+        request.url.path = url_path
+        request.method = method
+        if route_template is None:
+            request.scope = {}
+        else:
+            route = MagicMock()
+            route.path = route_template
+            request.scope = {"route": route}
+        return request
+
     @pytest.mark.asyncio
-    async def test_increments_counter_and_records_histogram(self):
+    async def test_matched_route_uses_template_for_endpoint_label(self):
+        """When Starlette resolves a route, the endpoint label is the template, not the raw URL."""
         with patch("prometheus_client.Counter") as MockCounter, patch("prometheus_client.Histogram") as MockHistogram:
-            mock_counter = MagicMock()
+            request_count = MagicMock()
+            unmatched_count = MagicMock()
+            MockCounter.side_effect = [request_count, unmatched_count]
             mock_histogram = MagicMock()
-            MockCounter.return_value = mock_counter
             MockHistogram.return_value = mock_histogram
 
             middleware = PrometheusMiddleware(app=MagicMock(), service_name="test", namespace="juniper_cascor")
@@ -189,36 +204,77 @@ class TestPrometheusMiddleware:
             async def mock_call_next(request):
                 return response
 
-            mock_route = MagicMock()
-            mock_route.path = "/v1/test"
-
-            request = MagicMock()
-            request.scope = {"route": mock_route}
-            request.url.path = "/v1/test"
-            request.method = "GET"
-
+            request = self._build_request(method="GET", url_path="/v1/training/abc-123", route_template="/v1/training/{run_id}")
             result = await middleware.dispatch(request, mock_call_next)
 
-            mock_counter.labels.assert_called_once_with(method="GET", endpoint="/v1/test", status="200")
-            mock_counter.labels().inc.assert_called_once()
-            mock_histogram.labels.assert_called_once_with(method="GET", endpoint="/v1/test")
+            request_count.labels.assert_called_once_with(method="GET", endpoint="/v1/training/{run_id}", status="200")
+            request_count.labels().inc.assert_called_once()
+            mock_histogram.labels.assert_called_once_with(method="GET", endpoint="/v1/training/{run_id}")
             mock_histogram.labels().observe.assert_called_once()
+            unmatched_count.labels.assert_not_called()
             assert result == response
 
     @pytest.mark.asyncio
+    async def test_unmatched_route_collapses_to_single_label(self):
+        """No resolved route → endpoint label collapses to UNMATCHED_ENDPOINT_LABEL and unmatched counter increments."""
+        with patch("prometheus_client.Counter") as MockCounter, patch("prometheus_client.Histogram") as MockHistogram:
+            request_count = MagicMock()
+            unmatched_count = MagicMock()
+            MockCounter.side_effect = [request_count, unmatched_count]
+            MockHistogram.return_value = MagicMock()
+
+            middleware = PrometheusMiddleware(app=MagicMock(), service_name="test", namespace="juniper_cascor")
+
+            response = MagicMock()
+            response.status_code = 404
+
+            async def mock_call_next(request):
+                return response
+
+            request = self._build_request(method="GET", url_path="/totally/unknown/path", route_template=None)
+            await middleware.dispatch(request, mock_call_next)
+
+            request_count.labels.assert_called_once_with(method="GET", endpoint=UNMATCHED_ENDPOINT_LABEL, status="404")
+            unmatched_count.labels.assert_called_once_with(method="GET")
+            unmatched_count.labels().inc.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cardinality_bounded_under_high_entropy_paths(self):
+        """Sending N distinct unmatched URLs must still produce only one endpoint label value."""
+        with patch("prometheus_client.Counter") as MockCounter, patch("prometheus_client.Histogram") as MockHistogram:
+            request_count = MagicMock()
+            unmatched_count = MagicMock()
+            MockCounter.side_effect = [request_count, unmatched_count]
+            MockHistogram.return_value = MagicMock()
+
+            middleware = PrometheusMiddleware(app=MagicMock(), service_name="test", namespace="juniper_cascor")
+
+            response = MagicMock()
+            response.status_code = 404
+
+            async def mock_call_next(request):
+                return response
+
+            for i in range(50):
+                request = self._build_request(method="GET", url_path=f"/attacker/{i}/abc", route_template=None)
+                await middleware.dispatch(request, mock_call_next)
+
+            distinct_endpoints = {call.kwargs["endpoint"] for call in request_count.labels.call_args_list}
+            assert distinct_endpoints == {UNMATCHED_ENDPOINT_LABEL}, f"endpoint label cardinality leaked: {distinct_endpoints}"
+            assert unmatched_count.labels.call_count == 50
+
+    @pytest.mark.asyncio
     async def test_namespace_prefix_applied_to_metric_names(self):
-        """Verify that the namespace parameter prefixes metric names."""
+        """Verify that the namespace parameter prefixes all three metric names."""
         with patch("prometheus_client.Counter") as MockCounter, patch("prometheus_client.Histogram") as MockHistogram:
             MockCounter.return_value = MagicMock()
             MockHistogram.return_value = MagicMock()
 
             PrometheusMiddleware(app=MagicMock(), service_name="test", namespace="juniper_cascor")
 
-            MockCounter.assert_called_once_with(
-                "juniper_cascor_http_requests_total",
-                "Total HTTP requests",
-                ["method", "endpoint", "status"],
-            )
+            counter_names = [call.args[0] for call in MockCounter.call_args_list]
+            assert "juniper_cascor_http_requests_total" in counter_names
+            assert "juniper_cascor_http_unmatched_requests_total" in counter_names
             MockHistogram.assert_called_once_with(
                 "juniper_cascor_http_request_duration_seconds",
                 "HTTP request duration in seconds",


### PR DESCRIPTION
## Summary

Aligns juniper-cascor's \`PrometheusMiddleware\` with the cross-repo cardinality contract introduced in pcalnon/juniper-data#49.

The middleware previously used the bare string \`\"unmatched\"\` for unresolved routes and did not expose unmatched-traffic volume on a separate counter. The \`endpoint\` label now takes only one of two values:
- the **resolved Starlette route template** (e.g. \`/v1/training/{run_id}\`), or
- the literal string \`\"_unmatched\"\` (consistent with juniper-data and juniper-canopy).

A new counter \`juniper_cascor_http_unmatched_requests_total{method}\` makes unmatched-traffic volume observable.

## Why

Roadmap item **R1.1** under [notes/code-review/METRICS_MONITORING_ROADMAP_2026-04-25.md](https://github.com/pcalnon/juniper-ml/blob/worktree-smooth-floating-umbrella/notes/code-review/METRICS_MONITORING_ROADMAP_2026-04-25.md#41-bound-prometheus-middleware-cardinality-seed-01), seed finding **seed-01**. Composite severity 4 (release-blocking).

Companion PRs: pcalnon/juniper-data#49, juniper-canopy (next).

## Test plan

- [x] Tests parse cleanly; \`UNMATCHED_ENDPOINT_LABEL\` exported and 4 \`TestPrometheusMiddleware\` methods present
- [x] \`pre-commit run\` clean (Black, isort, Flake8, MyPy, Bandit)
- [ ] Pytest local execution: pre-existing segfault on Python 3.14t free-threaded build (\`_brotli\` C extension; reproduces on \`main\` HEAD without my changes — **unrelated**, environmental). CI will validate.

### New tests

- \`test_matched_route_uses_template_for_endpoint_label\` — template wins over raw URL
- \`test_unmatched_route_collapses_to_single_label\` — unmatched routes use \`_unmatched\` and increment the unmatched counter
- \`test_cardinality_bounded_under_high_entropy_paths\` — 50 distinct unmatched URLs produce exactly 1 endpoint-label value

## Backwards compatibility

The \`endpoint\` label value for unresolved routes changes from \`\"unmatched\"\` (no underscore) to \`\"_unmatched\"\`. Any dashboard or alert rule keyed on \`\"unmatched\"\` must be updated. This brings cascor into alignment with juniper-data and juniper-canopy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)