### PR TITLE
feat(ws): GAP-WS-18 — topology size guard + chunked_message protocol

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -112,6 +112,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         max_replay_buffer_size=settings.ws_replay_buffer_size,
         send_timeout_seconds=settings.ws_send_timeout_seconds,
         max_connections_per_ip=settings.ws_max_connections_per_ip,  # SEC-03
+        max_message_size_bytes=settings.ws_max_message_size_bytes,  # GAP-WS-18
+        chunk_payload_size_bytes=settings.ws_chunk_payload_size_bytes,  # GAP-WS-18
     )
     ws_manager.set_event_loop(asyncio.get_running_loop())
     app.state.ws_manager = ws_manager

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -173,6 +173,28 @@ class Settings(BaseSettings):
         ge=0,
         validation_alias=AliasChoices("ws_initial_metrics_count", "JUNIPER_WS_INITIAL_METRICS_COUNT"),
     )
+    ws_max_message_size_bytes: int = Field(
+        default=60_000,
+        description=(
+            "GAP-WS-18: serialized JSON size threshold above which broadcasts are "
+            "split into chunked_message envelopes. Default 60_000 leaves headroom "
+            "below the WebSocket 64 KB per-frame limit imposed by some intermediaries. "
+            "Set to 0 to disable chunking entirely (oversized broadcasts will be sent "
+            "as-is and may cause silent connection teardown — only use for tests)."
+        ),
+        ge=0,
+        validation_alias=AliasChoices("ws_max_message_size_bytes", "JUNIPER_WS_MAX_MESSAGE_SIZE_BYTES"),
+    )
+    ws_chunk_payload_size_bytes: int = Field(
+        default=32_000,
+        description=(
+            "GAP-WS-18: maximum payload bytes per chunk when chunking is triggered. "
+            "Default 32_000 keeps each chunked envelope (payload + JSON wrapper) safely "
+            "under 60_000. Must be > 0."
+        ),
+        gt=0,
+        validation_alias=AliasChoices("ws_chunk_payload_size_bytes", "JUNIPER_WS_CHUNK_PAYLOAD_SIZE_BYTES"),
+    )
 
     api_keys: list[str] | None = _JUNIPER_CASCOR_API_KEYS_LIST_EMPTY
 

--- a/src/api/websocket/manager.py
+++ b/src/api/websocket/manager.py
@@ -65,6 +65,8 @@ class WebSocketManager:
         max_replay_buffer_size: int = 1024,
         send_timeout_seconds: float = 0.5,
         max_connections_per_ip: int = 5,
+        max_message_size_bytes: int = 60_000,
+        chunk_payload_size_bytes: int = 32_000,
     ):
         # Connection tracking
         self._active_connections: Set[WebSocket] = set()
@@ -103,6 +105,20 @@ class WebSocketManager:
         self._messages_sent_by_type: Dict[str, int] = {}
         self._bytes_sent_by_type: Dict[str, int] = {}
         self._send_failures: int = 0
