### PR TITLE
feat(workers): METRICS-MON R4.4b — accept R4.4 worker training-loop fields

### DIFF
--- a/src/api/routes/workers.py
+++ b/src/api/routes/workers.py
@@ -28,8 +28,14 @@ def _serialize_worker(worker) -> dict:
 
     METRICS-MON R1.3 / seed-04: includes ``in_flight_tasks``,
     ``last_task_completed_at``, and ``rss_mb`` from R1.3-aware workers'
-    enriched heartbeats. Workers running older images report these as
-    0/None defaults until they upgrade.
+    enriched heartbeats.
+
+    METRICS-MON R4.4: includes ``last_task_duration_seconds``,
+    ``recent_task_durations_seconds``, and ``gpu_utilization_pct`` from
+    R4.4-aware workers' training-loop instrumentation.
+
+    Workers running older images report missing fields as ``0`` / ``None``
+    / ``[]`` defaults until they upgrade.
     """
     return {
         "worker_id": worker.worker_id,
@@ -45,6 +51,10 @@ def _serialize_worker(worker) -> dict:
         "in_flight_tasks": worker.in_flight_tasks,
         "last_task_completed_at": worker.last_task_completed_at,
         "rss_mb": worker.rss_mb,
+        # METRICS-MON R4.4: training-loop instrumentation fields.
+        "last_task_duration_seconds": worker.last_task_duration_seconds,
+        "recent_task_durations_seconds": worker.recent_task_durations_seconds,
+        "gpu_utilization_pct": worker.gpu_utilization_pct,
     }
 
 

--- a/src/api/websocket/worker_stream.py
+++ b/src/api/websocket/worker_stream.py
@@ -213,6 +213,10 @@ async def _message_loop(
                 # fields when present. Workers running older images send
                 # only ``worker_id`` + ``timestamp``; the missing kwargs
                 # stay at None and prior values are preserved.
+                # METRICS-MON R4.4: three additional optional fields from
+                # R4.4-aware workers (training-loop instrumentation).
+                # ``msg.get(...)`` returns None for absent keys — same
+                # additive-compatibility shape as R1.3.
                 registry.heartbeat(
                     worker_id,
                     in_flight_tasks=msg.get("in_flight_tasks"),
@@ -220,6 +224,9 @@ async def _message_loop(
                     rss_mb=msg.get("rss_mb"),
                     tasks_completed=msg.get("tasks_completed"),
                     tasks_failed=msg.get("tasks_failed"),
+                    last_task_duration_seconds=msg.get("last_task_duration_seconds"),
+                    recent_task_durations_seconds=msg.get("recent_task_durations_seconds"),
+                    gpu_utilization_pct=msg.get("gpu_utilization_pct"),
                 )
                 await websocket.send_json(WorkerProtocol.build_heartbeat(worker_id))
 

--- a/src/api/workers/registry.py
+++ b/src/api/workers/registry.py
@@ -45,6 +45,21 @@ class WorkerRegistration:
     in_flight_tasks: int = 0
     last_task_completed_at: float | None = None
     rss_mb: float | None = None
+    # METRICS-MON R4.4: training-loop instrumentation fields populated by
+    # workers running images >= R4.4. Defaults match the R1.3 ``None`` /
+    # ``[]`` pattern so older workers leave the registration's prior
+    # values untouched. Field semantics:
+    # * ``last_task_duration_seconds`` — wall-clock duration of the
+    #   most recently completed task (any outcome).
+    # * ``recent_task_durations_seconds`` — sliding window (oldest →
+    #   newest) of the last N task durations. Server-side percentile
+    #   estimators (p50, p99) compute over the union of all workers'
+    #   windows on each scrape.
+    # * ``gpu_utilization_pct`` — best-effort 0–100 reading; ``None``
+    #   when no CUDA / NVML / torch.
+    last_task_duration_seconds: float | None = None
+    recent_task_durations_seconds: list[float] = field(default_factory=list)
+    gpu_utilization_pct: float | None = None
 
     @property
     def health_score(self) -> float:
@@ -70,12 +85,20 @@ class WorkerRegistration:
         rss_mb: float | None = None,
         tasks_completed: int | None = None,
         tasks_failed: int | None = None,
+        last_task_duration_seconds: float | None = None,
+        recent_task_durations_seconds: list[float] | None = None,
+        gpu_utilization_pct: float | None = None,
     ) -> None:
         """Update last heartbeat timestamp and (optionally) enriched fields.
 
         METRICS-MON R1.3 / seed-04: keyword-only enriched fields are
         accepted from R1.3-aware workers. Older workers omit them; the
         registration's prior values are preserved.
