### PR TITLE
feat(training): A-2 cascor — surface optimizer_type in TrainingParams + nested patch

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -23,6 +23,24 @@ from api.lifecycle.state_machine import Command, TrainingPhase, TrainingStateMac
 from cascor_constants.constants_api import _PROJECT_API_DRAIN_THREAD_JOIN_TIMEOUT, _PROJECT_API_LIFECYCLE_DEFAULT_CANDIDATE_PATIENCE, _PROJECT_API_LIFECYCLE_DEFAULT_EPOCHS_MAX, _PROJECT_API_LIFECYCLE_DEFAULT_MAX_HIDDEN_UNITS, _PROJECT_API_LIFECYCLE_DEFAULT_MAX_ITERATIONS, _PROJECT_API_NETWORK_INPUT_SIZE_DEFAULT, _PROJECT_API_NETWORK_LEARNING_RATE_DEFAULT, _PROJECT_API_NETWORK_OUTPUT_SIZE_DEFAULT, _PROJECT_API_PROGRESS_QUEUE_GET_TIMEOUT, _PROJECT_API_PROGRESS_QUEUE_WAIT_TIMEOUT
 
 
+def _read_optimizer_type(network: Any) -> str:
+    """CAN-010 / ENH-006 (A-2): read ``optimizer_type`` through the nested
+    ``config.optimizer_config`` path. Falls back to ``"Adam"`` if the chain
+    is missing — same default as ``OptimizerConfig`` itself."""
+    config = getattr(network, "config", None)
+    optimizer_config = getattr(config, "optimizer_config", None) if config is not None else None
+    return getattr(optimizer_config, "optimizer_type", "Adam") if optimizer_config is not None else "Adam"
+
+
+def _write_optimizer_type(network: Any, value: str) -> None:
+    """CAN-010 / ENH-006 (A-2): set ``optimizer_type`` through the nested
+    ``config.optimizer_config`` path. Used by ``update_params`` so the
+    setattr-on-network pattern in ``updatable_keys`` works for this nested
+    field. Raises if the chain is missing — matches the contract of the
+    other setters."""
+    network.config.optimizer_config.optimizer_type = value
+
+
 class TrainingLifecycleManager:
     """Central coordinator for CasCor network training lifecycle.
 
@@ -839,6 +857,10 @@ class TrainingLifecycleManager:
             # distinct from ``epochs_max`` (the global cap).
             "output_epochs": getattr(self.network, "output_epochs", 0),
             "init_output_weights": getattr(self.network, "init_output_weights", "zero"),
+            # CAN-010 / ENH-006 (Phase 6E Sprint A-2): output-layer optimizer.
+            # Reads through the nested ``config.optimizer_config`` so a runtime
+            # patch via ``update_params`` is reflected here on the next GET.
+            "optimizer_type": _read_optimizer_type(self.network),
         }
 
     def update_params(self, params: Dict[str, Any]) -> Dict[str, Any]:
@@ -888,19 +910,38 @@ class TrainingLifecycleManager:
                 "candidate_epochs",
                 "output_epochs",  # CAS-002 (Phase 6E Sprint A-1)
                 "init_output_weights",
+                "optimizer_type",  # CAN-010 / ENH-006 (Phase 6E Sprint A-2) — nested setter
             }
-            applicable = {k: v for k, v in params.items() if k in updatable_keys and hasattr(self.network, k)}
+            # Plain setattr targets — keys that map directly to network attributes.
+            simple_keys = updatable_keys - {"optimizer_type"}
+            applicable = {k: v for k, v in params.items() if k in simple_keys and hasattr(self.network, k)}
             old_values = {k: getattr(self.network, k) for k in applicable}
+
+            # CAN-010 / ENH-006: ``optimizer_type`` lives at
+            # ``self.network.config.optimizer_config.optimizer_type``, not on
+            # the network directly. Treated separately so the rollback path
+            # below still works through the same revert mechanism.
+            optimizer_pending = "optimizer_type" in params and params["optimizer_type"] is not None
+            old_optimizer_type = _read_optimizer_type(self.network) if optimizer_pending else None
+
             applied: list[str] = []
             try:
                 for key, value in applicable.items():
                     setattr(self.network, key, value)
                     applied.append(key)
+                if optimizer_pending:
+                    _write_optimizer_type(self.network, params["optimizer_type"])
+                    applied.append("optimizer_type")
             except Exception:
                 # GAP-WS-28: revert any partial application before propagating.
+                # CAN-010 / ENH-006 (A-2): optimizer_type goes through the
+                # nested setter, so the revert needs to mirror the apply path.
                 for key in reversed(applied):
                     try:
-                        setattr(self.network, key, old_values[key])
+                        if key == "optimizer_type":
+                            _write_optimizer_type(self.network, old_optimizer_type)
+                        else:
+                            setattr(self.network, key, old_values[key])
                     except Exception:
                         # If revert itself raises, log and continue rolling
                         # back the rest — best-effort consistency.

--- a/src/api/models/network.py
+++ b/src/api/models/network.py
@@ -37,6 +37,15 @@ class NetworkCreateRequest(BaseModel):
     epochs_max: int = Field(_PROJECT_API_NETWORK_EPOCHS_MAX_DEFAULT, ge=1)
     max_iterations: int = Field(_PROJECT_API_NETWORK_MAX_ITERATIONS_DEFAULT, ge=1, description="Maximum cascade growth iterations")
     init_output_weights: Literal["zero", "random"] = Field(_PROJECT_API_NETWORK_INIT_OUTPUT_WEIGHTS_DEFAULT, description="Initialization mode for new hidden unit output weights")
+    # CAN-010 / ENH-006 (Phase 6E Sprint A-2): output-layer optimizer.
+    # The full registry lives in ``cascade_correlation.py::_create_optimizer``
+    # — duplicating it as a Literal here keeps the API surface explicit and
+    # gives clients a 422 instead of a runtime warning when they ask for an
+    # unsupported optimizer.
+    optimizer_type: Literal[
+        "Adam", "AdamW", "SGD", "RMSprop", "NAdam", "RAdam", "Adamax",
+        "Adagrad", "Adadelta", "Adafactor", "ASGD", "LBFGS", "Rprop", "Muon",
+    ] = Field("Adam", description="Output-layer optimizer (defaults to Adam)")
 
 
 class NetworkInfo(BaseModel):

--- a/src/api/models/training.py
+++ b/src/api/models/training.py
@@ -63,6 +63,16 @@ class TrainingParams(BaseModel):
     # construction; this surfaces it on the start-of-training override surface.
     output_epochs: Optional[int] = Field(None, ge=1, le=1_000_000, description="Per-output-training-phase epoch budget (separate from epochs_max)")
     init_output_weights: Optional[Literal["zero", "random"]] = Field(None, description="Initialization mode for new hidden unit output weights")
+    # CAN-010 / ENH-006 (Phase 6E Sprint A-2): output-layer optimizer override.
+    # Honored at the next output-training pass — the network's
+    # ``_create_optimizer`` consults ``self.config.optimizer_config.optimizer_type``
+    # each pass, so changing this between passes swaps the optimizer cleanly.
+    # Mid-pass changes are not supported (the running optimizer instance keeps
+    # its momentum).
+    optimizer_type: Optional[Literal[
+        "Adam", "AdamW", "SGD", "RMSprop", "NAdam", "RAdam", "Adamax",
+        "Adagrad", "Adadelta", "Adafactor", "ASGD", "LBFGS", "Rprop", "Muon",
+    ]] = Field(None, description="Output-layer optimizer override")
 
 
 class TrainingStartRequest(BaseModel):
@@ -102,3 +112,8 @@ class TrainingParamUpdateRequest(BaseModel):
     # CAS-002 (Phase 6E Sprint A-1): runtime-patchable counterpart to TrainingParams.output_epochs.
     output_epochs: Optional[int] = Field(None, ge=1, description="Per-output-training-phase epoch budget (separate from epochs_max)")
     init_output_weights: Optional[Literal["zero", "random"]] = Field(None, description="Initialization mode for new hidden unit output weights")
+    # CAN-010 / ENH-006 (A-2): runtime-patchable counterpart.
+    optimizer_type: Optional[Literal[
+        "Adam", "AdamW", "SGD", "RMSprop", "NAdam", "RAdam", "Adamax",
+        "Adagrad", "Adadelta", "Adafactor", "ASGD", "LBFGS", "Rprop", "Muon",
+    ]] = Field(None, description="Output-layer optimizer override")

--- a/src/cascade_correlation/cascade_correlation_config/cascade_correlation_config.py
+++ b/src/cascade_correlation/cascade_correlation_config/cascade_correlation_config.py
@@ -167,6 +167,14 @@ class CascadeCorrelationConfig:
         random_value_scale: float = _CASCADE_CORRELATION_NETWORK_RANDOM_VALUE_SCALE,
         # Output weight initialization
         init_output_weights: str = _CASCADE_CORRELATION_NETWORK_INIT_OUTPUT_WEIGHTS,
+        # CAN-010 / ENH-006 (Phase 6E Sprint A-2): output-layer optimizer
+        # type. Mirrors to ``self.optimizer_config.optimizer_type`` so the
+        # existing ``_create_optimizer`` registry dispatch picks it up at
+        # the next output-training pass. Validation against the registry
+        # happens inside ``_create_optimizer`` (warns + falls back to
+        # "Adam" for unknown values). Pydantic Literal at the API boundary
+        # already restricts the wire to the supported set.
+        optimizer_type: str = "Adam",
         # Logging configuration
         log_config: LogConfig = None,
         log_file_name: str = _CASCADE_CORRELATION_NETWORK_LOG_FILE_NAME,
@@ -283,8 +291,11 @@ class CascadeCorrelationConfig:
         # Snapshot directory
         self.cascade_correlation_network_snapshots_dir = cascade_correlation_network_snapshots_dir
 
-        # Optimizer configuration
-        self.optimizer_config = OptimizerConfig(learning_rate=learning_rate)
+        # Optimizer configuration. CAN-010 / ENH-006 (A-2): forward
+        # ``optimizer_type`` from the constructor kwargs so creation-time
+        # selection (POST /v1/network with ``optimizer_type``) and
+        # start-time override (TrainingParams) both reach the registry.
+        self.optimizer_config = OptimizerConfig(learning_rate=learning_rate, optimizer_type=optimizer_type)
 
         # UUID
         self.uuid = uuid

--- a/src/tests/unit/api/test_api_runtime_params.py
+++ b/src/tests/unit/api/test_api_runtime_params.py
@@ -140,3 +140,51 @@ class TestUpdateTrainingParams:
         # Live network has a non-zero default — verify it's a positive int.
         assert isinstance(data["output_epochs"], int)
         assert data["output_epochs"] >= 1
+
+    # CAN-010 / ENH-006 (Phase 6E Sprint A-2): optimizer_type lives in a
+    # nested config (network.config.optimizer_config.optimizer_type) rather
+    # than directly on the network — runtime patching goes through a
+    # special-cased setter in update_params (_write_optimizer_type).
+    def test_update_optimizer_type_updates_nested_config(self, test_client_with_network):
+        """PATCH /v1/training/params applies optimizer_type to the nested config."""
+        response = test_client_with_network.patch(
+            "/v1/training/params",
+            json={"optimizer_type": "AdamW"},
+        )
+        assert response.status_code == 200
+        lifecycle = test_client_with_network.app.state.lifecycle
+        assert lifecycle.network.config.optimizer_config.optimizer_type == "AdamW"
+
+    def test_update_optimizer_type_rejects_unsupported(self, test_client_with_network):
+        """Pydantic Literal rejects optimizer names outside the supported set."""
+        response = test_client_with_network.patch(
+            "/v1/training/params",
+            json={"optimizer_type": "NotARealOptimizer"},
+        )
+        assert response.status_code == 422
+
+    def test_update_optimizer_type_accepts_full_registry(self, test_client_with_network):
+        """Each Literal-allowed optimizer is accepted by the API."""
+        for name in ("Adam", "AdamW", "SGD", "RMSprop", "NAdam", "RAdam", "Adamax", "Adagrad"):
+            response = test_client_with_network.patch(
+                "/v1/training/params",
+                json={"optimizer_type": name},
+            )
+            assert response.status_code == 200, f"PATCH rejected supported optimizer {name!r}"
+
+    def test_get_training_params_includes_optimizer_type(self, test_client_with_network):
+        """GET surfaces optimizer_type so UI clients can reconcile after reconnect."""
+        response = test_client_with_network.get("/v1/training/params")
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert "optimizer_type" in data
+        assert data["optimizer_type"] in {
+            "Adam", "AdamW", "SGD", "RMSprop", "NAdam", "RAdam", "Adamax",
+            "Adagrad", "Adadelta", "Adafactor", "ASGD", "LBFGS", "Rprop", "Muon",
+        }
+
+    def test_update_optimizer_type_round_trip(self, test_client_with_network):
+        """PATCH then GET — the optimizer_type round-trips correctly."""
+        test_client_with_network.patch("/v1/training/params", json={"optimizer_type": "SGD"})
+        data = test_client_with_network.get("/v1/training/params").json()["data"]
+        assert data["optimizer_type"] == "SGD"


### PR DESCRIPTION
## Summary

Phase 6E **Sprint A-2** — second wire-through PR. Surfaces cascor's existing 13-variant `_create_optimizer` registry on the API. Until this PR, the registry existed but no API path could select among its variants — clients always got the hardcoded `OptimizerConfig.optimizer_type = "Adam"` default.

## Code-surface evidence

- `cascade_correlation.py:2580–2732` — `_create_optimizer` registry with 13 PyTorch optimizers (Adam, AdamW, SGD, RMSprop, NAdam, RAdam, Adamax, Adagrad, Adadelta, Adafactor, ASGD, LBFGS, Rprop, Muon)
- `cascade_correlation_config.py:98` — `OptimizerConfig.optimizer_type: str = "Adam"` (default existed; no plumbing path)
- `cascade_correlation_config.py:287` — `CascadeCorrelationConfig.__init__` constructed `OptimizerConfig(learning_rate=...)` with no `optimizer_type` forwarding (gap closed here)
- `api/models/network.py`, `api/models/training.py` — neither model had `optimizer_type` (gap closed here)

## What changes

| File | Change |
|---|---|
| `cascade_correlation_config.py` | `CascadeCorrelationConfig.__init__` gains `optimizer_type` param; forwards to `OptimizerConfig` |
| `api/models/network.py` | `NetworkCreateRequest.optimizer_type: Literal[...]` (14 options matching the registry) |
| `api/models/training.py` | Same Literal in `TrainingParams` (start-time) and `TrainingParamUpdateRequest` (runtime patch) |
| `api/lifecycle/manager.py` | New `_read_optimizer_type` / `_write_optimizer_type` helpers; `update_params` whitelist + GAP-WS-28 rollback updated to handle the nested path |
| `tests/unit/api/test_api_runtime_params.py` | 5 new tests |

## Design choice — nested setter, not a property

`optimizer_type` lives at `self.network.config.optimizer_config.optimizer_type`, not on the network directly. Two approaches considered:

- **Property on the network class**: cleaner at the call site (`setattr(self.network, "optimizer_type", val)` would just work). But the network class has `__getstate__`/`__setstate__` for pickling during multiprocessing candidate training — adding properties can introduce subtle pickle issues.
- **Nested setter helpers in the lifecycle layer** (chosen): contained, doesn't touch the network class's pickling contract. Two two-line helpers handle read and write; `update_params` special-cases the key while keeping the GAP-WS-28 rollback semantics intact.

## What does NOT change

- `CascadeCorrelationNetwork.fit()` signature stays. The start-path kwarg-passthrough latent issue I uncovered during A-1 is documented separately (see follow-up PR).
- Optimizer is recreated each output-training pass anyway (`_create_optimizer` runs from `train_output_layer`), so mid-pass changes preserve the running instance's momentum (semantic choice, not a bug).

## Tests

5 new tests:
- PATCH applies value to nested `config.optimizer_config.optimizer_type`
- Pydantic Literal rejects unsupported names with 422
- All 8 commonly-used Literal options accepted via PATCH
- GET surfaces `optimizer_type`
- PATCH → GET round-trip preserves value

Cascor conda env can't run tests locally (torch + Py3.14 free-threading segfault per memory) — relying on CI.

## Test plan

- [ ] CI green (pre-commit + 3.12/3.13/3.14 unit tests)
- [ ] Pairs with juniper-canopy A-2 PR (TBD) for end-to-end smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)