### PR TITLE
fix(lifecycle): GAP-WS-28 — atomic update_params with rollback on setter failure

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -847,6 +847,15 @@ class TrainingLifecycleManager:
         Parameters effective at next cascade/epoch: max_hidden_units, epochs_max,
         patience.
 
+        GAP-WS-28: applies all updates atomically. If any setattr raises,
+        every previously-applied key is reverted to its pre-call value
+        before re-raising, so the network is never left in a half-updated
+        state. The ``_training_lock`` already prevents the race itself; this
+        adds the all-or-nothing semantics for the case where a property
+        setter rejects a value (currently no setters do, but adding a
+        defensive guard now means future validation can be wired in
+        without re-introducing torn writes).
+
         Args:
             params: Dict of parameter names and new values (None values excluded).
 
@@ -855,6 +864,8 @@ class TrainingLifecycleManager:
 
         Raises:
             ValueError: If no network exists.
+            Exception: Re-raises whatever setattr raised, after rolling back
+                any partially-applied updates.
         """
         with self._training_lock:
             if self.network is None:
@@ -874,9 +885,23 @@ class TrainingLifecycleManager:
                 "candidate_epochs",
                 "init_output_weights",
             }
-            for key, value in params.items():
-                if key in updatable_keys and hasattr(self.network, key):
+            applicable = {k: v for k, v in params.items() if k in updatable_keys and hasattr(self.network, k)}
+            old_values = {k: getattr(self.network, k) for k in applicable}
+            applied: list[str] = []
+            try:
+                for key, value in applicable.items():
                     setattr(self.network, key, value)
+                    applied.append(key)
+            except Exception:
+                # GAP-WS-28: revert any partial application before propagating.
+                for key in reversed(applied):
+                    try:
+                        setattr(self.network, key, old_values[key])
+                    except Exception:
+                        # If revert itself raises, log and continue rolling
+                        # back the rest — best-effort consistency.
+                        self.logger.exception("update_params rollback: revert of %s failed", key)
+                raise
             return self.get_training_params()
 
     # ------------------------------------------------------------------

--- a/src/tests/unit/api/test_lifecycle_manager.py
+++ b/src/tests/unit/api/test_lifecycle_manager.py
@@ -401,3 +401,112 @@ class TestLifecycleWorkerCoordinator:
         mgr.create_network(input_size=2, output_size=2)
         assert mgr.network._worker_coordinator is None
         assert mgr.network._remote_workers_enabled is False
+
+
+@pytest.mark.unit
+class TestUpdateParamsAtomicity:
+    """GAP-WS-28: update_params applies all keys or none — never half.
+
+    The race itself is closed by ``_training_lock`` (one writer at a time);
+    these tests cover the all-or-nothing semantics for the case where a
+    property setter rejects a value mid-loop. No setter currently raises,
+    so we drive the path with a fake network that raises on a chosen key.
+    """
+
+    class _FakeNetwork:
+        """Minimal stand-in with the attributes update_params() touches.
+
+        ``failing_key`` (when set) makes setattr for that key raise ValueError,
+        modeling a future property setter that validates input.
+        """
+
+        def __init__(self, failing_key: str | None = None):
+            self.learning_rate = 0.01
+            self.candidate_learning_rate = 0.02
+            self.correlation_threshold = 0.1
+            self.candidate_pool_size = 8
+            self.max_hidden_units = 50
+            self.epochs_max = 100
+            self.max_iterations = 200
+            self.patience = 5
+            self.convergence_threshold = 1e-4
+            self.candidate_convergence_threshold = 1e-4
+            self.candidate_patience = 3
+            self.candidate_epochs = 10
+            self.init_output_weights = "zero"
+            self._failing_key = failing_key
+
+        def __setattr__(self, name, value):
+            failing = self.__dict__.get("_failing_key")
+            if failing is not None and name == failing:
+                raise ValueError(f"setter rejected: {name}={value!r}")
+            object.__setattr__(self, name, value)
+
+    def _mgr_with_network(self, network):
+        mgr = TrainingLifecycleManager()
+        mgr.network = network
+        return mgr
+
+    def test_happy_path_applies_all_keys(self):
+        """All updatable keys are applied when no setter raises."""
+        net = self._FakeNetwork()
+        mgr = self._mgr_with_network(net)
+        mgr.update_params(
+            {"learning_rate": 0.005, "correlation_threshold": 0.2, "patience": 10}
+        )
+        assert net.learning_rate == pytest.approx(0.005)
+        assert net.correlation_threshold == pytest.approx(0.2)
+        assert net.patience == 10
+
+    def test_unrecognized_keys_silently_skipped(self):
+        """Unknown keys don't raise and don't change state."""
+        net = self._FakeNetwork()
+        mgr = self._mgr_with_network(net)
+        before = net.learning_rate
+        mgr.update_params({"this_is_not_a_real_key": 99, "learning_rate": before + 0.1})
+        assert net.learning_rate == pytest.approx(before + 0.1)
+
+    def test_setter_failure_rolls_back_earlier_keys(self):
+        """If patience setter raises, learning_rate and correlation_threshold
+        (applied before patience in iteration order) must be reverted."""
+        net = self._FakeNetwork(failing_key="patience")
+        mgr = self._mgr_with_network(net)
+
+        original_lr = net.learning_rate
+        original_threshold = net.correlation_threshold
+        original_patience = net.patience
+
+        with pytest.raises(ValueError, match="setter rejected: patience"):
+            # Dict order matters: in Python 3.7+ dicts preserve insertion order,
+            # so learning_rate and correlation_threshold are applied before patience.
+            mgr.update_params(
+                {
+                    "learning_rate": 0.999,
+                    "correlation_threshold": 0.999,
+                    "patience": 999,
+                }
+            )
+
+        # GAP-WS-28: all three must be at their original values.
+        assert net.learning_rate == pytest.approx(original_lr), "learning_rate not rolled back"
+        assert net.correlation_threshold == pytest.approx(original_threshold), "correlation_threshold not rolled back"
+        assert net.patience == original_patience, "patience never advanced (correct)"
+
+    def test_setter_failure_on_first_key_no_state_change(self):
+        """If the first key's setter raises, nothing was applied — nothing to revert."""
+        net = self._FakeNetwork(failing_key="learning_rate")
+        mgr = self._mgr_with_network(net)
+        original_lr = net.learning_rate
+        original_threshold = net.correlation_threshold
+
+        with pytest.raises(ValueError):
+            mgr.update_params({"learning_rate": 0.999, "correlation_threshold": 0.999})
+
+        assert net.learning_rate == pytest.approx(original_lr)
+        assert net.correlation_threshold == pytest.approx(original_threshold)
+
+    def test_no_network_raises_value_error(self):
+        """Pre-existing contract preserved: no network → ValueError."""
+        mgr = TrainingLifecycleManager()
+        with pytest.raises(ValueError, match="No network exists"):
+            mgr.update_params({"learning_rate": 0.005})


