### PR TITLE
feat(training): A-4 cascor — auto_snap_best lifecycle hook (CAS-006) + repair update_params dead-code merge artifact

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -127,7 +127,57 @@ class TrainingLifecycleManager:
         self._start_liveness_thread()
         self._register_liveness_monitor_callbacks()
 
+        # CAS-006 (Phase 6E Sprint A-4): auto-snap-best.
+        # Hooks ``training_monitor.epoch_end`` and saves a snapshot every
+        # time (validation) accuracy beats the best-seen-so-far for the
+        # current run. Defaults: feature off, 50-epoch warmup. Both are
+        # exposed via TrainingParams + TrainingParamUpdateRequest and
+        # included in ``updatable_keys`` so users can toggle mid-run.
+        self._auto_snap_best: bool = False
+        self._auto_snap_min_epochs: int = 50
+        self._auto_snap_best_metric: Optional[float] = None
+        self._auto_snap_lock = threading.Lock()
+        self.training_monitor.register_callback("epoch_end", self._maybe_auto_snap_callback)
+
         self.logger.info("TrainingLifecycleManager initialized")
+
+    def _maybe_auto_snap_callback(self, metrics=None, epoch=None, loss=None, accuracy=None, **_kwargs) -> None:
+        """CAS-006 (A-4): epoch_end callback that saves a snapshot when the
+        current (validation) accuracy beats the best-seen-so-far for the
+        current run. No-op when the feature is disabled, when the warmup
+        threshold has not been reached, or when no usable accuracy metric
+        is available.
+
+        Tracks the best metric on the lifecycle (not the network) because
+        a single network instance can be used across multiple training
+        runs; ``start_training`` resets the tracker so each run starts
+        fresh. Prefers ``validation_accuracy`` over ``accuracy`` so the
+        snapshot reflects generalization rather than training-set fit.
+        """
+        with self._auto_snap_lock:
+            if not self._auto_snap_best:
+                return
+            if epoch is None or epoch < self._auto_snap_min_epochs:
+                return
+            current = None
+            if isinstance(metrics, dict):
+                current = metrics.get("validation_accuracy")
+            if current is None:
+                current = accuracy
+            if current is None:
+                return
+            best = self._auto_snap_best_metric
+            if best is not None and current <= best:
+                return
+            self._auto_snap_best_metric = current
+            description = f"auto_snap_best epoch={epoch} accuracy={current:.6f}"
+        # Save outside the auto_snap_lock so a slow filesystem doesn't
+        # serialize the next epoch_end callback. ``save_snapshot`` has
+        # its own internal failure handling.
+        try:
+            self.save_snapshot(description=description)
+        except Exception:
+            self.logger.exception("auto_snap_best: save_snapshot failed (epoch=%s, accuracy=%s)", epoch, current)
 
     def _register_liveness_monitor_callbacks(self) -> None:
         """Bump the heartbeat from every training-monitor event so progress
@@ -724,6 +774,12 @@ class TrainingLifecycleManager:
             self._stop_requested.clear()
             self._pause_event.set()
 
+            # CAS-006 (A-4): each training run starts fresh — we don't want
+            # a snapshot from a previous run's accuracy ceiling to suppress
+            # auto-snaps in this run.
+            with self._auto_snap_lock:
+                self._auto_snap_best_metric = None
+
             if self._executor is None:
                 self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="cascor-train")
 
@@ -910,6 +966,12 @@ class TrainingLifecycleManager:
             "optimizer_type": _read_optimizer_type(self.network),
             # CAN-011 (Phase 6E Sprint A-3): hidden-unit activation function.
             "activation_function_name": _read_activation_function_name(self.network),
+            # CAS-006 (Phase 6E Sprint A-4): auto-snap-best lifecycle flags.
+            # These live on the lifecycle (not the network) so a single
+            # network instance can be re-used across runs while the auto-
+            # snap counter resets each ``start_training``.
+            "auto_snap_best": self._auto_snap_best,
+            "auto_snap_min_epochs": self._auto_snap_min_epochs,
         }
 
     def update_params(self, params: Dict[str, Any]) -> Dict[str, Any]:
@@ -942,75 +1004,6 @@ class TrainingLifecycleManager:
                 any partially-applied updates.
         """
         with self._training_lock:
-            if self.network is None:
-                raise ValueError("No network exists — create a network first")
-            updatable_keys = {
-                "learning_rate",
-                "candidate_learning_rate",
-                "correlation_threshold",
-                "candidate_pool_size",
-                "max_hidden_units",
-                "epochs_max",
-                "max_iterations",
-                "patience",
-                "convergence_threshold",
-                "candidate_convergence_threshold",
-                "candidate_patience",
-                "candidate_epochs",
-                "output_epochs",  # CAS-002 (Phase 6E Sprint A-1)
-                "init_output_weights",
-                "optimizer_type",  # CAN-010 / ENH-006 (Phase 6E Sprint A-2) — nested setter
-                "activation_function_name",  # CAN-011 (Phase 6E Sprint A-3) — re-init on swap
-            }
-            # Plain setattr targets — keys that map directly to network attributes.
-            # ``optimizer_type`` and ``activation_function_name`` go through
-            # special-cased setters that touch nested config / re-init paths.
-            nested_keys = {"optimizer_type", "activation_function_name"}
-            simple_keys = updatable_keys - nested_keys
-            applicable = {k: v for k, v in params.items() if k in simple_keys and hasattr(self.network, k)}
-            old_values = {k: getattr(self.network, k) for k in applicable}
-
-            # CAN-010 / ENH-006: ``optimizer_type`` lives at
-            # ``self.network.config.optimizer_config.optimizer_type``, not on
-            # the network directly. Treated separately so the rollback path
-            # below still works through the same revert mechanism.
-            optimizer_pending = "optimizer_type" in params and params["optimizer_type"] is not None
-            old_optimizer_type = _read_optimizer_type(self.network) if optimizer_pending else None
-
-            # CAN-011 (A-3): ``activation_function_name`` requires re-running
-            # ``_init_activation_function`` so ``activation_fn`` picks up the
-            # new mapping. Same revert pattern as optimizer_type.
-            activation_pending = "activation_function_name" in params and params["activation_function_name"] is not None
-            old_activation_function_name = _read_activation_function_name(self.network) if activation_pending else None
-
-            applied: list[str] = []
-            try:
-                for key, value in applicable.items():
-                    setattr(self.network, key, value)
-                    applied.append(key)
-                if optimizer_pending:
-                    _write_optimizer_type(self.network, params["optimizer_type"])
-                    applied.append("optimizer_type")
-                if activation_pending:
-                    _write_activation_function_name(self.network, params["activation_function_name"])
-                    applied.append("activation_function_name")
-            except Exception:
-                # GAP-WS-28: revert any partial application before propagating.
-                # CAN-010 / ENH-006 (A-2) + CAN-011 (A-3): nested setters
-                # need their own revert path — mirror the apply branch.
-                for key in reversed(applied):
-                    try:
-                        if key == "optimizer_type":
-                            _write_optimizer_type(self.network, old_optimizer_type)
-                        elif key == "activation_function_name":
-                            _write_activation_function_name(self.network, old_activation_function_name)
-                        else:
-                            setattr(self.network, key, old_values[key])
-                    except Exception:
-                        # If revert itself raises, log and continue rolling
-                        # back the rest — best-effort consistency.
-                        self.logger.exception("update_params rollback: revert of %s failed", key)
-                raise
             return self._apply_params_unlocked(params)
 
     def _apply_params_unlocked(self, params: Dict[str, Any]) -> Dict[str, Any]:
@@ -1019,7 +1012,25 @@ class TrainingLifecycleManager:
         Internal helper extracted from ``update_params`` so that
         ``start_training`` can route TrainingParams body fields through the
         same whitelist + atomic-rollback path without re-entering the
