### PR TITLE
feat(snapshot): retrain endpoint + lifecycle reset path (Phase 6E Sprint B B-1, CAN-015a)

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -1332,8 +1332,25 @@ class TrainingLifecycleManager:
             "description": description,
         }
 
-    def load_snapshot(self, snapshot_id: str) -> bool:
-        """Load a network snapshot by ID."""
+    # CAN-015 (Phase 6E Sprint B): keys on ``network.history`` whose contents
+    # represent per-epoch training metrics. ``restore_for_retrain`` empties
+    # each one so a freshly-retrained run starts with a clean curve. Kept as
+    # a class-level constant so the four B-sprint endpoints (Restore /
+    # Replay / Resume / Retrain) share a single source of truth for what
+    # "history" means; B-2 (Resume) and B-3 (Replay) will read from the
+    # same set when locking it as read-only.
+    _NETWORK_HISTORY_KEYS: tuple = ("train_loss", "value_loss", "train_accuracy", "value_accuracy")
+
+    def _load_snapshot_to_network(self, snapshot_id: str) -> bool:
+        """Locate the snapshot, deserialize, and install on the lifecycle.
+
+        Internal helper extracted from ``load_snapshot`` so each Phase 6E
+        Sprint B operation (Restore / Replay / Resume / Retrain) can share
+        the load semantics while diverging on post-load state mutations
+        (FSM transitions, history resets, replay-session setup, etc.).
+        Returns True on success, False if the snapshot is missing or the
+        deserializer fails.
+        """
         snapshots_dir = self._get_snapshots_dir()
         matches = [f for f in snapshots_dir.glob("*.h5") if f.stem == snapshot_id]
         if not matches:
@@ -1353,7 +1370,85 @@ class TrainingLifecycleManager:
         self._install_monitoring_hooks()
         if self._worker_coordinator is not None and hasattr(self.network, "set_worker_coordinator"):
             self.network.set_worker_coordinator(self._worker_coordinator)
-        self.logger.info(f"Snapshot restored: {snapshot_id}")
+        return True
+
+    def load_snapshot(self, snapshot_id: str) -> bool:
+        """Load a network snapshot by ID (Restore semantics).
+
+        Preserves the full snapshotted state — weights, topology, training
+        history, all meta-parameters per A-5 (CAN-014). Does NOT reset the
+        training-state counters or FSM; the user is expected to either
+        invoke a separate operation (Retrain / Resume) to enter a training
+        state, or modify the network and re-snapshot.
+
+        See ``notes/PHASE_6E_SPRINT_B_DESIGN.md`` §2.1.
+        """
+        ok = self._load_snapshot_to_network(snapshot_id)
+        if ok:
+            self.logger.info(f"Snapshot restored: {snapshot_id}")
+        return ok
+
+    def restore_for_retrain(self, snapshot_id: str) -> bool:
+        """Load a snapshot and reset training history for a fresh run (CAN-015a).
+
+        Phase 6E Sprint B B-1. Loads the snapshot identically to
+        ``load_snapshot`` (so weights, topology, and meta-params are
+        preserved per A-5) then resets every history-bearing field so the
+        next ``start_training`` call starts at epoch 0 with empty metric
+        curves. The user benefits from the snapshot's prior training as a
+        starting point but the new run is judged on its own merits.
+
+        Reset scope per ``notes/PHASE_6E_SPRINT_B_DESIGN.md`` §9:
+
+        - Network ``history`` arrays (train/value loss + accuracy) — cleared
+        - ``training_state`` counters (current_epoch, current_step) — 0
+        - ``_auto_snap_best_metric`` — None (so the new run gets fresh
+          ratchet baseline; this also happens in ``start_training`` but
+          we do it here too so a ``GET /v1/training/params`` between
+          retrain and start_training already shows the cleared value)
+        - FSM — Stopped / Idle (via ``Command.RESET``)
+        - ``training_monitor.metrics_buffer`` — cleared
+        - ``_last_emitted_history_len`` — 0
+        """
+        ok = self._load_snapshot_to_network(snapshot_id)
+        if not ok:
+            return False
+
+        # Clear history arrays on the network. ``getattr`` rather than direct
+        # attribute access so a network that doesn't expose ``history`` yet
+        # (older snapshots, or a partially-initialized network from a corner
+        # case) doesn't crash the retrain — best-effort consistency mirrors
+        # the legacy-snapshot tolerance from A-5.
+        history = getattr(self.network, "history", None)
+        if isinstance(history, dict):
+            for key in self._NETWORK_HISTORY_KEYS:
+                if key in history:
+                    # Preserve the container type (list vs deque vs other) by
+                    # replacing with an empty instance of the same type. Falls
+                    # back to ``[]`` if the container isn't a known builtin.
+                    try:
+                        history[key] = type(history[key])()
+                    except Exception:
+                        history[key] = []
+
+        # Reset lifecycle-level training state. Mirrors ``reset()`` (line ~840)
+        # but without the ``_stop_requested.set()`` since no training is
+        # currently running — Retrain is invoked from a stopped state and
+        # ``start_training`` will clear the event itself.
+        self._last_emitted_history_len = 0
+        self.state_machine.handle_command(Command.RESET)
+        self.training_monitor.clear_metrics()
+        self.training_state.update_state(
+            status="Stopped",
+            phase="Idle",
+            current_epoch=0,
+            current_step=0,
+        )
+        with self._auto_snap_lock:
+            self._auto_snap_best_metric = None
+        self._broadcast_training_state(force=True)
+
+        self.logger.info(f"Snapshot restored for retrain: {snapshot_id}")
         return True
 
     def list_snapshots(self) -> List[Dict[str, Any]]:

