### PR TITLE
docs: fix 10 broken doc-link references in cheatsheet, roadmaps, and migration plan

### DIFF
--- a/docs/DEVELOPER_CHEATSHEET.md
+++ b/docs/DEVELOPER_CHEATSHEET.md
@@ -39,7 +39,7 @@
 
 ```bash
 conda activate JuniperCascor && cd juniper-cascor && pip install -e ".[all]"
-cd src && python main.py                                       # native [start](start)
+cd src && python main.py                                       # native start
 curl -s http://localhost:8200/v1/health | python -m json.tool  # health
 docker compose --profile full up -d                            # Docker start
 ```
@@ -234,6 +234,6 @@ Core: `torch`, `numpy`, `h5py`, `matplotlib`, `PyYAML`, `requests`
 
 ## Cross-References
 
-[Ecosystem Cheatsheet](../../juniper-ml/notes/DEVELOPER_CHEATSHEET.md) | [juniper-cascor-client](../../juniper-cascor-client/docs/DEVELOPER_CHEATSHEET.md) | [juniper-deploy](../../juniper-deploy/docs/DEVELOPER_CHEATSHEET.md) | [Parent Ecosystem Guide](../../CLAUDE.md)
+[Ecosystem Cheatsheet](../../juniper-ml/docs/DEVELOPER_CHEATSHEET_JUNIPER-ML.md) | [juniper-cascor-client](../../juniper-cascor-client/docs/DEVELOPER_CHEATSHEET.md) | [juniper-deploy](../../juniper-deploy/docs/DEVELOPER_CHEATSHEET.md) | [Parent Ecosystem Guide](../../CLAUDE.md)
 
 ---

--- a/notes/ROADMAP_METHODOLOGY.md
+++ b/notes/ROADMAP_METHODOLOGY.md
@@ -411,9 +411,9 @@ The 4-phase structure balances:
 
 ## Related Documents
 
-- [DEVELOPMENT_ROADMAP.md](DEVELOPMENT_ROADMAP.md) - The resulting roadmap
-- [PROJECT_ANALYSIS.md](PROJECT_ANALYSIS.md) - Input analysis
-- [CASCOR_ENHANCEMENTS_ROADMAP.md](CASCOR_ENHANCEMENTS_ROADMAP.md) - Previous planning
+- [DEVELOPMENT_ROADMAP.md](history/DEVELOPMENT_ROADMAP.md) - The resulting roadmap (archived)
+- [PROJECT_ANALYSIS.md](history/PROJECT_ANALYSIS.md) - Input analysis (archived)
+- [CASCOR_ENHANCEMENTS_ROADMAP.md](development/CASCOR_ENHANCEMENTS_ROADMAP.md) - Previous planning
 
 ---
 

--- a/notes/development/CASCOR_ENHANCEMENTS_ROADMAP.md
+++ b/notes/development/CASCOR_ENHANCEMENTS_ROADMAP.md
@@ -1233,9 +1233,9 @@ pytest src/tests/integration/test_serialization.py::TestRandomStateRestoration::
 
 ### Related Documents
 
-- [NEXT_STEPS.md](NEXT_STEPS.md) - Original MVP plan
-- [P2_ENHANCEMENTS_PLAN.md](P2_ENHANCEMENTS_PLAN.md) - P2 optimization plan
-- [SERIALIZATION_FIXES_SUMMARY.md](SERIALIZATION_FIXES_SUMMARY.md) - Previous fixes
+- [NEXT_STEPS.md](../history/NEXT_STEPS.md) - Original MVP plan (archived)
+- [P2_ENHANCEMENTS_PLAN.md](../history/P2_ENHANCEMENTS_PLAN.md) - P2 optimization plan (archived)
+- [SERIALIZATION_FIXES_SUMMARY.md](../history/SERIALIZATION_FIXES_SUMMARY.md) - Previous fixes (archived)
 
 ### Key Files
 

--- a/notes/development/POLYREPO_MIGRATION_PLAN.md
+++ b/notes/development/POLYREPO_MIGRATION_PLAN.md
@@ -4,7 +4,7 @@
 **Version:** 1.7.4
 **Status:** Phase 7 Complete — All steps including 7.5.2
 **Author:** Paul Calnon / Claude Code
-**Companion Document:** [MONOREPO_ANALYSIS.md](MONOREPO_ANALYSIS.md)
+**Companion Document:** [MONOREPO_ANALYSIS.md](../history/MONOREPO_ANALYSIS.md)
 
 ---
 
@@ -1054,7 +1054,7 @@ Note: The worker needs PyTorch because it runs `CascadeCorrelationNetwork._worke
 **Risk:** High (core architectural change to Canopy)
 **Prerequisite:** Phases 2 and 3 complete
 **Status:** COMPLETE (2026-02-25) — Validated 2026-02-25
-**Detailed Plan:** [`DECOUPLE_CANOPY_FROM_CASCOR_PLAN.md`](DECOUPLE_CANOPY_FROM_CASCOR_PLAN.md)
+**Detailed Plan:** [`DECOUPLE_CANOPY_FROM_CASCOR_PLAN.md`](../history/DECOUPLE_CANOPY_FROM_CASCOR_PLAN.md)
 
 > **Note:** A comprehensive, standalone implementation plan exists in
 > `notes/DECOUPLE_CANOPY_FROM_CASCOR_PLAN.md`. It contains full adapter code,


### PR DESCRIPTION
Closes the 10 broken links surfaced by `scripts/check_doc_links.py --exclude templates --exclude history`.

Five categories of fix:

1. **docs/DEVELOPER_CHEATSHEET.md:42** — `[start](start)` was a placeholder annotation inside a bash code block; the link checker doesn't honour code fences and was treating it as a broken link. Replaced with plain `start` text.
2. **docs/DEVELOPER_CHEATSHEET.md:237** — fixed cross-repo Ecosystem Cheatsheet path (the monolithic `juniper-ml/notes/DEVELOPER_CHEATSHEET.md` was decomposed in 2026-03 → `juniper-ml/docs/DEVELOPER_CHEATSHEET_JUNIPER-ML.md`).
3. **notes/ROADMAP_METHODOLOGY.md** — `DEVELOPMENT_ROADMAP.md` and `PROJECT_ANALYSIS.md` are in `notes/history/`; `CASCOR_ENHANCEMENTS_ROADMAP.md` is in `notes/development/`.
4. **notes/development/CASCOR_ENHANCEMENTS_ROADMAP.md** — `NEXT_STEPS`, `P2_ENHANCEMENTS_PLAN`, `SERIALIZATION_FIXES_SUMMARY` all relocated to `notes/history/` (`../history/`).
5. **notes/development/POLYREPO_MIGRATION_PLAN.md** — `MONOREPO_ANALYSIS` and `DECOUPLE_CANOPY_FROM_CASCOR_PLAN` relocated to `notes/history/` (`../history/`).

`scripts/check_doc_links.py --exclude templates --exclude history` → 81 files, 0 broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)