### PR TITLE
feat(snapshot): restore enrichment + Investigating FSM + unified response shape (Phase 6E Sprint B B-4, CAN-015d) [stacked on #170]

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -770,6 +770,15 @@ class TrainingLifecycleManager:
         with self._training_lock:
             if self.state_machine.is_started():
                 raise RuntimeError("Training already in progress")
+            # CAN-015d (B-4): Investigating is the inspection / modification
+            # mode loaded by ``/restore``. Training commands are explicitly
+            # rejected — the user must invoke ``/retrain`` or ``/resume`` to
+            # transition out of Investigating before starting training.
+            # Failing fast at the API boundary is much clearer than
+            # letting the future submit and the FSM transition fail
+            # silently inside monitored_fit.
+            if self.state_machine.is_investigating():
+                raise RuntimeError("Cannot start training while Investigating a snapshot — invoke /v1/snapshots/{id}/retrain or /resume to transition out of Investigating first")
 
             if x is not None:
                 self._train_x = x
@@ -1395,17 +1404,40 @@ class TrainingLifecycleManager:
         """Load a network snapshot by ID (Restore semantics).
 
         Preserves the full snapshotted state — weights, topology, training
-        history, all meta-parameters per A-5 (CAN-014). Does NOT reset the
-        training-state counters or FSM; the user is expected to either
-        invoke a separate operation (Retrain / Resume) to enter a training
-        state, or modify the network and re-snapshot.
+        history, all meta-parameters per A-5 (CAN-014). The FSM transitions
+        to ``INVESTIGATING`` so the user can edit meta-params, replace the
+        dataset, and re-snapshot, but cannot start training directly. To
+        enter a training state, the user must invoke ``restore_for_retrain``
+        (clean slate) or ``resume_from_snapshot`` (extend history).
+
+        Rejected when training is currently active (Started / Paused) —
+        same FSM-guard contract as Resume / Retrain. Returns False so
+        the route layer can map to 409.
 
         See ``notes/PHASE_6E_SPRINT_B_DESIGN.md`` §2.1.
         """
+        # Same pre-flight as resume_from_snapshot: investigating an
+        # active training run would race with the running fit() and
+        # leave the lifecycle in a confused state.
+        if self.state_machine.is_started() or self.state_machine.is_paused():
+            self.logger.warning(f"load_snapshot rejected: training is {self.state_machine.status.name}")
+            return False
+
         ok = self._load_snapshot_to_network(snapshot_id)
-        if ok:
-            self.logger.info(f"Snapshot restored: {snapshot_id}")
-        return ok
+        if not ok:
+            return False
+
+        # CAN-015d (B-4): transition to Investigating and clear any
+        # state from prior snapshot operations. The user explicitly
+        # invoked /restore (not /retrain or /resume) so we want the
+        # inspection-only contract: training commands rejected, no
+        # implicit history reset, no resume marker.
+        self.state_machine.mark_investigating()
+        self._resume_point_epoch = None
+        self.training_state.update_state(status="Stopped", phase="Idle")
+        self._broadcast_training_state(force=True)
+        self.logger.info(f"Snapshot restored: {snapshot_id} (FSM=Investigating)")
+        return True
 
     def restore_for_retrain(self, snapshot_id: str) -> bool:
         """Load a snapshot and reset training history for a fresh run (CAN-015a).

--- a/src/api/lifecycle/state_machine.py
+++ b/src/api/lifecycle/state_machine.py
@@ -32,6 +32,15 @@ class TrainingStatus(Enum):
     # PRESERVING the loaded history (in contrast to a Retrain which
     # resets it). See ``notes/PHASE_6E_SPRINT_B_DESIGN.md`` §2.3.
     RESUME_READY = auto()
+    # CAN-015d (Phase 6E Sprint B B-4): a snapshot has been loaded with
+    # ``load_snapshot`` for inspection or modification — NOT for
+    # continuing training. The user can edit meta-params, replace the
+    # dataset, and re-snapshot, but ``start_training`` /
+    # ``pause_training`` / ``resume_training`` are explicitly rejected.
+    # The user must invoke ``/retrain`` or ``/resume`` (or load a
+    # different snapshot via those endpoints) to enter a training
+    # state. See ``notes/PHASE_6E_SPRINT_B_DESIGN.md`` §2.1.
+    INVESTIGATING = auto()
 
 
 class Command(Enum):
@@ -104,6 +113,12 @@ class TrainingStateMachine:
         continue from the snapshotted point."""
         return self._status == TrainingStatus.RESUME_READY
 
+    def is_investigating(self) -> bool:
+        """CAN-015d (Phase 6E Sprint B B-4): a snapshot has been loaded
+        for inspection / modification — training commands are explicitly
+        rejected from this state."""
+        return self._status == TrainingStatus.INVESTIGATING
+
     def handle_command(self, command: Command) -> bool:
         """Handle control command and perform state transition.
 
@@ -123,6 +138,14 @@ class TrainingStateMachine:
         return handler()
 
     def _handle_start(self) -> bool:
+        # CAN-015d (B-4): INVESTIGATING explicitly rejects training commands.
+        # The user loaded a snapshot for inspection / modification; they
+        # must invoke /retrain or /resume (or a different snapshot via
+        # those endpoints) before training can begin. Auto-transitioning
+        # silently would defeat the entire Investigating contract.
+        if self._status == TrainingStatus.INVESTIGATING:
+            self.logger.warning("Invalid transition: START while Investigating — invoke /retrain or /resume to enter a training state")
+            return False
         if self._status in (TrainingStatus.FAILED, TrainingStatus.COMPLETED):
             self.logger.info(f"Auto-resetting from terminal state {self._status.name} before start")
             self._reset_to_stopped()
@@ -250,7 +273,7 @@ class TrainingStateMachine:
         re-marking, e.g. if the user calls /resume twice on different
         snapshots without an intervening start).
         """
-        if self._status in (TrainingStatus.STOPPED, TrainingStatus.COMPLETED, TrainingStatus.FAILED, TrainingStatus.RESUME_READY):
+        if self._status in (TrainingStatus.STOPPED, TrainingStatus.COMPLETED, TrainingStatus.FAILED, TrainingStatus.RESUME_READY, TrainingStatus.INVESTIGATING):
             prev = self._status.name
             self._status = TrainingStatus.RESUME_READY
             self._phase = TrainingPhase.IDLE
@@ -259,6 +282,30 @@ class TrainingStateMachine:
             self.logger.info(f"State transition: {prev} -> ResumeReady")
             return True
         self.logger.warning(f"Invalid transition: mark_resume_ready while {self._status.name}")
+        return False
+
+    def mark_investigating(self) -> bool:
+        """CAN-015d (Phase 6E Sprint B B-4): mark the FSM as inspecting
+        a loaded snapshot. Call from ``lifecycle.load_snapshot`` after
+        the snapshot is loaded.
+
+        Investigating is the inspection / modification mode — the user
+        can edit meta-params and re-snapshot but cannot start training
+        directly (must invoke /retrain or /resume first). Permitted
+        from non-active states (Stopped / Completed / Failed /
+        RESUME_READY / INVESTIGATING) — a user can replace one loaded
+        snapshot with another without explicitly resetting in between.
+        Rejected from STARTED / PAUSED: training must stop first.
+        """
+        if self._status in (TrainingStatus.STOPPED, TrainingStatus.COMPLETED, TrainingStatus.FAILED, TrainingStatus.RESUME_READY, TrainingStatus.INVESTIGATING):
+            prev = self._status.name
+            self._status = TrainingStatus.INVESTIGATING
+            self._phase = TrainingPhase.IDLE
+            self._paused_phase = None
+            self._candidate_sub_state = None
+            self.logger.info(f"State transition: {prev} -> Investigating")
+            return True
+        self.logger.warning(f"Invalid transition: mark_investigating while {self._status.name}")
         return False
 
     def get_state_summary(self) -> dict:

--- a/src/api/routes/snapshots.py
+++ b/src/api/routes/snapshots.py
@@ -52,6 +52,80 @@ def _get_lifecycle(request: Request):
     return lifecycle
 
 
+def _compute_snapshot_window(lifecycle) -> dict:
+    """CAN-015d (Phase 6E Sprint B B-4): compute the snapshot window
+    metadata for the unified response shape's ``time_index`` block.
+
+    The window is derived from the longest history array on the loaded
+    network — same source as ``resume_from_snapshot``'s
+    ``_resume_point_epoch`` calculation. ``start_epoch`` is always 0
+    (snapshots can't yet represent a model that has skipped epochs);
+    ``end_epoch`` is the count of epochs the loaded network has trained
+    for. Falls back to ``{0, 0}`` when the network has no history.
+    """
+    network = getattr(lifecycle, "network", None)
+    if network is None:
+        return {"start_epoch": 0, "end_epoch": 0}
+    history = getattr(network, "history", None)
+    end = 0
+    if isinstance(history, dict):
+        # Match the lifecycle's _NETWORK_HISTORY_KEYS scope so the route
+        # surface stays consistent with what Resume / Retrain operate on.
+        for key in ("train_loss", "value_loss", "train_accuracy", "value_accuracy"):
+            series = history.get(key, ())
+            try:
+                end = max(end, len(series))
+            except TypeError:
+                continue
+    return {"start_epoch": 0, "end_epoch": end}
+
+
+def _build_unified_payload(
+    lifecycle,
+    snapshot_id: str,
+    operation: str,
+    time_index_default,
+    *,
+    extra: dict | None = None,
+) -> dict:
+    """CAN-015d (Phase 6E Sprint B B-4): assemble the unified response
+    body for the four snapshot operation endpoints.
+
+    Per ``notes/PHASE_6E_SPRINT_B_DESIGN.md`` §3, every snapshot
+    operation returns the same shape — ``snapshot_id`` + ``operation``
+    + ``fsm_state`` + ``time_index`` + ``training_params``. Fields like
+    ``status`` and ``resume_point_epoch`` (added pre-B-4 by B-1 and B-2
+    respectively) are preserved as a strict superset for backward
+    compatibility — existing canopy clients keying off them keep
+    working.
+
+    ``time_index_default`` is the operation-specific default position
+    in the snapshot's narrative: ``"end"`` for Restore / Resume,
+    ``0`` for Retrain (history reset), ``"start"`` for Replay (B-3,
+    not yet shipped).
+    """
+    fsm_state = lifecycle.state_machine.status.name
+    snapshot_window = _compute_snapshot_window(lifecycle)
+    payload: dict = {
+        "snapshot_id": snapshot_id,
+        "operation": operation,
+        "fsm_state": fsm_state,
+        "time_index": {
+            "default": time_index_default,
+            "snapshot_window": snapshot_window,
+        },
+    }
+    try:
+        payload["training_params"] = lifecycle.get_training_params()
+    except Exception:
+        # Defensive: surfacing params is best-effort. A failure here
+        # should not undo a successful snapshot operation.
+        logger.exception("snapshots: get_training_params failed after successful operation %r", operation)
+    if extra:
+        payload.update(extra)
+    return payload
+
+
 @router.post("")
 async def save_snapshot(request: Request, body: SnapshotCreateRequest = None) -> dict:
     """Save a snapshot of the current network state."""
@@ -88,37 +162,51 @@ async def get_snapshot(request: Request, snapshot_id: str) -> dict:
 
 @router.post("/{snapshot_id}/restore")
 async def restore_snapshot(request: Request, snapshot_id: str) -> dict:
-    """Restore a network from a snapshot.
+    """Restore a network from a snapshot for inspection and modification.
 
-    CAN-014 (Phase 6E Sprint A-5): the response now includes the
-    post-restore ``training_params`` so the client can verify the
-    round-trip without making a second ``GET /v1/training/params``
-    call. The serializer round-trips every field listed in
-    ``update_params``' whitelist (PR #163 / CAN-014); surfacing them
-    here lets a tuning UI immediately reconcile its local state.
+    CAN-015d (Phase 6E Sprint B B-4): Restore is now an explicit
+    inspection / modification mode rather than an implicit "load + can
+    train next" shortcut. The lifecycle transitions to the new
+    ``Investigating`` FSM state which rejects ``start_training`` /
+    ``pause_training`` / ``resume_training`` until the user explicitly
+    invokes ``/retrain`` or ``/resume``. The user can edit
+    meta-params via ``PATCH /v1/training/params``, replace the dataset,
+    and re-snapshot the modified state — all of which are permitted in
+    ``Investigating``.
+
+    Rejected with 409 if training is currently active (Started /
+    Paused) — same FSM-guard contract as Resume / Retrain.
+
+    CAN-014 (Sprint A-5): response includes the post-restore
+    ``training_params`` so a tuning UI can reconcile state. CAN-015d
+    further unifies the response shape with ``operation`` /
+    ``fsm_state`` / ``time_index``. The pre-existing ``status:
+    "restored"`` field is retained as a strict superset so existing
+    canopy clients keying off it keep working.
+
+    See ``juniper-ml/notes/PHASE_6E_SPRINT_B_DESIGN.md`` §2.1, §3.
     """
     _validate_snapshot_id(snapshot_id, client=request.client.host if request.client else None)
     lifecycle = _get_lifecycle(request)
+    # Pre-flight FSM check — surface 409 at the route boundary rather
+    # than letting the lifecycle's own check map to a generic 404.
+    if lifecycle.state_machine.is_started() or lifecycle.state_machine.is_paused():
+        raise HTTPException(status_code=409, detail=f"Cannot restore from snapshot while training is {lifecycle.state_machine.status.name}")
     # PERF-CC-01: serializer.load_network is synchronous HDF5 I/O. Run it
     # off the event loop so concurrent requests aren't blocked while the
     # snapshot is being read.
     success = await asyncio.to_thread(lifecycle.load_snapshot, snapshot_id)
     if not success:
         raise HTTPException(status_code=404, detail=f"Snapshot '{snapshot_id}' not found or failed to load")
-    # ``get_training_params`` is cheap (synchronous attribute reads under
-    # the training lock) and it would be surprising to surface restore
-    # without surfacing what the client actually got back.
-    try:
-        params = lifecycle.get_training_params()
-    except Exception:
-        # Defensive — if the params extraction fails, the restore itself
-        # already succeeded; fall back to the original minimal response
-        # rather than making the round-trip look failed.
-        logger.exception("restore_snapshot: get_training_params failed after successful restore")
-        params = None
-    payload: dict = {"snapshot_id": snapshot_id, "status": "restored"}
-    if params is not None:
-        payload["training_params"] = params
+    payload = _build_unified_payload(
+        lifecycle,
+        snapshot_id,
+        operation="restore",
+        time_index_default="end",
+        # Strict-superset backward-compatibility: keep the pre-B-4
+        # ``status: "restored"`` field so existing clients keep working.
+        extra={"status": "restored"},
+    )
     return success_response(payload)
 
 
@@ -153,14 +241,15 @@ async def retrain_from_snapshot(request: Request, snapshot_id: str) -> dict:
     success = await asyncio.to_thread(lifecycle.restore_for_retrain, snapshot_id)
     if not success:
         raise HTTPException(status_code=404, detail=f"Snapshot '{snapshot_id}' not found or failed to load")
-    try:
-        params = lifecycle.get_training_params()
-    except Exception:
-        logger.exception("retrain_from_snapshot: get_training_params failed after successful restore_for_retrain")
-        params = None
-    payload: dict = {"snapshot_id": snapshot_id, "operation": "retrain", "status": "ready"}
-    if params is not None:
-        payload["training_params"] = params
+    payload = _build_unified_payload(
+        lifecycle,
+        snapshot_id,
+        operation="retrain",
+        # Retrain resets history / counters to 0, so the time index is 0.
+        time_index_default=0,
+        # Strict-superset backward-compatibility for the B-1 response shape.
+        extra={"status": "ready"},
+    )
     return success_response(payload)
 
 
@@ -198,17 +287,16 @@ async def resume_snapshot(request: Request, snapshot_id: str) -> dict:
     success = await asyncio.to_thread(lifecycle.resume_from_snapshot, snapshot_id)
     if not success:
         raise HTTPException(status_code=404, detail=f"Snapshot '{snapshot_id}' not found or failed to load")
-    try:
-        params = lifecycle.get_training_params()
-    except Exception:
-        logger.exception("resume_snapshot: get_training_params failed after successful resume_from_snapshot")
-        params = None
-    payload: dict = {
-        "snapshot_id": snapshot_id,
-        "operation": "resume",
-        "status": "ready",
-        "resume_point_epoch": lifecycle._resume_point_epoch,
-    }
-    if params is not None:
-        payload["training_params"] = params
+    payload = _build_unified_payload(
+        lifecycle,
+        snapshot_id,
+        operation="resume",
+        # Resume lands the user at the snapshot's terminal epoch.
+        time_index_default="end",
+        # Strict-superset backward-compatibility for the B-2 response shape.
+        extra={
+            "status": "ready",
+            "resume_point_epoch": lifecycle._resume_point_epoch,
+        },
+    )
     return success_response(payload)

--- a/src/tests/unit/api/test_lifecycle_manager.py
+++ b/src/tests/unit/api/test_lifecycle_manager.py
@@ -769,10 +769,11 @@ class TestRestoreForRetrain:
             assert mgr.restore_for_retrain("snap") is True
         mgr.shutdown()
 
-    def test_load_snapshot_unchanged_by_retrain_refactor(self, tmp_path):
-        """Regression: ``load_snapshot`` (Restore semantics) keeps its
-        existing behavior after the ``_load_snapshot_to_network`` extraction.
-        It should NOT clear history or reset counters — that's only Retrain."""
+    def test_load_snapshot_preserves_history_and_counters(self, tmp_path):
+        """Regression: ``load_snapshot`` (Restore semantics) preserves
+        history arrays and ``training_state`` counters. B-4 added the FSM
+        transition to INVESTIGATING but the data-side preservation
+        contract is unchanged from B-1."""
         from unittest.mock import MagicMock, patch
 
         mgr = TrainingLifecycleManager()
@@ -788,7 +789,10 @@ class TestRestoreForRetrain:
         # History on the loaded network is preserved — Restore is a load,
         # not a reset.
         assert loaded.history["train_loss"] == [0.1, 0.2]
-        # Counters on training_state are NOT reset by Restore.
+        # Counters on training_state are NOT reset by Restore (only Retrain
+        # resets these). status / phase ARE updated by B-4 to keep
+        # training_state in sync with the FSM transition to Investigating,
+        # but the epoch/step counters reflect the loaded snapshot.
         state = mgr.training_state.get_state()
         assert state["current_epoch"] == 42
         assert state["current_step"] == 999
@@ -1031,4 +1035,123 @@ class TestResumeFromSnapshot:
                 mgr._training_future.result(timeout=10)
 
         assert mgr._auto_snap_best_metric is None
+        mgr.shutdown()
+
+
+@pytest.mark.unit
+class TestLoadSnapshotInvestigating:
+    """CAN-015d (Phase 6E Sprint B B-4): tests for the new ``load_snapshot``
+    Investigating contract.
+
+    Restore now transitions the FSM to ``INVESTIGATING`` so the user
+    can edit / re-snapshot but cannot start training directly.
+    Pre-flight check rejects when training is currently active.
+    """
+
+    def test_returns_false_when_training_active(self, tmp_path):
+        """load_snapshot rejected while training is Started."""
+        from unittest.mock import patch
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        mgr.state_machine.handle_command(Command.START)
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path):
+            assert mgr.load_snapshot("anything") is False
+        # FSM still in Started — Restore didn't sneak through.
+        assert mgr.state_machine.is_started()
+        mgr.shutdown()
+
+    def test_transitions_fsm_to_investigating(self, tmp_path):
+        """Successful load_snapshot transitions FSM to INVESTIGATING."""
+        from unittest.mock import MagicMock, patch
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        loaded = MagicMock()
+        loaded.history = {"train_loss": [0.1, 0.2], "value_loss": [], "train_accuracy": [], "value_accuracy": []}
+        fake_file = tmp_path / "snap.h5"
+        fake_file.write_bytes(b"")
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"):
+            assert mgr.load_snapshot("snap") is True
+
+        assert mgr.state_machine.is_investigating()
+        mgr.shutdown()
+
+    def test_clears_resume_marker(self, tmp_path):
+        """A Restore over a previously-resumed snapshot clears the
+        resume marker — Restore is the inspection-only entry point."""
+        from unittest.mock import MagicMock, patch
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        # Simulate a prior Resume having set the marker.
+        mgr._resume_point_epoch = 5
+        loaded = MagicMock()
+        loaded.history = {"train_loss": [], "value_loss": [], "train_accuracy": [], "value_accuracy": []}
+        fake_file = tmp_path / "snap.h5"
+        fake_file.write_bytes(b"")
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"):
+            mgr.load_snapshot("snap")
+
+        assert mgr._resume_point_epoch is None
+        mgr.shutdown()
+
+    def test_start_training_rejected_when_investigating(self):
+        """``start_training`` raises RuntimeError when FSM is INVESTIGATING.
+
+        The user must invoke /retrain or /resume to transition out of
+        Investigating before training can begin. Failing fast at the API
+        boundary is much clearer than letting the future submit and the
+        FSM transition fail silently inside monitored_fit.
+        """
+        import torch
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        # Force FSM to Investigating without actually loading a snapshot.
+        mgr.state_machine.mark_investigating()
+        x = torch.randn(20, 2)
+        y = torch.zeros(20, 2)
+        with pytest.raises(RuntimeError, match="Investigating"):
+            mgr.start_training(x=x, y=y)
+        # FSM unchanged — failed start didn't accidentally transition.
+        assert mgr.state_machine.is_investigating()
+        mgr.shutdown()
+
+    def test_retrain_after_restore_clears_investigating(self, tmp_path):
+        """Retrain after Restore transitions out of Investigating to
+        Stopped — Retrain explicitly moves to a training-ready state."""
+        from unittest.mock import MagicMock, patch
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        loaded = MagicMock()
+        loaded.history = {"train_loss": [0.1], "value_loss": [], "train_accuracy": [], "value_accuracy": []}
+        fake_file = tmp_path / "snap.h5"
+        fake_file.write_bytes(b"")
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"):
+            mgr.load_snapshot("snap")
+            assert mgr.state_machine.is_investigating()
+            mgr.restore_for_retrain("snap")
+            # After Retrain the FSM is Stopped (Retrain calls Command.RESET).
+            assert mgr.state_machine.is_stopped()
+            assert not mgr.state_machine.is_investigating()
+        mgr.shutdown()
+
+    def test_resume_after_restore_clears_investigating(self, tmp_path):
+        """Resume after Restore transitions Investigating -> ResumeReady."""
+        from unittest.mock import MagicMock, patch
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        loaded = MagicMock()
+        loaded.history = {"train_loss": [0.1, 0.2, 0.3], "value_loss": [], "train_accuracy": [], "value_accuracy": []}
+        fake_file = tmp_path / "snap.h5"
+        fake_file.write_bytes(b"")
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"):
+            mgr.load_snapshot("snap")
+            assert mgr.state_machine.is_investigating()
+            mgr.resume_from_snapshot("snap")
+            assert mgr.state_machine.is_resume_ready()
+            assert not mgr.state_machine.is_investigating()
         mgr.shutdown()