--- a/src/api/routes/snapshots.py
+++ b/src/api/routes/snapshots.py
@@ -120,3 +120,45 @@ async def restore_snapshot(request: Request, snapshot_id: str) -> dict:
     if params is not None:
         payload["training_params"] = params
     return success_response(payload)
+
+
+@router.post("/{snapshot_id}/retrain")
+async def retrain_from_snapshot(request: Request, snapshot_id: str) -> dict:
+    """Restore a snapshot and reset history for a fresh training run.
+
+    CAN-015a (Phase 6E Sprint B B-1). The lifecycle loads the snapshot
+    identically to ``/restore`` (preserving weights, topology, and all
+    A-5 meta-parameters) then resets the training history arrays,
+    counters, FSM state, and auto-snap-best ratchet so the next
+    ``POST /v1/training/start`` call begins at epoch 0 with empty
+    metric curves. The user benefits from the snapshot's prior
+    training as a starting point but the new run is judged on its own
+    merits.
+
+    See ``juniper-ml/notes/PHASE_6E_SPRINT_B_DESIGN.md`` §2.4 for the
+    full reset scope and §9 for the field-by-field table.
+
+    Response shape mirrors ``/restore`` (snapshot_id + training_params),
+    differing only in the ``operation`` field. The unified response
+    shape with ``fsm_state`` and ``time_index`` lands in B-4 alongside
+    the Investigating-state work; B-1 stays close to the existing
+    ``/restore`` shape so clients written against either endpoint can
+    transition between them with minimal changes.
+    """
+    _validate_snapshot_id(snapshot_id, client=request.client.host if request.client else None)
+    lifecycle = _get_lifecycle(request)
+    # PERF-CC-01: HDF5 I/O off the event loop, same as the other
+    # snapshot routes. The reset side-effects (FSM, monitor, training_state)
+    # are quick attribute writes — no need to fan out further.
+    success = await asyncio.to_thread(lifecycle.restore_for_retrain, snapshot_id)
+    if not success:
+        raise HTTPException(status_code=404, detail=f"Snapshot '{snapshot_id}' not found or failed to load")
+    try:
+        params = lifecycle.get_training_params()
+    except Exception:
+        logger.exception("retrain_from_snapshot: get_training_params failed after successful restore_for_retrain")
+        params = None
+    payload: dict = {"snapshot_id": snapshot_id, "operation": "retrain", "status": "ready"}
+    if params is not None:
+        payload["training_params"] = params
+    return success_response(payload)