+
+        METRICS-MON R4.4: three additional optional fields accepted from
+        R4.4-aware workers (``last_task_duration_seconds``,
+        ``recent_task_durations_seconds``, ``gpu_utilization_pct``).
+        Same ``None``-default-preserves-prior-value pattern as R1.3.
         """
         self.last_heartbeat = time.time()
         if in_flight_tasks is not None:
@@ -88,6 +111,14 @@ class WorkerRegistration:
             self.tasks_completed = tasks_completed
         if tasks_failed is not None:
             self.tasks_failed = tasks_failed
+        if last_task_duration_seconds is not None:
+            self.last_task_duration_seconds = last_task_duration_seconds
+        if recent_task_durations_seconds is not None:
+            # Defensive copy: callers shouldn't be able to mutate the
+            # registration's window through a shared reference.
+            self.recent_task_durations_seconds = list(recent_task_durations_seconds)
+        if gpu_utilization_pct is not None:
+            self.gpu_utilization_pct = gpu_utilization_pct
 
     def is_alive(self, timeout: float) -> bool:
         """Check if the worker is alive based on heartbeat timeout."""
@@ -183,12 +214,20 @@ class WorkerRegistry:
         rss_mb: float | None = None,
         tasks_completed: int | None = None,
         tasks_failed: int | None = None,
+        last_task_duration_seconds: float | None = None,
+        recent_task_durations_seconds: list[float] | None = None,
+        gpu_utilization_pct: float | None = None,
     ) -> bool:
         """Record a heartbeat for a worker.
 
         METRICS-MON R1.3 / seed-04: keyword-only enriched fields are
         forwarded to ``WorkerRegistration.record_heartbeat``. Pass
         ``None`` (the default) for any field not reported by the worker.
+
+        METRICS-MON R4.4: three additional R4.4-only fields forwarded to
+        ``record_heartbeat`` (training-loop instrumentation). Same
+        ``None``-default semantics: workers running pre-R4.4 images
+        don't send them; prior values are preserved.
 
         Returns:
             True if the worker exists, False otherwise.
@@ -203,6 +242,9 @@ class WorkerRegistry:
                 rss_mb=rss_mb,
                 tasks_completed=tasks_completed,
                 tasks_failed=tasks_failed,
+                last_task_duration_seconds=last_task_duration_seconds,
+                recent_task_durations_seconds=recent_task_durations_seconds,
+                gpu_utilization_pct=gpu_utilization_pct,
             )
             return True
 

--- a/src/tests/unit/api/test_worker_registry.py
+++ b/src/tests/unit/api/test_worker_registry.py
@@ -111,6 +111,92 @@ class TestWorkerRegistrationR1_3:
 
 
 @pytest.mark.unit