--- a/src/tests/unit/api/test_lifecycle_state_machine.py
+++ b/src/tests/unit/api/test_lifecycle_state_machine.py
@@ -304,3 +304,140 @@ class TestResumeReadyState:
         summary = sm.get_state_summary()
         assert summary["status"] == "RESUME_READY"
         assert summary["phase"] == "IDLE"
+
+
+@pytest.mark.unit
+class TestInvestigatingState:
+    """CAN-015d (Phase 6E Sprint B B-4): tests for the new
+    ``INVESTIGATING`` state and ``mark_investigating`` method.
+
+    Investigating is the inspection / modification mode loaded by
+    ``/restore`` — the user can edit meta-params and re-snapshot but
+    cannot start training directly. They must invoke ``/retrain`` or
+    ``/resume`` to transition out of Investigating before training can
+    begin.
+    """
+
+    def test_initial_state_is_not_investigating(self):
+        """Fresh state machine is Stopped, not Investigating."""
+        sm = TrainingStateMachine()
+        assert not sm.is_investigating()
+
+    def test_mark_investigating_from_stopped(self):
+        """Stopped -> Investigating transition succeeds."""
+        sm = TrainingStateMachine()
+        result = sm.mark_investigating()
+        assert result is True
+        assert sm.is_investigating()
+        assert sm.status == TrainingStatus.INVESTIGATING
+        assert sm.phase == TrainingPhase.IDLE
+
+    def test_mark_investigating_from_completed(self):
+        """Completed -> Investigating is permitted (load a snapshot after a finished run)."""
+        sm = TrainingStateMachine()
+        sm.handle_command(Command.START)
+        sm.mark_completed()
+        assert sm.is_completed()
+        assert sm.mark_investigating() is True
+        assert sm.is_investigating()
+
+    def test_mark_investigating_from_failed(self):
+        """Failed -> Investigating is permitted."""
+        sm = TrainingStateMachine()
+        sm.handle_command(Command.START)
+        sm.mark_failed("test failure")
+        assert sm.is_failed()
+        assert sm.mark_investigating() is True
+        assert sm.is_investigating()
+
+    def test_mark_investigating_from_resume_ready(self):
+        """ResumeReady -> Investigating is permitted (replace a Resume target with a Restore target)."""
+        sm = TrainingStateMachine()
+        sm.mark_resume_ready()
+        assert sm.is_resume_ready()
+        assert sm.mark_investigating() is True
+        assert sm.is_investigating()
+
+    def test_mark_investigating_idempotent(self):
+        """Investigating -> Investigating is permitted (replace one inspected snapshot with another)."""
+        sm = TrainingStateMachine()
+        sm.mark_investigating()
+        assert sm.mark_investigating() is True
+        assert sm.is_investigating()
+
+    def test_mark_investigating_rejected_when_started(self):
+        """Started -> Investigating is REJECTED — must stop training first."""
+        sm = TrainingStateMachine()
+        sm.handle_command(Command.START)
+        result = sm.mark_investigating()
+        assert result is False
+        assert sm.is_started()
+        assert not sm.is_investigating()
+
+    def test_mark_investigating_rejected_when_paused(self):
+        """Paused -> Investigating is REJECTED."""
+        sm = TrainingStateMachine()
+        sm.handle_command(Command.START)
+        sm.handle_command(Command.PAUSE)
+        result = sm.mark_investigating()
+        assert result is False
+        assert sm.is_paused()
+
+    def test_start_rejected_from_investigating(self):
+        """START command is REJECTED from Investigating — the whole
+        contract: user must invoke /retrain or /resume to enter a
+        training state."""
+        sm = TrainingStateMachine()
+        sm.mark_investigating()
+        assert sm.is_investigating()
+        result = sm.handle_command(Command.START)
+        assert result is False
+        # FSM still in Investigating — not silently auto-transitioned.
+        assert sm.is_investigating()
+        assert not sm.is_started()
+
+    def test_resume_command_rejected_from_investigating(self):
+        """RESUME command (used to resume from Paused) is REJECTED from
+        Investigating — same logic as START."""
+        sm = TrainingStateMachine()
+        sm.mark_investigating()
+        result = sm.handle_command(Command.RESUME)
+        assert result is False
+        assert sm.is_investigating()
+
+    def test_pause_rejected_from_investigating(self):
+        """PAUSE command is REJECTED from Investigating (no training to pause)."""
+        sm = TrainingStateMachine()
+        sm.mark_investigating()
+        result = sm.handle_command(Command.PAUSE)
+        assert result is False
+        assert sm.is_investigating()
+
+    def test_reset_from_investigating(self):
+        """RESET command transitions Investigating -> Stopped — escape hatch
+        for clearing the state if the user wants a fresh start without
+        going through /retrain or /resume."""
+        sm = TrainingStateMachine()
+        sm.mark_investigating()
+        result = sm.handle_command(Command.RESET)
+        assert result is True
+        assert sm.is_stopped()
+        assert not sm.is_investigating()
+
+    def test_mark_resume_ready_from_investigating(self):
+        """Investigating -> ResumeReady is permitted (the user explicitly
+        invokes /resume after first inspecting via /restore)."""
+        sm = TrainingStateMachine()
+        sm.mark_investigating()
+        result = sm.mark_resume_ready()
+        assert result is True
+        assert sm.is_resume_ready()
+        assert not sm.is_investigating()
+
+    def test_get_state_summary_reports_investigating(self):
+        """get_state_summary surfaces the new state name."""
+        sm = TrainingStateMachine()
+        sm.mark_investigating()
+        summary = sm.get_state_summary()
+        assert summary["status"] == "INVESTIGATING"
+        assert summary["phase"] == "IDLE"