-        non-reentrant ``_training_lock`` (see CASCOR_FIT_KWARGS_LATENT_BUG.md).
+        non-reentrant ``_training_lock`` (see CASCOR_FIT_KWARGS_LATENT_BUG.md
+        for the full rationale of the split).
+
+        Three storage flavors are supported:
+
+        - **simple_keys** — plain attributes on ``self.network`` set via
+          ``setattr``. The bulk of ``updatable_keys``.
+        - **nested_keys** — fields that live on ``network.config`` or in
+          a sub-config and need a special-cased setter (``optimizer_type``
+          via ``_write_optimizer_type``; ``activation_function_name`` via
+          ``_write_activation_function_name``, which also re-runs
+          ``_init_activation_function`` so ``activation_fn`` actually
+          refreshes from the registry).
+        - **lifecycle_keys** — flags that live on the lifecycle (``self``)
+          rather than the network (``auto_snap_*``).
+
+        All three flavors share the same GAP-WS-28 atomic-rollback contract:
+        if any setter raises, every previously-applied key is reverted to
+        its pre-call value before re-raising.
         """
         if self.network is None:
             raise ValueError("No network exists — create a network first")
@@ -1039,18 +1050,37 @@ class TrainingLifecycleManager:
             "output_epochs",  # CAS-002 (Phase 6E Sprint A-1)
             "init_output_weights",
             "optimizer_type",  # CAN-010 / ENH-006 (Phase 6E Sprint A-2) — nested setter
+            "activation_function_name",  # CAN-011 (Phase 6E Sprint A-3) — re-init on swap
+            "auto_snap_best",  # CAS-006 (Phase 6E Sprint A-4) — lifecycle attribute
+            "auto_snap_min_epochs",  # CAS-006 (Phase 6E Sprint A-4) — lifecycle attribute
         }
-        # Plain setattr targets — keys that map directly to network attributes.
-        simple_keys = updatable_keys - {"optimizer_type"}
+        nested_keys = {"optimizer_type", "activation_function_name"}
+        lifecycle_keys = {"auto_snap_best", "auto_snap_min_epochs"}
+        simple_keys = updatable_keys - nested_keys - lifecycle_keys
         applicable = {k: v for k, v in params.items() if k in simple_keys and hasattr(self.network, k)}
         old_values = {k: getattr(self.network, k) for k in applicable}
 
-        # CAN-010 / ENH-006: ``optimizer_type`` lives at
-        # ``self.network.config.optimizer_config.optimizer_type``, not on
-        # the network directly. Treated separately so the rollback path
-        # below still works through the same revert mechanism.
+        # CAN-010 / ENH-006 (A-2): ``optimizer_type`` lives at
+        # ``self.network.config.optimizer_config.optimizer_type``.
         optimizer_pending = "optimizer_type" in params and params["optimizer_type"] is not None
         old_optimizer_type = _read_optimizer_type(self.network) if optimizer_pending else None
+
+        # CAN-011 (A-3): ``activation_function_name`` requires re-running
+        # ``_init_activation_function`` so ``activation_fn`` picks up the
+        # new mapping.
+        activation_pending = "activation_function_name" in params and params["activation_function_name"] is not None
+        old_activation_function_name = _read_activation_function_name(self.network) if activation_pending else None
+
+        # CAS-006 (A-4): ``auto_snap_*`` live on the lifecycle. Snapshot
+        # the old values (plus the best-metric tracker) so the same
+        # rollback semantics extend to lifecycle storage.
+        auto_snap_pending = {k: params[k] for k in lifecycle_keys if k in params and params[k] is not None}
+        old_lifecycle_values: Dict[str, Any] = {}
+        old_auto_snap_best_metric: Optional[float] = None
+        if auto_snap_pending:
+            with self._auto_snap_lock:
+                old_lifecycle_values = {k: getattr(self, f"_{k}") for k in auto_snap_pending}
+                old_auto_snap_best_metric = self._auto_snap_best_metric
 
         applied: list[str] = []
         try:
@@ -1060,14 +1090,34 @@ class TrainingLifecycleManager:
             if optimizer_pending:
                 _write_optimizer_type(self.network, params["optimizer_type"])
                 applied.append("optimizer_type")
+            if activation_pending:
+                _write_activation_function_name(self.network, params["activation_function_name"])
+                applied.append("activation_function_name")
+            if auto_snap_pending:
+                with self._auto_snap_lock:
+                    for key, value in auto_snap_pending.items():
+                        setattr(self, f"_{key}", value)
+                        applied.append(key)
+                    # Toggling auto_snap_best off-then-on within a run would
+                    # otherwise inherit the prior ceiling. Reset the tracker
+                    # whenever the toggle flips on so the next epoch is
+                    # treated as a fresh baseline.
+                    if "auto_snap_best" in auto_snap_pending and auto_snap_pending["auto_snap_best"] and not old_lifecycle_values.get("auto_snap_best", False):
+                        self._auto_snap_best_metric = None
         except Exception:
             # GAP-WS-28: revert any partial application before propagating.
-            # CAN-010 / ENH-006 (A-2): optimizer_type goes through the
-            # nested setter, so the revert needs to mirror the apply path.
+            # CAN-010 / ENH-006 (A-2) + CAN-011 (A-3) + CAS-006 (A-4): each
+            # flavor has its own revert path — mirror the apply branch.
             for key in reversed(applied):
                 try:
                     if key == "optimizer_type":
                         _write_optimizer_type(self.network, old_optimizer_type)
+                    elif key == "activation_function_name":
+                        _write_activation_function_name(self.network, old_activation_function_name)
+                    elif key in lifecycle_keys:
+                        with self._auto_snap_lock:
+                            setattr(self, f"_{key}", old_lifecycle_values[key])
+                            self._auto_snap_best_metric = old_auto_snap_best_metric
                     else:
                         setattr(self.network, key, old_values[key])
                 except Exception:

--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -1004,6 +1004,81 @@ class TrainingLifecycleManager:
                 any partially-applied updates.
         """
         with self._training_lock:
