### PR TITLE
feat(snapshot): replay infrastructure + Replaying FSM + control endpoint (Phase 6E Sprint B B-3, CAN-015c) [stacked on #171]

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -60,6 +60,233 @@ def _write_activation_function_name(network: Any, value: str) -> None:
     network._init_activation_function()
 
 
+class _ReplaySession:
+    """CAN-015c (Phase 6E Sprint B B-3): per-snapshot replay session.
+
+    Holds the playback state for a single replay run — current time
+    index, speed (with sign for direction), pause flag, range
+    sub-window — plus the background thread that ticks while playing
+    and emits synthetic ``epoch_end`` events from the loaded network's
+    history arrays.
+
+    V1 scope (per ``notes/PHASE_6E_SPRINT_B_DESIGN.md`` §2.2 / §10.1):
+    metric arrays + topology evolution metadata only. Per-epoch weight
+    history (decision boundary playback, per-unit weight evolution) is
+    deferred to CAN-015g — would require a snapshot-format extension.
+
+    The thread emits via ``monitor._trigger_callbacks`` directly rather
+    than ``monitor.on_epoch_end`` so synthetic frames don't pollute the
+    live ``metrics_buffer``. Subscribers (WS broadcasters, canopy
+    metrics-curve renderer) receive the events identically — only the
+    replay-buffer side-effect differs.
+    """
+
+    # Allowed speed range. 0 ≡ pause, sign carries direction, magnitude
+    # caps at 10× to avoid pathological CPU usage on very long
+    # snapshots. Values beyond the range are clamped at /control time.
+    _MIN_SPEED: float = -10.0
+    _MAX_SPEED: float = 10.0
+    _MIN_NONZERO_MAG: float = 0.1
+    # Cap inter-frame sleeps so /pause / /seek wake up promptly even
+    # at very low speeds.
+    _MAX_TICK_SLEEP: float = 0.5
+
+    def __init__(self, snapshot_id: str, history: Dict[str, list], monitor) -> None:
+        self.snapshot_id = snapshot_id
+        # Pre-extract the history arrays we know about so the loop
+        # doesn't re-fetch every tick. Stored as plain lists (not
+        # references to network.history) so a future Restore-while-
+        # somehow-still-replaying race doesn't mutate them under us.
+        self._history: Dict[str, list] = {key: list(history.get(key, [])) for key in ("train_loss", "value_loss", "train_accuracy", "value_accuracy")}
+        # Length is the longest known array. Time index is bounded
+        # exclusively by ``self.length`` (i.e. valid indices are
+        # ``[0, length-1]``). Empty histories produce length=0 and the
+        # loop correctly idles.
+        self.length: int = max((len(v) for v in self._history.values()), default=0)
+        self._monitor = monitor
+        # Playback state — guarded by the lock for cross-thread reads.
+        self._lock = threading.Lock()
+        self.time_index: int = 0
+        self.speed: float = 1.0
+        self.paused: bool = True
+        self.range_start: int = 0
+        self.range_end: int = self.length  # exclusive
+        self._stop_event = threading.Event()
+        self._wake_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self.logger = logging.getLogger(__name__)
+
+    def start_thread(self) -> None:
+        """Start the playback driver thread. Idempotent (a session can
+        be re-started after pause without spawning a new thread)."""
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._thread = threading.Thread(target=self._run, name=f"replay-{self.snapshot_id}", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Signal the playback thread to exit and wait briefly for it
+        to drain. Safe to call from any thread including the lifecycle
+        shutdown path."""
+        self._stop_event.set()
+        self._wake_event.set()  # break out of any pending wait
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+            self._thread = None
+
+    def play(self) -> None:
+        with self._lock:
+            self.paused = False
+        self._wake_event.set()
+
+    def pause(self) -> None:
+        with self._lock:
+            self.paused = True
+        self._wake_event.set()
+
+    def seek(self, target: int) -> int:
+        """Jump to a specific time index. Returns the actual landed
+        position after clamping to the active range."""
+        with self._lock:
+            self.time_index = self._clamp_to_range(target)
+            landed = self.time_index
+        self._wake_event.set()
+        # Emit the seek-target frame immediately so canopy gets visual
+        # feedback even if we're paused.
+        self._emit_frame(landed)
+        return landed
+
+    def set_speed(self, value: float) -> float:
+        """Set playback speed. ``0`` is treated as pause. Returns the
+        effective (clamped) speed."""
+        # Clamp magnitude to [_MIN_NONZERO_MAG, _MAX_SPEED] preserving
+        # sign; treat tiny magnitudes as 0 (pause).
+        if abs(value) < self._MIN_NONZERO_MAG:
+            value = 0.0
+        elif value > 0:
+            value = min(value, self._MAX_SPEED)
+        else:
+            value = max(value, self._MIN_SPEED)
+        with self._lock:
+            self.speed = value
+            # speed=0 is functionally pause; surface the flag too so
+            # /play later doesn't have to also call /speed.
+            if value == 0.0:
+                self.paused = True
+        self._wake_event.set()
+        return value
+
+    def set_range(self, start: int, end: int) -> Dict[str, int]:
+        """Restrict playback to ``[start, end)``. End may be at most
+        ``self.length``. Time index is re-clamped if it's now outside
+        the new range. Returns the resulting range as a dict."""
+        with self._lock:
+            self.range_start = max(0, min(start, self.length))
+            self.range_end = max(self.range_start, min(end, self.length))
+            self.time_index = self._clamp_to_range(self.time_index)
+            result = {"start": self.range_start, "end": self.range_end, "time_index": self.time_index}
+        self._wake_event.set()
+        return result
+
+    def state_summary(self) -> Dict[str, Any]:
+        """Snapshot of the current session state for the route response."""
+        with self._lock:
+            return {
+                "snapshot_id": self.snapshot_id,
+                "length": self.length,
+                "time_index": self.time_index,
+                "speed": self.speed,
+                "paused": self.paused,
+                "range": {"start": self.range_start, "end": self.range_end},
+            }
+
+    def _clamp_to_range(self, index: int) -> int:
+        if self.range_end <= self.range_start:
+            return self.range_start
+        return max(self.range_start, min(self.range_end - 1, index))
+
+    def _emit_frame(self, index: int) -> None:
+        """Emit a synthetic ``epoch_end`` event for the given index.
+
+        Bypasses ``monitor.on_epoch_end`` (which would write to
+        ``metrics_buffer``) and calls ``_trigger_callbacks`` directly
+        so the WS broadcasters fire but live training state stays
+        untouched. Per the design's read-only-history guarantee."""
+        if self._monitor is None:
+            return
+        if index < 0 or index >= self.length:
+            return
+
+        def _series_at(key: str):
+            series = self._history.get(key, [])
+            return series[index] if index < len(series) else None
+
+        metrics = {
+            "epoch": index + 1,  # 1-indexed for canopy display, matches on_epoch_end
+            "loss": _series_at("train_loss"),
+            "accuracy": _series_at("train_accuracy"),
+            "validation_loss": _series_at("value_loss"),
+            "validation_accuracy": _series_at("value_accuracy"),
+            "phase": "Replay",
+            "replay": True,  # marker so subscribers can distinguish synthetic frames
+            "snapshot_id": self.snapshot_id,
+        }
+        try:
+            self._monitor._trigger_callbacks(
+                "epoch_end",
+                metrics=metrics,
+                epoch=metrics["epoch"],
+                loss=metrics["loss"],
+                accuracy=metrics["accuracy"],
+            )
+        except Exception:
+            # Best-effort emission — a subscriber that raises mustn't
+            # crash the playback thread.
+            self.logger.exception("replay session: synthetic _trigger_callbacks raised")
+
+    def _run(self) -> None:
+        """Background thread driver. Sleeps for ``1/abs(speed)`` between
+        frames while playing, polls every ``_MAX_TICK_SLEEP`` while
+        paused. Wake-event short-circuits any wait so /pause / /seek /
+        /speed take effect immediately."""
+        # Emit an initial frame on session start so subscribers see
+        # the entry point (epoch 0) before any /play.
+        self._emit_frame(0)
+        while not self._stop_event.is_set():
+            with self._lock:
+                paused = self.paused
+                speed = self.speed
+                time_index = self.time_index
+                range_start = self.range_start
+                range_end = self.range_end
+            if paused or abs(speed) < self._MIN_NONZERO_MAG:
+                # Idle until woken up — by /play, /seek, /speed change,
+                # or /stop. Bounded wait so /stop_event from a separate
+                # call still terminates the thread promptly.
+                if self._wake_event.wait(self._MAX_TICK_SLEEP):
+                    self._wake_event.clear()
+                continue
+            # Compute sleep duration for this frame. Bounded above so
+            # very low speeds still yield to wake events promptly.
+            sleep_s = min(1.0 / abs(speed), self._MAX_TICK_SLEEP)
+            if self._wake_event.wait(sleep_s):
+                self._wake_event.clear()
+                continue
+            # Advance the time index respecting direction and range.
+            with self._lock:
+                step = 1 if speed > 0 else -1
+                new_index = time_index + step
+                if new_index < range_start or new_index >= range_end:
+                    # Reached a boundary — auto-pause at the edge.
+                    self.paused = True
+                    self.time_index = self._clamp_to_range(new_index)
+                    landed = self.time_index
+                else:
+                    self.time_index = new_index
+                    landed = new_index
+            self._emit_frame(landed)
+
+
 class TrainingLifecycleManager:
     """Central coordinator for CasCor network training lifecycle.
 
@@ -137,6 +364,13 @@ class TrainingLifecycleManager:
         self._auto_snap_min_epochs: int = 50
         self._auto_snap_best_metric: Optional[float] = None
         self._auto_snap_lock = threading.Lock()
+
+        # CAN-015c (Phase 6E Sprint B B-3): replay session. ``None``
+        # outside of an active replay; an ``_ReplaySession`` instance
+        # while ``state_machine.is_replaying()``. The route layer reads
+        # the session state for /control responses and dispatches
+        # play/pause/seek/speed/range/stop into it.
+        self._replay_session: Optional["_ReplaySession"] = None
 
         # CAN-015b (Phase 6E Sprint B B-2): resume-from-snapshot marker.
         # ``resume_from_snapshot`` sets this to the snapshot's terminal
@@ -779,6 +1013,10 @@ class TrainingLifecycleManager:
             # silently inside monitored_fit.
             if self.state_machine.is_investigating():
                 raise RuntimeError("Cannot start training while Investigating a snapshot — invoke /v1/snapshots/{id}/retrain or /resume to transition out of Investigating first")
+            # CAN-015c (B-3): Replaying is read-only playback. Same
+            # rejection contract — user must /replay/control stop first.
+            if self.state_machine.is_replaying():
+                raise RuntimeError("Cannot start training while replaying a snapshot — invoke /v1/snapshots/{id}/replay/control with action='stop' first")
 
             if x is not None:
                 self._train_x = x
@@ -1418,9 +1656,11 @@ class TrainingLifecycleManager:
         """
         # Same pre-flight as resume_from_snapshot: investigating an
         # active training run would race with the running fit() and
-        # leave the lifecycle in a confused state.
-        if self.state_machine.is_started() or self.state_machine.is_paused():
-            self.logger.warning(f"load_snapshot rejected: training is {self.state_machine.status.name}")
+        # leave the lifecycle in a confused state. CAN-015c (B-3) adds
+        # the REPLAYING rejection so a Restore can't yank the network
+        # out from under an active replay thread.
+        if self.state_machine.is_started() or self.state_machine.is_paused() or self.state_machine.is_replaying():
+            self.logger.warning(f"load_snapshot rejected: lifecycle is {self.state_machine.status.name}")
             return False
 
         ok = self._load_snapshot_to_network(snapshot_id)
@@ -1460,7 +1700,13 @@ class TrainingLifecycleManager:
         - FSM — Stopped / Idle (via ``Command.RESET``)
         - ``training_monitor.metrics_buffer`` — cleared
         - ``_last_emitted_history_len`` — 0
+
+        CAN-015c (B-3): rejected when a replay session is active (would
+        race with the replay thread reading from network.history).
         """
+        if self.state_machine.is_started() or self.state_machine.is_paused() or self.state_machine.is_replaying():
+            self.logger.warning(f"restore_for_retrain rejected: lifecycle is {self.state_machine.status.name}")
+            return False
         ok = self._load_snapshot_to_network(snapshot_id)
         if not ok:
             return False
@@ -1533,8 +1779,8 @@ class TrainingLifecycleManager:
         See ``notes/PHASE_6E_SPRINT_B_DESIGN.md`` §2.3 for the full
         spec.
         """
-        if self.state_machine.is_started() or self.state_machine.is_paused():
-            self.logger.warning(f"resume_from_snapshot rejected: training is {self.state_machine.status.name}")
+        if self.state_machine.is_started() or self.state_machine.is_paused() or self.state_machine.is_replaying():
+            self.logger.warning(f"resume_from_snapshot rejected: lifecycle is {self.state_machine.status.name}")
             return False
 
         ok = self._load_snapshot_to_network(snapshot_id)
@@ -1576,6 +1822,128 @@ class TrainingLifecycleManager:
         self.logger.info(f"Snapshot restored for resume: {snapshot_id} (resume_point_epoch={resume_point})")
         return True
 
+    def start_replay(self, snapshot_id: str) -> bool:
+        """Load a snapshot and start a replay session (CAN-015c).
+
+        Phase 6E Sprint B B-3. Loads the snapshot identically to
+        ``load_snapshot`` then transitions the FSM to ``REPLAYING`` and
+        spawns a background ``_ReplaySession`` thread that emits
+        synthetic ``epoch_end`` events from the loaded network's
+        history arrays at a configurable speed.
+
+        V1 scope: metric arrays + topology evolution metadata only.
+        Per-epoch weight history (decision-boundary playback) is
+        deferred to CAN-015g — would require a snapshot-format
+        extension.
+
+        Rejected when training is currently active (Started / Paused).
+        Replacing one replay session with another is permitted — the
+        old session's thread is stopped and the new session is
+        installed.
+
+        See ``notes/PHASE_6E_SPRINT_B_DESIGN.md`` §2.2.
+        """
+        if self.state_machine.is_started() or self.state_machine.is_paused():
+            self.logger.warning(f"start_replay rejected: training is {self.state_machine.status.name}")
+            return False
+
+        ok = self._load_snapshot_to_network(snapshot_id)
+        if not ok:
+            return False
+
+        # If a previous replay session was running, tear it down first
+        # so its thread doesn't keep emitting against the new history.
+        prev_session = self._replay_session
+        if prev_session is not None:
+            try:
+                prev_session.stop()
+            except Exception:
+                self.logger.exception("start_replay: failed to stop previous replay session")
+
+        history = getattr(self.network, "history", None)
+        history_dict = history if isinstance(history, dict) else {}
+        session = _ReplaySession(snapshot_id, history_dict, self.training_monitor)
+        self._replay_session = session
+        # Marker fields used by Resume / Restore are not relevant here.
+        self._resume_point_epoch = None
+        self.state_machine.mark_replaying()
+        self.training_state.update_state(status="Stopped", phase="Idle")
+        self._broadcast_training_state(force=True)
+        # Start the driver thread AFTER the FSM transitions so the
+        # initial frame emission lands while subscribers are looking
+        # at a Replaying state.
+        session.start_thread()
+
+        self.logger.info(f"Snapshot replay started: {snapshot_id} (length={session.length})")
+        return True
+
+    def replay_control(self, action: str, **params: Any) -> Dict[str, Any]:
+        """Apply a control action to the active replay session (CAN-015c).
+
+        Supported actions: ``play`` / ``pause`` / ``seek`` (param
+        ``time_index``) / ``speed`` (param ``value``) / ``range``
+        (params ``start`` and ``end``) / ``stop``. ``stop`` exits
+        Replaying — the FSM transitions back to ``STOPPED`` and the
+        session thread is joined.
+
+        Returns the post-action session state for the route response.
+        Raises ``RuntimeError`` if no session is active.
+        """
+        session = self._replay_session
+        if session is None or not self.state_machine.is_replaying():
+            raise RuntimeError("No active replay session")
+
+        action_lower = action.lower() if isinstance(action, str) else ""
+        if action_lower == "play":
+            session.play()
+        elif action_lower == "pause":
+            session.pause()
+        elif action_lower == "seek":
+            target = params.get("time_index")
+            if target is None:
+                raise ValueError("seek requires a 'time_index' parameter")
+            session.seek(int(target))
+        elif action_lower == "speed":
+            value = params.get("value")
+            if value is None:
+                raise ValueError("speed requires a 'value' parameter")
+            session.set_speed(float(value))
+        elif action_lower == "range":
+            start = params.get("start")
+            end = params.get("end")
+            if start is None or end is None:
+                raise ValueError("range requires both 'start' and 'end' parameters")
+            session.set_range(int(start), int(end))
+        elif action_lower == "stop":
+            return self.stop_replay()
+        else:
+            raise ValueError(f"Unknown replay action: {action!r}")
+        return session.state_summary()
+
+    def stop_replay(self) -> Dict[str, Any]:
+        """End the active replay session (CAN-015c).
+
+        Joins the background thread, clears ``_replay_session``,
+        transitions the FSM to STOPPED via ``Command.RESET``, and
+        broadcasts the resulting state. Idempotent — calling on an
+        inactive session returns a minimal "not_active" status.
+        """
+        session = self._replay_session
+        if session is None:
+            return {"status": "not_active"}
+        try:
+            session.stop()
+        finally:
+            self._replay_session = None
+        # RESET is the universal "back to Stopped" transition. The FSM
+        # already documents that REPLAYING accepts RESET as the escape
+        # hatch alongside the explicit /control stop.
+        self.state_machine.handle_command(Command.RESET)
+        self.training_state.update_state(status="Stopped", phase="Idle")
+        self._broadcast_training_state(force=True)
+        self.logger.info(f"Snapshot replay stopped: {session.snapshot_id}")
+        return {"status": "stopped", "snapshot_id": session.snapshot_id}
+
     def list_snapshots(self) -> List[Dict[str, Any]]:
         """List available snapshots."""
         snapshots_dir = self._get_snapshots_dir()
@@ -1614,6 +1982,14 @@ class TrainingLifecycleManager:
         self._stop_requested.set()
         self.stop_liveness_heartbeat()
         self._restore_original_methods()
+        # CAN-015c (B-3): drain any active replay session so the
+        # background driver thread doesn't outlive the lifecycle.
+        if self._replay_session is not None:
+            try:
+                self._replay_session.stop()
+            except Exception:
+                self.logger.exception("shutdown: failed to stop replay session")
+            self._replay_session = None
         if self._executor:
             self._executor.shutdown(wait=False, cancel_futures=True)
             self._executor = None

--- a/src/api/lifecycle/state_machine.py
+++ b/src/api/lifecycle/state_machine.py
@@ -41,6 +41,15 @@ class TrainingStatus(Enum):
     # different snapshot via those endpoints) to enter a training
     # state. See ``notes/PHASE_6E_SPRINT_B_DESIGN.md`` §2.1.
     INVESTIGATING = auto()
+    # CAN-015c (Phase 6E Sprint B B-3): a replay session is active —
+    # the lifecycle is emitting synthetic ``epoch_end`` events from a
+    # snapshot's training history at a configurable speed. All training
+    # commands AND meta-param mutations are rejected; only
+    # ``/replay/control`` (play/pause/seek/speed/range/stop) is
+    # permitted. Exit via ``/replay/control`` with ``action="stop"`` or
+    # via ``Command.RESET``. See ``notes/PHASE_6E_SPRINT_B_DESIGN.md``
+    # §2.2.
+    REPLAYING = auto()
 
 
 class Command(Enum):
@@ -119,6 +128,12 @@ class TrainingStateMachine:
         rejected from this state."""
         return self._status == TrainingStatus.INVESTIGATING
 
+    def is_replaying(self) -> bool:
+        """CAN-015c (Phase 6E Sprint B B-3): a replay session is active.
+        Training commands and meta-param mutations are rejected; only
+        replay-control commands are permitted."""
+        return self._status == TrainingStatus.REPLAYING
+
     def handle_command(self, command: Command) -> bool:
         """Handle control command and perform state transition.
 
@@ -145,6 +160,13 @@ class TrainingStateMachine:
         # silently would defeat the entire Investigating contract.
         if self._status == TrainingStatus.INVESTIGATING:
             self.logger.warning("Invalid transition: START while Investigating — invoke /retrain or /resume to enter a training state")
+            return False
+        # CAN-015c (B-3): REPLAYING explicitly rejects training commands.
+        # The user is watching a snapshot's training history play back;
+        # they must invoke /replay/control with action="stop" before any
+        # training-related command is permitted.
+        if self._status == TrainingStatus.REPLAYING:
+            self.logger.warning("Invalid transition: START while Replaying — stop replay first")
             return False
         if self._status in (TrainingStatus.FAILED, TrainingStatus.COMPLETED):
             self.logger.info(f"Auto-resetting from terminal state {self._status.name} before start")
@@ -295,7 +317,8 @@ class TrainingStateMachine:
         from non-active states (Stopped / Completed / Failed /
         RESUME_READY / INVESTIGATING) — a user can replace one loaded
         snapshot with another without explicitly resetting in between.
-        Rejected from STARTED / PAUSED: training must stop first.
+        Rejected from STARTED / PAUSED / REPLAYING: training or replay
+        must stop first.
         """
         if self._status in (TrainingStatus.STOPPED, TrainingStatus.COMPLETED, TrainingStatus.FAILED, TrainingStatus.RESUME_READY, TrainingStatus.INVESTIGATING):
             prev = self._status.name
@@ -306,6 +329,29 @@ class TrainingStateMachine:
             self.logger.info(f"State transition: {prev} -> Investigating")
             return True
         self.logger.warning(f"Invalid transition: mark_investigating while {self._status.name}")
+        return False
+
+    def mark_replaying(self) -> bool:
+        """CAN-015c (Phase 6E Sprint B B-3): mark the FSM as replaying
+        a snapshot's training history. Call from
+        ``lifecycle.start_replay`` after the snapshot is loaded and the
+        replay session is initialized.
+
+        Permitted from non-active states (Stopped / Completed / Failed
+        / RESUME_READY / INVESTIGATING / REPLAYING — replacing one
+        replay session with another is fine). Rejected from STARTED /
+        PAUSED: a live training run can't be replaced by a replay
+        session without explicit shutdown first.
+        """
+        if self._status in (TrainingStatus.STOPPED, TrainingStatus.COMPLETED, TrainingStatus.FAILED, TrainingStatus.RESUME_READY, TrainingStatus.INVESTIGATING, TrainingStatus.REPLAYING):
+            prev = self._status.name
+            self._status = TrainingStatus.REPLAYING
+            self._phase = TrainingPhase.IDLE
+            self._paused_phase = None
+            self._candidate_sub_state = None
+            self.logger.info(f"State transition: {prev} -> Replaying")
+            return True
+        self.logger.warning(f"Invalid transition: mark_replaying while {self._status.name}")
         return False
 
     def get_state_summary(self) -> dict:

--- a/src/api/routes/snapshots.py
+++ b/src/api/routes/snapshots.py
@@ -300,3 +300,108 @@ async def resume_snapshot(request: Request, snapshot_id: str) -> dict:
         },
     )
     return success_response(payload)
+
+
+class ReplayControlRequest(BaseModel):
+    """CAN-015c (Phase 6E Sprint B B-3): body for the replay-control
+    endpoint. ``action`` is the discriminator; the parameter fields
+    are validated by the lifecycle's ``replay_control`` method."""
+
+    action: str
+    time_index: int | None = None
+    value: float | None = None
+    start: int | None = None
+    end: int | None = None
+
+
+@router.post("/{snapshot_id}/replay")
+async def start_replay_endpoint(request: Request, snapshot_id: str) -> dict:
+    """Start a replay session for a snapshot's training history (CAN-015c).
+
+    Phase 6E Sprint B B-3. Loads the snapshot, transitions the FSM to
+    ``REPLAYING``, and spawns a background driver thread that emits
+    synthetic ``epoch_end`` events from the loaded network's history
+    arrays at a configurable speed. The session is initially paused
+    at time index 0; canopy controls playback via
+    ``POST /v1/snapshots/{snapshot_id}/replay/control``.
+
+    V1 scope: metric arrays + topology evolution metadata only. Per-
+    epoch weight history is deferred to CAN-015g.
+
+    Rejected with 409 if training is currently active (Started /
+    Paused) — same FSM-guard contract as Resume / Restore. Replacing
+    one replay session with another is permitted (the old session is
+    torn down first).
+
+    See ``juniper-ml/notes/PHASE_6E_SPRINT_B_DESIGN.md`` §2.2.
+    """
+    _validate_snapshot_id(snapshot_id, client=request.client.host if request.client else None)
+    lifecycle = _get_lifecycle(request)
+    if lifecycle.state_machine.is_started() or lifecycle.state_machine.is_paused():
+        raise HTTPException(status_code=409, detail=f"Cannot start replay while training is {lifecycle.state_machine.status.name}")
+    # PERF-CC-01: HDF5 I/O off the event loop. The thread spawn itself
+    # is fast but lives on the worker so we don't need a separate path.
+    success = await asyncio.to_thread(lifecycle.start_replay, snapshot_id)
+    if not success:
+        raise HTTPException(status_code=404, detail=f"Snapshot '{snapshot_id}' not found or failed to load")
+    payload = _build_unified_payload(
+        lifecycle,
+        snapshot_id,
+        operation="replay",
+        # Replay starts at the beginning of the snapshot window.
+        time_index_default="start",
+        extra={
+            "status": "replaying",
+            "session": lifecycle._replay_session.state_summary() if lifecycle._replay_session is not None else None,
+        },
+    )
+    return success_response(payload)
+
+
+@router.post("/{snapshot_id}/replay/control")
+async def replay_control_endpoint(request: Request, snapshot_id: str, body: ReplayControlRequest) -> dict:
+    """Control the active replay session (CAN-015c).
+
+    Phase 6E Sprint B B-3. Dispatches to the lifecycle's
+    ``replay_control`` method. Supported actions:
+
+    - ``play`` — start advancing the time index at current speed
+    - ``pause`` — stop advancing
+    - ``seek`` — jump to ``time_index`` (clamped to range)
+    - ``speed`` — set playback ``value`` (allowed -10×..10×, |value| < 0.1 treated as pause)
+    - ``range`` — restrict playback to ``[start, end)``
+    - ``stop`` — exit ``REPLAYING`` and tear down the session
+
+    The ``snapshot_id`` in the URL must match the active session's
+    ``snapshot_id`` — a 409 is returned otherwise to prevent a stale
+    canopy tab from accidentally controlling a different replay.
+    """
+    _validate_snapshot_id(snapshot_id, client=request.client.host if request.client else None)
+    lifecycle = _get_lifecycle(request)
+    if not lifecycle.state_machine.is_replaying() or lifecycle._replay_session is None:
+        raise HTTPException(status_code=409, detail="No active replay session — call POST /snapshots/{id}/replay first")
+    if lifecycle._replay_session.snapshot_id != snapshot_id:
+        raise HTTPException(status_code=409, detail=f"Active replay is for '{lifecycle._replay_session.snapshot_id}', not '{snapshot_id}'")
+    params: dict = {}
+    if body.time_index is not None:
+        params["time_index"] = body.time_index
+    if body.value is not None:
+        params["value"] = body.value
+    if body.start is not None:
+        params["start"] = body.start
+    if body.end is not None:
+        params["end"] = body.end
+    try:
+        # Replay control is fast (mutex + condition signal), no need to
+        # offload to a thread. ``stop`` does join the driver but that's
+        # bounded by the session's join timeout.
+        result = lifecycle.replay_control(body.action, **params)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    payload: dict = {"snapshot_id": snapshot_id, "operation": "replay_control", "action": body.action.lower(), "result": result}
+    # If stop succeeded, surface the post-stop FSM state for clarity.
+    if isinstance(result, dict) and result.get("status") == "stopped":
+        payload["fsm_state"] = lifecycle.state_machine.status.name
+    return success_response(payload)

--- a/src/tests/unit/api/test_lifecycle_manager.py
+++ b/src/tests/unit/api/test_lifecycle_manager.py
@@ -1155,3 +1155,324 @@ class TestLoadSnapshotInvestigating:
             assert mgr.state_machine.is_resume_ready()
             assert not mgr.state_machine.is_investigating()
         mgr.shutdown()
+
+
+@pytest.mark.unit
+class TestReplaySessionUnit:
+    """CAN-015c (Phase 6E Sprint B B-3): unit tests for the
+    ``_ReplaySession`` class itself, exercised without the full
+    lifecycle context. Validates the playback state transitions
+    (play/pause/seek/speed/range), boundary handling, and the
+    synthetic-event emission contract.
+
+    The background thread is NOT started in these tests — each method
+    is exercised synchronously via the public API."""
+
+    def _make_session(self, history=None, monitor=None):
+        from unittest.mock import MagicMock
+
+        from api.lifecycle.manager import _ReplaySession
+
+        if history is None:
+            history = {
+                "train_loss": [0.5, 0.4, 0.3, 0.2, 0.1],
+                "value_loss": [0.6, 0.5, 0.4, 0.3, 0.2],
+                "train_accuracy": [0.6, 0.7, 0.8, 0.85, 0.9],
+                "value_accuracy": [0.55, 0.65, 0.75, 0.8, 0.85],
+            }
+        if monitor is None:
+            monitor = MagicMock()
+            monitor._trigger_callbacks = MagicMock()
+        return _ReplaySession("snap-test", history, monitor), monitor
+
+    def test_initializes_with_paused_at_index_zero(self):
+        session, _ = self._make_session()
+        assert session.length == 5
+        assert session.time_index == 0
+        assert session.speed == 1.0
+        assert session.paused is True
+        assert session.range_start == 0
+        assert session.range_end == 5
+
+    def test_play_clears_paused_flag(self):
+        session, _ = self._make_session()
+        session.play()
+        assert session.paused is False
+
+    def test_pause_sets_paused_flag(self):
+        session, _ = self._make_session()
+        session.play()
+        session.pause()
+        assert session.paused is True
+
+    def test_seek_clamps_to_valid_range(self):
+        session, monitor = self._make_session()
+        landed = session.seek(99)
+        assert landed == 4
+        landed = session.seek(-1)
+        assert landed == 0
+        # Seek emits the frame each time — 2 calls so far.
+        assert monitor._trigger_callbacks.call_count == 2
+
+    def test_seek_emits_synthetic_event_with_replay_marker(self):
+        session, monitor = self._make_session()
+        session.seek(2)
+        assert monitor._trigger_callbacks.call_count == 1
+        call = monitor._trigger_callbacks.call_args
+        assert call.args[0] == "epoch_end"
+        metrics = call.kwargs["metrics"]
+        assert metrics["loss"] == pytest.approx(0.3)
+        assert metrics["accuracy"] == pytest.approx(0.8)
+        assert metrics["validation_loss"] == pytest.approx(0.4)
+        assert metrics["validation_accuracy"] == pytest.approx(0.75)
+        assert metrics["replay"] is True
+        assert metrics["snapshot_id"] == "snap-test"
+        assert metrics["phase"] == "Replay"
+
+    def test_set_speed_clamps_to_allowed_range(self):
+        session, _ = self._make_session()
+        assert session.set_speed(100.0) == 10.0
+        assert session.set_speed(-100.0) == -10.0
+        assert session.set_speed(0.05) == 0.0
+        assert session.paused is True
+
+    def test_set_speed_zero_pauses(self):
+        session, _ = self._make_session()
+        session.play()
+        session.set_speed(0)
+        assert session.paused is True
+        assert session.speed == 0.0
+
+    def test_set_speed_preserves_negative_sign(self):
+        session, _ = self._make_session()
+        assert session.set_speed(-2.0) == -2.0
+        assert session.speed == -2.0
+
+    def test_set_range_clamps_and_re_clamps_time_index(self):
+        session, _ = self._make_session()
+        session.seek(4)
+        result = session.set_range(0, 3)
+        assert result == {"start": 0, "end": 3, "time_index": 2}
+        assert session.time_index == 2
+
+    def test_set_range_clamps_negative_start(self):
+        session, _ = self._make_session()
+        result = session.set_range(-10, 100)
+        assert result["start"] == 0
+        assert result["end"] == 5
+
+    def test_state_summary_includes_all_fields(self):
+        session, _ = self._make_session()
+        session.set_speed(2.5)
+        session.seek(1)
+        summary = session.state_summary()
+        assert summary["snapshot_id"] == "snap-test"
+        assert summary["length"] == 5
+        assert summary["time_index"] == 1
+        assert summary["speed"] == 2.5
+        session.set_range(0, 4)
+        summary = session.state_summary()
+        assert summary["range"] == {"start": 0, "end": 4}
+
+    def test_emit_frame_skips_when_index_out_of_history(self):
+        session, monitor = self._make_session()
+        session._emit_frame(99)
+        assert monitor._trigger_callbacks.call_count == 0
+
+    def test_empty_history_produces_zero_length(self):
+        session, monitor = self._make_session(history={})
+        assert session.length == 0
+        landed = session.seek(0)
+        assert landed == 0
+        assert monitor._trigger_callbacks.call_count == 0
+
+
+@pytest.mark.unit
+class TestReplayLifecycleIntegration:
+    """CAN-015c (Phase 6E Sprint B B-3): tests for ``start_replay`` /
+    ``replay_control`` / ``stop_replay`` on the lifecycle manager."""
+
+    def _stub_load(self, mgr, tmp_path, history):
+        """Helper: install a stub snapshot at ``tmp_path`` and patch the
+        serializer to return a network with the given history."""
+        from unittest.mock import MagicMock, patch
+
+        loaded = MagicMock()
+        loaded.history = history
+        (tmp_path / "snap.h5").write_bytes(b"")
+        return patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks")
+
+    def test_start_replay_returns_false_when_training_active(self, tmp_path):
+        from unittest.mock import patch
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        mgr.state_machine.handle_command(Command.START)
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path):
+            assert mgr.start_replay("anything") is False
+        assert mgr.state_machine.is_started()
+        mgr.shutdown()
+
+    def test_start_replay_returns_false_when_snapshot_missing(self, tmp_path):
+        from unittest.mock import patch
+
+        mgr = TrainingLifecycleManager()
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path):
+            assert mgr.start_replay("nonexistent") is False
+        assert mgr.state_machine.is_stopped()
+        assert mgr._replay_session is None
+        mgr.shutdown()
+
+    def test_start_replay_transitions_fsm_and_installs_session(self, tmp_path):
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        ctxs = self._stub_load(mgr, tmp_path, {"train_loss": [0.1, 0.2, 0.3], "value_loss": [], "train_accuracy": [], "value_accuracy": []})
+        with ctxs[0], ctxs[1], ctxs[2], ctxs[3]:
+            try:
+                assert mgr.start_replay("snap") is True
+                assert mgr.state_machine.is_replaying()
+                assert mgr._replay_session is not None
+                assert mgr._replay_session.snapshot_id == "snap"
+                assert mgr._replay_session.length == 3
+            finally:
+                mgr.stop_replay()
+        mgr.shutdown()
+
+    def test_start_replay_replaces_prior_session(self, tmp_path):
+        from unittest.mock import MagicMock, patch
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        loaded_a = MagicMock()
+        loaded_a.history = {"train_loss": [0.1], "value_loss": [], "train_accuracy": [], "value_accuracy": []}
+        loaded_b = MagicMock()
+        loaded_b.history = {"train_loss": [0.5, 0.4, 0.3], "value_loss": [], "train_accuracy": [], "value_accuracy": []}
+        (tmp_path / "snap-a.h5").write_bytes(b"")
+        (tmp_path / "snap-b.h5").write_bytes(b"")
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"):
+            try:
+                with patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded_a):
+                    mgr.start_replay("snap-a")
+                first_session = mgr._replay_session
+                assert first_session is not None
+                with patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded_b):
+                    mgr.start_replay("snap-b")
+                second_session = mgr._replay_session
+                assert second_session is not first_session
+                assert second_session.snapshot_id == "snap-b"
+                assert second_session.length == 3
+            finally:
+                mgr.stop_replay()
+        mgr.shutdown()
+
+    def test_replay_control_dispatches_play_pause(self, tmp_path):
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        ctxs = self._stub_load(mgr, tmp_path, {"train_loss": [0.1, 0.2, 0.3], "value_loss": [], "train_accuracy": [], "value_accuracy": []})
+        with ctxs[0], ctxs[1], ctxs[2], ctxs[3]:
+            try:
+                mgr.start_replay("snap")
+                state = mgr.replay_control("play")
+                assert state["paused"] is False
+                state = mgr.replay_control("pause")
+                assert state["paused"] is True
+            finally:
+                mgr.stop_replay()
+        mgr.shutdown()
+
+    def test_replay_control_seek_speed_range(self, tmp_path):
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        ctxs = self._stub_load(mgr, tmp_path, {"train_loss": [0.1, 0.2, 0.3, 0.4, 0.5], "value_loss": [], "train_accuracy": [], "value_accuracy": []})
+        with ctxs[0], ctxs[1], ctxs[2], ctxs[3]:
+            try:
+                mgr.start_replay("snap")
+                state = mgr.replay_control("seek", time_index=3)
+                assert state["time_index"] == 3
+                state = mgr.replay_control("speed", value=2.5)
+                assert state["speed"] == 2.5
+                state = mgr.replay_control("range", start=1, end=4)
+                assert state["range"] == {"start": 1, "end": 4}
+            finally:
+                mgr.stop_replay()
+        mgr.shutdown()
+
+    def test_replay_control_stop_exits_replaying(self, tmp_path):
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        ctxs = self._stub_load(mgr, tmp_path, {"train_loss": [0.1], "value_loss": [], "train_accuracy": [], "value_accuracy": []})
+        with ctxs[0], ctxs[1], ctxs[2], ctxs[3]:
+            mgr.start_replay("snap")
+            assert mgr.state_machine.is_replaying()
+            result = mgr.replay_control("stop")
+            assert result["status"] == "stopped"
+            assert mgr.state_machine.is_stopped()
+            assert mgr._replay_session is None
+        mgr.shutdown()
+
+    def test_replay_control_seek_requires_time_index(self, tmp_path):
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        ctxs = self._stub_load(mgr, tmp_path, {"train_loss": [0.1], "value_loss": [], "train_accuracy": [], "value_accuracy": []})
+        with ctxs[0], ctxs[1], ctxs[2], ctxs[3]:
+            try:
+                mgr.start_replay("snap")
+                with pytest.raises(ValueError, match="time_index"):
+                    mgr.replay_control("seek")
+            finally:
+                mgr.stop_replay()
+        mgr.shutdown()
+
+    def test_replay_control_unknown_action_raises(self, tmp_path):
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        ctxs = self._stub_load(mgr, tmp_path, {"train_loss": [0.1], "value_loss": [], "train_accuracy": [], "value_accuracy": []})
+        with ctxs[0], ctxs[1], ctxs[2], ctxs[3]:
+            try:
+                mgr.start_replay("snap")
+                with pytest.raises(ValueError, match="Unknown replay action"):
+                    mgr.replay_control("teleport")
+            finally:
+                mgr.stop_replay()
+        mgr.shutdown()
+
+    def test_replay_control_without_active_session_raises(self):
+        mgr = TrainingLifecycleManager()
+        with pytest.raises(RuntimeError, match="No active replay session"):
+            mgr.replay_control("play")
+        mgr.shutdown()
+
+    def test_stop_replay_without_session_returns_not_active(self):
+        mgr = TrainingLifecycleManager()
+        result = mgr.stop_replay()
+        assert result == {"status": "not_active"}
+        mgr.shutdown()
+
+    def test_start_training_rejected_while_replaying(self, tmp_path):
+        import torch
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        ctxs = self._stub_load(mgr, tmp_path, {"train_loss": [0.1], "value_loss": [], "train_accuracy": [], "value_accuracy": []})
+        with ctxs[0], ctxs[1], ctxs[2], ctxs[3]:
+            try:
+                mgr.start_replay("snap")
+                x = torch.randn(20, 2)
+                y = torch.zeros(20, 2)
+                with pytest.raises(RuntimeError, match="replay"):
+                    mgr.start_training(x=x, y=y)
+            finally:
+                mgr.stop_replay()
+        mgr.shutdown()
+
+    def test_load_snapshot_rejected_while_replaying(self, tmp_path):
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        ctxs = self._stub_load(mgr, tmp_path, {"train_loss": [0.1], "value_loss": [], "train_accuracy": [], "value_accuracy": []})
+        with ctxs[0], ctxs[1], ctxs[2], ctxs[3]:
+            try:
+                mgr.start_replay("snap")
+                assert mgr.load_snapshot("snap") is False
+            finally:
+                mgr.stop_replay()
+        mgr.shutdown()