--- a/src/tests/unit/api/test_snapshot_route_coverage.py
+++ b/src/tests/unit/api/test_snapshot_route_coverage.py
@@ -497,3 +497,144 @@ class TestPerfCC01InvariantSource:
         path = Path(__file__).resolve().parents[3] / "api" / "routes" / "snapshots.py"
         source = path.read_text(encoding="utf-8")
         assert "import asyncio" in source
+
+
+class TestUnifiedResponseShape:
+    """CAN-015d (Phase 6E Sprint B B-4): all four snapshot operation
+    endpoints share a unified response shape — ``snapshot_id``,
+    ``operation``, ``fsm_state``, ``time_index``, and
+    ``training_params``. Pre-B-4 fields like ``status`` and
+    ``resume_point_epoch`` are retained as a strict superset.
+
+    These tests pin the new fields. Existing tests in
+    TestRestoreSnapshot / TestRetrainFromSnapshot / TestResumeSnapshot
+    pin the legacy backward-compat fields and remain unchanged.
+    """
+
+    def _force_fsm_state(self, lifecycle, target_marker: str):
+        """Helper: mock load_snapshot/restore_for_retrain/resume_from_snapshot
+        to actually transition the FSM, since the route reads
+        state_machine.status.name to populate the response.
+
+        ``target_marker`` is one of "investigating", "stopped", "resume_ready".
+        """
+        if target_marker == "investigating":
+            return lambda *args, **kwargs: (lifecycle.state_machine.mark_investigating(), True)[1]
+        if target_marker == "resume_ready":
+            return lambda *args, **kwargs: (lifecycle.state_machine.mark_resume_ready(), True)[1]
+        if target_marker == "stopped":
+            from api.lifecycle.state_machine import Command
+
+            return lambda *args, **kwargs: (lifecycle.state_machine.handle_command(Command.RESET), True)[1]
+        raise ValueError(f"unknown target_marker {target_marker!r}")
+
+    def test_restore_response_includes_unified_fields(self, client):
+        """POST /restore response contains operation/fsm_state/time_index."""
+        lifecycle = client.app.state.lifecycle
+        side_effect = self._force_fsm_state(lifecycle, "investigating")
+        with patch.object(lifecycle, "load_snapshot", side_effect=side_effect):
+            response = client.post("/v1/snapshots/snap-001/restore")
+            assert response.status_code == 200
+            body = response.json()
+            data = body["data"]
+            assert data["operation"] == "restore"
+            assert data["fsm_state"] == "INVESTIGATING"
+            assert "time_index" in data
+            assert data["time_index"]["default"] == "end"
+            assert "snapshot_window" in data["time_index"]
+            assert "start_epoch" in data["time_index"]["snapshot_window"]
+            assert "end_epoch" in data["time_index"]["snapshot_window"]
+            # Backward-compat fields preserved.
+            assert data["status"] == "restored"
+            assert data["snapshot_id"] == "snap-001"
+
+    def test_retrain_response_includes_unified_fields(self, client):
+        """POST /retrain response contains operation/fsm_state/time_index."""
+        lifecycle = client.app.state.lifecycle
+        side_effect = self._force_fsm_state(lifecycle, "stopped")
+        with patch.object(lifecycle, "restore_for_retrain", side_effect=side_effect):
+            response = client.post("/v1/snapshots/snap-002/retrain")
+            assert response.status_code == 200
+            data = response.json()["data"]
+            assert data["operation"] == "retrain"
+            # Retrain transitions to Stopped.
+            assert data["fsm_state"] == "STOPPED"
+            # Retrain resets history to 0, so time_index default is 0.
+            assert data["time_index"]["default"] == 0
+            # Backward-compat fields preserved.
+            assert data["status"] == "ready"
+            assert data["snapshot_id"] == "snap-002"
+
+    def test_resume_response_includes_unified_fields(self, client):
+        """POST /resume response contains operation/fsm_state/time_index plus resume_point_epoch."""
+        lifecycle = client.app.state.lifecycle
+
+        def side_effect(snapshot_id):
+            lifecycle.state_machine.mark_resume_ready()
+            lifecycle._resume_point_epoch = 42
+            return True
+
+        with patch.object(lifecycle, "resume_from_snapshot", side_effect=side_effect):
+            response = client.post("/v1/snapshots/snap-003/resume")
+            assert response.status_code == 200
+            data = response.json()["data"]
+            assert data["operation"] == "resume"
+            assert data["fsm_state"] == "RESUME_READY"
+            # Resume lands at end of window.
+            assert data["time_index"]["default"] == "end"
+            # Backward-compat fields from B-2 preserved.
+            assert data["status"] == "ready"
+            assert data["resume_point_epoch"] == 42
+
+    def test_time_index_snapshot_window_reflects_loaded_history(self, client):
+        """``snapshot_window.end_epoch`` matches the longest history array's length."""
+        lifecycle = client.app.state.lifecycle
+
+        # Install a fake network with a known history.
+        class FakeNetwork:
+            history = {
+                "train_loss": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7],  # 7 entries
+                "value_loss": [0.2, 0.3, 0.4],                       # 3 entries
+                "train_accuracy": [0.6, 0.7],                         # 2 entries
+                "value_accuracy": [],                                  # 0 entries
+            }
+
+        lifecycle.network = FakeNetwork()
+        side_effect = self._force_fsm_state(lifecycle, "investigating")
+        try:
+            with patch.object(lifecycle, "load_snapshot", side_effect=side_effect):
+                response = client.post("/v1/snapshots/snap-window/restore")
+                assert response.status_code == 200
+                data = response.json()["data"]
+                # Longest array (train_loss) has 7 entries.
+                assert data["time_index"]["snapshot_window"] == {"start_epoch": 0, "end_epoch": 7}
+        finally:
+            lifecycle.network = None
+
+    def test_restore_rejected_when_training_active(self, client):
+        """The pre-flight FSM check returns 409 when training is Started.
+        This was an implicit contract before (load_snapshot would race
+        with the running fit) — B-4 makes it explicit at the route layer."""
+        from api.lifecycle.state_machine import Command
+
+        lifecycle = client.app.state.lifecycle
+        lifecycle.state_machine.handle_command(Command.START)
+        try:
+            response = client.post("/v1/snapshots/snap-active/restore")
+            assert response.status_code == 409
+            assert "Cannot restore" in response.json()["detail"]
+        finally:
+            lifecycle.state_machine.handle_command(Command.RESET)
+
+    def test_restore_rejected_when_paused(self, client):
+        """Paused state also rejected with 409."""
+        from api.lifecycle.state_machine import Command
+
+        lifecycle = client.app.state.lifecycle
+        lifecycle.state_machine.handle_command(Command.START)
+        lifecycle.state_machine.handle_command(Command.PAUSE)
+        try:
+            response = client.post("/v1/snapshots/snap-paused/restore")
+            assert response.status_code == 409
+        finally:
+            lifecycle.state_machine.handle_command(Command.RESET)


