### PR TITLE
ci: fix Coverage Gate "No data to report" (P-6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -676,7 +676,14 @@ jobs:
 
       - name: Verify Package Import
         run: |
-          docker exec juniper-cascor-test python -c "import juniper_cascor; print(juniper_cascor.__version__)"
+          # The wheel publishes as PyPI name ``juniper-cascor`` but the
+          # source is laid out as flat modules (``cascade_correlation``,
+          # ``api``, ``snapshots``, …) under ``src/``, with no
+          # importable top-level ``juniper_cascor`` namespace. Use
+          # ``importlib.metadata.version`` to confirm the wheel is
+          # installed, then import a real module to confirm it loads.
+          docker exec juniper-cascor-test python -c "from importlib.metadata import version; print('juniper-cascor', version('juniper-cascor'))"
+          docker exec juniper-cascor-test python -c "import cascade_correlation, api, snapshots; print('modules importable')"
 
       - name: Verify Health Endpoint
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,18 +202,30 @@ jobs:
           mkdir -p logs src/logs reports/junit reports/htmlcov src/tests/reports
 
       - name: Run Unit Tests
+        env:
+          # P-6: pyproject.toml's ``[tool.coverage.run] data_file =
+          # "src/tests/reports/.coverage"`` + ``parallel = true`` was
+          # causing pytest-cov to silently lose its writes — pytest
+          # exited 0 but no .coverage file was written anywhere on disk
+          # (verified by the diagnostic step). Force COVERAGE_FILE to a
+          # known-good location at the repo root and disable buffered
+          # stdout so any session-finish summary or pytest-cov error
+          # actually surfaces in the live log.
+          COVERAGE_FILE: ${{ github.workspace }}/.coverage
+          PYTHONUNBUFFERED: "1"
         run: |
           echo "╔════════════════════════════════════════════════════════════╗"
           echo "║       Juniper Cascor - Unit Tests (Fast Only)              ║"
           echo "╚════════════════════════════════════════════════════════════╝"
 
-          # P-6 diagnostic: pytest-cov was silently dropping its writes
-          # in CI even after we created src/tests/reports. Capture
-          # stdout+stderr to a file so the post-run inventory step below
-          # can echo the full pytest tail (GitHub Actions' streaming-log
-          # API truncates the last ~5 seconds of any step's output).
+          # Diagnostics for P-6 follow-up: confirm pytest-cov is loaded
+          # and the version pin we're testing against.
+          python -m pytest --version 2>&1 || true
+          python -c "import pytest_cov; print(f'pytest-cov={pytest_cov.__version__}')" 2>&1 || true
+          python -c "import coverage; print(f'coverage={coverage.__version__}')" 2>&1 || true
+
           set -o pipefail
-          python -m pytest \
+          python -u -m pytest \
             -m "unit and not slow" \
             src/tests/unit \
             --verbose \
@@ -224,6 +236,9 @@ jobs:
             --cov-report=term-missing \
             --cov-report=xml:reports/coverage.xml \
             --cov-report=html:reports/htmlcov 2>&1 | tee reports/pytest-output.log
+          PYTEST_EXIT=${PIPESTATUS[0]}
+          echo "═════════ pytest exit code: ${PYTEST_EXIT} ═════════"
+          exit "${PYTEST_EXIT}"
 
       - name: Diagnostic — show pytest tail and reports directory
         if: always()
@@ -241,6 +256,8 @@ jobs:
           find . -name '.coverage*' -not -path './.git/*' 2>/dev/null || true
 
       - name: Enforce Coverage Gate (80%)
+        env:
+          COVERAGE_FILE: ${{ github.workspace }}/.coverage
         run: |
           echo "╔════════════════════════════════════════════════════════════╗"
           echo "║       Juniper Cascor - Coverage Gate Enforcement           ║"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,30 +202,12 @@ jobs:
           mkdir -p logs src/logs reports/junit reports/htmlcov src/tests/reports
 
       - name: Run Unit Tests
-        env:
-          # P-6: pyproject.toml's ``[tool.coverage.run] data_file =
-          # "src/tests/reports/.coverage"`` + ``parallel = true`` was
-          # causing pytest-cov to silently lose its writes — pytest
-          # exited 0 but no .coverage file was written anywhere on disk
-          # (verified by the diagnostic step). Force COVERAGE_FILE to a
-          # known-good location at the repo root and disable buffered
-          # stdout so any session-finish summary or pytest-cov error
-          # actually surfaces in the live log.
-          COVERAGE_FILE: ${{ github.workspace }}/.coverage
-          PYTHONUNBUFFERED: "1"
         run: |
           echo "╔════════════════════════════════════════════════════════════╗"
           echo "║       Juniper Cascor - Unit Tests (Fast Only)              ║"
           echo "╚════════════════════════════════════════════════════════════╝"
 
-          # Diagnostics for P-6 follow-up: confirm pytest-cov is loaded
-          # and the version pin we're testing against.
-          python -m pytest --version 2>&1 || true
-          python -c "import pytest_cov; print(f'pytest-cov={pytest_cov.__version__}')" 2>&1 || true
-          python -c "import coverage; print(f'coverage={coverage.__version__}')" 2>&1 || true
-
-          set -o pipefail
-          python -u -m pytest \
+          python -m pytest \
             -m "unit and not slow" \
             src/tests/unit \
             --verbose \
@@ -235,29 +217,9 @@ jobs:
             --cov=src \
             --cov-report=term-missing \
             --cov-report=xml:reports/coverage.xml \
-            --cov-report=html:reports/htmlcov 2>&1 | tee reports/pytest-output.log
-          PYTEST_EXIT=${PIPESTATUS[0]}
-          echo "═════════ pytest exit code: ${PYTEST_EXIT} ═════════"
-          exit "${PYTEST_EXIT}"
-
-      - name: Diagnostic — show pytest tail and reports directory
-        if: always()
-        run: |
-          echo "═════════ pytest tail (last 80 lines) ═════════"
-          tail -80 reports/pytest-output.log 2>/dev/null || echo "(no pytest-output.log)"
-          echo "═════════ reports/ tree ═════════"
-          ls -la reports/ 2>/dev/null || echo "(no reports/)"
-          ls -la reports/junit/ 2>/dev/null || echo "(no reports/junit/)"
-          echo "═════════ src/tests/reports/ tree ═════════"
-          ls -la src/tests/reports/ 2>/dev/null || echo "(no src/tests/reports/)"
-          echo "═════════ stray .coverage* files in repo root ═════════"
-          ls -la .coverage* 2>/dev/null || echo "(no .coverage* in repo root)"
-          echo "═════════ all .coverage* files anywhere ═════════"
-          find . -name '.coverage*' -not -path './.git/*' 2>/dev/null || true
+            --cov-report=html:reports/htmlcov
 
       - name: Enforce Coverage Gate (80%)
-        env:
-          COVERAGE_FILE: ${{ github.workspace }}/.coverage
         run: |
           echo "╔════════════════════════════════════════════════════════════╗"
           echo "║       Juniper Cascor - Coverage Gate Enforcement           ║"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,12 @@ jobs:
           echo "║       Juniper Cascor - Unit Tests (Fast Only)              ║"
           echo "╚════════════════════════════════════════════════════════════╝"
 
+          # P-6 diagnostic: pytest-cov was silently dropping its writes
+          # in CI even after we created src/tests/reports. Capture
+          # stdout+stderr to a file so the post-run inventory step below
+          # can echo the full pytest tail (GitHub Actions' streaming-log
+          # API truncates the last ~5 seconds of any step's output).
+          set -o pipefail
           python -m pytest \
             -m "unit and not slow" \
             src/tests/unit \
@@ -217,7 +223,22 @@ jobs:
             --cov=src \
             --cov-report=term-missing \
             --cov-report=xml:reports/coverage.xml \
-            --cov-report=html:reports/htmlcov
+            --cov-report=html:reports/htmlcov 2>&1 | tee reports/pytest-output.log
+
+      - name: Diagnostic — show pytest tail and reports directory
+        if: always()
+        run: |
+          echo "═════════ pytest tail (last 80 lines) ═════════"
+          tail -80 reports/pytest-output.log 2>/dev/null || echo "(no pytest-output.log)"
+          echo "═════════ reports/ tree ═════════"
+          ls -la reports/ 2>/dev/null || echo "(no reports/)"
+          ls -la reports/junit/ 2>/dev/null || echo "(no reports/junit/)"
+          echo "═════════ src/tests/reports/ tree ═════════"
+          ls -la src/tests/reports/ 2>/dev/null || echo "(no src/tests/reports/)"
+          echo "═════════ stray .coverage* files in repo root ═════════"
+          ls -la .coverage* 2>/dev/null || echo "(no .coverage* in repo root)"
+          echo "═════════ all .coverage* files anywhere ═════════"
+          find . -name '.coverage*' -not -path './.git/*' 2>/dev/null || true
 
       - name: Enforce Coverage Gate (80%)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -593,6 +593,47 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
+      # juniper-cascor's runtime ``JUNIPER_DATA_URL`` defaults to
+      # ``http://localhost:8100`` and the ``/v1/health/ready`` probe pings
+      # ``$JUNIPER_DATA_URL/v1/health/live`` (see src/api/routes/health.py:141).
+      # The smoke test therefore needs a juniper-data sidecar reachable on
+      # the same Docker network, otherwise readiness returns 503 and the
+      # container never reports ``healthy``.
+      - name: Clone juniper-data sidecar source
+        run: |
+          # Cloned to /tmp (outside the workspace) so it doesn't bloat
+          # cascor's docker build context.
+          git clone --depth 1 https://github.com/pcalnon/juniper-data.git /tmp/juniper-data
+
+      - name: Create Docker network
+        run: docker network create juniper-smoke
+
+      - name: Build & start juniper-data sidecar
+        run: |
+          echo "╔════════════════════════════════════════════════════════════╗"
+          echo "║       Juniper Data - Sidecar Build & Start                ║"
+          echo "╚════════════════════════════════════════════════════════════╝"
+          docker build -t juniper-data:ci-${{ github.sha }} /tmp/juniper-data
+          docker run -d --name juniper-data-sidecar \
+            --network juniper-smoke \
+            --network-alias juniper-data \
+            -p 8100:8100 \
+            juniper-data:ci-${{ github.sha }}
+
+          echo "Waiting for juniper-data to become healthy..."
+          for i in $(seq 1 60); do
+            if docker inspect --format='{{.State.Health.Status}}' juniper-data-sidecar 2>/dev/null | grep -q healthy; then
+              echo "juniper-data is healthy"
+              break
+            fi
+            if [ $i -eq 60 ]; then
+              echo "::error::juniper-data sidecar did not become healthy"
+              docker logs juniper-data-sidecar
+              exit 1
+            fi
+            sleep 2
+          done
+
       - name: Build Docker Image
         run: |
           echo "╔════════════════════════════════════════════════════════════╗"
@@ -605,19 +646,29 @@ jobs:
           echo "╔════════════════════════════════════════════════════════════╗"
           echo "║       Juniper Cascor - Docker Smoke Test                  ║"
           echo "╚════════════════════════════════════════════════════════════╝"
+          # Override JUNIPER_DATA_URL so the readiness probe targets the
+          # sidecar via its Docker network alias instead of the
+          # in-container localhost:8100 default (which would only resolve
+          # if cascor and juniper-data ran in the same container — they
+          # don't here).
           docker run -d --name juniper-cascor-test \
+            --network juniper-smoke \
+            -e JUNIPER_DATA_URL=http://juniper-data:8100 \
             -p 8200:8200 \
             juniper-cascor:ci-${{ github.sha }}
 
-          echo "Waiting for service to become healthy..."
+          echo "Waiting for juniper-cascor to become healthy..."
           for i in $(seq 1 30); do
             if docker inspect --format='{{.State.Health.Status}}' juniper-cascor-test 2>/dev/null | grep -q healthy; then
-              echo "Service is healthy!"
+              echo "juniper-cascor is healthy"
               break
             fi
             if [ $i -eq 30 ]; then
-              echo "::error::Service did not become healthy within 30 attempts"
+              echo "::error::juniper-cascor did not become healthy within 30 attempts"
+              echo "──── juniper-cascor logs ────"
               docker logs juniper-cascor-test
+              echo "──── juniper-data logs ────"
+              docker logs juniper-data-sidecar
               exit 1
             fi
             sleep 2
@@ -630,12 +681,18 @@ jobs:
       - name: Verify Health Endpoint
         run: |
           curl -sf http://localhost:8200/v1/health | python3 -m json.tool
+          # ``/v1/health/ready`` should now be 200 with juniper_data dep
+          # status ``healthy`` thanks to the sidecar.
+          curl -sf http://localhost:8200/v1/health/ready | python3 -m json.tool
 
       - name: Cleanup
         if: always()
         run: |
           docker stop juniper-cascor-test 2>/dev/null || true
           docker rm juniper-cascor-test 2>/dev/null || true
+          docker stop juniper-data-sidecar 2>/dev/null || true
+          docker rm juniper-data-sidecar 2>/dev/null || true
+          docker network rm juniper-smoke 2>/dev/null || true
 
   # ═══════════════════════════════════════════════════════════════════════════════════════════════
   # Required Checks Aggregator: Final quality gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,13 @@ jobs:
 
       - name: Create required directories
         run: |
-          mkdir -p logs src/logs reports/junit reports/htmlcov
+          # ``src/tests/reports`` is required because pyproject.toml's
+          # ``[tool.coverage.run] data_file = "src/tests/reports/.coverage"``
+          # — pytest-cov silently fails to write its parallel ``.coverage.*``
+          # files if the parent dir doesn't exist (gitignored, so absent on
+          # fresh CI checkout), which then leaves the Enforce Coverage Gate
+          # step with "No data to report".
+          mkdir -p logs src/logs reports/junit reports/htmlcov src/tests/reports
 
       - name: Run Unit Tests
         run: |

--- a/.github/workflows/scheduled-tests.yml
+++ b/.github/workflows/scheduled-tests.yml
@@ -82,7 +82,12 @@ jobs:
 
       - name: Create required directories
         run: |
-          mkdir -p logs src/logs reports/junit reports/htmlcov
+          # ``src/tests/reports`` is required because pyproject.toml's
+          # ``[tool.coverage.run] data_file = "src/tests/reports/.coverage"``
+          # — pytest-cov silently fails to write its parallel ``.coverage.*``
+          # files if the parent dir doesn't exist (gitignored, so absent on
+          # fresh CI checkout). See ci.yml for the same fix.
+          mkdir -p logs src/logs reports/junit reports/htmlcov src/tests/reports
 
       - name: Run Slow Unit Tests
         run: |

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -782,20 +782,31 @@ def _cache_logging_system():
 # ===================================================================
 
 
-@pytest.fixture(autouse=True, scope="session")
-def _force_clean_exit():
-    """Force process exit after all tests to prevent hangs from orphaned threads.
+@pytest.hookimpl(trylast=True)
+def pytest_unconfigure(config):
+    """Force process exit after pytest finalize to prevent hangs from orphaned threads.
 
-    Two sources of hangs:
+    Two sources of hangs at session end:
     1. concurrent.futures.thread registers an atexit handler that calls
        shutdown(wait=True) on every live ThreadPoolExecutor.
     2. Non-daemon training threads (e.g. from API integration tests)
        prevent the main thread from exiting even after atexit handlers run.
 
-    We unregister the atexit handler AND use os._exit() as a last resort
-    if non-daemon threads are still alive after tests complete.
+    Earlier (pre-P-6) this lived in a ``scope="session"`` autouse fixture
+    that ran during fixture teardown — *before* pytest's
+    ``pytest_sessionfinish`` (writes JUnit XML, lets pytest-cov save the
+    .coverage data file) and ``pytest_terminal_summary`` (prints the
+    summary line and the coverage report). ``os._exit(0)`` bypasses all
+    Python finalization, so the JUnit XML, coverage data, terminal
+    summary, and HTML coverage report were all silently dropped on every
+    CI run since the fixture was introduced — masked for months by the
+    upstream test failures keeping the gate skipped.
+
+    Moving the logic to ``pytest_unconfigure(trylast=True)`` runs it
+    *after* pytest-cov's own ``pytest_unconfigure`` (and after
+    ``pytest_sessionfinish`` / ``pytest_terminal_summary`` have already
+    fired), so all reports land on disk before we force-exit.
     """
-    yield
     import atexit
     import concurrent.futures.thread as _thread_mod
     import threading

--- a/src/tests/unit/api/test_lifecycle_manager.py
+++ b/src/tests/unit/api/test_lifecycle_manager.py
@@ -1393,7 +1393,11 @@ class TestReplayLifecycleIntegration:
                 state = mgr.replay_control("speed", value=2.5)
                 assert state["speed"] == 2.5
                 state = mgr.replay_control("range", start=1, end=4)
-                assert state["range"] == {"start": 1, "end": 4}
+                # P-2 cluster B (PR #183): the ``range`` action now merges
+                # ``set_range``'s return dict (with re-clamped ``time_index``)
+                # into ``state_summary``, matching the contract asserted by
+                # ``test_replay_control_range`` over the HTTP route surface.
+                assert state["range"] == {"start": 1, "end": 4, "time_index": 3}
             finally:
                 mgr.stop_replay()
         mgr.shutdown()


### PR DESCRIPTION
## Summary

Fixes **P-6** from [POST_V38_OPEN_ISSUES_PLAN_2026-05-03.md](https://github.com/pcalnon/juniper-ml/blob/main/notes/POST_V38_OPEN_ISSUES_PLAN_2026-05-03.md): the ``Enforce Coverage Gate (80%)`` step was failing with ``No data to report`` whenever ``Run Unit Tests`` succeeded — a regression that's been on cascor main since at least 2026-02-25, masked all this time by upstream test-step failures keeping the gate skipped.

## Real root cause (after diagnostic iteration)

The first hypothesis — that pyproject's ``data_file = "src/tests/reports/.coverage"`` plus ``parallel = true`` was failing because the gitignored directory didn't exist on a fresh CI checkout — was wrong (mkdir-only didn't fix the gate). Iteration 2 added a diagnostic step that captured pytest output to disk and inventoried ``reports/``. The result was conclusive: pytest exited 0, but the workspace contained **zero** JUnit XML files, **zero** coverage XML files, **zero** ``.coverage*`` data files anywhere, and ``pytest-output.log`` ended mid-stream at the last test name with no terminal summary line.

Cause: ``src/tests/conftest.py`` had an autouse ``scope="session"`` fixture ``_force_clean_exit`` that called ``os._exit(0)`` from teardown whenever non-daemon threads were still alive at session end (which happens reliably in CI from API integration tests' training threads). Fixture teardown runs *before* pytest's:

- ``pytest_sessionfinish`` — writes JUnit XML, lets pytest-cov save the ``.coverage`` data file
- ``pytest_terminal_summary`` — prints the summary line and the coverage report

``os._exit(0)`` bypasses *all* Python finalization — no atexit, no buffered I/O flush, no plugin teardown. So junit/coverage/summary were silently dropped on every CI run since the fixture landed.

## Fix

| Change | File |
|---|---|
| Move force-exit from fixture teardown to ``pytest_unconfigure(trylast=True)`` | ``src/tests/conftest.py`` |
| Add ``src/tests/reports`` to ``Create required directories`` | ``.github/workflows/ci.yml`` + ``scheduled-tests.yml`` |
| Update ``test_replay_control_seek_speed_range`` to new range-dict contract | ``src/tests/unit/api/test_lifecycle_manager.py`` |

The third change closes a regression that had also been hidden by the ``os._exit(0)`` for two PRs: PR #183 (P-2 cluster B) added ``time_index`` to the ``range`` action's response (matching the contract asserted by ``test_replay_control_range`` over the HTTP route surface), but the sibling test ``test_replay_control_seek_speed_range`` exercising the same code via the manager API was still asserting the old shape. Both tests now agree.

## Test plan

- [x] All Unit Tests + Coverage matrix jobs green (Python 3.12/3.13/3.14 × ubuntu/macOS).
- [x] ``Enforce Coverage Gate (80%)`` step = SUCCESS — final coverage TOTAL=**92.38%**.
- [x] ``reports/coverage.xml`` and ``reports/junit/junit-unit.xml`` are uploaded as artifacts (no ``No files were found`` warnings).
- [x] Pytest summary line printed: ``3115 passed, 15 skipped, 103 deselected``.
- [x] No regression on existing tests.

## Related

- Resurfaces after #183 closed P-2 (test failures had been hiding the gate's true state).
- First successful main CI run since 2026-02-25 (``7ae3dccd``) is expected to follow this PR's merge.