--- a/src/tests/unit/api/test_lifecycle_manager.py
+++ b/src/tests/unit/api/test_lifecycle_manager.py
@@ -592,3 +592,204 @@ class TestUpdateParamsAtomicity:
         mgr = TrainingLifecycleManager()
         with pytest.raises(ValueError, match="No network exists"):
             mgr.update_params({"learning_rate": 0.005})
+
+
+@pytest.mark.unit
+class TestRestoreForRetrain:
+    """CAN-015a (Phase 6E Sprint B B-1): tests for the new
+    ``restore_for_retrain`` lifecycle path.
+
+    The method shares the load step with ``load_snapshot`` but adds the
+    full reset scope from ``PHASE_6E_SPRINT_B_DESIGN.md`` §9. These tests
+    pin each piece of the reset contract individually plus the
+    return-False-on-missing-snapshot behavior.
+    """
+
+    def test_returns_false_when_snapshot_missing(self, tmp_path):
+        """Snapshot ID with no matching .h5 file → False, no state changes."""
+        from unittest.mock import patch
+
+        mgr = TrainingLifecycleManager()
+        # Empty snapshots dir — no matching file.
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path):
+            assert mgr.restore_for_retrain("nonexistent-snapshot") is False
+        # No network was created — verify the call didn't accidentally make one.
+        assert mgr.network is None
+        mgr.shutdown()
+
+    def test_returns_false_when_deserializer_fails(self, tmp_path):
+        """Deserializer returning None → False, original network preserved."""
+        from unittest.mock import patch
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        original_network = mgr.network
+        fake_file = tmp_path / "broken.h5"
+        fake_file.write_bytes(b"not actually an hdf5 file")
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=None):
+            assert mgr.restore_for_retrain("broken") is False
+        # Original network is still installed — failed retrain doesn't
+        # leave the lifecycle in a half-replaced state.
+        assert mgr.network is original_network
+        mgr.shutdown()
+
+    def test_resets_network_history_arrays(self, tmp_path):
+        """After successful restore_for_retrain, network.history arrays are empty."""
+        from unittest.mock import MagicMock, patch
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        loaded = MagicMock()
+        loaded.history = {
+            "train_loss": [0.5, 0.4, 0.3],
+            "value_loss": [0.6, 0.5, 0.4],
+            "train_accuracy": [0.7, 0.8, 0.85],
+            "value_accuracy": [0.65, 0.75, 0.8],
+        }
+        fake_file = tmp_path / "snap.h5"
+        fake_file.write_bytes(b"")
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"):
+            assert mgr.restore_for_retrain("snap") is True
+
+        for key in ("train_loss", "value_loss", "train_accuracy", "value_accuracy"):
+            assert loaded.history[key] == [], f"history[{key!r}] not cleared by retrain"
+        mgr.shutdown()
+
+    def test_resets_training_state_counters(self, tmp_path):
+        """current_epoch / current_step go to 0; status is Stopped, phase is Idle."""
+        from unittest.mock import MagicMock, patch
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        mgr.training_state.update_state(current_epoch=42, current_step=999, status="Started", phase="Output")
+        loaded = MagicMock()
+        loaded.history = {}
+        fake_file = tmp_path / "snap.h5"
+        fake_file.write_bytes(b"")
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"):
+            mgr.restore_for_retrain("snap")
+
+        state = mgr.training_state.get_state()
+        assert state["current_epoch"] == 0
+        assert state["current_step"] == 0
+        assert state["status"] == "Stopped"
+        assert state["phase"] == "Idle"
+        mgr.shutdown()
+
+    def test_resets_auto_snap_best_metric(self, tmp_path):
+        """The auto-snap-best ratchet is reset so the next run starts
+        from a fresh accuracy ceiling."""
+        from unittest.mock import MagicMock, patch
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        with mgr._auto_snap_lock:
+            mgr._auto_snap_best_metric = 0.95
+        loaded = MagicMock()
+        loaded.history = {}
+        fake_file = tmp_path / "snap.h5"
+        fake_file.write_bytes(b"")
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"):
+            mgr.restore_for_retrain("snap")
+
+        assert mgr._auto_snap_best_metric is None
+        mgr.shutdown()
+
+    def test_resets_last_emitted_history_len(self, tmp_path):
+        """The history-emission cursor is reset so the next training run
+        re-emits from epoch 0 rather than skipping to the loaded snapshot's
+        end."""
+        from unittest.mock import MagicMock, patch
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        mgr._last_emitted_history_len = 100
+        loaded = MagicMock()
+        loaded.history = {}
+        fake_file = tmp_path / "snap.h5"
+        fake_file.write_bytes(b"")
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"):
+            mgr.restore_for_retrain("snap")
+
+        assert mgr._last_emitted_history_len == 0
+        mgr.shutdown()
+
+    def test_clears_training_monitor_metrics(self, tmp_path):
+        """The training_monitor's metrics buffer is cleared."""
+        from unittest.mock import MagicMock, patch
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        loaded = MagicMock()
+        loaded.history = {}
+        fake_file = tmp_path / "snap.h5"
+        fake_file.write_bytes(b"")
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"), patch.object(mgr.training_monitor, "clear_metrics") as mock_clear:
+            mgr.restore_for_retrain("snap")
+            mock_clear.assert_called_once()
+        mgr.shutdown()
+
+    def test_tolerates_missing_history_attr(self, tmp_path):
+        """A loaded network without a ``history`` attribute doesn't crash
+        the retrain — best-effort consistency mirroring A-5's
+        legacy-snapshot tolerance."""
+        from unittest.mock import patch
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+
+        class NetworkWithoutHistory:
+            input_size = 2
+            output_size = 2
+
+        loaded = NetworkWithoutHistory()
+        fake_file = tmp_path / "snap.h5"
+        fake_file.write_bytes(b"")
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"):
+            assert mgr.restore_for_retrain("snap") is True
+        mgr.shutdown()
+
+    def test_tolerates_non_dict_history(self, tmp_path):
+        """A loaded network whose ``history`` is not a dict (e.g. None) is
+        also tolerated — same defensive reasoning."""
+        from unittest.mock import patch
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+
+        class NetworkWithNoneHistory:
+            input_size = 2
+            output_size = 2
+            history = None
+
+        loaded = NetworkWithNoneHistory()
+        fake_file = tmp_path / "snap.h5"
+        fake_file.write_bytes(b"")
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"):
+            assert mgr.restore_for_retrain("snap") is True
+        mgr.shutdown()
+
+    def test_load_snapshot_unchanged_by_retrain_refactor(self, tmp_path):
+        """Regression: ``load_snapshot`` (Restore semantics) keeps its
+        existing behavior after the ``_load_snapshot_to_network`` extraction.
+        It should NOT clear history or reset counters — that's only Retrain."""
+        from unittest.mock import MagicMock, patch
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        mgr.training_state.update_state(current_epoch=42, current_step=999)
+        loaded = MagicMock()
+        loaded.history = {"train_loss": [0.1, 0.2], "value_loss": [], "train_accuracy": [], "value_accuracy": []}
+        fake_file = tmp_path / "snap.h5"
+        fake_file.write_bytes(b"")
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"):
+            assert mgr.load_snapshot("snap") is True
+
+        # History on the loaded network is preserved — Restore is a load,
+        # not a reset.
+        assert loaded.history["train_loss"] == [0.1, 0.2]
+        # Counters on training_state are NOT reset by Restore.
+        state = mgr.training_state.get_state()
+        assert state["current_epoch"] == 42
+        assert state["current_step"] == 999
+        mgr.shutdown()