+class TestWorkerRegistrationR4_4:
+    """METRICS-MON R4.4: training-loop instrumentation fields.
+
+    Mirrors R1.3 test patterns above — defaults, minimal-heartbeat
+    preserves prior values, kwargs update only what's provided.
+    """
+
+    def test_r4_4_field_defaults(self):
+        """New registration defaults R4.4 fields to None / [] / None."""
+        reg = WorkerRegistration(worker_id="w1")
+        assert reg.last_task_duration_seconds is None
+        assert reg.recent_task_durations_seconds == []
+        assert reg.gpu_utilization_pct is None
+
+    def test_record_heartbeat_minimal_preserves_r4_4_fields(self):
+        """Pre-R4.4 worker (minimal heartbeat) preserves prior R4.4 values.
+
+        Backward-compat regression guard: if a worker is upgraded to R4.4,
+        downgraded to pre-R4.4, then sends a minimal heartbeat, the prior
+        R4.4 values must persist (matches the R1.3 pattern). Operators
+        watching the dashboard for the percentile window during a
+        rolling restart should not see the values reset to defaults.
+        """
+        reg = WorkerRegistration(worker_id="w1")
+        reg.last_task_duration_seconds = 0.42
+        reg.recent_task_durations_seconds = [0.1, 0.2, 0.42]
+        reg.gpu_utilization_pct = 67.5
+        reg.record_heartbeat()
+        assert reg.last_task_duration_seconds == 0.42
+        assert reg.recent_task_durations_seconds == [0.1, 0.2, 0.42]
+        assert reg.gpu_utilization_pct == 67.5
+
+    def test_record_heartbeat_with_r4_4_fields(self):
+        """R4.4-aware worker reports all 3 fields → applied atomically."""
+        reg = WorkerRegistration(worker_id="w1")
+        reg.record_heartbeat(
+            last_task_duration_seconds=1.25,
+            recent_task_durations_seconds=[0.5, 0.8, 1.25],
+            gpu_utilization_pct=88.0,
+        )
+        assert reg.last_task_duration_seconds == 1.25
+        assert reg.recent_task_durations_seconds == [0.5, 0.8, 1.25]
+        assert reg.gpu_utilization_pct == 88.0
+
+    def test_record_heartbeat_recent_durations_defensive_copy(self):
+        """Caller's list mutation must not leak through to the registration.
+
+        Pinning this matters because the worker's deque is converted to a
+        list right before send; if cascor stored a shared reference, a
+        future refactor that reuses the list buffer (e.g. via msgpack
+        zero-copy) would silently mutate registered worker state.
+        """
+        reg = WorkerRegistration(worker_id="w1")
+        caller_list = [0.1, 0.2, 0.3]
+        reg.record_heartbeat(recent_task_durations_seconds=caller_list)
+        caller_list.append(999.0)
+        assert reg.recent_task_durations_seconds == [0.1, 0.2, 0.3]
+
+    def test_record_heartbeat_partial_r4_4_kwargs(self):
+        """Mixed: only the provided R4.4 fields update; others preserved."""
+        reg = WorkerRegistration(worker_id="w1")
+        reg.last_task_duration_seconds = 0.5
+        reg.gpu_utilization_pct = 50.0
+        reg.record_heartbeat(last_task_duration_seconds=0.8)
+        assert reg.last_task_duration_seconds == 0.8
+        assert reg.gpu_utilization_pct == 50.0  # preserved
+        assert reg.recent_task_durations_seconds == []  # never set
+
+    def test_registry_heartbeat_forwards_r4_4_fields(self):
+        """``WorkerRegistry.heartbeat()`` forwards R4.4 kwargs to ``record_heartbeat``."""
+        registry = WorkerRegistry()
+        registry.register("w1", {"cpu_cores": 8})
+        ok = registry.heartbeat(
+            "w1",
+            last_task_duration_seconds=2.5,
+            recent_task_durations_seconds=[1.0, 2.5],
+            gpu_utilization_pct=90.0,
+        )
+        assert ok is True
+        reg = registry.get("w1")
+        assert reg.last_task_duration_seconds == 2.5
+        assert reg.recent_task_durations_seconds == [1.0, 2.5]
+        assert reg.gpu_utilization_pct == 90.0
+
+
+@pytest.mark.unit
 class TestWorkerRegistry:
     """Test WorkerRegistry thread-safe operations."""
 


### PR DESCRIPTION
Companion to juniper-cascor-worker#43 (R4.4 worker side). Cascor server now explicitly accepts the three new R4.4 training-loop fields workers are starting to emit: last_task_duration_seconds, recent_task_durations_seconds (list), gpu_utilization_pct. WorkerRegistration dataclass + record_heartbeat() + WorkerRegistry.heartbeat() + worker_stream.py dispatch handler + /v1/workers serializer all updated. R1.3-style None-preserves-prior-value pattern; backward compatible with pre-R4.4 worker images. 6 new tests pin all paths including defensive copy + rolling-restart preservation. Local cascor env unable to run pytest (known torch C-extension issue); all logic verified directly via Python script.