--- a/src/tests/unit/api/test_lifecycle_state_machine.py
+++ b/src/tests/unit/api/test_lifecycle_state_machine.py
@@ -441,3 +441,115 @@ class TestInvestigatingState:
         summary = sm.get_state_summary()
         assert summary["status"] == "INVESTIGATING"
         assert summary["phase"] == "IDLE"
+
+
+@pytest.mark.unit
+class TestReplayingState:
+    """CAN-015c (Phase 6E Sprint B B-3): tests for the new ``REPLAYING``
+    state and ``mark_replaying`` method.
+
+    Replaying is the read-only-playback mode used by ``/replay``.
+    Training commands are rejected; only ``/replay/control`` is
+    permitted. ``RESET`` exits the state.
+    """
+
+    def test_initial_state_is_not_replaying(self):
+        sm = TrainingStateMachine()
+        assert not sm.is_replaying()
+
+    def test_mark_replaying_from_stopped(self):
+        sm = TrainingStateMachine()
+        assert sm.mark_replaying() is True
+        assert sm.is_replaying()
+        assert sm.status == TrainingStatus.REPLAYING
+        assert sm.phase == TrainingPhase.IDLE
+
+    def test_mark_replaying_from_investigating(self):
+        """Replay over a prior Restore is permitted."""
+        sm = TrainingStateMachine()
+        sm.mark_investigating()
+        assert sm.mark_replaying() is True
+        assert sm.is_replaying()
+
+    def test_mark_replaying_from_resume_ready(self):
+        sm = TrainingStateMachine()
+        sm.mark_resume_ready()
+        assert sm.mark_replaying() is True
+
+    def test_mark_replaying_idempotent(self):
+        """Replacing one replay session with another is permitted."""
+        sm = TrainingStateMachine()
+        sm.mark_replaying()
+        assert sm.mark_replaying() is True
+        assert sm.is_replaying()
+
+    def test_mark_replaying_from_completed(self):
+        sm = TrainingStateMachine()
+        sm.handle_command(Command.START)
+        sm.mark_completed()
+        assert sm.mark_replaying() is True
+
+    def test_mark_replaying_from_failed(self):
+        sm = TrainingStateMachine()
+        sm.handle_command(Command.START)
+        sm.mark_failed("test")
+        assert sm.mark_replaying() is True
+
+    def test_mark_replaying_rejected_when_started(self):
+        sm = TrainingStateMachine()
+        sm.handle_command(Command.START)
+        assert sm.mark_replaying() is False
+        assert sm.is_started()
+
+    def test_mark_replaying_rejected_when_paused(self):
+        sm = TrainingStateMachine()
+        sm.handle_command(Command.START)
+        sm.handle_command(Command.PAUSE)
+        assert sm.mark_replaying() is False
+        assert sm.is_paused()
+
+    def test_start_rejected_from_replaying(self):
+        sm = TrainingStateMachine()
+        sm.mark_replaying()
+        assert sm.handle_command(Command.START) is False
+        assert sm.is_replaying()
+
+    def test_pause_rejected_from_replaying(self):
+        sm = TrainingStateMachine()
+        sm.mark_replaying()
+        assert sm.handle_command(Command.PAUSE) is False
+        assert sm.is_replaying()
+
+    def test_resume_command_rejected_from_replaying(self):
+        sm = TrainingStateMachine()
+        sm.mark_replaying()
+        assert sm.handle_command(Command.RESUME) is False
+        assert sm.is_replaying()
+
+    def test_reset_from_replaying(self):
+        """RESET transitions Replaying -> Stopped (escape hatch alongside /replay/control stop)."""
+        sm = TrainingStateMachine()
+        sm.mark_replaying()
+        assert sm.handle_command(Command.RESET) is True
+        assert sm.is_stopped()
+
+    def test_get_state_summary_reports_replaying(self):
+        sm = TrainingStateMachine()
+        sm.mark_replaying()
+        summary = sm.get_state_summary()
+        assert summary["status"] == "REPLAYING"
+        assert summary["phase"] == "IDLE"
+
+    def test_mark_investigating_rejected_from_replaying(self):
+        """A Restore can't pre-empt a running replay — user must /replay/control stop first."""
+        sm = TrainingStateMachine()
+        sm.mark_replaying()
+        assert sm.mark_investigating() is False
+        assert sm.is_replaying()
+
+    def test_mark_resume_ready_rejected_from_replaying(self):
+        """Same for Resume."""
+        sm = TrainingStateMachine()
+        sm.mark_replaying()
+        assert sm.mark_resume_ready() is False
+        assert sm.is_replaying()