### PR DESCRIPTION
## Summary

Phase 6E Sprint B **B-4** — third of four cascor PRs implementing the
expanded snapshot operations matrix from
[`PHASE_6E_SPRINT_B_DESIGN.md`](https://github.com/pcalnon/juniper-ml/blob/main/notes/PHASE_6E_SPRINT_B_DESIGN.md)
(Restore / Replay / Resume / Retrain).

**STACKED on #170 (B-2 Resume)** — base is `feature/b-2-snapshot-resume`.
Both PRs touch `state_machine.py` / `manager.py` / `snapshots.py` and
need to land in B-1 → B-2 → B-4 order. After #170 merges, GitHub will
auto-rebase this PR's base to `main`.

**Restore semantics promoted** from "load + can train next" to
"load for inspection / modification, NOT for training." The user can
edit meta-params via `PATCH /v1/training/params`, replace the dataset,
and re-snapshot, but cannot start training directly. To enter a
training state they must invoke `/retrain` (clean slate) or `/resume`
(extend history).

## Changes

### `api/lifecycle/state_machine.py`

- New `TrainingStatus.INVESTIGATING` enum value
- New `is_investigating()` predicate
- New `mark_investigating()` method:
  - Permitted from non-active states (Stopped / Completed / Failed /
    RESUME_READY / INVESTIGATING)
  - Rejected from Started / Paused
- `_handle_start` explicitly rejects `START` from `INVESTIGATING` —
  the user must invoke /retrain or /resume to exit Investigating
- `mark_resume_ready` accepts `INVESTIGATING → RESUME_READY` so a
  user can transition between snapshot operations cleanly

### `api/lifecycle/manager.py`

- **`load_snapshot`**: pre-flight FSM check rejects when training is
  active. On success, calls `state_machine.mark_investigating()`,
  clears `_resume_point_epoch`, and updates `training_state`. Counters
  and history are preserved (Restore is inspection-only).
- **`start_training`**: new explicit guard rejects with `RuntimeError`
  when FSM is `INVESTIGATING`. Failing fast at the API boundary is
  clearer than letting the future submit and the FSM transition fail
  silently inside `monitored_fit`.

### `api/routes/snapshots.py`

- **New `_compute_snapshot_window()` helper** derives the snapshot
  window metadata from the loaded network's longest history array.
- **New `_build_unified_payload()` helper** assembles the response
  body for all four snapshot operation endpoints. Per design doc §3,
  every endpoint returns `operation` + `fsm_state` + `time_index` +
  `training_params`. Pre-B-4 fields like `status` (B-1) and
  `resume_point_epoch` (B-2) are preserved as a strict superset for
  backward compatibility — existing canopy clients keep working.
- **`restore_snapshot`**: pre-flight FSM check returns 409 when
  training is active. Uses `_build_unified_payload` with
  `operation="restore"`, `time_index_default="end"`,
  `extra={"status": "restored"}`.
- **`retrain_from_snapshot`** and **`resume_snapshot`** both updated
  to use `_build_unified_payload` with their respective operation
  defaults; legacy fields preserved.

## Tests (26 new + 1 renamed)

- **`test_lifecycle_state_machine.py`** — new `TestInvestigatingState`
  with **14 tests** covering each transition in/out of INVESTIGATING,
  rejection of START/RESUME/PAUSE while Investigating, RESET escape
  hatch, and `Investigating → ResumeReady` transition.
- **`test_lifecycle_manager.py`** — new `TestLoadSnapshotInvestigating`
  with **6 tests**: pre-flight rejection when training active, FSM
  transition to Investigating on success, resume marker clearing,
  `start_training` raises RuntimeError from Investigating, and
  Retrain / Resume after Restore correctly clearing Investigating.
- **`test_snapshot_route_coverage.py`** — new `TestUnifiedResponseShape`
  with **6 tests**: each existing route now emits operation /
  fsm_state / time_index, snapshot_window calculation reflects the
  longest history array, 409 pre-flight from Started / Paused.
- Pre-existing `test_load_snapshot_unchanged_by_retrain_refactor`
  renamed to `test_load_snapshot_preserves_history_and_counters` with
  docstring updated to reflect B-4's FSM transition.

## Backward compatibility

The unified response shape is a **strict superset** of the pre-B-4
shapes — `status: "restored"` / `status: "ready"` /
`resume_point_epoch` are all retained. New fields (`operation`,
`fsm_state`, `time_index`) are additive. Existing clients that key off
the original fields keep working.

**Behavioral change**: `start_training` now fails fast (RuntimeError)
when invoked while FSM is INVESTIGATING. Pre-B-4, a user could call
`POST /restore` then `POST /training/start` and training would proceed.
Post-B-4, that flow returns 500 (RuntimeError); the user must invoke
`/retrain` or `/resume` first. This is the deliberate design choice
from the user's spec — Restore is inspection-only.

## Sprint B status after this PR

| PR | CAN-ID | Repo | State |
|---|---|---|---|
| B-1 | CAN-015a | cascor | merged |
| B-2 | CAN-015b | cascor | open (#170) |
| B-3 | CAN-015c | cascor | not started (Replay infra + Replaying FSM) |
| **B-4** | CAN-015d | cascor | **this PR (stacked on #170)** |
| B-5 | CAN-015e | canopy | not started |
| B-6 | CAN-015f | canopy | not started |

## Test plan

- [x] `flake8 --max-line-length=512` clean on all 3 modified production files
- [x] `py_compile` clean on all 6 modified files
- [ ] Local `pytest` couldn't run in this env (Py3.14 free-threading +
  torch C-extensions ImportError) — CI will exercise the 26 new tests
- [ ] Manual smoke (deferred): create network, train briefly, snapshot,
  POST /v1/snapshots/{id}/restore, verify response shows
  `fsm_state: INVESTIGATING` and `time_index.snapshot_window` matches
  the trained epoch count, attempt POST /v1/training/start (expect 500
  with Investigating message), POST /v1/snapshots/{id}/retrain (FSM →
  Stopped, ready to train fresh)

## References

- [PHASE_6E_SPRINT_B_DESIGN.md](https://github.com/pcalnon/juniper-ml/blob/main/notes/PHASE_6E_SPRINT_B_DESIGN.md) §2.1 (Restore spec), §3 (unified response shape), §5 (FSM extensions)
- [PHASE_6E_DESIGN.md](https://github.com/pcalnon/juniper-ml/blob/main/notes/PHASE_6E_DESIGN.md) Sprint B table

🤖 Generated with [Claude Code](https://claude.com/claude-code)