### PR TITLE
feat(snapshot): resume endpoint + ResumeReady FSM state (Phase 6E Sprint B B-2, CAN-015b)

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -137,6 +137,16 @@ class TrainingLifecycleManager:
         self._auto_snap_min_epochs: int = 50
         self._auto_snap_best_metric: Optional[float] = None
         self._auto_snap_lock = threading.Lock()
+
+        # CAN-015b (Phase 6E Sprint B B-2): resume-from-snapshot marker.
+        # ``resume_from_snapshot`` sets this to the snapshot's terminal
+        # epoch count so canopy can render a visual boundary in the
+        # metrics-curve component (a vertical line separating the
+        # pre-resume read-only history from the new training that
+        # appends past it). Cleared once consumed by ``start_training``
+        # (so a subsequent run from the same snapshot doesn't mistakenly
+        # carry over the marker).
+        self._resume_point_epoch: Optional[int] = None
         self.training_monitor.register_callback("epoch_end", self._maybe_auto_snap_callback)
 
         self.logger.info("TrainingLifecycleManager initialized")
@@ -774,11 +784,20 @@ class TrainingLifecycleManager:
             self._stop_requested.clear()
             self._pause_event.set()
 
-            # CAS-006 (A-4): each training run starts fresh — we don't want
-            # a snapshot from a previous run's accuracy ceiling to suppress
-            # auto-snaps in this run.
-            with self._auto_snap_lock:
-                self._auto_snap_best_metric = None
+            # CAS-006 (A-4) + CAN-015b (B-2): each training run normally
+            # starts fresh — we don't want a snapshot from a previous run's
+            # accuracy ceiling to suppress auto-snaps in this run. EXCEPTION:
+            # when the FSM is RESUME_READY we're continuing a snapshotted
+            # run, so the loaded ratchet stays as the baseline (a re-snap
+            # only fires when the resumed training truly beats the prior
+            # run's best). We also clear the resume marker once consumed
+            # so a stop-then-restart-without-resume doesn't carry it over.
+            resuming = self.state_machine.is_resume_ready()
+            if not resuming:
+                with self._auto_snap_lock:
+                    self._auto_snap_best_metric = None
+            else:
+                self._resume_point_epoch = None
 
             if self._executor is None:
                 self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="cascor-train")
@@ -1446,9 +1465,83 @@ class TrainingLifecycleManager:
         )
         with self._auto_snap_lock:
             self._auto_snap_best_metric = None
+        # CAN-015b (B-2): a Retrain over a previously-loaded Resume
+        # snapshot should not carry forward the resume marker — the
+        # whole point of Retrain is the clean slate.
+        self._resume_point_epoch = None
         self._broadcast_training_state(force=True)
 
         self.logger.info(f"Snapshot restored for retrain: {snapshot_id}")
+        return True
+
+    def resume_from_snapshot(self, snapshot_id: str) -> bool:
+        """Load a snapshot and prepare to continue training (CAN-015b).
+
+        Phase 6E Sprint B B-2. Loads the snapshot identically to
+        ``load_snapshot`` (so weights, topology, meta-params, AND the
+        training history are preserved) then transitions the FSM to
+        ``RESUME_READY`` and records the snapshot's terminal-epoch count
+        as ``_resume_point_epoch`` so canopy can render a visual
+        boundary between the pre-resume read-only history and the new
+        training that extends past it.
+
+        In contrast to ``restore_for_retrain`` (which clears history,
+        counters, and the auto-snap-best ratchet so the new run starts
+        fresh), Resume PRESERVES every history-bearing field. The next
+        ``start_training`` extends the existing arrays rather than
+        starting at epoch 0, and the auto-snap-best ratchet keeps its
+        prior accuracy ceiling so a re-snapshot only fires when the new
+        training genuinely beats the previous run.
+
+        Resume requires a non-active state (Stopped / Completed /
+        Failed / RESUME_READY again). From STARTED or PAUSED the
+        underlying ``mark_resume_ready`` call rejects and this method
+        returns False.
+
+        See ``notes/PHASE_6E_SPRINT_B_DESIGN.md`` §2.3 for the full
+        spec.
+        """
+        if self.state_machine.is_started() or self.state_machine.is_paused():
+            self.logger.warning(f"resume_from_snapshot rejected: training is {self.state_machine.status.name}")
+            return False
+
+        ok = self._load_snapshot_to_network(snapshot_id)
+        if not ok:
+            return False
+
+        # Compute the resume-point epoch from the loaded network's
+        # history. Use the longest array's length so a snapshot that's
+        # missing some keys still produces a sensible marker. Falls back
+        # to 0 if no history is present (a network freshly loaded with
+        # no training-state included would land here — unusual but
+        # tolerated).
+        history = getattr(self.network, "history", None)
+        resume_point = 0
+        if isinstance(history, dict):
+            for key in self._NETWORK_HISTORY_KEYS:
+                series = history.get(key, ())
+                try:
+                    resume_point = max(resume_point, len(series))
+                except TypeError:
+                    # Unexpected type — skip, keep current best.
+                    continue
+
+        self._resume_point_epoch = resume_point
+        self.state_machine.mark_resume_ready()
+        # Surface the resume point in the broadcast so canopy clients
+        # that subscribe to state updates pick it up immediately.
+        # Mirrors the pattern used by reset() / restore_for_retrain.
+        # NOTE: ``training_state.status`` stays "Stopped" rather than
+        # "ResumeReady" — canopy reads RESUME_READY from the FSM summary
+        # (state_machine.get_state_summary()), not from training_state.
+        self.training_state.update_state(
+            status="Stopped",
+            phase="Idle",
+            current_epoch=resume_point,
+        )
+        self._broadcast_training_state(force=True)
+
+        self.logger.info(f"Snapshot restored for resume: {snapshot_id} (resume_point_epoch={resume_point})")
         return True
 
     def list_snapshots(self) -> List[Dict[str, Any]]:

--- a/src/api/lifecycle/state_machine.py
+++ b/src/api/lifecycle/state_machine.py
@@ -26,6 +26,12 @@ class TrainingStatus(Enum):
     PAUSED = auto()
     COMPLETED = auto()
     FAILED = auto()
+    # CAN-015b (Phase 6E Sprint B B-2): a snapshot has been loaded with
+    # ``resume_from_snapshot`` and the lifecycle is ready to continue
+    # training. The next ``start_training`` transitions to STARTED while
+    # PRESERVING the loaded history (in contrast to a Retrain which
+    # resets it). See ``notes/PHASE_6E_SPRINT_B_DESIGN.md`` §2.3.
+    RESUME_READY = auto()
 
 
 class Command(Enum):
@@ -92,6 +98,12 @@ class TrainingStateMachine:
     def is_failed(self) -> bool:
         return self._status == TrainingStatus.FAILED
 
+    def is_resume_ready(self) -> bool:
+        """CAN-015b (Phase 6E Sprint B B-2): a snapshot has been loaded
+        for resume, the lifecycle is awaiting ``start_training`` to
+        continue from the snapshotted point."""
+        return self._status == TrainingStatus.RESUME_READY
+
     def handle_command(self, command: Command) -> bool:
         """Handle control command and perform state transition.
 
@@ -120,6 +132,18 @@ class TrainingStateMachine:
             self._paused_phase = None
             self._candidate_sub_state = None
             self.logger.info("State transition: Stopped -> Started (Output)")
+            return True
+        # CAN-015b (B-2): RESUME_READY transitions to STARTED with the
+        # same fresh-phase semantics as STOPPED -> STARTED. The history
+        # difference (RESUME_READY preserves the snapshotted history,
+        # whereas a fresh STOPPED -> STARTED has no history yet) is a
+        # data-side concern handled by the lifecycle, not the FSM.
+        if self._status == TrainingStatus.RESUME_READY:
+            self._status = TrainingStatus.STARTED
+            self._phase = TrainingPhase.OUTPUT
+            self._paused_phase = None
+            self._candidate_sub_state = None
+            self.logger.info("State transition: ResumeReady -> Started (Output)")
             return True
         if self._status == TrainingStatus.PAUSED:
             return self._restore_from_paused()
@@ -211,6 +235,30 @@ class TrainingStateMachine:
             self.logger.info(f"State transition: {prev} -> Failed ({reason})")
             return True
         self.logger.warning(f"Invalid transition: mark_failed while {self._status.name}")
+        return False
+
+    def mark_resume_ready(self) -> bool:
+        """CAN-015b (Phase 6E Sprint B B-2): mark the FSM as ready to
+        resume from a loaded snapshot. Call from
+        ``lifecycle.resume_from_snapshot`` after the snapshot is loaded
+        but before ``start_training`` runs.
+
+        Permitted from non-active states (Stopped / Completed / Failed)
+        — a user who finishes one run and resumes from its snapshot is
+        fine. From STARTED or PAUSED the call is rejected: the user
+        must stop training first. RESUME_READY is idempotent (allows
+        re-marking, e.g. if the user calls /resume twice on different
+        snapshots without an intervening start).
+        """
+        if self._status in (TrainingStatus.STOPPED, TrainingStatus.COMPLETED, TrainingStatus.FAILED, TrainingStatus.RESUME_READY):
+            prev = self._status.name
+            self._status = TrainingStatus.RESUME_READY
+            self._phase = TrainingPhase.IDLE
+            self._paused_phase = None
+            self._candidate_sub_state = None
+            self.logger.info(f"State transition: {prev} -> ResumeReady")
+            return True
+        self.logger.warning(f"Invalid transition: mark_resume_ready while {self._status.name}")
         return False
 
     def get_state_summary(self) -> dict:

--- a/src/api/routes/snapshots.py
+++ b/src/api/routes/snapshots.py
@@ -33,7 +33,7 @@ def _validate_snapshot_id(snapshot_id: str, client: str | None = None) -> None:
     if not _SNAPSHOT_ID_PATTERN.fullmatch(snapshot_id or ""):
         logger.warning(
             "Rejected snapshot_id (invalid format): %r client=%s",
-            snapshot_id,
+            snapshot_id.replace('\r\n','').replace('\n',''),
             client or "unknown",
         )
         raise HTTPException(status_code=400, detail="Invalid snapshot_id format")

--- a/src/api/routes/snapshots.py
+++ b/src/api/routes/snapshots.py
@@ -162,3 +162,53 @@ async def retrain_from_snapshot(request: Request, snapshot_id: str) -> dict:
     if params is not None:
         payload["training_params"] = params
     return success_response(payload)
+
+
+@router.post("/{snapshot_id}/resume")
+async def resume_snapshot(request: Request, snapshot_id: str) -> dict:
+    """Restore a snapshot and prepare to continue training (CAN-015b).
+
+    Phase 6E Sprint B B-2. The lifecycle loads the snapshot identically
+    to ``/restore`` (preserving weights, topology, all A-5
+    meta-parameters, AND the training history) then transitions to the
+    ``RESUME_READY`` FSM state. The next ``POST /v1/training/start``
+    extends the existing history arrays from the snapshot's terminal
+    epoch rather than starting fresh, and the auto-snap-best ratchet
+    keeps its prior accuracy ceiling.
+
+    Response includes ``resume_point_epoch`` — the snapshot's terminal
+    epoch count — so a tuning UI can render a visual boundary in the
+    metrics-curve component (vertical dashed line separating the
+    pre-resume read-only history from the new training that appends
+    past it).
+
+    Rejected with 409 if training is currently active (Started /
+    Paused) — the user must stop training before resuming.
+
+    See ``juniper-ml/notes/PHASE_6E_SPRINT_B_DESIGN.md`` §2.3.
+    """
+    _validate_snapshot_id(snapshot_id, client=request.client.host if request.client else None)
+    lifecycle = _get_lifecycle(request)
+    # Pre-flight check on FSM state. The lifecycle method also checks
+    # but we surface the conflict as 409 at the route boundary for a
+    # clean client error rather than a generic 404.
+    if lifecycle.state_machine.is_started() or lifecycle.state_machine.is_paused():
+        raise HTTPException(status_code=409, detail=f"Cannot resume from snapshot while training is {lifecycle.state_machine.status.name}")
+    # PERF-CC-01: HDF5 I/O off the event loop, same as the other snapshot routes.
+    success = await asyncio.to_thread(lifecycle.resume_from_snapshot, snapshot_id)
+    if not success:
+        raise HTTPException(status_code=404, detail=f"Snapshot '{snapshot_id}' not found or failed to load")
+    try:
+        params = lifecycle.get_training_params()
+    except Exception:
+        logger.exception("resume_snapshot: get_training_params failed after successful resume_from_snapshot")
+        params = None
+    payload: dict = {
+        "snapshot_id": snapshot_id,
+        "operation": "resume",
+        "status": "ready",
+        "resume_point_epoch": lifecycle._resume_point_epoch,
+    }
+    if params is not None:
+        payload["training_params"] = params
+    return success_response(payload)

--- a/src/tests/unit/api/test_lifecycle_manager.py
+++ b/src/tests/unit/api/test_lifecycle_manager.py
@@ -793,3 +793,242 @@ class TestRestoreForRetrain:
         assert state["current_epoch"] == 42
         assert state["current_step"] == 999
         mgr.shutdown()
+
+
+@pytest.mark.unit
+class TestResumeFromSnapshot:
+    """CAN-015b (Phase 6E Sprint B B-2): tests for the new
+    ``resume_from_snapshot`` lifecycle method.
+
+    Resume preserves history (in contrast to Retrain which resets it),
+    transitions the FSM to ``RESUME_READY``, and records
+    ``_resume_point_epoch`` so canopy can render a visual boundary.
+    The auto-snap-best ratchet is also preserved so a re-snap only
+    fires when the resumed training beats the prior run's best.
+    """
+
+    def test_returns_false_when_snapshot_missing(self, tmp_path):
+        """Snapshot ID with no matching .h5 file → False, no FSM transition."""
+        from unittest.mock import patch
+
+        mgr = TrainingLifecycleManager()
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path):
+            assert mgr.resume_from_snapshot("nonexistent") is False
+        assert mgr.state_machine.is_stopped()
+        assert not mgr.state_machine.is_resume_ready()
+        mgr.shutdown()
+
+    def test_returns_false_when_training_active(self, tmp_path):
+        """Resume rejected while training is Started; FSM unchanged."""
+        from unittest.mock import patch
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        mgr.state_machine.handle_command(Command.START)
+        assert mgr.state_machine.is_started()
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path):
+            assert mgr.resume_from_snapshot("anything") is False
+        assert mgr.state_machine.is_started()
+        assert not mgr.state_machine.is_resume_ready()
+        mgr.shutdown()
+
+    def test_preserves_network_history_arrays(self, tmp_path):
+        """After successful resume_from_snapshot, network.history arrays are intact."""
+        from unittest.mock import MagicMock, patch
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        loaded = MagicMock()
+        loaded.history = {
+            "train_loss": [0.5, 0.4, 0.3],
+            "value_loss": [0.6, 0.5, 0.4],
+            "train_accuracy": [0.7, 0.8, 0.85],
+            "value_accuracy": [0.65, 0.75, 0.8],
+        }
+        fake_file = tmp_path / "snap.h5"
+        fake_file.write_bytes(b"")
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"):
+            assert mgr.resume_from_snapshot("snap") is True
+
+        assert loaded.history["train_loss"] == [0.5, 0.4, 0.3]
+        assert loaded.history["value_loss"] == [0.6, 0.5, 0.4]
+        assert loaded.history["train_accuracy"] == [0.7, 0.8, 0.85]
+        assert loaded.history["value_accuracy"] == [0.65, 0.75, 0.8]
+        mgr.shutdown()
+
+    def test_preserves_auto_snap_best_metric(self, tmp_path):
+        """Resume preserves the auto-snap-best ratchet (in contrast to Retrain)."""
+        from unittest.mock import MagicMock, patch
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        with mgr._auto_snap_lock:
+            mgr._auto_snap_best_metric = 0.95
+        loaded = MagicMock()
+        loaded.history = {"train_loss": [], "value_loss": [], "train_accuracy": [], "value_accuracy": []}
+        fake_file = tmp_path / "snap.h5"
+        fake_file.write_bytes(b"")
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"):
+            mgr.resume_from_snapshot("snap")
+
+        assert mgr._auto_snap_best_metric == 0.95
+        mgr.shutdown()
+
+    def test_transitions_fsm_to_resume_ready(self, tmp_path):
+        """FSM goes to RESUME_READY after a successful resume."""
+        from unittest.mock import MagicMock, patch
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        loaded = MagicMock()
+        loaded.history = {"train_loss": [0.1], "value_loss": [], "train_accuracy": [], "value_accuracy": []}
+        fake_file = tmp_path / "snap.h5"
+        fake_file.write_bytes(b"")
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"):
+            mgr.resume_from_snapshot("snap")
+
+        assert mgr.state_machine.is_resume_ready()
+        mgr.shutdown()
+
+    def test_records_resume_point_epoch(self, tmp_path):
+        """``_resume_point_epoch`` reflects the longest history array's length."""
+        from unittest.mock import MagicMock, patch
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        loaded = MagicMock()
+        loaded.history = {
+            "train_loss": [0.1, 0.2, 0.3, 0.4, 0.5],  # 5
+            "value_loss": [0.2, 0.3],                  # 2
+            "train_accuracy": [0.6, 0.7, 0.8],         # 3
+            "value_accuracy": [],                       # 0
+        }
+        fake_file = tmp_path / "snap.h5"
+        fake_file.write_bytes(b"")
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"):
+            mgr.resume_from_snapshot("snap")
+
+        # Longest array (train_loss) = 5.
+        assert mgr._resume_point_epoch == 5
+        mgr.shutdown()
+
+    def test_resume_point_zero_for_empty_history(self, tmp_path):
+        """An empty history dict produces resume_point_epoch=0."""
+        from unittest.mock import MagicMock, patch
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        loaded = MagicMock()
+        loaded.history = {}
+        fake_file = tmp_path / "snap.h5"
+        fake_file.write_bytes(b"")
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"):
+            assert mgr.resume_from_snapshot("snap") is True
+
+        assert mgr._resume_point_epoch == 0
+        mgr.shutdown()
+
+    def test_resume_point_zero_when_history_missing(self, tmp_path):
+        """A network without a ``history`` attribute produces resume_point_epoch=0."""
+        from unittest.mock import patch
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+
+        class NetworkWithoutHistory:
+            input_size = 2
+            output_size = 2
+
+        loaded = NetworkWithoutHistory()
+        fake_file = tmp_path / "snap.h5"
+        fake_file.write_bytes(b"")
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"):
+            assert mgr.resume_from_snapshot("snap") is True
+
+        assert mgr._resume_point_epoch == 0
+        mgr.shutdown()
+
+    def test_retrain_after_resume_clears_marker(self, tmp_path):
+        """A Retrain after a Resume clears the resume marker — Retrain is a clean slate."""
+        from unittest.mock import MagicMock, patch
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        loaded = MagicMock()
+        loaded.history = {"train_loss": [0.1, 0.2, 0.3], "value_loss": [], "train_accuracy": [], "value_accuracy": []}
+        fake_file = tmp_path / "snap.h5"
+        fake_file.write_bytes(b"")
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"):
+            mgr.resume_from_snapshot("snap")
+            assert mgr._resume_point_epoch == 3
+            mgr.restore_for_retrain("snap")
+            assert mgr._resume_point_epoch is None
+        mgr.shutdown()
+
+    def test_start_training_after_resume_preserves_auto_snap_baseline(self, tmp_path):
+        """When start_training fires from RESUME_READY, the auto-snap baseline
+        is preserved (the existing reset-on-start applies only to non-resume
+        starts). The resume marker is consumed (cleared) once start_training
+        runs."""
+        from unittest.mock import MagicMock, patch
+
+        import torch
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2, candidate_pool_size=2, candidate_epochs=2, output_epochs=2, patience=1)
+        loaded = MagicMock()
+        loaded.history = {"train_loss": [0.5, 0.4], "value_loss": [], "train_accuracy": [], "value_accuracy": []}
+        # Carry the network attributes start_training reads.
+        for attr in ("input_size", "output_size"):
+            setattr(loaded, attr, getattr(mgr.network, attr, 2))
+
+        fake_file = tmp_path / "snap.h5"
+        fake_file.write_bytes(b"")
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"):
+            mgr.resume_from_snapshot("snap")
+
+        # Set ratchet to a known value AFTER resume to isolate this test.
+        with mgr._auto_snap_lock:
+            mgr._auto_snap_best_metric = 0.85
+        assert mgr.state_machine.is_resume_ready()
+        assert mgr._resume_point_epoch == 2
+
+        x = torch.randn(20, 2)
+        y = torch.zeros(20, 2)
+        y[:10, 0] = 1
+        y[10:, 1] = 1
+        with patch.object(mgr.network, "fit", return_value={"train_loss": [0.3]}):
+            mgr.start_training(x=x, y=y)
+            if mgr._training_future is not None:
+                mgr._training_future.result(timeout=10)
+
+        # Ratchet preserved across the resume-to-start transition.
+        assert mgr._auto_snap_best_metric == 0.85
+        # Resume marker consumed.
+        assert mgr._resume_point_epoch is None
+        mgr.shutdown()
+
+    def test_start_training_from_stopped_resets_auto_snap_baseline(self, tmp_path):
+        """Regression: a normal start_training (FSM = Stopped, not RESUME_READY)
+        still resets the auto-snap ratchet."""
+        from unittest.mock import patch
+
+        import torch
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2, candidate_pool_size=2, candidate_epochs=2, output_epochs=2, patience=1)
+        with mgr._auto_snap_lock:
+            mgr._auto_snap_best_metric = 0.85
+        assert mgr.state_machine.is_stopped()
+
+        x = torch.randn(20, 2)
+        y = torch.zeros(20, 2)
+        y[:10, 0] = 1
+        y[10:, 1] = 1
+        with patch.object(mgr.network, "fit", return_value={"train_loss": [0.3]}):
+            mgr.start_training(x=x, y=y)
+            if mgr._training_future is not None:
+                mgr._training_future.result(timeout=10)
+
+        assert mgr._auto_snap_best_metric is None
+        mgr.shutdown()