### PR DESCRIPTION
## Summary

Closes the all-or-nothing-semantics gap surfaced during the [2026-04-28 GAP-WS audit](https://github.com/pcalnon/juniper-ml/pull/163). The race itself was already closed (`_training_lock` serializes the entire setattr loop), but the loop applied keys in iteration order and re-raised on the first failure — leaving keys 1..N-1 committed and keys N..end unapplied.

With no current property setter raising, this was a defensive concern. But it blocks any future addition of validating setters (type-checking, range-checking, etc.) without re-introducing torn writes.

## Approach

Capture-then-revert, not validate-then-commit:

1. Filter `params` to recognized keys with `hasattr` matches.
2. Snapshot current values for every applicable key.
3. Loop `setattr`; on any exception, walk the applied list in reverse and restore each key.
4. Re-raise the original exception.

Revert errors are caught and logged via `logger.exception` so a secondary failure during rollback does not mask the original.

## Files changed

- `src/api/lifecycle/manager.py` — `update_params` rewritten with the snapshot-and-revert pattern
- `src/tests/unit/api/test_lifecycle_manager.py` — 5 new tests in `TestUpdateParamsAtomicity` (direct unit tests bypass TestClient)

## Tests

- happy path applies all keys
- unrecognized keys silently skipped (existing contract preserved)
- setter raise mid-loop reverts earlier keys (drives the failure path with a fake network whose `__setattr__` rejects a chosen key)
- setter raise on first key leaves nothing to revert
- `no network` still raises `ValueError`

Cascor conda env can't run tests locally (torch + Py3.14 free-threading segfault per memory) — relying on CI.

## Test plan

- [ ] CI green (pre-commit + unit tests across Py3.12/3.13/3.14)
- [ ] No regressions in existing `test_api_runtime_params.py` (PATCH /v1/training/params still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)