+
+            ########################################################################################
+            # Do NOT remove this commented out code block until explicit approval has been granted
+            ########################################################################################
+            # if self.network is None:
+            #     raise ValueError("No network exists — create a network first")
+            # updatable_keys = {
+            #     "learning_rate",
+            #     "candidate_learning_rate",
+            #     "correlation_threshold",
+            #     "candidate_pool_size",
+            #     "max_hidden_units",
+            #     "epochs_max",
+            #     "max_iterations",
+            #     "patience",
+            #     "convergence_threshold",
+            #     "candidate_convergence_threshold",
+            #     "candidate_patience",
+            #     "candidate_epochs",
+            #     "output_epochs",  # CAS-002 (Phase 6E Sprint A-1)
+            #     "init_output_weights",
+            #     "optimizer_type",  # CAN-010 / ENH-006 (Phase 6E Sprint A-2) — nested setter
+            #     "activation_function_name",  # CAN-011 (Phase 6E Sprint A-3) — re-init on swap
+            # }
+            # # Plain setattr targets — keys that map directly to network attributes.
+            # # ``optimizer_type`` and ``activation_function_name`` go through
+            # # special-cased setters that touch nested config / re-init paths.
+            # nested_keys = {"optimizer_type", "activation_function_name"}
+            # simple_keys = updatable_keys - nested_keys
+            # applicable = {k: v for k, v in params.items() if k in simple_keys and hasattr(self.network, k)}
+            # old_values = {k: getattr(self.network, k) for k in applicable}
+
+            # # CAN-010 / ENH-006: ``optimizer_type`` lives at
+            # # ``self.network.config.optimizer_config.optimizer_type``, not on
+            # # the network directly. Treated separately so the rollback path
+            # # below still works through the same revert mechanism.
+            # optimizer_pending = "optimizer_type" in params and params["optimizer_type"] is not None
+            # old_optimizer_type = _read_optimizer_type(self.network) if optimizer_pending else None
+
+            # # CAN-011 (A-3): ``activation_function_name`` requires re-running
+            # # ``_init_activation_function`` so ``activation_fn`` picks up the
+            # # new mapping. Same revert pattern as optimizer_type.
+            # activation_pending = "activation_function_name" in params and params["activation_function_name"] is not None
+            # old_activation_function_name = _read_activation_function_name(self.network) if activation_pending else None
+
+            # applied: list[str] = []
+            # try:
+            #     for key, value in applicable.items():
+            #         setattr(self.network, key, value)
+            #         applied.append(key)
+            #     if optimizer_pending:
+            #         _write_optimizer_type(self.network, params["optimizer_type"])
+            #         applied.append("optimizer_type")
+            #     if activation_pending:
+            #         _write_activation_function_name(self.network, params["activation_function_name"])
+            #         applied.append("activation_function_name")
+            # except Exception:
+            #     # GAP-WS-28: revert any partial application before propagating.
+            #     # CAN-010 / ENH-006 (A-2) + CAN-011 (A-3): nested setters
+            #     # need their own revert path — mirror the apply branch.
+            #     for key in reversed(applied):
+            #         try:
+            #             if key == "optimizer_type":
+            #                 _write_optimizer_type(self.network, old_optimizer_type)
+            #             elif key == "activation_function_name":
+            #                 _write_activation_function_name(self.network, old_activation_function_name)
+            #             else:
+            #                 setattr(self.network, key, old_values[key])
+            #         except Exception:
+            #             # If revert itself raises, log and continue rolling
+            #             # back the rest — best-effort consistency.
+            #             self.logger.exception("update_params rollback: revert of %s failed", key)
+            #     raise
+            ########################################################################################
+            
             return self._apply_params_unlocked(params)
 
     def _apply_params_unlocked(self, params: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/api/models/training.py
+++ b/src/api/models/training.py
@@ -83,6 +83,14 @@ class TrainingParams(BaseModel):
         "Softmax", "Softplus", "Hardtanh", "Softshrink", "Tanhshrink",
         "tanh", "sigmoid", "relu",
     ]] = Field(None, description="Hidden-unit activation function override")
