### PR TITLE
feat(protocol): promote juniper-cascor-protocol 0.1.0a0 → 0.1.0 stable — R2.2.3

### DIFF
--- a/juniper-cascor-protocol/CHANGELOG.md
+++ b/juniper-cascor-protocol/CHANGELOG.md
@@ -8,6 +8,18 @@ with [PEP 440](https://peps.python.org/pep-0440/) pre-release identifiers.
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-04-30
+
+### Changed
+
+- **First stable promotion** (METRICS-MON R2.2.3 / seed-05). Promoted from pre-release to stable now that the first consumer (juniper-cascor server, [pcalnon/juniper-cascor#159](https://github.com/pcalnon/juniper-cascor/pull/159)) has shipped without surfacing a wire-format regression. **No public-API changes** vs `0.1.0a0` — same surface, same behavior; only the version string and trove classifier change.
+- Trove classifier moved from `Development Status :: 3 - Alpha` to `Development Status :: 4 - Beta` to reflect the 0.1.x stability commitment.
+- Consumers should pin `juniper-cascor-protocol>=0.1.0` going forward. Existing pins of `>=0.1.0a0` continue to resolve to the latest published version, which is now `0.1.0`.
+
+### Notes
+
+- The previous alpha (`0.1.0a0`) remains on PyPI for reproducibility of historical builds. Yanking is intentionally avoided; consumers can downgrade in a hotfix scenario by pinning explicitly.
+
 ## [0.1.0a0] - 2026-04-29
 
 Initial publishable alpha. METRICS-MON R2.2.1 / seed-05.
@@ -28,5 +40,6 @@ Initial publishable alpha. METRICS-MON R2.2.1 / seed-05.
 - This release ships the schemas only. The cascor server adopts them in R2.2.2, then the alpha is promoted to `0.1.0` in R2.2.3 after a soak. Consumers (cascor-client R2.2.4, canopy R2.2.5, worker R2.2.6) pin `>=0.1.0` once stable.
 - See the design at [`notes/code-review/METRICS_MONITORING_R2.2_WS_FRAME_SCHEMA_DESIGN_2026-04-29.md`](https://github.com/pcalnon/juniper-ml/blob/main/notes/code-review/METRICS_MONITORING_R2.2_WS_FRAME_SCHEMA_DESIGN_2026-04-29.md) in juniper-ml.
 
-[Unreleased]: https://github.com/pcalnon/juniper-cascor/compare/juniper-cascor-protocol-v0.1.0a0...HEAD
+[Unreleased]: https://github.com/pcalnon/juniper-cascor/compare/juniper-cascor-protocol-v0.1.0...HEAD
+[0.1.0]: https://github.com/pcalnon/juniper-cascor/releases/tag/juniper-cascor-protocol-v0.1.0
 [0.1.0a0]: https://github.com/pcalnon/juniper-cascor/releases/tag/juniper-cascor-protocol-v0.1.0a0

--- a/juniper-cascor-protocol/juniper_cascor_protocol/_version.py
+++ b/juniper-cascor-protocol/juniper_cascor_protocol/_version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the package version."""
 
-__version__ = "0.1.0a0"
+__version__ = "0.1.0"

--- a/juniper-cascor-protocol/pyproject.toml
+++ b/juniper-cascor-protocol/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "juniper-cascor-protocol"
-version = "0.1.0a0"
+version = "0.1.0"
 description = "Cross-process WebSocket frame schemas for the juniper-cascor protocol (envelope + worker)"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -12,7 +12,7 @@ license = { text = "MIT" }
 authors = [{ name = "Paul Calnon" }]
 keywords = ["juniper", "cascor", "websocket", "protocol", "schema"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",

--- a/juniper-cascor-protocol/tests/test_public_api.py
+++ b/juniper-cascor-protocol/tests/test_public_api.py
@@ -62,9 +62,14 @@ def test_worker_all_matches_expected():
         assert hasattr(worker_pkg, sym), f"missing worker symbol: {sym}"
 
 
-def test_version_is_alpha_string():
-    """0.1.0a0 — first publishable alpha, never released."""
-    assert juniper_cascor_protocol.__version__ == "0.1.0a0"
+def test_version_is_stable_string():
+    """0.1.0 — first stable release after the cascor server soak (R2.2.3).
+
+    Released as the post-alpha stable. The previous alpha (``0.1.0a0``)
+    remains on PyPI for reproducibility but consumers should pin
+    ``juniper-cascor-protocol>=0.1.0`` going forward.
+    """
+    assert juniper_cascor_protocol.__version__ == "0.1.0"
 
 
 def test_worker_subpackage_does_not_import_pydantic():


### PR DESCRIPTION
## Summary

METRICS-MON **R2.2.3 / seed-05**. Promotes the WS frame schema package from pre-release to stable now that the first consumer (cascor server, [#159](https://github.com/pcalnon/juniper-cascor/pull/159)) has shipped without surfacing a wire-format regression.

**No public-API changes** vs `0.1.0a0` — same 20-symbol surface, same byte-for-byte emit shapes; only the version string and trove classifier change.

## Changes

- `juniper-cascor-protocol/juniper_cascor_protocol/_version.py` — `__version__ = \"0.1.0\"`
- `juniper-cascor-protocol/pyproject.toml` — `version = \"0.1.0\"`; classifier `Development Status :: 3 - Alpha` → `Development Status :: 4 - Beta`
- `juniper-cascor-protocol/tests/test_public_api.py` — renamed `test_version_is_alpha_string` → `test_version_is_stable_string` asserting `\"0.1.0\"`
- `juniper-cascor-protocol/CHANGELOG.md` — `[0.1.0] — 2026-04-30` entry with cross-reference to the cascor server soak

## Local verification

60/60 tests pass at 99% coverage in a clean Python 3.12 venv. `python -m build` produces `juniper_cascor_protocol-0.1.0` sdist + wheel; `twine check dist/*` passes both.

Pre-commit clean (markdownlint, TOML/AST checks).

## Consumer pinning policy

Consumers should pin `juniper-cascor-protocol>=0.1.0` going forward. Existing pins of `>=0.1.0a0` (currently in juniper-cascor's own `pyproject.toml` after R2.2.2) continue to resolve to the latest published version, which after this lands and the tag fires will be `0.1.0`.

## Test plan

- [ ] CI: `ci-protocol` workflow passes on Python 3.12 + 3.13 with ≥95% coverage
- [ ] CI: build + twine check pass
- [ ] After merge: push tag `juniper-cascor-protocol-v0.1.0` → fires `publish-protocol.yml` → TestPyPI install verify → PyPI via OIDC

## Next

After this PR merges + tag pushed + 0.1.0 is on PyPI:

- **R2.2.4** — juniper-cascor-client validates inbound `/ws/training` and `/ws/control` frames against the envelope models; counter on `[observability]` extra
- **R2.2.5** — juniper-canopy validates inbound frames; counter on existing `/metrics`
- **R2.2.6** — juniper-cascor-worker single-sources `WorkerMessageType` + `BinaryFrame`; structured log line on unknown types
- **R2.2.7** — juniper-ml: roadmap §9 R2.2 → done; close R2 phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)