### PR TITLE
fix(health): R1.2 probe semantics + lifecycle heartbeat (seed-02 / seed-03)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed (potentially breaking)
+
+- **METRICS-MON R1.2 / seed-02 / seed-03**: `/v1/health/ready` now returns **HTTP 503** (not 200) when a required dependency is unhealthy, with body `status="not_ready"`. Required deps for cascor are the lifecycle manager (always) and JuniperData (when `JUNIPER_DATA_URL` is set). `/v1/health/live` runs an in-process liveness tick (consults a new `lifecycle.is_alive()` accessor backed by a 1-second heartbeat counter) within a 250 ms budget and returns **HTTP 503** on tick failure or budget exceedance. Both endpoints emit a new `X-Juniper-Readiness` header / liveness body fields (`tick`, `duration_ms`) so probe diagnostics surface in orchestrator logs without body parsing. Adds `TrainingLifecycleManager.bump_liveness()`, `is_alive(stale_after_seconds=30.0)`, and `stop_liveness_heartbeat()` plumbing; `TrainingMonitor` event callbacks (epoch, cascade, phase-change, training-start/end, candidate-progress, topology-change) bump the heartbeat so progress in the training thread is an additional liveness signal. See [`notes/code-review/METRICS_MONITORING_R1.2_PROBE_DESIGN_2026-04-27.md`](https://github.com/pcalnon/juniper-ml/blob/main/notes/code-review/METRICS_MONITORING_R1.2_PROBE_DESIGN_2026-04-27.md) in juniper-ml for the cross-repo contract; companion PRs land in juniper-data, juniper-canopy, and juniper-deploy. `/v1/health` (the legacy combined endpoint) is unchanged.
+
 ### Added
 
 - Phase D (§S10) per-command timeouts on `/ws/control`: commands dispatched via `asyncio.to_thread` and bounded by `asyncio.wait_for` with `start=10s`, `stop/pause/resume/reset=2s`, `set_params=1s`. Timeouts emit `command_response{status:"error", error:"Command timed out after Ns"}` while the connection stays open.

--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -77,7 +77,73 @@ class TrainingLifecycleManager:
         # Worker coordinator (set via set_worker_coordinator)
         self._worker_coordinator = None
 
+        # METRICS-MON R1.2 / seed-03: liveness heartbeat. A 1-second daemon
+        # bumps ``_liveness_counter`` and ``_liveness_last_tick_at``; the
+        # liveness probe consults ``is_alive()`` to detect a wedged process.
+        # The TrainingMonitor callbacks also bump the counter so progress
+        # in the training thread is an additional liveness signal.
+        self._liveness_counter: int = 0
+        self._liveness_last_tick_at: float = time.monotonic()
+        self._liveness_lock = threading.Lock()
+        self._liveness_stop_event = threading.Event()
+        self._liveness_thread: Optional[threading.Thread] = None
+        self._start_liveness_thread()
+        self._register_liveness_monitor_callbacks()
+
         self.logger.info("TrainingLifecycleManager initialized")
+
+    def _register_liveness_monitor_callbacks(self) -> None:
+        """Bump the heartbeat from every training-monitor event so progress
+        in the training thread is an additional liveness signal.
+        """
+        bump = lambda **_kw: self.bump_liveness()  # noqa: E731 — concise wrapper
+        for event in ("epoch_start", "epoch_end", "cascade_add", "training_start", "training_end", "topology_change", "candidate_progress", "phase_change"):
+            self.training_monitor.register_callback(event, bump)
+
+    def bump_liveness(self) -> None:
+        """Record that the lifecycle is making forward progress.
+
+        Called from the 1-second daemon thread and from TrainingMonitor
+        event callbacks. The probe layer reads the resulting timestamp
+        via ``is_alive()`` to decide liveness.
+        """
+        with self._liveness_lock:
+            self._liveness_counter += 1
+            self._liveness_last_tick_at = time.monotonic()
+
+    def is_alive(self, stale_after_seconds: float = 30.0) -> bool:
+        """Return True if the heartbeat has been bumped within the window.
+
+        ``stale_after_seconds`` defaults to 30 s — well above the daemon
+        thread's 1-second cadence, so transient scheduling jitter does
+        not flap liveness, but well below typical Helm
+        ``failureThreshold`` × ``periodSeconds`` so real wedges still
+        get caught.
+        """
+        with self._liveness_lock:
+            last = self._liveness_last_tick_at
+        return (time.monotonic() - last) < stale_after_seconds
+
+    def _start_liveness_thread(self) -> None:
+        """Start the 1-second daemon that bumps the heartbeat."""
+
+        def _loop() -> None:
+            while not self._liveness_stop_event.is_set():
+                self.bump_liveness()
+                self._liveness_stop_event.wait(1.0)
+
+        self._liveness_thread = threading.Thread(
+            target=_loop,
+            name="lifecycle-liveness",
+            daemon=True,
+        )
+        self._liveness_thread.start()
+
+    def stop_liveness_heartbeat(self) -> None:
+        """Stop the heartbeat thread (used in shutdown / tests)."""
+        self._liveness_stop_event.set()
+        if self._liveness_thread is not None:
+            self._liveness_thread.join(timeout=2.0)
 
     def set_ws_manager(self, ws_manager, state_throttle_interval: float = 1.0) -> None:
         """Set the WebSocket manager for real-time broadcasting.
@@ -1003,6 +1069,7 @@ class TrainingLifecycleManager:
     def shutdown(self) -> None:
         """Clean up resources."""
         self._stop_requested.set()
+        self.stop_liveness_heartbeat()
         self._restore_original_methods()
         if self._executor:
             self._executor.shutdown(wait=False, cancel_futures=True)

--- a/src/api/routes/health.py
+++ b/src/api/routes/health.py
@@ -1,45 +1,128 @@
 """Health check endpoints for container orchestration.
 
 Provides three health check endpoints:
+
 - /v1/health: Combined health check (backward compatible)
-- /v1/health/live: Liveness probe - is the process running?
-- /v1/health/ready: Readiness probe - is the service ready to accept traffic?
+- /v1/health/live: Liveness probe — runs an in-process tick within a strict
+  budget; returns 503 if the lifecycle heartbeat is stale or no lifecycle
+  is bound, so the orchestrator can restart wedged pods.
+- /v1/health/ready: Readiness probe — returns 200 when all required
+  dependencies are healthy, 200 with status "degraded" when only optional
+  dependencies are unhealthy, and 503 when a required dependency is
+  unhealthy so load balancers can shed traffic without parsing the body.
 
 Health endpoints return flat JSON (not wrapped in ResponseEnvelope) for
 compatibility with Docker healthcheck and Kubernetes httpGet probes that
 expect a top-level ``status`` field.
+
+See ``notes/code-review/METRICS_MONITORING_R1.2_PROBE_DESIGN_2026-04-27.md``
+in juniper-ml for the cross-repo contract this implements (R1.2 / seed-02
+and seed-03).
 """
 
 import os
+import time
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Request, Response
 
-from api.models.health import ReadinessResponse, probe_dependency
+from api.models.health import DependencyStatus, ReadinessResponse, probe_dependency
 
 _API_VERSION: str = "0.4.0"
+
+# R1.2: liveness tick budget. The tick is purely in-process (consults the
+# lifecycle heartbeat counter); 250 ms catches event-loop stalls and CPU
+# starvation. Helm timeoutSeconds (5–10) wraps this with headroom.
+LIVENESS_TICK_BUDGET_MS = 250
+
+# R1.2: header surfaces readiness state to ``kubectl describe pod`` /
+# ``curl -I`` without requiring body parsing.
+READINESS_HEADER = "X-Juniper-Readiness"
+
+# R1.2: heartbeat staleness threshold. Lifecycle daemon thread bumps every
+# 1 second; a staleness > 30 s reliably indicates a wedged process.
+LIVENESS_STALENESS_SECONDS = 30.0
 
 router = APIRouter(tags=["health"])
 
 
+def _liveness_tick(request: Request) -> None:
+    """Run the juniper-cascor liveness tick.
+
+    Pure in-process work: consults ``app.state.lifecycle.is_alive()``.
+    Raises if the lifecycle is missing or the heartbeat is stale.
+    """
+    lifecycle = getattr(request.app.state, "lifecycle", None)
+    if lifecycle is None:
+        raise RuntimeError("lifecycle manager not bound on app.state")
+    if not lifecycle.is_alive(stale_after_seconds=LIVENESS_STALENESS_SECONDS):
+        raise RuntimeError(f"lifecycle heartbeat stale (> {LIVENESS_STALENESS_SECONDS}s)")
+
+
 @router.get("/health")
 async def health_check() -> dict:
-    """Combined health check endpoint (backward compatible)."""
+    """Combined health check endpoint (backward compatible).
+
+    Always returns 200 while the process can respond. Reserved for legacy
+    integrations; new probes should use ``/health/live`` or
+    ``/health/ready``.
+    """
     return {"status": "ok", "version": _API_VERSION}
 
 
 @router.get("/health/live")
-async def liveness_probe() -> dict:
-    """Liveness probe for container orchestration."""
-    return {"status": "alive"}
+async def liveness_probe(request: Request, response: Response) -> dict:
+    """Liveness probe — runs an in-process tick within a strict budget.
+
+    Returns 200 with ``{"status": "alive", "tick": "juniper-cascor",
+    "duration_ms": N}`` when the tick succeeds within
+    ``LIVENESS_TICK_BUDGET_MS``. Returns 503 with ``{"status":
+    "unresponsive", ...}`` otherwise.
+    """
+    started = time.perf_counter()
+    try:
+        _liveness_tick(request)
+    except Exception as exc:  # noqa: BLE001 — health probe must surface every failure
+        duration_ms = int((time.perf_counter() - started) * 1000)
+        response.status_code = 503
+        return {
+            "status": "unresponsive",
+            "tick": "juniper-cascor",
+            "error": str(exc),
+            "duration_ms": duration_ms,
+        }
+
+    duration_ms = int((time.perf_counter() - started) * 1000)
+    if duration_ms > LIVENESS_TICK_BUDGET_MS:
+        response.status_code = 503
+        return {
+            "status": "unresponsive",
+            "tick": "juniper-cascor",
+            "error": f"tick exceeded budget: {duration_ms}ms > {LIVENESS_TICK_BUDGET_MS}ms",
+            "duration_ms": duration_ms,
+        }
+
+    return {
+        "status": "alive",
+        "tick": "juniper-cascor",
+        "duration_ms": duration_ms,
+    }
 
 
 @router.get("/health/ready", response_model=ReadinessResponse)
-async def readiness_probe(request: Request) -> ReadinessResponse:
-    """Readiness probe for container orchestration.
+async def readiness_probe(request: Request, response: Response) -> ReadinessResponse:
+    """Readiness probe — drives orchestrator traffic decisions via status code.
 
-    Reports ready when the lifecycle manager is available. Probes the
-    JuniperData service health endpoint when ``JUNIPER_DATA_URL`` is set.
-    Returns a flat ReadinessResponse (no envelope).
+    Status code semantics:
+
+    - 200, body status="ready"     — lifecycle bound and (when configured)
+      JuniperData reachable.
+    - 200, body status="degraded"  — required deps healthy, an optional
+      dep unhealthy. juniper-cascor has no optional deps; this branch is
+      unreachable for this service.
+    - 503, body status="not_ready" — lifecycle missing OR (when
+      ``JUNIPER_DATA_URL`` set) JuniperData unreachable.
+
+    Sets ``X-Juniper-Readiness`` header to mirror body status.
     """
     lifecycle = getattr(request.app.state, "lifecycle", None)
     network_loaded = lifecycle.has_network() if lifecycle else False
@@ -52,18 +135,32 @@ async def readiness_probe(request: Request) -> ReadinessResponse:
         except Exception:  # nosec B110 - intentional pass for health check resilience
             pass
 
-    # Probe JuniperData
-    data_url = os.getenv("JUNIPER_DATA_URL")
     dependencies: dict = {}
-    if data_url:
-        data_dep = probe_dependency("JuniperData Service", f"{data_url.rstrip('/')}/v1/health/live")
-        dependencies["juniper_data"] = data_dep
 
-    overall = "ready"
-    for dep in dependencies.values():
-        if dep.status == "unhealthy":
-            overall = "degraded"
-            break
+    # Required dep: lifecycle manager.
+    dependencies["lifecycle"] = DependencyStatus(
+        name="Lifecycle Manager",
+        status="healthy" if lifecycle is not None else "unhealthy",
+        message="bound" if lifecycle is not None else "not bound on app.state",
+    )
+
+    # Required-when-configured dep: JuniperData. URL unset → dep skipped
+    # entirely (collapses to ready); URL set + unhealthy → not_ready.
+    data_url = os.getenv("JUNIPER_DATA_URL")
+    if data_url:
+        dependencies["juniper_data"] = probe_dependency("JuniperData Service", f"{data_url.rstrip('/')}/v1/health/live")
+
+    # Required deps for cascor: lifecycle (always) and juniper_data when
+    # configured. ``not_configured`` is treated as healthy for readiness.
+    required_unhealthy = any(dep.status == "unhealthy" for dep_name, dep in dependencies.items() if dep_name in {"lifecycle", "juniper_data"})
+
+    if required_unhealthy:
+        overall = "not_ready"
+        response.status_code = 503
+    else:
+        overall = "ready"
+
+    response.headers[READINESS_HEADER] = overall
 
     return ReadinessResponse(
         status=overall,

--- a/src/tests/unit/api/test_api_health.py
+++ b/src/tests/unit/api/test_api_health.py
@@ -32,26 +32,76 @@ class TestHealthEndpoints:
         assert body["version"] == "0.4.0"
 
     def test_liveness_probe(self, client):
-        """Test GET /v1/health/live returns alive."""
+        """R1.2: GET /v1/health/live runs in-process tick + returns 200 with tick metadata."""
         response = client.get("/v1/health/live")
         assert response.status_code == 200
         body = response.json()
         assert body["status"] == "alive"
+        assert body["tick"] == "juniper-cascor"
+        assert isinstance(body["duration_ms"], int)
+
+    def test_liveness_503_when_lifecycle_missing(self, client):
+        """R1.2 / seed-03: tick raises when lifecycle not bound → 503."""
+        # Clear the lifecycle the lifespan installed.
+        original = client.app.state.lifecycle
+        client.app.state.lifecycle = None
+        try:
+            response = client.get("/v1/health/live")
+            assert response.status_code == 503
+            body = response.json()
+            assert body["status"] == "unresponsive"
+            assert body["tick"] == "juniper-cascor"
+            assert "lifecycle" in body["error"]
+        finally:
+            client.app.state.lifecycle = original
+
+    def test_liveness_503_when_heartbeat_stale(self, client):
+        """R1.2 / seed-03: stale heartbeat → 503."""
+        from api.routes import health as health_module
+
+        # Force the lifecycle's last-tick timestamp to long-past so is_alive() is False.
+        lifecycle = client.app.state.lifecycle
+        with lifecycle._liveness_lock:
+            lifecycle._liveness_last_tick_at = lifecycle._liveness_last_tick_at - (health_module.LIVENESS_STALENESS_SECONDS + 5)
+        # Stop the heartbeat thread so it can't recover before our check.
+        lifecycle.stop_liveness_heartbeat()
+
+        response = client.get("/v1/health/live")
+        assert response.status_code == 503
+        body = response.json()
+        assert body["status"] == "unresponsive"
+        assert "stale" in body["error"]
 
     def test_readiness_probe_default(self, client):
-        """Test GET /v1/health/ready with default lifecycle state."""
+        """Test GET /v1/health/ready with lifecycle bound → 200 + ready."""
         response = client.get("/v1/health/ready")
         assert response.status_code == 200
+        assert response.headers.get("X-Juniper-Readiness") == "ready"
         body = response.json()
-        assert body["status"] in ("ready", "degraded")
+        assert body["status"] == "ready"
         assert body["version"] == "0.4.0"
         assert body["service"] == "juniper-cascor"
         assert "timestamp" in body
         assert body["details"]["network_loaded"] is False
         assert "training_state" in body["details"]
+        assert body["dependencies"]["lifecycle"]["status"] == "healthy"
+
+    def test_readiness_503_when_lifecycle_missing(self, client):
+        """R1.2 / seed-02: lifecycle unbound → 503 + status=not_ready."""
+        original = client.app.state.lifecycle
+        client.app.state.lifecycle = None
+        try:
+            response = client.get("/v1/health/ready")
+            assert response.status_code == 503
+            assert response.headers.get("X-Juniper-Readiness") == "not_ready"
+            body = response.json()
+            assert body["status"] == "not_ready"
+            assert body["dependencies"]["lifecycle"]["status"] == "unhealthy"
+        finally:
+            client.app.state.lifecycle = original
 
     def test_readiness_probe_with_lifecycle(self, client):
-        """Test GET /v1/health/ready with lifecycle manager that has a network."""
+        """Test GET /v1/health/ready details surface mock lifecycle state."""
 
         class MockLifecycle:
             def has_network(self):
@@ -71,16 +121,17 @@ class TestHealthEndpoints:
         assert body["details"]["training_state"] == "idle"
 
     @patch.dict("os.environ", {"JUNIPER_DATA_URL": "http://fake-data:8100"})
-    def test_readiness_probe_data_unhealthy(self, client):
-        """Test degraded status when JuniperData is unreachable."""
+    def test_readiness_503_when_juniper_data_unhealthy(self, client):
+        """R1.2 / seed-02: when JUNIPER_DATA_URL set + dep unhealthy → 503 not_ready."""
         response = client.get("/v1/health/ready")
-        assert response.status_code == 200
+        assert response.status_code == 503
+        assert response.headers.get("X-Juniper-Readiness") == "not_ready"
         body = response.json()
-        assert body["status"] == "degraded"
+        assert body["status"] == "not_ready"
         assert body["dependencies"]["juniper_data"]["status"] == "unhealthy"
 
     def test_readiness_probe_no_data_url(self, client):
-        """Test readiness without JUNIPER_DATA_URL set."""
+        """When JUNIPER_DATA_URL unset, juniper_data dep is skipped entirely → ready."""
         with patch.dict("os.environ", {}, clear=False):
             import os
 
@@ -88,7 +139,7 @@ class TestHealthEndpoints:
             response = client.get("/v1/health/ready")
             assert response.status_code == 200
             body = response.json()
-            # No juniper_data dependency when URL not set
+            assert body["status"] == "ready"
             assert "juniper_data" not in body.get("dependencies", {})
 
 
@@ -173,6 +224,7 @@ class TestResponseFormat:
         response = client.get("/v1/health/live")
         body = response.json()
         assert body["status"] == "alive"
+        assert body["tick"] == "juniper-cascor"
         assert "data" not in body
 
     def test_readiness_flat_response(self, client):

--- a/src/tests/unit/api/test_lifecycle_manager.py
+++ b/src/tests/unit/api/test_lifecycle_manager.py
@@ -137,6 +137,66 @@ class TestLifecycleManagerNetwork:
 
 
 @pytest.mark.unit
+class TestLifecycleHeartbeat:
+    """R1.2 / seed-03: liveness heartbeat counter and is_alive() accessor."""
+
+    def test_heartbeat_initially_alive(self):
+        """Fresh manager: heartbeat just bumped → is_alive() True."""
+        mgr = TrainingLifecycleManager()
+        try:
+            assert mgr.is_alive() is True
+            assert mgr._liveness_counter >= 1  # bumped at least by the daemon thread tick
+        finally:
+            mgr.stop_liveness_heartbeat()
+
+    def test_bump_advances_counter_and_timestamp(self):
+        """bump_liveness() increments counter and updates monotonic timestamp."""
+        mgr = TrainingLifecycleManager()
+        try:
+            mgr.stop_liveness_heartbeat()  # avoid races with the daemon
+            before = mgr._liveness_counter
+            t_before = mgr._liveness_last_tick_at
+            time.sleep(0.001)
+            mgr.bump_liveness()
+            assert mgr._liveness_counter == before + 1
+            assert mgr._liveness_last_tick_at > t_before
+        finally:
+            mgr.stop_liveness_heartbeat()
+
+    def test_is_alive_false_when_stale(self):
+        """is_alive() returns False when last tick is older than the staleness window."""
+        mgr = TrainingLifecycleManager()
+        try:
+            mgr.stop_liveness_heartbeat()
+            with mgr._liveness_lock:
+                mgr._liveness_last_tick_at = time.monotonic() - 100
+            assert mgr.is_alive(stale_after_seconds=30) is False
+        finally:
+            mgr.stop_liveness_heartbeat()
+
+    def test_monitor_event_callback_bumps_heartbeat(self):
+        """TrainingMonitor event callbacks bump the heartbeat (training-thread liveness signal)."""
+        mgr = TrainingLifecycleManager()
+        try:
+            mgr.stop_liveness_heartbeat()
+            before = mgr._liveness_counter
+            mgr.training_monitor.on_phase_change("output")
+            assert mgr._liveness_counter > before
+        finally:
+            mgr.stop_liveness_heartbeat()
+
+    def test_daemon_thread_bumps_periodically(self):
+        """Daemon heartbeat thread bumps the counter at ~1s cadence."""
+        mgr = TrainingLifecycleManager()
+        try:
+            before = mgr._liveness_counter
+            time.sleep(1.5)
+            assert mgr._liveness_counter > before
+        finally:
+            mgr.stop_liveness_heartbeat()
+
+
+@pytest.mark.unit
 class TestLifecycleManagerTrainingControl:
     """Test training start/stop/pause/resume/reset."""
 


### PR DESCRIPTION
## Summary

Implements the R1.2 cross-repo health-probe contract for juniper-cascor per [notes/code-review/METRICS_MONITORING_R1.2_PROBE_DESIGN_2026-04-27.md](https://github.com/pcalnon/juniper-ml/blob/main/notes/code-review/METRICS_MONITORING_R1.2_PROBE_DESIGN_2026-04-27.md) in juniper-ml.

## Changes

### Lifecycle heartbeat (new plumbing)

`TrainingLifecycleManager` now has a 1-second daemon thread that bumps a heartbeat counter:
- `bump_liveness()` — increments counter + updates monotonic timestamp
- `is_alive(stale_after_seconds=30.0)` — returns False if last bump is older than the window
- `stop_liveness_heartbeat()` — joins the daemon (called from `shutdown()`)

`TrainingMonitor` event callbacks (`epoch_start/end`, `cascade_add`, `training_start/end`, `topology_change`, `candidate_progress`, `phase_change`) also bump the counter so progress in the training thread is an additional liveness signal.

### Probe contract

**`/v1/health/live`** — replaces no-op `{"status": "alive"}` with in-process tick (`lifecycle.is_alive()`) inside a 250 ms budget:
- 200 + `{"status": "alive", "tick": "juniper-cascor", "duration_ms": N}` on success
- 503 + `{"status": "unresponsive", ...}` on tick failure or budget exceedance

**`/v1/health/ready`** — returns 503 when any required dep is unhealthy:
- Required: lifecycle manager (always); JuniperData (when `JUNIPER_DATA_URL` is set)
- 503 body has `status="not_ready"`
- Sets `X-Juniper-Readiness` response header mirroring body status

**`/v1/health`** — unchanged.

## Why

Roadmap **R1.2** seed findings **seed-02** (`/health/ready` 200-on-degraded) and **seed-03** (liveness no-op). Composite severity 4 (release-blocking).

Second of four PRs in the R1.2 cluster:
1. ✅ pcalnon/juniper-data#51 (merged)
2. **this PR** — juniper-cascor
3. juniper-canopy (queued)
4. juniper-deploy Helm chart correction (queued)

## Test plan

- [x] AST parse clean for all 4 modified files
- [x] `pre-commit run` clean (Black, isort, Flake8, MyPy, Bandit)
- [x] Direct-import smoke: health route exposes `LIVENESS_TICK_BUDGET_MS=250`, `READINESS_HEADER`, `LIVENESS_STALENESS_SECONDS=30.0`, `_liveness_tick`; `TrainingLifecycleManager.bump_liveness/is_alive/stop_liveness_heartbeat` callable; bump increments counter; monitor callback bumps counter
- [ ] Pytest local execution: pre-existing segfault on Python 3.14t free-threaded build (`_brotli` C extension; reproduces on `main` HEAD without my changes — environmental). CI will validate.

### New tests

`test_api_health.py`:
- `test_liveness_503_when_lifecycle_missing`
- `test_liveness_503_when_heartbeat_stale`
- `test_readiness_503_when_lifecycle_missing`
- `test_readiness_503_when_juniper_data_unhealthy` (replaces `test_readiness_probe_data_unhealthy` which asserted broken 200/degraded)

`test_lifecycle_manager.py`:
- `TestLifecycleHeartbeat` suite (5 cases): initial alive state, bump increments counter+timestamp, `is_alive()` false when stale, monitor callback bumps counter, daemon thread bumps periodically

## Backwards compatibility

| Audience | Change | Mitigation |
|---|---|---|
| External monitoring | `/v1/health/ready` now 503 when lifecycle unbound or `JUNIPER_DATA_URL`-pointed service unhealthy | CHANGELOG entry under "Changed (potentially breaking)" |
| Helm | Cascor deployment template currently points readiness at `/v1/health/ready` (correct); liveness at `/v1/health` (incorrect — fixed in juniper-deploy companion PR) | Companion juniper-deploy PR ships in same release |
| `/v1/health` | unchanged | n/a |

## References

- Design: [notes/code-review/METRICS_MONITORING_R1.2_PROBE_DESIGN_2026-04-27.md](https://github.com/pcalnon/juniper-ml/blob/main/notes/code-review/METRICS_MONITORING_R1.2_PROBE_DESIGN_2026-04-27.md)
- Roadmap: [notes/code-review/METRICS_MONITORING_ROADMAP_2026-04-25.md §R1.2](https://github.com/pcalnon/juniper-ml/blob/main/notes/code-review/METRICS_MONITORING_ROADMAP_2026-04-25.md)
- Predecessor: pcalnon/juniper-data#51 (R1.2 / data — merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)