+    # CAS-006 (Phase 6E Sprint A-4): auto-snap-best toggle. When True, the
+    # lifecycle subscribes to the training monitor's epoch_end event and
+    # saves an HDF5 snapshot every time the (validation) accuracy beats
+    # the best-seen-so-far for the current run, gated by
+    # ``auto_snap_min_epochs`` to suppress noise from the early epochs of
+    # training when the metric is volatile.
+    auto_snap_best: Optional[bool] = Field(None, description="Auto-save a snapshot whenever the model beats its best (validation) accuracy")
+    auto_snap_min_epochs: Optional[int] = Field(None, ge=0, le=1_000_000, description="Suppress auto-snap until this many epochs have elapsed (default 50)")
 
 
 class TrainingStartRequest(BaseModel):
@@ -133,3 +141,6 @@ class TrainingParamUpdateRequest(BaseModel):
         "Softmax", "Softplus", "Hardtanh", "Softshrink", "Tanhshrink",
         "tanh", "sigmoid", "relu",
     ]] = Field(None, description="Hidden-unit activation function override")
+    # CAS-006 (A-4): runtime-patchable counterparts to TrainingParams.auto_snap_*.
+    auto_snap_best: Optional[bool] = Field(None, description="Auto-save a snapshot whenever the model beats its best (validation) accuracy")
+    auto_snap_min_epochs: Optional[int] = Field(None, ge=0, le=1_000_000, description="Suppress auto-snap until this many epochs have elapsed")

--- a/src/tests/unit/api/test_api_runtime_params.py
+++ b/src/tests/unit/api/test_api_runtime_params.py
@@ -248,3 +248,215 @@ class TestUpdateTrainingParams:
         test_client_with_network.patch("/v1/training/params", json={"activation_function_name": "GELU"})
         data = test_client_with_network.get("/v1/training/params").json()["data"]
         assert data["activation_function_name"] == "GELU"