--- a/src/tests/unit/api/test_lifecycle_state_machine.py
+++ b/src/tests/unit/api/test_lifecycle_state_machine.py
@@ -201,3 +201,106 @@ class TestTrainingStateMachine:
         result = sm.handle_command(Command.START)
         assert result is True
         assert sm.is_started()
+
+
+@pytest.mark.unit
+class TestResumeReadyState:
+    """CAN-015b (Phase 6E Sprint B B-2): tests for the new
+    ``RESUME_READY`` state and ``mark_resume_ready`` method."""
+
+    def test_initial_state_is_not_resume_ready(self):
+        """Fresh state machine is Stopped, not ResumeReady."""
+        sm = TrainingStateMachine()
+        assert not sm.is_resume_ready()
+
+    def test_mark_resume_ready_from_stopped(self):
+        """Stopped -> ResumeReady transition succeeds."""
+        sm = TrainingStateMachine()
+        result = sm.mark_resume_ready()
+        assert result is True
+        assert sm.is_resume_ready()
+        assert sm.status == TrainingStatus.RESUME_READY
+        # Phase resets to IDLE on entry — same as Stopped.
+        assert sm.phase == TrainingPhase.IDLE
+
+    def test_mark_resume_ready_from_completed(self):
+        """Completed -> ResumeReady is permitted (resume after a finished run)."""
+        sm = TrainingStateMachine()
+        sm.handle_command(Command.START)
+        sm.mark_completed()
+        assert sm.is_completed()
+        result = sm.mark_resume_ready()
+        assert result is True
+        assert sm.is_resume_ready()
+
+    def test_mark_resume_ready_from_failed(self):
+        """Failed -> ResumeReady is permitted (resume after a failed run)."""
+        sm = TrainingStateMachine()
+        sm.handle_command(Command.START)
+        sm.mark_failed("test failure")
+        assert sm.is_failed()
+        result = sm.mark_resume_ready()
+        assert result is True
+        assert sm.is_resume_ready()
+
+    def test_mark_resume_ready_idempotent(self):
+        """ResumeReady -> ResumeReady is permitted (re-resume on a different snapshot)."""
+        sm = TrainingStateMachine()
+        sm.mark_resume_ready()
+        assert sm.is_resume_ready()
+        # Calling again still succeeds.
+        result = sm.mark_resume_ready()
+        assert result is True
+        assert sm.is_resume_ready()
+
+    def test_mark_resume_ready_rejected_when_started(self):
+        """Started -> ResumeReady is REJECTED — must stop training first."""
+        sm = TrainingStateMachine()
+        sm.handle_command(Command.START)
+        assert sm.is_started()
+        result = sm.mark_resume_ready()
+        assert result is False
+        # FSM unchanged.
+        assert sm.is_started()
+        assert not sm.is_resume_ready()
+
+    def test_mark_resume_ready_rejected_when_paused(self):
+        """Paused -> ResumeReady is REJECTED — must stop training first."""
+        sm = TrainingStateMachine()
+        sm.handle_command(Command.START)
+        sm.handle_command(Command.PAUSE)
+        assert sm.is_paused()
+        result = sm.mark_resume_ready()
+        assert result is False
+        # FSM unchanged.
+        assert sm.is_paused()
+        assert not sm.is_resume_ready()
+
+    def test_start_from_resume_ready_transitions_to_started(self):
+        """ResumeReady + START command -> Started (Output phase) — same as
+        Stopped + START, but the lifecycle wraps this with history-preserving
+        logic. The FSM transition itself looks identical."""
+        sm = TrainingStateMachine()
+        sm.mark_resume_ready()
+        assert sm.is_resume_ready()
+        result = sm.handle_command(Command.START)
+        assert result is True
+        assert sm.is_started()
+        assert sm.phase == TrainingPhase.OUTPUT
+
+    def test_reset_from_resume_ready(self):
+        """ResumeReady + RESET command -> Stopped (any state -> Stopped)."""
+        sm = TrainingStateMachine()
+        sm.mark_resume_ready()
+        result = sm.handle_command(Command.RESET)
+        assert result is True
+        assert sm.is_stopped()
+        assert not sm.is_resume_ready()
+
+    def test_get_state_summary_reports_resume_ready(self):
+        """get_state_summary surfaces the new state name."""
+        sm = TrainingStateMachine()
+        sm.mark_resume_ready()
+        summary = sm.get_state_summary()
+        assert summary["status"] == "RESUME_READY"
+        assert summary["phase"] == "IDLE"