--- a/src/tests/unit/api/test_snapshot_route_coverage.py
+++ b/src/tests/unit/api/test_snapshot_route_coverage.py
@@ -281,6 +281,91 @@ class TestRestoreSnapshot:
             assert captured["thread"] != "MainThread", f"load_snapshot ran on MainThread ({captured['thread']!r}); expected an asyncio worker"
 
 
+class TestRetrainFromSnapshot:
+    """CAN-015a (Phase 6E Sprint B B-1): tests for the new
+    ``POST /v1/snapshots/{id}/retrain`` route. The route mirrors
+    ``/restore`` in shape (snapshot_id + training_params + status) but
+    the lifecycle method it calls (``restore_for_retrain``) additionally
+    resets training history / counters / FSM / auto-snap-best so the
+    next ``start_training`` begins at epoch 0 with empty curves. Lifecycle
+    behavior itself is exercised in test_lifecycle_manager.py — these
+    tests pin the route contract."""
+
+    def test_retrain_snapshot_success(self, client):
+        """retrain route returns success with ``operation: retrain`` and ``status: ready``."""
+        with patch.object(client.app.state.lifecycle, "restore_for_retrain", return_value=True):
+            response = client.post("/v1/snapshots/snap-001/retrain")
+            assert response.status_code == 200
+            body = response.json()
+            assert body["status"] == "success"
+            assert body["data"]["snapshot_id"] == "snap-001"
+            assert body["data"]["operation"] == "retrain"
+            assert body["data"]["status"] == "ready"
+
+    def test_retrain_snapshot_surfaces_post_reset_training_params(self, client):
+        """Response includes training_params so a tuning UI can reconcile
+        (matches the post-A-5 behavior of /restore)."""
+        fake_params = {
+            "learning_rate": 0.005,
+            "epochs_max": 1234,
+            "optimizer_type": "AdamW",
+            "activation_function_name": "ReLU",
+        }
+        with patch.object(client.app.state.lifecycle, "restore_for_retrain", return_value=True), patch.object(client.app.state.lifecycle, "get_training_params", return_value=fake_params):
+            response = client.post("/v1/snapshots/snap-with-params/retrain")
+            assert response.status_code == 200
+            body = response.json()
+            assert "training_params" in body["data"]
+            assert body["data"]["training_params"] == fake_params
+
+    def test_retrain_snapshot_falls_back_when_get_training_params_fails(self, client):
+        """A failing ``get_training_params`` after a successful restore_for_retrain
+        must NOT make the route appear failed — return 200 with the
+        minimal payload, same defensive pattern as /restore."""
+        with patch.object(client.app.state.lifecycle, "restore_for_retrain", return_value=True), patch.object(client.app.state.lifecycle, "get_training_params", side_effect=RuntimeError("boom")):
+            response = client.post("/v1/snapshots/snap-fallback/retrain")
+            assert response.status_code == 200
+            body = response.json()
+            assert body["data"]["snapshot_id"] == "snap-fallback"
+            assert body["data"]["operation"] == "retrain"
+            assert body["data"]["status"] == "ready"
+            assert "training_params" not in body["data"]
+
+    def test_retrain_snapshot_not_found_returns_404(self, client):
+        """When restore_for_retrain returns False (missing snapshot or
+        deserializer failure) the route maps to 404, identical to /restore."""
+        with patch.object(client.app.state.lifecycle, "restore_for_retrain", return_value=False):
+            response = client.post("/v1/snapshots/nonexistent/retrain")
+            assert response.status_code == 404
+            assert "not found or failed to load" in response.json()["detail"]
+
+    def test_retrain_snapshot_runs_in_thread(self, client):
+        """PERF-CC-01: HDF5 I/O off the main event loop."""
+        captured: dict = {}
+
+        def fake_restore_for_retrain(snapshot_id: str):
+            import threading
+
+            captured["thread"] = threading.current_thread().name
+            return True
+
+        with patch.object(client.app.state.lifecycle, "restore_for_retrain", side_effect=fake_restore_for_retrain):
+            response = client.post("/v1/snapshots/snap-thread/retrain")
+            assert response.status_code == 200
+            assert captured["thread"] != "MainThread", f"restore_for_retrain ran on MainThread ({captured['thread']!r}); expected an asyncio worker"
+
+    def test_retrain_snapshot_validates_id_format(self, client):
+        """SEC-17: invalid snapshot_id format is rejected at the route boundary."""
+        # Path with .. would attempt traversal — rejected with 400.
+        response = client.post("/v1/snapshots/..%2Fevil/retrain")
+        # FastAPI normalizes %2F before the validator, so the result is
+        # either a 400 (validator catches it) or a 404 (path doesn't match
+        # the route). Both are acceptable — the key is "not 200 / not
+        # 500." We accept either since the route registration handles
+        # it identically to other snapshot endpoints.
+        assert response.status_code in (400, 404, 422), f"unexpected status {response.status_code} for traversal attempt"
+
+
 class TestPerfCC01InvariantSource:
     """PERF-CC-01: lock asyncio.to_thread usage in route source."""
 