+
+    # CAS-006 (Phase 6E Sprint A-4): auto_snap_best is a lifecycle-level
+    # toggle (not a network attribute). Runtime PATCH lands on
+    # ``self._auto_snap_best`` / ``self._auto_snap_min_epochs`` on the
+    # lifecycle manager, and ``get_training_params`` surfaces the
+    # current values. The functional behavior — the epoch_end callback
+    # actually saving a snapshot when accuracy beats the best — is
+    # exercised by ``TestAutoSnapBestCallback`` further down.
+    def test_update_auto_snap_best_updates_lifecycle_flag(self, test_client_with_network):
+        """PATCH /v1/training/params toggles auto_snap_best on the lifecycle."""
+        response = test_client_with_network.patch(
+            "/v1/training/params",
+            json={"auto_snap_best": True},
+        )
+        assert response.status_code == 200
+        lifecycle = test_client_with_network.app.state.lifecycle
+        assert lifecycle._auto_snap_best is True
+
+    def test_update_auto_snap_min_epochs_updates_lifecycle(self, test_client_with_network):
+        """PATCH /v1/training/params updates auto_snap_min_epochs on the lifecycle."""
+        response = test_client_with_network.patch(
+            "/v1/training/params",
+            json={"auto_snap_min_epochs": 200},
+        )
+        assert response.status_code == 200
+        lifecycle = test_client_with_network.app.state.lifecycle
+        assert lifecycle._auto_snap_min_epochs == 200
+
+    def test_update_auto_snap_min_epochs_rejects_negative(self, test_client_with_network):
+        """PATCH /v1/training/params enforces ``auto_snap_min_epochs >= 0``."""
+        response = test_client_with_network.patch(
+            "/v1/training/params",
+            json={"auto_snap_min_epochs": -1},
+        )
+        assert response.status_code == 422
+
+    def test_get_training_params_includes_auto_snap_fields(self, test_client_with_network):
+        """GET surfaces both auto_snap_* fields so a reconnecting client can reconcile."""
+        response = test_client_with_network.get("/v1/training/params")
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert "auto_snap_best" in data
+        assert "auto_snap_min_epochs" in data
+        assert isinstance(data["auto_snap_best"], bool)
+        assert isinstance(data["auto_snap_min_epochs"], int)
+        assert data["auto_snap_min_epochs"] >= 0
+
+    def test_update_auto_snap_round_trip(self, test_client_with_network):
+        """PATCH then GET — both auto_snap_* fields round-trip correctly."""
+        test_client_with_network.patch(
+            "/v1/training/params",
+            json={"auto_snap_best": True, "auto_snap_min_epochs": 75},
+        )
+        data = test_client_with_network.get("/v1/training/params").json()["data"]
+        assert data["auto_snap_best"] is True
+        assert data["auto_snap_min_epochs"] == 75
+
+    def test_update_auto_snap_best_resets_metric_tracker_on_toggle_on(self, test_client_with_network):
+        """Toggling auto_snap_best from False -> True resets the best-metric tracker.
+
+        Otherwise a previous run's accuracy ceiling would suppress every
+        snapshot in the new run — an obvious footgun if the user enables
+        the feature mid-session after some earlier experiment.
+        """
+        lifecycle = test_client_with_network.app.state.lifecycle
+        # Simulate a prior run leaving a stale tracker (without disturbing
+        # any lifecycle thread state).
+        with lifecycle._auto_snap_lock:
+            lifecycle._auto_snap_best_metric = 0.95
+        # Toggle on via the API.
+        test_client_with_network.patch("/v1/training/params", json={"auto_snap_best": True})
+        assert lifecycle._auto_snap_best is True
+        assert lifecycle._auto_snap_best_metric is None
+
+
+@pytest.mark.unit
+class TestAutoSnapBestCallback:
+    """Functional tests for the CAS-006 epoch_end callback.
+
+    The route-level tests above cover the wiring (PATCH lands the flag,
+    GET surfaces it, validation rejects bad values). These tests cover
+    the actual behavior: when ``training_monitor.on_epoch_end`` fires,
+    does the lifecycle save a snapshot at the right moments and skip
+    the wrong ones?
+    """
+
+    def test_callback_skips_when_disabled(self):
+        """Default state: feature off → no snapshot saved no matter what."""
+        from unittest.mock import MagicMock
+
+        from api.lifecycle.manager import TrainingLifecycleManager
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        mgr.save_snapshot = MagicMock()  # type: ignore[method-assign]
+        # auto_snap_best defaults to False.
+        mgr._maybe_auto_snap_callback(metrics={"validation_accuracy": 0.99}, epoch=1000, loss=0.01, accuracy=0.99)
+        mgr.save_snapshot.assert_not_called()
+        mgr.shutdown()
+
+    def test_callback_skips_during_warmup(self):
+        """Even with feature on, snapshots are suppressed until ``auto_snap_min_epochs`` is reached."""
+        from unittest.mock import MagicMock
+
+        from api.lifecycle.manager import TrainingLifecycleManager
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        mgr.save_snapshot = MagicMock()  # type: ignore[method-assign]
+        with mgr._auto_snap_lock:
+            mgr._auto_snap_best = True
+            mgr._auto_snap_min_epochs = 100
+        mgr._maybe_auto_snap_callback(metrics={"validation_accuracy": 0.5}, epoch=10, loss=0.5, accuracy=0.5)
+        mgr._maybe_auto_snap_callback(metrics={"validation_accuracy": 0.9}, epoch=99, loss=0.1, accuracy=0.9)
+        mgr.save_snapshot.assert_not_called()
+        mgr.shutdown()
+
+    def test_callback_saves_on_first_eligible_epoch(self):
+        """First eligible epoch (post-warmup, accuracy > None) saves a snapshot."""
+        from unittest.mock import MagicMock
+
+        from api.lifecycle.manager import TrainingLifecycleManager
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        mgr.save_snapshot = MagicMock(return_value={"id": "snap_x"})  # type: ignore[method-assign]
+        with mgr._auto_snap_lock:
+            mgr._auto_snap_best = True
+            mgr._auto_snap_min_epochs = 50
+            mgr._auto_snap_best_metric = None
+        mgr._maybe_auto_snap_callback(metrics={"validation_accuracy": 0.7}, epoch=50, loss=0.3, accuracy=0.6)
+        assert mgr.save_snapshot.call_count == 1
+        # Should track the validation_accuracy, not the (lower) training accuracy.
+        assert mgr._auto_snap_best_metric == 0.7
+        # Description carries the epoch + accuracy so the snapshot list is human-readable.
+        kwargs = mgr.save_snapshot.call_args.kwargs
+        assert "epoch=50" in kwargs.get("description", "")
+        assert "0.700000" in kwargs.get("description", "")
+        mgr.shutdown()
+
+    def test_callback_only_snaps_on_strict_improvement(self):
+        """Tied or worse accuracy after the first save → no additional snapshots."""
+        from unittest.mock import MagicMock
+
+        from api.lifecycle.manager import TrainingLifecycleManager
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        mgr.save_snapshot = MagicMock(return_value={"id": "snap_x"})  # type: ignore[method-assign]
+        with mgr._auto_snap_lock:
+            mgr._auto_snap_best = True
+            mgr._auto_snap_min_epochs = 0
+        mgr._maybe_auto_snap_callback(metrics={"validation_accuracy": 0.8}, epoch=10, loss=0.2, accuracy=0.8)
+        mgr._maybe_auto_snap_callback(metrics={"validation_accuracy": 0.8}, epoch=11, loss=0.2, accuracy=0.8)  # tie
+        mgr._maybe_auto_snap_callback(metrics={"validation_accuracy": 0.79}, epoch=12, loss=0.21, accuracy=0.79)  # worse
+        mgr._maybe_auto_snap_callback(metrics={"validation_accuracy": 0.85}, epoch=13, loss=0.15, accuracy=0.85)  # better → snap
+        assert mgr.save_snapshot.call_count == 2
+        assert mgr._auto_snap_best_metric == 0.85
+        mgr.shutdown()
+
+    def test_callback_falls_back_to_training_accuracy_without_validation(self):
+        """When ``validation_accuracy`` is None, the callback uses ``accuracy`` instead."""
+        from unittest.mock import MagicMock
+
+        from api.lifecycle.manager import TrainingLifecycleManager
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        mgr.save_snapshot = MagicMock(return_value={"id": "snap_x"})  # type: ignore[method-assign]
+        with mgr._auto_snap_lock:
+            mgr._auto_snap_best = True
+            mgr._auto_snap_min_epochs = 0
+        mgr._maybe_auto_snap_callback(metrics={"validation_accuracy": None}, epoch=5, loss=0.3, accuracy=0.7)
+        assert mgr.save_snapshot.call_count == 1
+        assert mgr._auto_snap_best_metric == 0.7
+        mgr.shutdown()
+
+    def test_callback_swallows_save_snapshot_exceptions(self):
+        """A failing ``save_snapshot`` must not crash the training loop."""
+        from unittest.mock import MagicMock
+
+        from api.lifecycle.manager import TrainingLifecycleManager
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        mgr.save_snapshot = MagicMock(side_effect=RuntimeError("disk full"))  # type: ignore[method-assign]
+        with mgr._auto_snap_lock:
+            mgr._auto_snap_best = True
+            mgr._auto_snap_min_epochs = 0
+        # Should NOT raise — the exception is caught and logged.
+        mgr._maybe_auto_snap_callback(metrics={"validation_accuracy": 0.9}, epoch=5, loss=0.1, accuracy=0.9)
+        assert mgr.save_snapshot.call_count == 1
+        mgr.shutdown()
+
+    def test_callback_subscribed_to_epoch_end_event(self):
+        """The callback is registered on ``training_monitor.epoch_end`` at __init__."""
+        from unittest.mock import MagicMock
+
+        from api.lifecycle.manager import TrainingLifecycleManager
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        # Stub the actual snapshot so we can observe firing.
+        mgr.save_snapshot = MagicMock(return_value={"id": "snap_x"})  # type: ignore[method-assign]
+        with mgr._auto_snap_lock:
+            mgr._auto_snap_best = True
+            mgr._auto_snap_min_epochs = 0
+        # Trigger the public monitor event — the lifecycle's callback
+        # registration must wire through.
+        mgr.training_monitor.on_epoch_end(epoch=10, loss=0.2, accuracy=0.8, learning_rate=0.01, validation_accuracy=0.85)
+        assert mgr.save_snapshot.call_count == 1
+        mgr.shutdown()