--- a/src/tests/unit/api/test_snapshot_route_coverage.py
+++ b/src/tests/unit/api/test_snapshot_route_coverage.py
@@ -638,3 +638,178 @@ class TestUnifiedResponseShape:
             assert response.status_code == 409
         finally:
             lifecycle.state_machine.handle_command(Command.RESET)
+
+
+class TestReplaySnapshot:
+    """CAN-015c (Phase 6E Sprint B B-3): tests for the new
+    ``POST /v1/snapshots/{id}/replay`` and
+    ``POST /v1/snapshots/{id}/replay/control`` routes."""
+
+    def _install_replay_session(self, lifecycle, snapshot_id="snap-test", length=5):
+        """Install a synthetic replay session bypassing the load step."""
+        from api.lifecycle.manager import _ReplaySession
+
+        history = {
+            "train_loss": [0.5] * length,
+            "value_loss": [],
+            "train_accuracy": [],
+            "value_accuracy": [],
+        }
+        session = _ReplaySession(snapshot_id, history, lifecycle.training_monitor)
+        lifecycle._replay_session = session
+        lifecycle.state_machine.mark_replaying()
+        return session
+
+    def _teardown_replay_session(self, lifecycle):
+        from api.lifecycle.state_machine import Command
+
+        if lifecycle._replay_session is not None:
+            lifecycle._replay_session.stop()
+            lifecycle._replay_session = None
+        lifecycle.state_machine.handle_command(Command.RESET)
+
+    def test_start_replay_route_success(self, client):
+        lifecycle = client.app.state.lifecycle
+
+        def fake_start(snapshot_id):
+            self._install_replay_session(lifecycle, snapshot_id, length=3)
+            return True
+
+        try:
+            with patch.object(lifecycle, "start_replay", side_effect=fake_start):
+                response = client.post("/v1/snapshots/snap-001/replay")
+                assert response.status_code == 200
+                data = response.json()["data"]
+                assert data["snapshot_id"] == "snap-001"
+                assert data["operation"] == "replay"
+                assert data["fsm_state"] == "REPLAYING"
+                assert data["time_index"]["default"] == "start"
+                assert data["status"] == "replaying"
+                assert data["session"]["snapshot_id"] == "snap-001"
+                assert data["session"]["length"] == 3
+        finally:
+            self._teardown_replay_session(lifecycle)
+
+    def test_start_replay_route_404_when_load_fails(self, client):
+        with patch.object(client.app.state.lifecycle, "start_replay", return_value=False):
+            response = client.post("/v1/snapshots/nonexistent/replay")
+            assert response.status_code == 404
+
+    def test_start_replay_route_409_when_training_active(self, client):
+        from api.lifecycle.state_machine import Command
+
+        lifecycle = client.app.state.lifecycle
+        lifecycle.state_machine.handle_command(Command.START)
+        try:
+            response = client.post("/v1/snapshots/snap-active/replay")
+            assert response.status_code == 409
+            assert "Cannot start replay" in response.json()["detail"]
+        finally:
+            lifecycle.state_machine.handle_command(Command.RESET)
+
+    def test_start_replay_route_runs_in_thread(self, client):
+        captured: dict = {}
+
+        def fake_start(snapshot_id):
+            import threading
+
+            captured["thread"] = threading.current_thread().name
+            self._install_replay_session(client.app.state.lifecycle, snapshot_id)
+            return True
+
+        try:
+            with patch.object(client.app.state.lifecycle, "start_replay", side_effect=fake_start):
+                response = client.post("/v1/snapshots/snap-thread/replay")
+                assert response.status_code == 200
+                assert captured["thread"] != "MainThread"
+        finally:
+            self._teardown_replay_session(client.app.state.lifecycle)
+
+    def test_replay_control_play(self, client):
+        lifecycle = client.app.state.lifecycle
+        try:
+            self._install_replay_session(lifecycle, "snap-ctrl", length=3)
+            response = client.post("/v1/snapshots/snap-ctrl/replay/control", json={"action": "play"})
+            assert response.status_code == 200
+            data = response.json()["data"]
+            assert data["operation"] == "replay_control"
+            assert data["action"] == "play"
+            assert data["result"]["paused"] is False
+        finally:
+            self._teardown_replay_session(lifecycle)
+
+    def test_replay_control_seek(self, client):
+        lifecycle = client.app.state.lifecycle
+        try:
+            self._install_replay_session(lifecycle, "snap-seek", length=5)
+            response = client.post("/v1/snapshots/snap-seek/replay/control", json={"action": "seek", "time_index": 3})
+            assert response.status_code == 200
+            assert response.json()["data"]["result"]["time_index"] == 3
+        finally:
+            self._teardown_replay_session(lifecycle)
+
+    def test_replay_control_speed(self, client):
+        lifecycle = client.app.state.lifecycle
+        try:
+            self._install_replay_session(lifecycle, "snap-speed", length=3)
+            response = client.post("/v1/snapshots/snap-speed/replay/control", json={"action": "speed", "value": 2.5})
+            assert response.status_code == 200
+            assert response.json()["data"]["result"]["speed"] == 2.5
+        finally:
+            self._teardown_replay_session(lifecycle)
+
+    def test_replay_control_range(self, client):
+        lifecycle = client.app.state.lifecycle
+        try:
+            self._install_replay_session(lifecycle, "snap-range", length=5)
+            response = client.post("/v1/snapshots/snap-range/replay/control", json={"action": "range", "start": 1, "end": 4})
+            assert response.status_code == 200
+            assert response.json()["data"]["result"]["range"] == {"start": 1, "end": 4, "time_index": 1}
+        finally:
+            self._teardown_replay_session(lifecycle)
+
+    def test_replay_control_stop(self, client):
+        lifecycle = client.app.state.lifecycle
+        self._install_replay_session(lifecycle, "snap-stop")
+        response = client.post("/v1/snapshots/snap-stop/replay/control", json={"action": "stop"})
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert data["action"] == "stop"
+        assert data["result"]["status"] == "stopped"
+        assert data["fsm_state"] == "STOPPED"
+        assert lifecycle._replay_session is None
+
+    def test_replay_control_without_active_session_returns_409(self, client):
+        response = client.post("/v1/snapshots/snap-none/replay/control", json={"action": "play"})
+        assert response.status_code == 409
+        assert "No active replay session" in response.json()["detail"]
+
+    def test_replay_control_snapshot_id_mismatch_returns_409(self, client):
+        lifecycle = client.app.state.lifecycle
+        try:
+            self._install_replay_session(lifecycle, "snap-actual")
+            response = client.post("/v1/snapshots/snap-different/replay/control", json={"action": "play"})
+            assert response.status_code == 409
+            assert "snap-actual" in response.json()["detail"]
+        finally:
+            self._teardown_replay_session(lifecycle)
+
+    def test_replay_control_unknown_action_returns_400(self, client):
+        lifecycle = client.app.state.lifecycle
+        try:
+            self._install_replay_session(lifecycle, "snap-bad-action")
+            response = client.post("/v1/snapshots/snap-bad-action/replay/control", json={"action": "teleport"})
+            assert response.status_code == 400
+            assert "Unknown replay action" in response.json()["detail"]
+        finally:
+            self._teardown_replay_session(lifecycle)
+
+    def test_replay_control_seek_missing_param_returns_400(self, client):
+        lifecycle = client.app.state.lifecycle
+        try:
+            self._install_replay_session(lifecycle, "snap-missing-param")
+            response = client.post("/v1/snapshots/snap-missing-param/replay/control", json={"action": "seek"})
+            assert response.status_code == 400
+            assert "time_index" in response.json()["detail"]
+        finally:
+            self._teardown_replay_session(lifecycle)