+
+        # GAP-WS-18: message-size guard + chunking. Broadcasts whose serialized
+        # JSON exceeds ``max_message_size_bytes`` are split into a sequence of
+        # ``chunked_message`` envelopes (each with payload ≤ ``chunk_payload_size_bytes``)
+        # so we never push a single frame over the typical 64 KB WebSocket
+        # intermediary limit. Each chunk is its own broadcast (own seq, own
+        # replay-buffer slot), so resume on reconnect reorders them naturally.
+        # ``messages_chunked_total`` counts how often a logical message was
+        # chunked (not how many chunks were emitted) — surfaced via
+        # transport_stats() for observability.
+        self._max_message_size_bytes = max_message_size_bytes
+        self._chunk_payload_size_bytes = chunk_payload_size_bytes
+        self._messages_chunked_total: int = 0
+        self._chunks_emitted_total: int = 0
 
         logger.info(
             "WebSocketManager initialized (max_connections=%d, replay_buffer=%d, send_timeout=%.1fs)",
@@ -333,20 +349,85 @@ class WebSocketManager:
             return buffered[idx:]
 
     # ------------------------------------------------------------------
+    # Chunking (GAP-WS-18)
+    # ------------------------------------------------------------------
+
+    def _maybe_chunk_message(self, message: dict) -> List[dict]:
+        """Return [message] if under threshold, else a list of chunked envelopes.
+
+        GAP-WS-18: oversized broadcasts (~64 KB) silently tear down WebSocket
+        connections at intermediaries. We split here, BEFORE seq assignment,
+        so each chunk gets its own seq + replay slot and resume-on-reconnect
+        reorders chunks naturally.
+
+        Chunking is skipped (returns ``[message]``) when:
+        - ``ws_max_message_size_bytes`` is 0 (kill-switch for tests)
+        - The serialized JSON length is ≤ the threshold
+        - The message is already a ``chunked_message`` envelope (no recursion)
+        """
+        if self._max_message_size_bytes <= 0:
+            return [message]
+        if message.get("type") == "chunked_message":
+            return [message]
+        try:
+            serialized = json.dumps(message, default=str)
+        except (TypeError, ValueError):
+            # If we can't serialize for sizing, let _send_json handle the error.
+            return [message]
+        if len(serialized) <= self._max_message_size_bytes:
+            return [message]
+
+        chunk_size = self._chunk_payload_size_bytes
+        chunk_id = str(uuid.uuid4())
+        original_type = str(message.get("type") or "unknown")
+        payloads = [serialized[i : i + chunk_size] for i in range(0, len(serialized), chunk_size)]
+        total = len(payloads)
+        chunks = [
+            {
+                "type": "chunked_message",
+                "timestamp": time.time(),
+                "data": {
+                    "chunk_id": chunk_id,
+                    "chunk_index": idx,
+                    "total_chunks": total,
+                    "original_type": original_type,
+                    "payload": payload,
+                },
+            }
+            for idx, payload in enumerate(payloads)
+        ]
+        with self._seq_lock:
+            self._messages_chunked_total += 1
+            self._chunks_emitted_total += total
+        logger.info(
+            "WebSocket: chunked %s message (%d bytes) into %d chunks (chunk_id=%s)",
+            original_type,
+            len(serialized),
+            total,
+            chunk_id,
+        )
+        return chunks
+
+    # ------------------------------------------------------------------
     # Broadcasting
     # ------------------------------------------------------------------
 
     async def broadcast(self, message: dict) -> None:
-        """Assign seq and send a message to all active (non-pending) clients."""
+        """Assign seq and send a message to all active (non-pending) clients.
+
+        GAP-WS-18: oversized messages are split into chunked_message envelopes
+        before seq assignment so each chunk gets its own seq and replay slot.
+        """
         if not self._active_connections:
             return
-        message = self._assign_seq_and_buffer(message)
-        disconnected = []
-        for ws in self._active_connections.copy():
-            if not await self._send_json(ws, message):
-                disconnected.append(ws)
-        for ws in disconnected:
-            await self.disconnect(ws)
+        for sub_message in self._maybe_chunk_message(message):
+            enriched = self._assign_seq_and_buffer(sub_message)
+            disconnected = []
+            for ws in self._active_connections.copy():
+                if not await self._send_json(ws, enriched):
+                    disconnected.append(ws)
+            for ws in disconnected:
+                await self.disconnect(ws)
 
     def broadcast_from_thread(self, message: dict) -> None:
         """Thread-safe broadcast using asyncio.run_coroutine_threadsafe.
@@ -376,8 +457,20 @@ class WebSocketManager:
             logger.error("Broadcast from thread failed: %s", exc, exc_info=exc)
 
     async def send_personal_message(self, websocket: WebSocket, message: dict) -> bool:
-        """Send a message to a specific client (no seq assignment)."""
-        return await self._send_json(websocket, message)
+        """Send a message to a specific client (no seq assignment).
+
+        GAP-WS-18: oversized personal messages are split into chunked_message
+        envelopes the same way broadcasts are. Personal messages don't carry
+        seq, so on reconnect a partially-delivered chunk group is dropped by
+        the client (no resume), but no socket teardown.
+
+        Returns True only if every chunk was delivered successfully.
+        """
+        chunks = self._maybe_chunk_message(message)
+        for sub_message in chunks:
+            if not await self._send_json(websocket, sub_message):
+                return False
+        return True
 
     async def _send_json(self, websocket: WebSocket, message: dict) -> bool:
         """Send JSON message to a single WebSocket with timeout.
@@ -427,6 +520,11 @@ class WebSocketManager:
         Surfaced via ``GET /v1/metrics/transport`` to validate the bandwidth
         delta from REST polling (P0 motivator) once GAP-WS-16 lands. All
         counters are cumulative since process start.
+
+        GAP-WS-18: also exposes ``messages_chunked_total`` (number of logical
+        messages that exceeded the size threshold and were split) and
+        ``chunks_emitted_total`` (total chunk envelopes emitted), so we can
+        see how often the chunker is firing in production.
         """
         with self._seq_lock:
             return {
@@ -441,6 +539,10 @@ class WebSocketManager:
                 "current_seq": self._next_seq - 1,
                 "replay_buffer_size": len(self._replay_buffer),
                 "replay_buffer_capacity": self._replay_buffer_max_size,
+                "messages_chunked_total": self._messages_chunked_total,
+                "chunks_emitted_total": self._chunks_emitted_total,
+                "max_message_size_bytes": self._max_message_size_bytes,
+                "chunk_payload_size_bytes": self._chunk_payload_size_bytes,
             }
 
     # ------------------------------------------------------------------

--- a/src/api/websocket/messages.py
+++ b/src/api/websocket/messages.py
@@ -99,6 +99,44 @@ def create_cascade_add_message(
     return _build_envelope("cascade_add", data, seq=seq, emitted_at_monotonic=emitted_at_monotonic)
 
 
+def create_chunked_message(
+    *,
+    chunk_id: str,
+    chunk_index: int,
+    total_chunks: int,
+    original_type: str,
+    payload: str,
+) -> Dict[str, Any]:
+    """GAP-WS-18: build one chunk of a fragmented oversized message.
+
+    Each chunk is itself a normal envelope and gets its own ``seq`` from the
+    manager — chunks of one logical message land on consecutive seqs so the
+    replay buffer reorders them naturally on resume.
+
+    Args:
+        chunk_id: UUID4 identifying the logical message all chunks belong to.
+        chunk_index: 0-based position of this chunk within the message.
+        total_chunks: Total number of chunks the logical message was split into.
+        original_type: ``type`` field of the pre-chunked message (e.g., "topology").
+        payload: A slice of the JSON-serialized original message as a string.
+            The client concatenates payloads in chunk_index order and parses the
+            result as JSON to reconstruct the original envelope.
+
+    Returns:
+        Envelope with type "chunked_message".
+    """
+    return _build_envelope(
+        "chunked_message",
+        {
+            "chunk_id": chunk_id,
+            "chunk_index": chunk_index,
+            "total_chunks": total_chunks,
+            "original_type": original_type,
+            "payload": payload,
+        },
+    )
+
+
 def create_initial_metrics_message(
     metrics: list,
     *,

--- a/src/tests/unit/api/test_websocket_manager.py
+++ b/src/tests/unit/api/test_websocket_manager.py
@@ -265,3 +265,122 @@ class TestTransportStats:
         assert stats["replay_buffer_capacity"] == 512
         assert stats["replay_buffer_size"] == 0
         assert stats["current_seq"] == 0
+
+
+@pytest.mark.unit
+class TestSizeGuardAndChunking:
+    """GAP-WS-18: oversized broadcasts split into chunked_message envelopes
+    so we never push a single frame past the 64 KB intermediary limit."""
+
+    def test_small_message_is_not_chunked(self):
+        mgr = WebSocketManager(max_message_size_bytes=60_000, chunk_payload_size_bytes=32_000)
+        chunks = mgr._maybe_chunk_message({"type": "topology", "data": {"x": 1}})
+        assert len(chunks) == 1
+        assert chunks[0]["type"] == "topology"
+
+    def test_oversized_message_is_chunked(self):
+        # Build a message whose serialized JSON exceeds the threshold.
+        big_data = {"hidden_layers": [{"name": f"layer_{i}", "weights": list(range(100))} for i in range(200)]}
+        mgr = WebSocketManager(max_message_size_bytes=10_000, chunk_payload_size_bytes=4_000)
+        chunks = mgr._maybe_chunk_message({"type": "topology", "data": big_data})
+        assert len(chunks) >= 2
+        # All chunks share a chunk_id.
+        chunk_ids = {c["data"]["chunk_id"] for c in chunks}
+        assert len(chunk_ids) == 1
+        # chunk_index runs 0..N-1, total_chunks is consistent.
+        total = chunks[0]["data"]["total_chunks"]
+        assert total == len(chunks)
+        for idx, chunk in enumerate(chunks):
+            assert chunk["type"] == "chunked_message"
+            assert chunk["data"]["chunk_index"] == idx
+            assert chunk["data"]["total_chunks"] == total
+            assert chunk["data"]["original_type"] == "topology"
+
+    def test_chunks_reassemble_to_original_message(self):
+        """Concatenating payloads in chunk_index order must yield the original JSON."""
+        original = {"type": "topology", "data": {"big": "x" * 50_000}}
+        mgr = WebSocketManager(max_message_size_bytes=10_000, chunk_payload_size_bytes=4_000)
+        chunks = mgr._maybe_chunk_message(original)
+        assert len(chunks) > 1
+        reassembled_text = "".join(c["data"]["payload"] for c in chunks)
+        import json as _json
+        reassembled = _json.loads(reassembled_text)
+        assert reassembled["type"] == original["type"]
+        assert reassembled["data"]["big"] == original["data"]["big"]
+
+    def test_chunking_disabled_when_threshold_zero(self):
+        """ws_max_message_size_bytes=0 is a kill-switch that disables chunking."""
+        mgr = WebSocketManager(max_message_size_bytes=0, chunk_payload_size_bytes=4_000)
+        big_data = {"hidden_layers": list(range(10_000))}
+        chunks = mgr._maybe_chunk_message({"type": "topology", "data": big_data})
+        assert len(chunks) == 1
+        assert chunks[0]["type"] == "topology"
+
+    def test_chunked_message_is_not_re_chunked(self):
+        """Already-chunked envelopes must never recurse through the chunker."""
+        mgr = WebSocketManager(max_message_size_bytes=100, chunk_payload_size_bytes=50)
+        chunked = {
+            "type": "chunked_message",
+            "data": {"chunk_id": "x", "chunk_index": 0, "total_chunks": 1, "original_type": "topology", "payload": "y" * 1000},
+        }
+        chunks = mgr._maybe_chunk_message(chunked)
+        assert len(chunks) == 1
+        assert chunks[0] is chunked
+
+    @pytest.mark.asyncio
+    async def test_broadcast_assigns_consecutive_seqs_to_chunks(self):
+        """Each chunk gets its own seq so the replay buffer reorders them on resume."""
+        mgr = WebSocketManager(max_message_size_bytes=10_000, chunk_payload_size_bytes=4_000)
+        ws = AsyncMock()
+        await mgr.connect(ws)
+        seq_before = mgr.current_seq
+        await mgr.broadcast({"type": "topology", "data": {"big": "x" * 50_000}})
+        seq_after = mgr.current_seq
+        # current_seq advanced by N (number of chunks), not 1.
+        assert seq_after - seq_before >= 2
+
+    @pytest.mark.asyncio
+    async def test_broadcast_chunks_each_carry_seq_and_replay(self):
+        mgr = WebSocketManager(max_message_size_bytes=10_000, chunk_payload_size_bytes=4_000, max_replay_buffer_size=100)
+        ws = AsyncMock()
+        await mgr.connect(ws)
+        await mgr.broadcast({"type": "topology", "data": {"big": "x" * 30_000}})
+        # Replay buffer holds connection_established? No — that's a personal
+        # message. Only broadcast chunks land in the replay buffer.
+        replayed = mgr.replay_since(0)
+        assert len(replayed) >= 2
+        # All replayed entries are chunked_message envelopes carrying a seq.
+        for msg in replayed:
+            assert msg["type"] == "chunked_message"
+            assert "seq" in msg
+
+    def test_transport_stats_exposes_chunk_counters(self):
+        mgr = WebSocketManager(max_message_size_bytes=60_000, chunk_payload_size_bytes=32_000)
+        stats = mgr.transport_stats()
+        assert "messages_chunked_total" in stats
+        assert "chunks_emitted_total" in stats
+        assert "max_message_size_bytes" in stats
+        assert "chunk_payload_size_bytes" in stats
+        assert stats["messages_chunked_total"] == 0
+        assert stats["chunks_emitted_total"] == 0
+        assert stats["max_message_size_bytes"] == 60_000
+        assert stats["chunk_payload_size_bytes"] == 32_000
+
+    def test_chunk_counters_increment_on_split(self):
+        mgr = WebSocketManager(max_message_size_bytes=10_000, chunk_payload_size_bytes=4_000)
+        chunks = mgr._maybe_chunk_message({"type": "topology", "data": {"big": "x" * 50_000}})
+        stats = mgr.transport_stats()
+        assert stats["messages_chunked_total"] == 1
+        assert stats["chunks_emitted_total"] == len(chunks)
+
+    @pytest.mark.asyncio
+    async def test_send_personal_message_chunks_oversized(self):
+        mgr = WebSocketManager(max_message_size_bytes=10_000, chunk_payload_size_bytes=4_000)
+        ws = AsyncMock()
+        await mgr.connect(ws)
+        # Reset send_json call count after the connection_established message
+        ws.send_json.reset_mock()
+        result = await mgr.send_personal_message(ws, {"type": "topology", "data": {"big": "x" * 30_000}})
+        assert result is True
+        # Multiple sends → multiple chunks
+        assert ws.send_json.await_count >= 2

--- a/src/tests/unit/api/test_websocket_messages.py
+++ b/src/tests/unit/api/test_websocket_messages.py
@@ -4,7 +4,7 @@ import time
 
 import pytest
 
-from api.websocket.messages import create_candidate_progress_message, create_cascade_add_message, create_control_ack_message, create_event_message, create_initial_metrics_message, create_metrics_message, create_state_message, create_topology_message
+from api.websocket.messages import create_candidate_progress_message, create_cascade_add_message, create_chunked_message, create_control_ack_message, create_event_message, create_initial_metrics_message, create_metrics_message, create_state_message, create_topology_message
 
 
 @pytest.mark.unit
@@ -124,3 +124,38 @@ class TestInitialMetricsMessage:
     def test_current_seq_defaults_when_omitted(self):
         msg = create_initial_metrics_message([{"epoch": 1}])
         assert msg["data"]["current_seq"] == 0
+
+
+@pytest.mark.unit
+class TestChunkedMessageBuilder:
+    """GAP-WS-18: chunked_message envelope shape."""
+
+    def test_envelope_shape(self):
+        msg = create_chunked_message(
+            chunk_id="abc-123",
+            chunk_index=0,
+            total_chunks=3,
+            original_type="topology",
+            payload="<json-fragment>",
+        )
+        assert msg["type"] == "chunked_message"
+        assert "timestamp" in msg
+        assert msg["data"]["chunk_id"] == "abc-123"
+        assert msg["data"]["chunk_index"] == 0
+        assert msg["data"]["total_chunks"] == 3
+        assert msg["data"]["original_type"] == "topology"
+        assert msg["data"]["payload"] == "<json-fragment>"
+
+    def test_no_seq_field_at_construction(self):
+        """Builder does not embed seq — manager assigns one per chunk on broadcast."""
+        msg = create_chunked_message(
+            chunk_id="x", chunk_index=0, total_chunks=1, original_type="t", payload=""
+        )
+        assert "seq" not in msg
+
+    def test_payload_can_be_empty(self):
+        """An empty payload is legal (e.g., the tail chunk of an exact-multiple split)."""
+        msg = create_chunked_message(
+            chunk_id="x", chunk_index=2, total_chunks=3, original_type="t", payload=""
+        )
+        assert msg["data"]["payload"] == ""


### PR DESCRIPTION
## Summary

Server-side half of **GAP-WS-18**. Pairs with [juniper-canopy reassembler PR #197](https://github.com/pcalnon/juniper-canopy/pull/197).

Closes the silent-teardown bug where any broadcast whose serialized JSON exceeds ~64 KB caused intermediaries to drop the WebSocket connection without warning. Approach: chunking, not truncation — the original message is reconstructible client-side, no information lost.

## Wire format

```json
{
  "type": "chunked_message",
  "timestamp": ...,
  "data": {
    "chunk_id": "<uuid4>",
    "chunk_index": 0,
    "total_chunks": 3,
    "original_type": "topology",
    "payload": "<json-fragment>"
  },
  "seq": 42
}
```

Each chunk is a normal broadcast (own seq, own replay-buffer slot), so chunks of one logical message land on consecutive seqs and resume-on-reconnect reorders them naturally.

## Settings

- `ws_max_message_size_bytes` (default 60_000): threshold above which chunking kicks in. 0 disables (kill-switch).
- `ws_chunk_payload_size_bytes` (default 32_000): max payload bytes per chunk.

Both also accept env vars `JUNIPER_WS_MAX_MESSAGE_SIZE_BYTES` / `JUNIPER_WS_CHUNK_PAYLOAD_SIZE_BYTES`.

## Files changed

- `src/api/settings.py` — two new fields
- `src/api/websocket/messages.py` — `create_chunked_message` builder
- `src/api/websocket/manager.py` — `_maybe_chunk_message`, `broadcast`/`send_personal_message` integration, two new `transport_stats` counters
- `src/api/app.py` — pass settings to manager constructor

## Tests

10 new unit tests across 2 classes:
- `TestChunkedMessageBuilder` — envelope shape, no seq at construction, empty payload legality
- `TestSizeGuardAndChunking` — small message passes through; oversized splits into N chunks with shared chunk_id; payloads concatenate to round-trip the original JSON; threshold=0 disables; chunked envelopes don't recurse; `broadcast` advances seq by N (not 1); each chunk lands in replay buffer; `transport_stats` exposes `messages_chunked_total` / `chunks_emitted_total`; `send_personal_message` splits and sends all chunks

Tests parse + AST-check clean. Conda env can't run cascor tests locally (torch ImportError under Py3.14 free-threading) — relying on CI.

## Test plan

- [ ] CI green (pre-commit + Python 3.12/3.13/3.14 unit tests)
- [ ] Manual smoke: trigger a deep-network train (>50 hidden units), confirm `transport_stats` shows `messages_chunked_total > 0` and the canopy network visualizer paints correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)