### PR DESCRIPTION
## Summary

Phase 6E Sprint A-4 (CAS-006). Adds **auto-snap-best** to the
lifecycle: when enabled, the lifecycle automatically saves an HDF5
snapshot every time the (validation) accuracy beats the best-seen-so-
far for the current training run, gated by an
``auto_snap_min_epochs`` warmup so the first dozens of volatile
epochs don't trigger churn snapshots.

**Bonus repair**: this PR also fixes a merge artifact left in main
when #161 (fit-kwargs split, extracted ``_apply_params_unlocked``)
and #162 (A-3 activation_function_name) landed in succession. The
conflict resolution left BOTH the inline body of ``update_params``
AND the ``return self._apply_params_unlocked(params)`` delegating
call — so PATCH `/v1/training/params` was double-applying simple keys
while ``start_training`` (which calls ``_apply_params_unlocked``
directly) was silently dropping ``activation_function_name``. Both
paths now share the same consolidated body.

## Changes

### `api/models/training.py`
- `auto_snap_best: Optional[bool]` and
  `auto_snap_min_epochs: Optional[int]` (`ge=0, le=1_000_000`)
  added to both `TrainingParams` (start-of-training override) and
  `TrainingParamUpdateRequest` (runtime PATCH).
- Intentionally **not** added to `NetworkCreateRequest` — these are
  lifecycle toggles, not network config.

