### PR TITLE
fix(tests): block dash/playwright pytest plugin autoload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,15 @@ addopts = [
     "--strict-config",
     "--continue-on-collection-errors",
     "--tb=short",
+    # Block pytest plugins whose entrypoints get auto-discovered from the
+    # active env even when this project does not use them. dash.testing.plugin
+    # transitively imports psutil; if the env's psutil wheel is built for the
+    # wrong CPython ABI (e.g. a non-FT abi3 wheel landing in a python3.14t env),
+    # the dash plugin import segfaults during pytest startup before the
+    # free-threading guard in src/tests/conftest.py can fire. pytest_playwright
+    # is similarly autoloaded and breaks when `playwright` is not installed.
+    "-p", "no:dash",
+    "-p", "no:playwright",
 ]
 # MED-007: Targeted warning filters instead of suppressing all warnings
 filterwarnings = [


### PR DESCRIPTION
## Summary

- Append `-p no:dash` and `-p no:playwright` to `addopts` in `pyproject.toml`.
- The existing free-threading guard in `src/tests/conftest.py` is preserved and now actually fires (it was being preceded by a SIGSEGV).

## Why

Pytest's setuptools-entrypoint autoloader runs *before* `conftest.py` is imported. In the `JuniperCascor` env, autoloading `dash.testing.plugin` transitively imports `psutil`, and the env had a non-FT `psutil-7.2.1` `abi3.so` that segfaults when loaded under the free-threading interpreter (`cpython-314t`):

```
Fatal Python error: Segmentation fault
  File "psutil/_psutil_linux.abi3.so" — PyInit__psutil_linux+0x12
  File "psutil/_pslinux.py", line 26 in <module>
  File "dash/testing/application_runners.py", line 15 in <module>
  File "dash/testing/plugin.py", line 28 in <module>
  File "pluggy/_manager.py", line 416 — load_setuptools_entrypoints
```

The guard at `src/tests/conftest.py:53` correctly identifies free-threading as unsupported and `SystemExit(2)`s with instructions, but it never got the chance — autoload crashed pytest first.

Disabling these plugins in `addopts` lets the guard fire as designed. The user gets a clear actionable error message instead of `Segmentation fault (core dumped)`.

## Verification

Before: `pytest --collect-only` → SIGSEGV (exit 139).

After: `pytest --collect-only` → guard fires cleanly:
```
ERROR: pytest is running under a free-threading CPython build (Py_GIL_DISABLED=1).
       Recreate the JuniperCascor conda env with a regular (GIL) Python:
         conda create -n JuniperCascor python=3.13 -c conda-forge -y
         conda activate JuniperCascor && pip install -e .
       To override this guard at your own risk, set CASCOR_ALLOW_FREE_THREADING=1.
```

## Test plan

- [x] Pytest no longer segfaults under the (broken) JuniperCascor FT env
- [x] Free-threading guard now fires with actionable error instead
- [ ] Tests run under a regular CPython 3.13 env (will validate after env rebuild)

## Companion PRs

One of 5 PRs across the Juniper fleet fixing the same root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)