### PR TITLE
feat(training): A-1 cascor — surface output_epochs in TrainingParams + patch path

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -835,6 +835,9 @@ class TrainingLifecycleManager:
             "candidate_patience": getattr(self.network, "candidate_patience", _PROJECT_API_LIFECYCLE_DEFAULT_CANDIDATE_PATIENCE),
             "candidate_convergence_threshold": getattr(self.network, "candidate_convergence_threshold", 0.001),
             "candidate_epochs": getattr(self.network, "candidate_epochs", 0),
+            # CAS-002 (Phase 6E Sprint A-1): per-output-training-phase budget,
+            # distinct from ``epochs_max`` (the global cap).
+            "output_epochs": getattr(self.network, "output_epochs", 0),
             "init_output_weights": getattr(self.network, "init_output_weights", "zero"),
         }
 
@@ -883,6 +886,7 @@ class TrainingLifecycleManager:
                 "candidate_convergence_threshold",
                 "candidate_patience",
                 "candidate_epochs",
+                "output_epochs",  # CAS-002 (Phase 6E Sprint A-1)
                 "init_output_weights",
             }
             applicable = {k: v for k, v in params.items() if k in updatable_keys and hasattr(self.network, k)}

--- a/src/api/models/training.py
+++ b/src/api/models/training.py
@@ -57,6 +57,11 @@ class TrainingParams(BaseModel):
     candidate_convergence_threshold: Optional[float] = Field(None, gt=0, description="Minimum loss improvement for candidate training patience")
     candidate_patience: Optional[int] = Field(None, ge=1, le=100_000, description="Candidate training patience epochs")
     candidate_epochs: Optional[int] = Field(None, ge=1, le=1_000_000, description="Number of epochs for candidate training")
+    # CAS-002 (Phase 6E Sprint A-1): per-output-training-phase epoch budget,
+    # distinct from the global ``epochs_max``. The network already exposes
+    # ``self.output_epochs`` and consumes ``self.config.output_epochs`` at
+    # construction; this surfaces it on the start-of-training override surface.
+    output_epochs: Optional[int] = Field(None, ge=1, le=1_000_000, description="Per-output-training-phase epoch budget (separate from epochs_max)")
     init_output_weights: Optional[Literal["zero", "random"]] = Field(None, description="Initialization mode for new hidden unit output weights")
 
 
@@ -94,4 +99,6 @@ class TrainingParamUpdateRequest(BaseModel):
     candidate_convergence_threshold: Optional[float] = Field(None, gt=0, description="Minimum loss improvement for candidate training patience")
     candidate_patience: Optional[int] = Field(None, ge=1, description="Candidate training early stopping patience epochs")
     candidate_epochs: Optional[int] = Field(None, ge=1, description="Number of epochs for candidate training")
+    # CAS-002 (Phase 6E Sprint A-1): runtime-patchable counterpart to TrainingParams.output_epochs.
+    output_epochs: Optional[int] = Field(None, ge=1, description="Per-output-training-phase epoch budget (separate from epochs_max)")
     init_output_weights: Optional[Literal["zero", "random"]] = Field(None, description="Initialization mode for new hidden unit output weights")

--- a/src/tests/unit/api/test_api_runtime_params.py
+++ b/src/tests/unit/api/test_api_runtime_params.py
@@ -105,3 +105,38 @@ class TestUpdateTrainingParams:
             json={"init_output_weights": "invalid"},
         )
         assert response.status_code == 422
+
+    # CAS-002 (Phase 6E Sprint A-1): output_epochs is a per-output-training-phase
+    # epoch budget, distinct from the global ``epochs_max``. The network already
+    # exposes ``self.output_epochs``; this PR surfaces it on the param-update
+    # surface (TrainingParamUpdateRequest) and the get/set lifecycle path.
+    def test_update_output_epochs_updates_live_network(self, test_client_with_network):
+        """PATCH /v1/training/params applies output_epochs to the live network."""
+        response = test_client_with_network.patch(
+            "/v1/training/params",
+            json={"output_epochs": 250},
+        )
+        assert response.status_code == 200
+        lifecycle = test_client_with_network.app.state.lifecycle
+        assert lifecycle.network.output_epochs == 250
+
+    def test_update_output_epochs_rejects_non_positive(self, test_client_with_network):
+        """PATCH /v1/training/params enforces output_epochs >= 1 (matches the
+        Pydantic validator on TrainingParamUpdateRequest)."""
+        response = test_client_with_network.patch(
+            "/v1/training/params",
+            json={"output_epochs": 0},
+        )
+        assert response.status_code == 422
+
+    def test_get_training_params_includes_output_epochs(self, test_client_with_network):
+        """GET /v1/training/params returns output_epochs alongside the other fields,
+        so a reconnecting client can reconcile UI state without falling back to
+        stale defaults."""
+        response = test_client_with_network.get("/v1/training/params")
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert "output_epochs" in data
+        # Live network has a non-zero default — verify it's a positive int.
+        assert isinstance(data["output_epochs"], int)
+        assert data["output_epochs"] >= 1


### PR DESCRIPTION
## Summary

Phase 6E **Sprint A-1** — first wire-through PR. Surfaces cascor's existing `self.output_epochs` (per-output-training-phase epoch budget) on the API training-param surface, exposing CAS-002's "separate epoch limits" capability that was already implemented network-side but invisible above the API.

## Code-surface evidence

- `cascade_correlation.py:672` — `self.output_epochs = self.config.output_epochs or _CASCADE_CORRELATION_NETWORK_OUTPUT_EPOCHS` (already there)
- `api/models/network.py:36` — `output_epochs` already in `NetworkCreateRequest`
- `api/models/training.py:32` — `TrainingParams` was missing it (gap closed here)
- `api/models/training.py:82` — `TrainingParamUpdateRequest` was missing it (gap closed here)
- `lifecycle/manager.py:873` — `updatable_keys` whitelist was missing it (gap closed here)
- `lifecycle/manager.py:826` — `get_training_params` return shape was missing it (gap closed here)

## What changes

| File | Change |
|---|---|
| `api/models/training.py` | `output_epochs: Optional[int]` added to `TrainingParams` and `TrainingParamUpdateRequest` (both with `ge=1` validator) |
| `api/lifecycle/manager.py` | Added to `updatable_keys` whitelist + `get_training_params` return |
| `tests/unit/api/test_api_runtime_params.py` | 3 new tests (PATCH applies, rejects 0, GET returns field) |

## What does NOT change

`CascadeCorrelationNetwork.fit()` signature stays as-is. The kwarg-passthrough path (routes → `start_training(**kwargs)` → `fit(**kwargs)`) does not gain `output_epochs` because `fit` only accepts a narrow kwarg set today. **Canopy uses `set_params` (the PATCH-equivalent), which IS wired here.** Routing arbitrary `TrainingParams` fields through `fit()` is a pre-existing latent issue independent of this PR.

## Tests

3 new tests in `TestUpdateTrainingParams`:
- `test_update_output_epochs_updates_live_network` — PATCH applies value to `self.network.output_epochs`
- `test_update_output_epochs_rejects_non_positive` — Pydantic `ge=1` rejects 0 with 422
- `test_get_training_params_includes_output_epochs` — GET returns the field with a positive int default

Cascor conda env can't run tests locally (torch + Py3.14 free-threading segfault per memory) — relying on CI.

## Test plan

- [ ] CI green (pre-commit + 3.12/3.13/3.14 unit tests)
- [ ] Pairs with juniper-canopy A-1 PR (TBD) for end-to-end smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)