### `api/lifecycle/manager.py`
- **State** in `__init__`: `_auto_snap_best=False`,
  `_auto_snap_min_epochs=50`, `_auto_snap_best_metric=None`,
  `_auto_snap_lock`. Registers `_maybe_auto_snap_callback` on
  `training_monitor.epoch_end`.
- **`_maybe_auto_snap_callback(metrics, epoch, loss, accuracy, …)`** —
  no-op when feature is off or epoch < warmup. Prefers
  `validation_accuracy` over `accuracy` so the snapshot reflects
  generalization, not training-set fit. Saves on strict improvement
  (ties don't fire). Save runs outside the auto_snap_lock so a slow
  filesystem doesn't serialize subsequent epoch_ends. Exceptions
  are caught + logged so the training loop is never affected.
- **`start_training`** — resets `_auto_snap_best_metric` to `None`
  on every run so a single network instance can be re-used across
  experiments without a prior run's accuracy ceiling suppressing
  every snap in the new run.
- **`_apply_params_unlocked`** — gains a third `lifecycle_keys`
  flavor alongside the existing `simple_keys` / `nested_keys` split.
  Lifecycle keys setattr on `self` under the auto_snap_lock; the
  GAP-WS-28 atomic-rollback semantics extend to lifecycle storage
  with a matching revert branch. Toggling `auto_snap_best` off→on
  resets the best-metric tracker so the next epoch is a fresh
  baseline.
- **`update_params`** — collapsed to
  `with self._training_lock: return self._apply_params_unlocked(params)`.
  The inline body left behind by the #161/#162 merge is removed.
- **`get_training_params`** — surfaces both `auto_snap_*` fields
  so reconnecting clients can reconcile UI state.

### `tests/unit/api/test_api_runtime_params.py`
- **6 new route-level tests** in `TestUpdateTrainingParams`: PATCH
  lands on the lifecycle, range validation rejects negative
  `min_epochs`, GET surfaces both fields, round-trip,
  toggle-resets-tracker invariant.
- **New `TestAutoSnapBestCallback` class with 7 functional tests**:
  skipped when disabled, suppressed during warmup, fires on first
  eligible epoch with correct description format, only on strict
  improvement (ties + worsening are silent), falls back to training
  accuracy when validation is None, swallows `save_snapshot`
  exceptions without crashing the training loop, and confirms the
  callback is actually wired into `training_monitor.epoch_end` at
  `__init__` (regression guard against losing the
  `register_callback`).

## Why Track best metric on the lifecycle, not the network

A single network instance can be re-used across multiple training
runs (especially during interactive experimentation in canopy).
Storing the best-metric on the lifecycle (and resetting it in
`start_training`) means each run is judged against its own ceiling.
Storing it on the network would either (a) leak across runs in the
same Python process or (b) require the network class to know about
training-run boundaries.

## Test plan

- [x] `flake8 --max-line-length=512` clean on `api/lifecycle/manager.py`
  and `api/models/training.py`
- [x] `py_compile` clean on all 3 modified files
- [x] Pydantic field smoke test: `TrainingParams.model_fields` and
  `TrainingParamUpdateRequest.model_fields` both contain
  `auto_snap_best` and `auto_snap_min_epochs`
- [ ] Local `pytest` couldn't run in this env (Py3.14 free-threading
  + torch C-extensions ImportError, known unrelated issue) — CI will
  exercise the 13 new tests
- [ ] Manual smoke (deferred): create a network, PATCH
  `auto_snap_best=true`, start a long training run, observe HDF5
  files appearing in the snapshots dir at each accuracy improvement
  past epoch 50

## Sprint context

- A-1 cascor + canopy: merged
- A-2 cascor + canopy: merged
- A-3 cascor (#162): merged
- A-3 canopy: pending
- A-4 cascor (this PR): wires CAS-006 backend
- A-4 canopy: toggle UI — pending this PR's merge
- A-5 (snapshot tuning round-trip, CAN-014): not started
- Latent fit() bug fix (#161): merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)