--- a/src/tests/unit/api/test_snapshot_route_coverage.py
+++ b/src/tests/unit/api/test_snapshot_route_coverage.py
@@ -366,6 +366,115 @@ class TestRetrainFromSnapshot:
         assert response.status_code in (400, 404, 422), f"unexpected status {response.status_code} for traversal attempt"
 
 
+class TestResumeSnapshot:
+    """CAN-015b (Phase 6E Sprint B B-2): tests for the new
+    ``POST /v1/snapshots/{id}/resume`` route. The route mirrors the
+    /restore + /retrain shape (snapshot_id + training_params + status)
+    and additionally surfaces ``resume_point_epoch`` so canopy can
+    render the visual boundary between pre-resume read-only history and
+    new training. Lifecycle reset/preserve semantics are exercised in
+    test_lifecycle_manager.py."""
+
+    def test_resume_snapshot_success(self, client):
+        """resume route returns ``operation: resume``, ``status: ready``,
+        and the resume_point_epoch read from the lifecycle."""
+        # Mock the lifecycle method directly; we set _resume_point_epoch
+        # before the call so the route observes it after success.
+        lifecycle = client.app.state.lifecycle
+        lifecycle._resume_point_epoch = 42
+
+        with patch.object(lifecycle, "resume_from_snapshot", return_value=True):
+            response = client.post("/v1/snapshots/snap-001/resume")
+            assert response.status_code == 200
+            body = response.json()
+            assert body["status"] == "success"
+            assert body["data"]["snapshot_id"] == "snap-001"
+            assert body["data"]["operation"] == "resume"
+            assert body["data"]["status"] == "ready"
+            assert body["data"]["resume_point_epoch"] == 42
+
+    def test_resume_snapshot_surfaces_post_load_training_params(self, client):
+        """Response includes training_params so canopy can reconcile."""
+        fake_params = {
+            "learning_rate": 0.005,
+            "epochs_max": 1234,
+            "optimizer_type": "AdamW",
+        }
+        lifecycle = client.app.state.lifecycle
+        lifecycle._resume_point_epoch = 7
+        with patch.object(lifecycle, "resume_from_snapshot", return_value=True), patch.object(lifecycle, "get_training_params", return_value=fake_params):
+            response = client.post("/v1/snapshots/snap-with-params/resume")
+            assert response.status_code == 200
+            body = response.json()
+            assert "training_params" in body["data"]
+            assert body["data"]["training_params"] == fake_params
+
+    def test_resume_snapshot_falls_back_when_get_training_params_fails(self, client):
+        """A failing ``get_training_params`` after a successful resume must
+        NOT make the route appear failed — same defensive pattern as /restore."""
+        lifecycle = client.app.state.lifecycle
+        lifecycle._resume_point_epoch = 0
+        with patch.object(lifecycle, "resume_from_snapshot", return_value=True), patch.object(lifecycle, "get_training_params", side_effect=RuntimeError("boom")):
+            response = client.post("/v1/snapshots/snap-fallback/resume")
+            assert response.status_code == 200
+            body = response.json()
+            assert body["data"]["snapshot_id"] == "snap-fallback"
+            assert body["data"]["operation"] == "resume"
+            assert "training_params" not in body["data"]
+
+    def test_resume_snapshot_not_found_returns_404(self, client):
+        """When resume_from_snapshot returns False (missing snapshot or
+        deserializer failure), the route maps to 404."""
+        with patch.object(client.app.state.lifecycle, "resume_from_snapshot", return_value=False):
+            response = client.post("/v1/snapshots/nonexistent/resume")
+            assert response.status_code == 404
+            assert "not found or failed to load" in response.json()["detail"]
+
+    def test_resume_snapshot_rejected_when_training_active(self, client):
+        """The pre-flight FSM check returns 409 when training is Started."""
+        from api.lifecycle.state_machine import Command
+
+        lifecycle = client.app.state.lifecycle
+        # Force the FSM to Started (no actual network/training needed for the check).
+        lifecycle.state_machine.handle_command(Command.START)
+        try:
+            response = client.post("/v1/snapshots/snap-active/resume")
+            assert response.status_code == 409
+            assert "Cannot resume" in response.json()["detail"]
+        finally:
+            # Clean up so other tests aren't affected.
+            lifecycle.state_machine.handle_command(Command.RESET)
+
+    def test_resume_snapshot_rejected_when_paused(self, client):
+        """Paused state also rejected with 409."""
+        from api.lifecycle.state_machine import Command
+
+        lifecycle = client.app.state.lifecycle
+        lifecycle.state_machine.handle_command(Command.START)
+        lifecycle.state_machine.handle_command(Command.PAUSE)
+        try:
+            response = client.post("/v1/snapshots/snap-paused/resume")
+            assert response.status_code == 409
+        finally:
+            lifecycle.state_machine.handle_command(Command.RESET)
+
+    def test_resume_snapshot_runs_in_thread(self, client):
+        """PERF-CC-01: HDF5 I/O off the main event loop."""
+        captured: dict = {}
+
+        def fake_resume(snapshot_id: str):
+            import threading
+
+            captured["thread"] = threading.current_thread().name
+            return True
+
+        client.app.state.lifecycle._resume_point_epoch = 0
+        with patch.object(client.app.state.lifecycle, "resume_from_snapshot", side_effect=fake_resume):
+            response = client.post("/v1/snapshots/snap-thread/resume")
+            assert response.status_code == 200
+            assert captured["thread"] != "MainThread", f"resume_from_snapshot ran on MainThread ({captured['thread']!r}); expected an asyncio worker"
+
+
 class TestPerfCC01InvariantSource:
     """PERF-CC-01: lock asyncio.to_thread usage in route source."""
 