@@ -289,9 +374,11 @@ class TestPerfCC01InvariantSource:
 
         path = Path(__file__).resolve().parents[3] / "api" / "routes" / "snapshots.py"
         source = path.read_text(encoding="utf-8")
-        # Both save and restore route handlers must offload via asyncio.to_thread.
+        # Save / restore / retrain route handlers must all offload via asyncio.to_thread.
         assert "asyncio.to_thread(lifecycle.save_snapshot" in source
         assert "asyncio.to_thread(lifecycle.load_snapshot" in source
+        # CAN-015a (Phase 6E Sprint B B-1): retrain route added.
+        assert "asyncio.to_thread(lifecycle.restore_for_retrain" in source
 
     def test_imports_asyncio(self):
         from pathlib import Path


### PR DESCRIPTION
## Summary

Phase 6E Sprint B **B-1** — first of four cascor PRs implementing the
expanded snapshot operations matrix from
[`PHASE_6E_SPRINT_B_DESIGN.md`](https://github.com/pcalnon/juniper-ml/blob/main/notes/PHASE_6E_SPRINT_B_DESIGN.md)
(Restore / Replay / Resume / Retrain).

**Retrain semantics**: load a snapshot's weights + topology +
meta-params identically to Restore (so the new run benefits from
prior training) but reset all history-bearing fields so the next
`POST /v1/training/start` begins at epoch 0 with empty metric curves.
Closest match to the original CAN-015 intent — "snapshot replay → fresh
training."

## Changes

### `api/lifecycle/manager.py`

- **Refactored** `load_snapshot` body into a private
  `_load_snapshot_to_network` helper. The public `load_snapshot`
  becomes a thin wrapper, preserving its existing Restore semantics.
  The helper is the shared load step that B-2 (Resume), B-3 (Replay),
  and B-4 (Restore enrichment) will also call.
- **New** `restore_for_retrain(snapshot_id)` method. Calls the helper
  for the load step, then applies the full reset scope from the
  design doc §9:
  - Network `history` arrays cleared (`train_loss`, `value_loss`,
    `train_accuracy`, `value_accuracy`)
  - `training_state` counters → 0; status → Stopped, phase → Idle
  - `_auto_snap_best_metric` → None (under `_auto_snap_lock`)
  - FSM → Stopped/Idle via `Command.RESET`
  - `training_monitor.metrics_buffer` cleared
  - `_last_emitted_history_len` → 0
- **Class-level constant** `_NETWORK_HISTORY_KEYS` — single source of
  truth for what counts as "history" across the four B-sprint
  operations.
- **Defensive history-clearing** with `getattr(..., None)` and
  `isinstance(history, dict)` checks so older snapshots / non-dict
  history attrs load cleanly — mirrors A-5's legacy-snapshot
  tolerance.

### `api/routes/snapshots.py`

- **New** `POST /v1/snapshots/{snapshot_id}/retrain` route. Same
  `asyncio.to_thread` pattern as the other snapshot routes (HDF5 I/O
  off the event loop). Returns
  `{snapshot_id, operation: "retrain", status: "ready", training_params: {...}}`.
- **Defensive** `try/except` around `get_training_params` — failure
  after a successful retrain still returns 200 with the minimal
  payload rather than making the route appear failed.

### Note on response shape

The unified response shape with `fsm_state` and `time_index` (per
design doc §3) lands in **B-4** alongside the Investigating-state
work. B-1 stays close to `/restore`'s existing shape so clients can
transition between them with minimal changes; B-4 will then
retro-actively unify both endpoints.

## Tests

### `tests/unit/api/test_snapshot_route_coverage.py`

New `TestRetrainFromSnapshot` class with **6 tests**:

- success path returns `operation: retrain`, `status: ready`
- response includes `training_params` (CAN-014 contract carried forward)
- defensive fallback when `get_training_params` raises
- 404 when `restore_for_retrain` returns False
- PERF-CC-01: route runs `restore_for_retrain` off the main event loop
- SEC-17: invalid snapshot_id format rejected at the route boundary

Plus the existing PERF-CC-01 invariant-source test extended to assert
the new route uses `asyncio.to_thread`.

### `tests/unit/api/test_lifecycle_manager.py`

New `TestRestoreForRetrain` class with **9 tests** pinning each piece
of the reset contract:

- returns False on missing snapshot file
- returns False on deserializer failure (and original network is preserved)
- network `history` arrays cleared on success
- `training_state` counters reset (current_epoch, current_step → 0; status → Stopped; phase → Idle)
- `_auto_snap_best_metric` reset to None
- `_last_emitted_history_len` reset to 0
- `training_monitor.clear_metrics()` invoked
- tolerates missing `history` attr (no crash)
- tolerates `history = None` (no crash)
- regression: `load_snapshot` (Restore) keeps its existing non-resetting
  behavior after the helper extraction

## Sprint B status after this PR

| PR | CAN-ID | Repo | State |
|---|---|---|---|
| **B-1** | CAN-015a | cascor | **this PR** |
| B-2 | CAN-015b | cascor | not started (Resume + ResumeReady FSM) |
| B-3 | CAN-015c | cascor | not started (Replay infra + Replaying FSM) |
| B-4 | CAN-015d | cascor | not started (Restore enrichment + Investigating FSM + unified response shape) |
| B-5 | CAN-015e | canopy | not started (UX entry points) |
| B-6 | CAN-015f | canopy | not started (Replay player UI) |

## Test plan

- [x] `flake8 --max-line-length=512` clean on all 4 modified files
- [x] `py_compile` clean
- [ ] Local `pytest` couldn't run in this env (Py3.14 free-threading +
  torch C-extensions ImportError, known unrelated issue) — CI will
  exercise the 15 new tests
- [ ] Manual smoke (deferred): create a small network, train briefly,
  POST /v1/snapshots, modify some params, POST /v1/snapshots/{id}/retrain,
  verify `GET /v1/training/params` shows the snapshotted values
  (NOT the modified values), `GET /v1/metrics` shows empty history,
  start a fresh training run, verify metrics start at epoch 1

## References

- [PHASE_6E_SPRINT_B_DESIGN.md](https://github.com/pcalnon/juniper-ml/blob/main/notes/PHASE_6E_SPRINT_B_DESIGN.md) §2.4 (Retrain spec), §9 (Reset scope)
- [PHASE_6E_DESIGN.md](https://github.com/pcalnon/juniper-ml/blob/main/notes/PHASE_6E_DESIGN.md) Sprint B table

🤖 Generated with [Claude Code](https://claude.com/claude-code)