### PR DESCRIPTION
## Summary

Phase 6E Sprint B **B-3** — fourth and final cascor PR implementing the
expanded snapshot operations matrix from
[`PHASE_6E_SPRINT_B_DESIGN.md`](https://github.com/pcalnon/juniper-ml/blob/main/notes/PHASE_6E_SPRINT_B_DESIGN.md).

**STACKED on #171 (B-4 Restore enrichment)** — base is
`feature/b-4-restore-investigating`. After #171 merges, GitHub will
auto-rebase. After this and #170 + #171 land, **the cascor side of
Sprint B is feature-complete** and canopy can begin B-5 / B-6.

**Replay semantics**: read-only playback of a snapshotted training
run. Loads the snapshot, transitions FSM to `REPLAYING`, spawns a
background driver thread that emits synthetic `epoch_end` events from
the loaded history at a configurable speed. Canopy controls playback
via `POST /v1/snapshots/{id}/replay/control` with actions
`play / pause / seek / speed / range / stop`.

**V1 scope**: metric arrays + topology evolution metadata only.
Per-epoch weight history is deferred to CAN-015g.

## Changes

### `api/lifecycle/state_machine.py` (+48 lines)

- New `TrainingStatus.REPLAYING` enum value
- New `is_replaying()` predicate
- New `mark_replaying()` method:
  - Permitted from Stopped / Completed / Failed / RESUME_READY /
    INVESTIGATING / REPLAYING (idempotent re-mark)
  - Rejected from Started / Paused
- `_handle_start` rejects `START` from `REPLAYING`

### `api/lifecycle/manager.py` (+386 lines)

- **New `_ReplaySession` class**: encapsulates per-snapshot playback
  state. Cached history arrays, time index, speed (signed for
  direction), pause flag, range sub-window, daemon driver thread.
  - `play()` / `pause()` / `seek(target)` / `set_speed(value)` /
    `set_range(start, end)` / `stop()` / `state_summary()`
  - Auto-pause at range boundaries
  - Wake-event signals so /control changes take effect immediately
  - Speed clamped to [−10×, 10×]; |value| < 0.1 treated as pause
  - Synthetic events emitted via `monitor._trigger_callbacks`
    (NOT `on_epoch_end`) so they don't pollute `metrics_buffer` —
    read-only contract per design doc §2.2
  - Events carry `"replay": True` and `snapshot_id` markers so
    subscribers can distinguish them from live training
- **New `start_replay(snapshot_id)`** — pre-flight, load,
  install session, mark FSM, start thread
- **New `replay_control(action, **params)`** — dispatches to session;
  raises `RuntimeError` (no session) / `ValueError` (bad params)
- **New `stop_replay()`** — joins thread, clears session, RESETs FSM
- `start_training` rejects from REPLAYING
- `load_snapshot` / `restore_for_retrain` / `resume_from_snapshot`
  all reject from REPLAYING (would race with driver thread)
- `shutdown` drains the replay session

### `api/routes/snapshots.py` (+105 lines)

- New `POST /v1/snapshots/{id}/replay` — pre-flight 409 when
  training active; calls `start_replay` via `asyncio.to_thread`
  (PERF-CC-01); returns unified response with
  `operation="replay"`, `time_index_default="start"`, and a
  `session` block summarizing the new session
- New `POST /v1/snapshots/{id}/replay/control` — Pydantic
  `ReplayControlRequest` body; pre-flight: REPLAYING + snapshot_id
  matches active session (409 mismatch); maps `ValueError` → 400,
  `RuntimeError` → 409; returns post-action session state

## Tests (53 new)

- **`test_lifecycle_state_machine.py`** — new `TestReplayingState`
  with **16 tests** covering each transition in/out of REPLAYING
- **`test_lifecycle_manager.py`** —
  - new `TestReplaySessionUnit` with **12 tests** pinning the
    `_ReplaySession` API (state init, play/pause/seek/speed/range,
    boundary clamping, synthetic event marker fields, empty history,
    sign preservation)
  - new `TestReplayLifecycleIntegration` with **13 tests** covering
    `start_replay` / `replay_control` / `stop_replay` end-to-end,
    plus REPLAYING rejection of `start_training` / `load_snapshot`
- **`test_snapshot_route_coverage.py`** — new `TestReplaySnapshot`
  with **12 tests** covering `/replay` (success, 404, 409,
  off-event-loop) and `/replay/control` (each action, snapshot-id
  mismatch, unknown action, missing param, no-session-active)

## Sprint B status after this PR

| PR | CAN-ID | Repo | State |
|---|---|---|---|
| B-1 | CAN-015a | cascor | merged |
| B-2 | CAN-015b | cascor | merged |
| B-4 | CAN-015d | cascor | open (#171) |
| **B-3** | CAN-015c | cascor | **this PR (stacked on #171)** |
| B-5 | CAN-015e | canopy | not started |
| B-6 | CAN-015f | canopy | not started |

After this and #171 land, the cascor side of Sprint B is
feature-complete. Canopy work (B-5 entry-points + B-6 replay player UI)
is unblocked.

## Test plan

- [x] `flake8 --max-line-length=512` clean on all 3 modified production files
- [x] `py_compile` clean on all 6 modified files
- [ ] Local `pytest` couldn't run in this env (Py3.14 free-threading +
  torch C-extensions ImportError) — CI will exercise the 53 new tests
- [ ] Manual smoke (deferred): create network, train ~10 epochs,
  snapshot, POST /v1/snapshots/{id}/replay, observe response includes
  fsm_state=REPLAYING + session.length=10, POST /control with
  action=play, observe synthetic events on the WS stream, POST /control
  with action=stop, verify FSM returns to STOPPED

## References

- [PHASE_6E_SPRINT_B_DESIGN.md](https://github.com/pcalnon/juniper-ml/blob/main/notes/PHASE_6E_SPRINT_B_DESIGN.md) §2.2 (Replay spec), §3 (unified response shape), §5 (FSM extensions), §10.1 (V2 deferred)
- [PHASE_6E_DESIGN.md](https://github.com/pcalnon/juniper-ml/blob/main/notes/PHASE_6E_DESIGN.md) Sprint B table

🤖 Generated with [Claude Code](https://claude.com/claude-code)