@@ -374,11 +483,13 @@ class TestPerfCC01InvariantSource:
 
         path = Path(__file__).resolve().parents[3] / "api" / "routes" / "snapshots.py"
         source = path.read_text(encoding="utf-8")
-        # Save / restore / retrain route handlers must all offload via asyncio.to_thread.
+        # Save / restore / retrain / resume route handlers must all offload via asyncio.to_thread.
         assert "asyncio.to_thread(lifecycle.save_snapshot" in source
         assert "asyncio.to_thread(lifecycle.load_snapshot" in source
         # CAN-015a (Phase 6E Sprint B B-1): retrain route added.
         assert "asyncio.to_thread(lifecycle.restore_for_retrain" in source
+        # CAN-015b (Phase 6E Sprint B B-2): resume route added.
+        assert "asyncio.to_thread(lifecycle.resume_from_snapshot" in source
 
     def test_imports_asyncio(self):
         from pathlib import Path


### PR DESCRIPTION
## Summary

Phase 6E Sprint B **B-2** — second of four cascor PRs implementing the
expanded snapshot operations matrix from
[`PHASE_6E_SPRINT_B_DESIGN.md`](https://github.com/pcalnon/juniper-ml/blob/main/notes/PHASE_6E_SPRINT_B_DESIGN.md)
(Restore / Replay / Resume / Retrain).

**Resume semantics**: load a snapshot identically to Restore
(preserving weights, topology, all A-5 meta-parameters, AND the
training history) then transition to a new `RESUME_READY` FSM state.
The next `start_training` extends the existing history arrays from
the snapshot's terminal epoch rather than starting fresh, and the
auto-snap-best ratchet keeps its prior accuracy ceiling so a re-snap
only fires when the resumed training genuinely beats the previous run.

**Contrast with B-1 Retrain**: Retrain *clears* history / counters /
ratchet for a clean slate. Resume *preserves* every history-bearing
field. Re-snapshotting after Resume training captures a comprehensive
end-to-end record.

## Changes

### `api/lifecycle/state_machine.py`

- New `TrainingStatus.RESUME_READY` enum value
- New `is_resume_ready()` predicate
- New `mark_resume_ready()` method:
  - Permitted from Stopped / Completed / Failed / RESUME_READY
    (idempotent re-mark allowed)
  - Rejected from Started / Paused — user must stop training first
- `_handle_start` gains an explicit `RESUME_READY → STARTED`
  transition mirroring `STOPPED → STARTED`. The history-extension
  semantics are a data-side concern (handled by the lifecycle); the
  FSM transition itself looks identical.

### `api/lifecycle/manager.py`

- New `self._resume_point_epoch: Optional[int]` attribute. Records
  the snapshot's terminal-epoch count so canopy can render a visual
  boundary in the metrics-curve component. Cleared once consumed by
  `start_training`.
- New `resume_from_snapshot(snapshot_id)` method. Calls the shared
  `_load_snapshot_to_network` helper (from B-1), computes the
  resume-point as the longest history array's length, transitions
  the FSM to `RESUME_READY`. Does NOT clear history, counters, or
  the auto-snap-best ratchet.
- **`start_training` is now conditional on FSM state**:
  - From `RESUME_READY`: preserves `_auto_snap_best_metric` and
    clears `_resume_point_epoch` (consumed)
  - From Stopped / other: existing reset-on-start applies as before
- `restore_for_retrain` also clears `_resume_point_epoch` — a Retrain
  over a previously-resumed snapshot should not carry the marker
  forward.

### `api/routes/snapshots.py`

- New `POST /v1/snapshots/{snapshot_id}/resume` route
- Pre-flight FSM check returns 409 (Conflict) when training is active
- Otherwise calls `resume_from_snapshot` via `asyncio.to_thread`
  (PERF-CC-01) and returns
  `{snapshot_id, operation: "resume", status: "ready", resume_point_epoch, training_params}`
- Defensive `try/except` around `get_training_params` (post-A-5 pattern)

## Tests (28 new)

- **`test_lifecycle_state_machine.py`** — new `TestResumeReadyState`
  class with **10 tests** covering each transition in/out of
  `RESUME_READY`, plus get_state_summary surfacing
- **`test_lifecycle_manager.py`** — new `TestResumeFromSnapshot` class
  with **11 tests** pinning each piece of the contract: return-False
  paths, history preservation, ratchet preservation, FSM transition,
  resume_point_epoch computation (with edge cases for empty/missing
  history), retrain-after-resume marker clearing, and two
  start_training-after-resume tests (resume-path preserves the
  ratchet; non-resume-path still resets, regression-protected)
- **`test_snapshot_route_coverage.py`** — new `TestResumeSnapshot`
  class with **7 tests** (success path with resume_point_epoch,
  training_params surfacing, defensive fallback, 404, 409 from
  Started / Paused, off-event-loop verification). Plus PERF-CC-01
  invariant-source test extended.

## Sprint B status after this PR

| PR | CAN-ID | Repo | State |
|---|---|---|---|
| B-1 | CAN-015a | cascor | merged |
| **B-2** | CAN-015b | cascor | **this PR** |
| B-3 | CAN-015c | cascor | not started (Replay infra + Replaying FSM) |
| B-4 | CAN-015d | cascor | not started (Restore enrichment + Investigating FSM + unified response shape) |
| B-5 | CAN-015e | canopy | not started |
| B-6 | CAN-015f | canopy | not started |

## Test plan

- [x] `flake8 --max-line-length=512` clean on all 3 modified production files
- [x] `py_compile` clean on all 6 modified files
- [ ] Local `pytest` couldn't run in this env (Py3.14 free-threading +
  torch C-extensions ImportError, known unrelated issue) — CI will
  exercise the 28 new tests
- [ ] Manual smoke (deferred): create network, train briefly, snapshot,
  POST /v1/snapshots/{id}/resume, verify response shows
  resume_point_epoch=N matching the snapshot, modify learning_rate via
  PATCH, start_training, verify metrics extend (don't restart) and
  auto_snap baseline is preserved

## References

- [PHASE_6E_SPRINT_B_DESIGN.md](https://github.com/pcalnon/juniper-ml/blob/main/notes/PHASE_6E_SPRINT_B_DESIGN.md) §2.3 (Resume spec), §5 (FSM extensions)
- [PHASE_6E_DESIGN.md](https://github.com/pcalnon/juniper-ml/blob/main/notes/PHASE_6E_DESIGN.md) Sprint B table

🤖 Generated with [Claude Code](https://claude.com/claude-code)