### PR TITLE
metrics(r5-4-pre): cascor training counters + train-step histogram + worker→Prometheus bridge

### DIFF
--- a/notes/observability/HISTOGRAM_BUCKETS_RATIONALE_2026-05-02.md
+++ b/notes/observability/HISTOGRAM_BUCKETS_RATIONALE_2026-05-02.md
@@ -1,17 +1,20 @@
 # juniper-cascor — Histogram Bucket Rationale
 
-**Date:** 2026-05-02 (R4.1 draft) / 2026-05-03 (R5.1b update)
-**METRICS-MON sub-track:** R4.1 / seed-14, plus **R5.1b** (this PR)
-**Status:** §4 and §5 layouts **implemented in R5.1b**. §2 and §3
-remain **tentative pending R5.1** SLO ratification.
+**Date:** 2026-05-02 (R4.1 draft) / 2026-05-03 (R5.1b update) / 2026-05-03 (R5.4-pre §6 add)
+**METRICS-MON sub-track:** R4.1 / seed-14, plus **R5.1b** and **R5.4-pre**
+**Status:** §4, §5 layouts **implemented in R5.1b**. §6 layout
+**implemented in R5.4-pre** (this addendum) and is **born SLO-aligned**
+(no "tentative pending R5.1" suffix — bound to SLO 3.4 in
+juniper-deploy SLO_CATALOG_2026-05-03.md). §2 and §3 remain
+**tentative pending R5.1** SLO ratification.
 **Related:** [`METRICS_MONITORING_R4_ENTRY_PLAN_2026-05-01.md`](https://github.com/pcalnon/juniper-ml/blob/main/notes/code-review/METRICS_MONITORING_R4_ENTRY_PLAN_2026-05-01.md) §3 Q1 (hybrid: document current rationale now; mark tentative; R5.1 ratifies).
 
 ---
 
 ## 1. Inventory
 
-juniper-cascor exposes **four** Prometheus histograms on the production
-surface:
+juniper-cascor exposes **five** Prometheus histograms on the production
+surface (four pre-existing plus one added by R5.4-pre):
 
 | Metric | Labels | Bucket constant | Purpose |
 |---|---|---|---|
@@ -19,13 +22,50 @@ surface:
 | `cascor_ws_resume_replayed_events` | _(none)_ | `_WS_RESUME_REPLAY_BUCKETS` (local) | Number of buffered events replayed when a WebSocket client successfully resumes via the seq-replay handshake. **Discrete count, not duration.** |
 | `cascor_ws_broadcast_send_duration_seconds` | `type` | `_WS_SUB_MS_LATENCY_BUCKETS` (R5.1b) | Wall-clock for individual WebSocket `send_*` operations on a single client. |
 | `cascor_ws_command_handler_seconds` | `command` | `_WS_SUB_MS_LATENCY_BUCKETS` (R5.1b) | Wall-clock for command-handler dispatch (e.g. `pause`, `resume`, `start_training`). |
+| `juniper_cascor_training_step_duration_seconds` | `phase` | `_TRAINING_STEP_DURATION_BUCKETS` (R5.4-pre) | Wall-clock around one forward+backward+update cycle of the cascor train loop (one output-phase epoch over the training batch). Binds SLO 3.4. |
 
-As of **R5.1b** (this PR) all four histograms now carry explicit
+As of **R5.1b** all four pre-existing histograms carry explicit
 buckets chosen for their distribution shape. The two WebSocket
 latency histograms previously used the Prometheus default layout
 (`(.005, .01, .025, .05, .075, .1, .25, .5, .75, 1, 2.5, 5, 7.5, 10,
 +inf)`); they have been re-bucketed to the shared
-`_WS_SUB_MS_LATENCY_BUCKETS` constant — see §4.
+`_WS_SUB_MS_LATENCY_BUCKETS` constant — see §4. The fifth metric is
+new in R5.4-pre — see §6.
+
+### 1.1 Train-step boundary choice (R5.4-pre)
+
+The `juniper_cascor_training_step_duration_seconds` histogram is
+emitted from the **api-lifecycle** layer (`api.lifecycle.manager`'s
+`_output_training_callback`), measuring the delta between successive
+per-epoch callback invocations using `time.perf_counter`. A single
+emission represents one output-phase epoch — the train loop's
+forward + backward + optimizer-step over the entire training batch.
+
+Two boundary alternatives were considered:
+
+- **Per mini-batch step** inside `cascade_correlation.cascade_correlation`
+  (around `loss.backward(); optimizer.step()`). Rejected: that file
+  lives below the api boundary and adding a Prometheus dependency
+  there would couple the neural-net layer to the observability
+  surface. Rejected per layering discipline.
+- **Per epoch at the api-lifecycle level** (chosen). The boundary
+  that the existing `_output_training_callback` already wraps; the
+  same span the `cascor_ws_command_handler_seconds` histogram covers
+  but at a different code level (api-lifecycle vs. WS command
+  dispatch). The "step" naming aligns with the SLO catalog's
+  vocabulary even though the granularity is one cascor epoch — for
+  the cascade correlation algorithm the per-epoch path IS the
+  forward+backward+update granularity at the api layer, and matches
+  the SLO target ("p95 < 5 s") which was authored against this
+  layer's emission rate.
+
+**I/O exclusion.** The measurement is wall-clock `perf_counter`
+deltas around the in-thread training step; there is no network /
+disk I/O inside the boundary (data is already loaded as tensors when
+fit() runs). The candidate-phase epoch loop is NOT instrumented in
+this PR — the `phase` label is currently only ever `"output"`. A
+follow-up may wire candidate-phase emission once the candidate-loop
+callback contract stabilises.
 
 ---
 
@@ -201,7 +241,70 @@ event, not just a re-bucket, and is out of scope for R5.1b.
 
 ---
 
-## 6. R5.1 ratification queue
+## 6. `juniper_cascor_training_step_duration_seconds`
+
+### 6.1 Bucket layout
+
+**Implemented in R5.4-pre (this addendum).** Defined as
+`_TRAINING_STEP_DURATION_BUCKETS` in `src/api/observability.py`:
+
+```python
+_TRAINING_STEP_DURATION_BUCKETS: tuple = (
+    0.05,    # 50 ms
+    0.1,     # 100 ms
+    0.5,     # 500 ms
+    1.0,     # 1 s
+    2.0,     # 2 s
+    5.0,     # 5 s — SLO 3.4 p95 target
+    10.0,    # 10 s
+    30.0,    # 30 s
+    float("inf"),
+)
+```
+
+9 buckets including `+inf`. Spans 3 orders of magnitude (50 ms → 30 s).
+
+### 6.2 Rationale per boundary
+
+Targets SLO 3.4 ("p95 train-step duration < 5 s"; see juniper-deploy
+`notes/SLO_CATALOG_2026-05-03.md` §3.4) and bracket every legitimate
+operational regime — fast steps on small models with hot caches up
+through slow steps on large networks or saturated GPUs.
+
+| Boundary | What it discriminates | SLO target served |
+|---|---|---|
+| **0.05 s (50 ms)** | Hot-cache step on a tiny network (~10 hidden units, small batch). Floor of the healthy regime. | Useful for "ideal" floor / capacity headroom queries. |
+| **0.1 s (100 ms)** | Typical sub-second step on a small-to-medium network. | Operational signal. |
+| **0.5 s (500 ms)** | Mid-sized network step under nominal load. | Operational signal. |
+| **1.0 s (1 s)** | Approaching the warning band — large network, modest batch. | **Candidate** for an "early warning" alert at p95. |
+| **2.0 s (2 s)** | Resolution boundary just below the SLO target. | Quantile precision around the SLO. |
+| **5.0 s (5 s)** | **SLO 3.4 p95 target.** The load-bearing boundary. | **Required** by SLO 3.4 PromQL. |
+| **10.0 s (10 s)** | "Slow step" — large network on a saturated GPU, OR I/O contention if the boundary leaks. | Alert threshold candidate. |
+| **30.0 s (30 s)** | Pathological — usually indicates GPU contention with another tenant or a swap-thrashing host. | Pageable threshold. |
+| **+inf** | Mandatory upper bound. | — |
+
+### 6.3 Trade-off
+
+9 buckets is denser than the WS sub-ms layout (8) but appropriate for
+the wider operational range (50 ms → 30 s spans 600x; the WS layout
+spans 1000x in 8 boundaries because the distribution is bimodal
+between sub-ms healthy and slow-path commands). The 5 s boundary is
+load-bearing and may NOT be removed without SLO-catalog renegotiation.
+
+### 6.4 R5.4-pre implementation note
+
+The HELP line carries the explicit SLO callout (`Buckets target SLO
+3.4 (p95 < 5s); see SLO_CATALOG §3.4 in juniper-deploy.`) and does
+NOT carry the `(R4.1 buckets tentative pending R5.1)` suffix — this
+metric is born SLO-aligned. The metric is emitted at the
+api-lifecycle layer (see §1.1 for the boundary discussion); the
+`phase` label is currently always `"output"` because only the
+output-phase epoch callback is instrumented. Candidate / input phase
+emission is on the R5.4 follow-up queue.
+
+---
+
+## 7. R5.1 ratification queue
 
 When R5.1 designs the cascor SLO catalog:
 
@@ -225,7 +328,7 @@ When R5.1 designs the cascor SLO catalog:
 
 ---
 
-## 7. Process notes
+## 8. Process notes
 
 - HELP-string markers: as of R5.1b, the two re-bucketed histograms
   (`cascor_ws_broadcast_send_duration_seconds` and

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -58,6 +58,53 @@ def _log_startup_task_exception(task: asyncio.Task) -> None:
         logger.error("Startup task %s failed: %s", task.get_name(), exc, exc_info=exc)
 
 
+def _register_worker_metrics_collector(app: FastAPI, settings: Settings, worker_registry: WorkerRegistry) -> None:
+    """Register the worker -> Prometheus bridge collector at startup.
+
+    METRICS-MON R5.4-pre: closes the gap flagged by R5.1
+    (juniper-deploy#48) and R5.3 (juniper-deploy#46) — heartbeat
+    freshness, last-task duration, recent-task p50/p95, and GPU
+    utilisation are now exposed on the cascor ``/metrics`` surface for
+    two internal SLIs and the operator dashboard. Single-registration
+    per R1.4: the collector instance is held on ``app.state`` so the
+    shutdown path can unregister it cleanly when the lifespan exits.
+    Extracted from the lifespan handler purely for cyclomatic-complexity
+    discipline (flake8 C901 budget) — the initialization itself is
+    one-shot and unconditional given ``metrics_enabled``.
+    """
+    if not settings.metrics_enabled:
+        return
+
+    from prometheus_client import REGISTRY
+
+    from api.workers.metrics import WorkerRegistryCollector
+
+    worker_metrics_collector = WorkerRegistryCollector(worker_registry)
+    REGISTRY.register(worker_metrics_collector)
+    app.state.worker_metrics_collector = worker_metrics_collector
+    logger.info("Worker -> Prometheus bridge collector registered")
+
+
+def _unregister_worker_metrics_collector(app: FastAPI) -> None:
+    """Unregister the worker bridge collector at shutdown.
+
+    METRICS-MON R5.4-pre: re-creating the app (test harness, in-process
+    restart) without unregistering would trip the prometheus_client
+    "duplicated metric" guard. Best-effort: a missing or already-gone
+    collector is logged at debug level rather than raised.
+    """
+    worker_metrics_collector = getattr(app.state, "worker_metrics_collector", None)
+    if worker_metrics_collector is None:
+        return
+    try:
+        from prometheus_client import REGISTRY
+
+        REGISTRY.unregister(worker_metrics_collector)
+        logger.info("Worker -> Prometheus bridge collector unregistered")
+    except Exception as exc:
+        logger.debug("Best-effort worker collector unregister failed: %s", exc)
+
+
 def _init_worker_security(app: FastAPI, settings: Settings, worker_coordinator: WorkerCoordinator) -> None:
     """Initialize optional worker-security subsystems based on feature flags."""
     if settings.worker_rate_limit_enabled:
@@ -141,6 +188,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     lifecycle.set_worker_coordinator(worker_coordinator)
     logger.info("Worker registry and coordinator initialized")
 
+    _register_worker_metrics_collector(app, settings, worker_registry)
+
     # Worker Security (Phase 4) — conditionally initialize based on feature flags
     _init_worker_security(app, settings, worker_coordinator)
 
@@ -201,6 +250,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         for task in in_flight_startup_tasks:
             task.cancel()
         await asyncio.gather(*in_flight_startup_tasks, return_exceptions=True)
+
+    _unregister_worker_metrics_collector(app)
 
     # Shutdown: stop worker coordinator
     worker_coordinator = getattr(app.state, "worker_coordinator", None)

--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -20,6 +20,7 @@ import torch
 
 from api.lifecycle.monitor import TrainingMonitor, TrainingState
 from api.lifecycle.state_machine import Command, TrainingPhase, TrainingStateMachine
+from api.observability import TRAINING_SESSION_STATUS_CANCELLED, TRAINING_SESSION_STATUS_FAILURE, TRAINING_SESSION_STATUS_SUCCESS, inc_training_session_completed, observe_training_step_duration
 from cascor_constants.constants_api import _PROJECT_API_DRAIN_THREAD_JOIN_TIMEOUT, _PROJECT_API_LIFECYCLE_DEFAULT_CANDIDATE_PATIENCE, _PROJECT_API_LIFECYCLE_DEFAULT_EPOCHS_MAX, _PROJECT_API_LIFECYCLE_DEFAULT_MAX_HIDDEN_UNITS, _PROJECT_API_LIFECYCLE_DEFAULT_MAX_ITERATIONS, _PROJECT_API_NETWORK_INPUT_SIZE_DEFAULT, _PROJECT_API_NETWORK_LEARNING_RATE_DEFAULT, _PROJECT_API_NETWORK_OUTPUT_SIZE_DEFAULT, _PROJECT_API_PROGRESS_QUEUE_GET_TIMEOUT, _PROJECT_API_PROGRESS_QUEUE_WAIT_TIMEOUT
 
 
@@ -666,6 +667,17 @@ class TrainingLifecycleManager:
         sm = self.state_machine
         manager_ref = self
 
+        # METRICS-MON R5.4-pre: per-fit closure box that holds the
+        # ``time.perf_counter()`` of the most recent epoch boundary so
+        # ``_output_training_callback`` can compute the train-step
+        # duration as a delta between successive callback invocations.
+        # The box is reset by ``monitored_fit`` on each new fit() entry
+        # so observations from the previous run never leak into the next
+        # one. ``None`` means "no prior boundary recorded yet" — the
+        # first callback of a fit() seeds the timer instead of emitting
+        # a bogus first-epoch sample.
+        _step_timer: dict[str, float | None] = {"prev": None}
+
         def _output_training_callback(epoch, epochs, loss):
             monitor.on_epoch_end(
                 epoch=epoch,
@@ -678,9 +690,32 @@ class TrainingLifecycleManager:
                 current_epoch=epoch,
                 phase_detail="training_output",
             )
+            # METRICS-MON R5.4-pre: train-step duration histogram. One
+            # output-phase epoch == one forward+backward+update cycle
+            # over the training batch (see HISTOGRAM_BUCKETS_RATIONALE
+            # §6 for the boundary discussion). Measured as the delta
+            # between successive callback invocations using
+            # ``time.perf_counter`` so the sample reflects actual
+            # compute time and is robust to wall-clock adjustments. The
+            # first callback of a fit() seeds the timer and emits no
+            # sample; subsequent callbacks emit the time-since-prior.
+            now = time.perf_counter()
+            prev = _step_timer["prev"]
+            if prev is not None:
+                try:
+                    observe_training_step_duration("output", now - prev)
+                except Exception:
+                    # Defensive: never let metrics emission break the
+                    # train loop. The metric is best-effort by design.
+                    manager_ref.logger.debug("training_step_duration emission failed", exc_info=True)
+            _step_timer["prev"] = now
 
         def monitored_fit(x, y, x_val=None, y_val=None, **kwargs):
             manager_ref._last_emitted_history_len = 0
+            # METRICS-MON R5.4-pre: reset the per-fit step timer so
+            # observations from a previous fit() can't leak into this
+            # one (e.g. across retrain or resume_from_snapshot).
+            _step_timer["prev"] = None
             monitor.on_training_start()
             # BUG-CC-07: phase is updated via state-machine wrapper, not manually.
             sm.handle_command(Command.START)
@@ -701,16 +736,25 @@ class TrainingLifecycleManager:
                     sm.handle_command(Command.STOP)
                     state.update_state(status="Stopped", phase="Idle")
                     manager_ref._broadcast_training_state(force=True)
+                    # METRICS-MON R5.4-pre: terminal transition —
+                    # session was cancelled by an explicit stop request.
+                    inc_training_session_completed(TRAINING_SESSION_STATUS_CANCELLED)
                 else:
                     sm.mark_completed()
                     state.update_state(status="Completed", phase="Idle")
                     manager_ref._broadcast_training_state(force=True)
+                    # METRICS-MON R5.4-pre: terminal transition —
+                    # session reached convergence / max-iterations cleanly.
+                    inc_training_session_completed(TRAINING_SESSION_STATUS_SUCCESS)
 
                 return result
             except Exception as e:
                 sm.mark_failed(str(e))
                 state.update_state(status="Failed", phase="Idle")
                 manager_ref._broadcast_training_state(force=True)
+                # METRICS-MON R5.4-pre: terminal transition — session
+                # ended with an unhandled exception.
+                inc_training_session_completed(TRAINING_SESSION_STATUS_FAILURE)
                 raise
             finally:
                 monitor.on_training_end()

--- a/src/api/observability.py
+++ b/src/api/observability.py
@@ -136,6 +136,28 @@ def configure_sentry(dsn: str | None, service_name: str, version: str) -> None:
 
 _training_metrics: dict | None = None
 
+# METRICS-MON R5.4-pre: bucket layout for the train-step duration
+# histogram. Targets SLO 3.4 ("p95 train-step duration < 5 s"; see
+# juniper-deploy notes/SLO_CATALOG_2026-05-03.md §3.4) and bracket every
+# legitimate operational regime: sub-100 ms (small models, hot cache),
+# ~1 s (typical mid-sized network output-phase epoch), 5 s (SLO p95
+# target), 30 s (saturated GPU / very large network). Boundaries are
+# logarithmic-ish to keep bucket count low (9 incl. +inf) while still
+# giving quantile-precision around the SLO target. Per-boundary
+# rationale in
+# ``notes/observability/HISTOGRAM_BUCKETS_RATIONALE_2026-05-02.md`` §6.
+_TRAINING_STEP_DURATION_BUCKETS: tuple = (
+    0.05,  # 50 ms
+    0.1,  # 100 ms
+    0.5,  # 500 ms
+    1.0,  # 1 s
+    2.0,  # 2 s
+    5.0,  # 5 s — SLO 3.4 p95 target
+    10.0,  # 10 s
+    30.0,  # 30 s
+    float("inf"),
+)
+
 
 def _ensure_training_metrics() -> dict:
     """Create training-related Prometheus metrics on first access."""
@@ -147,6 +169,20 @@ def _ensure_training_metrics() -> dict:
             "sessions_active": Gauge(
                 "juniper_cascor_training_sessions_active",
                 "Number of currently active training sessions",
+            ),
+            # METRICS-MON R5.4-pre: terminal-transition counter that
+            # binds SLO 3.3 (training-session success ratio). Closed-set
+            # ``status`` label values — ``success`` / ``failure`` /
+            # ``cancelled`` — per R1.1 cardinality discipline. Bumped
+            # exactly once per terminal FSM transition by the lifecycle
+            # manager. SLO PromQL:
+            #   sum(rate(juniper_cascor_training_sessions_completed_total{status="success"}[5m]))
+            #   / sum(rate(juniper_cascor_training_sessions_completed_total[5m]))
+            # See juniper-deploy notes/SLO_CATALOG_2026-05-03.md §3.3.
+            "sessions_completed_total": Counter(
+                "juniper_cascor_training_sessions_completed_total",
+                "Total terminal training-session transitions by outcome (closed-set status)",
+                ["status"],
             ),
             "epochs_total": Counter(
                 "juniper_cascor_training_epochs_total",
@@ -182,6 +218,22 @@ def _ensure_training_metrics() -> dict:
                 # ``notes/observability/HISTOGRAM_BUCKETS_RATIONALE_2026-05-02.md``.
                 "Inference latency in seconds (R4.1 buckets tentative pending R5.1)",
                 buckets=_LOGGER_PROMETHEUS_LATENCY_BUCKETS,
+            ),
+            # METRICS-MON R5.4-pre: train-step duration histogram born
+            # SLO-aligned (no "tentative pending R5.1" suffix). Buckets
+            # target SLO 3.4 (p95 < 5s); see SLO_CATALOG §3.4 in
+            # juniper-deploy and §6 of
+            # ``notes/observability/HISTOGRAM_BUCKETS_RATIONALE_2026-05-02.md``
+            # for per-boundary rationale and the train-step boundary
+            # choice. The metric measures wall-clock around one
+            # forward+backward+update cycle (an "epoch" at the
+            # api-lifecycle level — see §1 / §6 of the rationale doc for
+            # the boundary discussion).
+            "step_duration_seconds": Histogram(
+                "juniper_cascor_training_step_duration_seconds",
+                "Buckets target SLO 3.4 (p95 < 5s); see SLO_CATALOG §3.4 in juniper-deploy.",
+                ["phase"],
+                buckets=_TRAINING_STEP_DURATION_BUCKETS,
             ),
         }
     return _training_metrics
@@ -254,6 +306,58 @@ def record_inference(duration: float) -> None:
     m = _ensure_training_metrics()
     m["inference_requests_total"].inc()
     m["inference_duration_seconds"].observe(duration)
+
+
+# METRICS-MON R5.4-pre: closed-set status values for the
+# ``training_sessions_completed_total`` counter (R1.1 cardinality
+# discipline — every increment site MUST pass one of these strings).
+TRAINING_SESSION_STATUS_SUCCESS: str = "success"
+TRAINING_SESSION_STATUS_FAILURE: str = "failure"
+TRAINING_SESSION_STATUS_CANCELLED: str = "cancelled"
+_TRAINING_SESSION_STATUSES: frozenset[str] = frozenset(
+    {
+        TRAINING_SESSION_STATUS_SUCCESS,
+        TRAINING_SESSION_STATUS_FAILURE,
+        TRAINING_SESSION_STATUS_CANCELLED,
+    }
+)
+
+
+def inc_training_session_completed(status: str) -> None:
+    """Increment the terminal-transition counter for a training session.
+
+    METRICS-MON R5.4-pre: bumped exactly once per terminal FSM transition
+    by the lifecycle manager. Binds SLO 3.3 (training-session success
+    ratio) — see juniper-deploy notes/SLO_CATALOG_2026-05-03.md §3.3.
+
+    Args:
+        status: One of ``"success"``, ``"failure"``, or ``"cancelled"``
+            (closed set, R1.1 cardinality discipline).
+
+    Raises:
+        ValueError: If ``status`` is not in the closed set. Catches
+            instrumentation drift early rather than silently emitting
+            high-cardinality labels.
+    """
+    if status not in _TRAINING_SESSION_STATUSES:
+        raise ValueError(f"invalid training-session status {status!r}; expected one of {sorted(_TRAINING_SESSION_STATUSES)!r}")
+    _ensure_training_metrics()["sessions_completed_total"].labels(status=status).inc()
+
+
+def observe_training_step_duration(phase: str, duration: float) -> None:
+    """Record a single train-step duration observation.
+
+    METRICS-MON R5.4-pre: measures wall-clock around one
+    forward+backward+update cycle. Binds SLO 3.4 (p95 train-step
+    duration < 5 s) — see juniper-deploy notes/SLO_CATALOG_2026-05-03.md
+    §3.4 and §6 of the cascor histogram-buckets rationale doc.
+
+    Args:
+        phase: Training phase — "output", "candidate", or "input".
+        duration: Step duration in seconds (typically a
+            ``time.perf_counter`` delta).
+    """
+    _ensure_training_metrics()["step_duration_seconds"].labels(phase=phase).observe(duration)
 
 
 # ---------------------------------------------------------------------------

--- a/src/api/workers/metrics.py
+++ b/src/api/workers/metrics.py
@@ -1,0 +1,204 @@
+"""Worker -> Prometheus bridge collector (METRICS-MON R5.4-pre).
+
+The R4.4 PR added three training-loop instrumentation fields to
+``WorkerRegistration`` (``last_task_duration_seconds``,
+``recent_task_durations_seconds``, ``gpu_utilization_pct``) plus
+``last_heartbeat`` from the original R1.3 work, but never exposed any
+of them on the cascor Prometheus surface — they were JSON-only via
+``/v1/workers``. The R5.1 SLO catalog (juniper-deploy#48) and the R5.3
+operator dashboard (juniper-deploy#46) both flagged this as the
+missing surface for two internal-supporting SLIs ("worker heartbeat
+freshness" and "worker recent task duration p95").
+
+This module defines :class:`WorkerRegistryCollector`, a
+``prometheus_client``-compatible custom collector that holds a
+reference to the in-process :class:`WorkerRegistry` and snapshots it
+on every ``collect()`` call. The collector emits, **per worker**:
+
+- ``juniper_cascor_worker_last_task_duration_seconds{worker_id}``
+  (Gauge) — wall-clock duration of the most recently completed task.
+- ``juniper_cascor_worker_gpu_utilization_pct{worker_id}`` (Gauge) —
+  best-effort 0-100 reading.
+- ``juniper_cascor_worker_recent_task_duration_seconds_p50{worker_id}``
+  (Gauge) — p50 over the registration's sliding window of recent
+  durations.
+- ``juniper_cascor_worker_recent_task_duration_seconds_p95{worker_id}``
+  (Gauge) — p95 over the same window.
+- ``juniper_cascor_worker_heartbeat_age_seconds{worker_id}`` (Gauge)
+  — ``time.time() - last_heartbeat``.
+
+**Gauge-omission strategy.** Workers that haven't reported a given
+field (``None`` on the registration) are NOT emitted with a zero
+value — Prometheus interprets a missing series as "no data" which is
+the correct semantic for "no observation yet". Specifically:
+
+- ``last_task_duration_seconds`` / ``gpu_utilization_pct``: skipped
+  when ``None``.
+- ``recent_task_duration_seconds_p50/p95``: skipped when the window
+  has fewer than 2 samples (``statistics.quantiles`` requires >=2).
+- ``heartbeat_age_seconds``: always emitted (every registered worker
+  has a ``last_heartbeat`` populated by the registration constructor).
+
+Per R1.4 single-registration discipline the collector instance must
+be registered with the cascor ``prometheus_client.REGISTRY`` exactly
+once at startup; the lifespan handler in :mod:`api.app` performs that
+registration.
+
+References:
+
+- ``notes/code-review/SLO_CATALOG_2026-05-03.md`` (juniper-deploy#48,
+  §3.3 / §3.4 / supporting-SLI catalog).
+- ``notes/observability/HISTOGRAM_BUCKETS_RATIONALE_2026-05-02.md`` —
+  the rationale for buckets, not directly relevant here (these are
+  gauges) but referenced because future histogramization of
+  ``recent_task_durations_seconds`` is on the R5.4 follow-up queue.
+"""
+
+from __future__ import annotations
+
+import logging
+import statistics
+import time
+from typing import TYPE_CHECKING, Callable, Iterable
+
+if TYPE_CHECKING:
+    from prometheus_client.core import Metric
+
+    from api.workers.registry import WorkerRegistry
+
+logger = logging.getLogger("juniper_cascor.api.workers.metrics")
+
+
+# METRICS-MON R5.4-pre: emitted metric names. Kept module-level so the
+# regression test can assert exact wire shape without importing
+# private symbols.
+_METRIC_LAST_TASK_DURATION: str = "juniper_cascor_worker_last_task_duration_seconds"
+_METRIC_GPU_UTILIZATION_PCT: str = "juniper_cascor_worker_gpu_utilization_pct"
+_METRIC_RECENT_DURATION_P50: str = "juniper_cascor_worker_recent_task_duration_seconds_p50"
+_METRIC_RECENT_DURATION_P95: str = "juniper_cascor_worker_recent_task_duration_seconds_p95"
+_METRIC_HEARTBEAT_AGE: str = "juniper_cascor_worker_heartbeat_age_seconds"
+
+
+class WorkerRegistryCollector:
+    """Bridge a :class:`WorkerRegistry` snapshot to Prometheus on each scrape.
+
+    Intentionally NOT a subclass of any prometheus_client type — the
+    library uses duck-typing on ``collect()`` so a plain class with
+    that one method works everywhere a ``Collector`` does. This keeps
+    the unit test free of prometheus_client registry side-effects (the
+    test instantiates the class directly and calls ``collect()``).
+
+    Args:
+        registry: The cascor :class:`WorkerRegistry` to snapshot. The
+            collector keeps a reference and re-reads it on every
+            scrape; it does NOT copy on construction.
+        time_source: Optional callable returning the current wall-clock
+            time as a float (defaults to :func:`time.time`). Injected
+            for deterministic unit tests.
+    """
+
+    def __init__(
+        self,
+        registry: "WorkerRegistry",
+        *,
+        time_source: Callable[[], float] = time.time,
+    ) -> None:
+        self._registry = registry
+        self._now = time_source
+
+    def collect(self) -> Iterable["Metric"]:  # noqa: D401 — prometheus_client interface
+        """Snapshot the registry and emit per-worker gauge samples.
+
+        Called by ``prometheus_client.REGISTRY`` on every ``/metrics``
+        scrape. All sample emission is best-effort — a malformed
+        registration is logged and skipped rather than failing the
+        scrape.
+        """
+        # Local imports keep prometheus_client an optional runtime
+        # dependency at module import time (the cascor pattern in
+        # ``observability.py``).
+        from prometheus_client.core import GaugeMetricFamily
+
+        last_task_duration = GaugeMetricFamily(
+            _METRIC_LAST_TASK_DURATION,
+            "Wall-clock duration of the most recently completed task on this worker.",
+            labels=["worker_id"],
+        )
+        gpu_utilization = GaugeMetricFamily(
+            _METRIC_GPU_UTILIZATION_PCT,
+            "Best-effort 0-100 GPU utilization reading on this worker (CUDA / NVML / torch).",
+            labels=["worker_id"],
+        )
+        recent_p50 = GaugeMetricFamily(
+            _METRIC_RECENT_DURATION_P50,
+            "p50 of the worker's sliding window of recent task durations (seconds).",
+            labels=["worker_id"],
+        )
+        recent_p95 = GaugeMetricFamily(
+            _METRIC_RECENT_DURATION_P95,
+            "p95 of the worker's sliding window of recent task durations (seconds).",
+            labels=["worker_id"],
+        )
+        heartbeat_age = GaugeMetricFamily(
+            _METRIC_HEARTBEAT_AGE,
+            "Seconds since the worker's last heartbeat. Critical for SLI 'heartbeat freshness'.",
+            labels=["worker_id"],
+        )
+
+        now = self._now()
+        try:
+            workers = self._registry.get_all_workers()
+        except Exception:
+            logger.exception("WorkerRegistryCollector failed to snapshot registry — emitting empty scrape")
+            workers = []
+
+        for reg in workers:
+            try:
+                worker_id = reg.worker_id
+
+                # Always emit heartbeat age — every registration has a
+                # ``last_heartbeat`` populated by the constructor.
+                heartbeat_age.add_metric([worker_id], max(0.0, now - reg.last_heartbeat))
+
+                # Optional fields: skip on None / empty (do NOT zero-emit).
+                if reg.last_task_duration_seconds is not None:
+                    last_task_duration.add_metric([worker_id], float(reg.last_task_duration_seconds))
+
+                if reg.gpu_utilization_pct is not None:
+                    gpu_utilization.add_metric([worker_id], float(reg.gpu_utilization_pct))
+
+                # ``statistics.quantiles`` requires at least 2 samples;
+                # below that threshold any percentile is degenerate so
+                # we omit rather than emit a misleading value.
+                window = list(reg.recent_task_durations_seconds or [])
+                if len(window) >= 2:
+                    p50, p95 = _percentiles(window)
+                    recent_p50.add_metric([worker_id], p50)
+                    recent_p95.add_metric([worker_id], p95)
+            except Exception:
+                logger.exception(
+                    "WorkerRegistryCollector skipping malformed registration (worker_id=%r)",
+                    getattr(reg, "worker_id", "<unknown>"),
+                )
+
+        yield heartbeat_age
+        yield last_task_duration
+        yield gpu_utilization
+        yield recent_p50
+        yield recent_p95
+
+
+def _percentiles(samples: list[float]) -> tuple[float, float]:
+    """Compute (p50, p95) over a list of floats.
+
+    Uses :func:`statistics.quantiles` with ``n=20`` so the boundary at
+    index 9 is the 50th percentile (10/20) and the boundary at index
+    18 is the 95th percentile (19/20). Caller MUST guarantee
+    ``len(samples) >= 2`` — :func:`statistics.quantiles` raises on
+    fewer.
+    """
+    qs = statistics.quantiles(samples, n=20, method="inclusive")
+    # qs has 19 cut points: qs[i] is the (i+1)/20 percentile.
+    p50 = qs[9]
+    p95 = qs[18]
+    return float(p50), float(p95)

--- a/src/tests/unit/api/test_metrics_r5_4_pre.py
+++ b/src/tests/unit/api/test_metrics_r5_4_pre.py
@@ -1,0 +1,443 @@
+"""METRICS-MON R5.4-pre regression tests.
+
+Covers the three instrumentation gaps closed by R5.4-pre:
+
+1. ``juniper_cascor_training_sessions_completed_total`` — closed-set
+   ``status`` counter bumped at every terminal lifecycle transition.
+2. ``juniper_cascor_training_step_duration_seconds`` — train-step
+   duration histogram emitted from the api-lifecycle output-phase
+   epoch callback.
+3. :class:`api.workers.metrics.WorkerRegistryCollector` — bridge that
+   snapshots :class:`WorkerRegistry` on each scrape and emits per-worker
+   gauges, omitting unset fields rather than zero-emitting.
+"""
+
+import logging
+import time
+
+import pytest
+
+from api.observability import TRAINING_SESSION_STATUS_CANCELLED, TRAINING_SESSION_STATUS_FAILURE, TRAINING_SESSION_STATUS_SUCCESS, _ensure_training_metrics, inc_training_session_completed, observe_training_step_duration
+
+
+def _reset_training_metrics() -> None:
+    """Force lazy re-init so each test sees a fresh metric set.
+
+    Mirrors the pattern used by the existing R5.1b shim tests in
+    ``test_api_observability.py``: drop the cached dict, unregister
+    each metric from the global REGISTRY, and let the next access
+    recreate the family. Keeps tests order-independent and avoids the
+    "Duplicated timeseries" guard that prometheus_client raises on
+    re-registration.
+    """
+    from prometheus_client import REGISTRY
+
+    import api.observability as obs
+
+    if obs._training_metrics is not None:
+        for metric in list(obs._training_metrics.values()):
+            try:
+                REGISTRY.unregister(metric)
+            except Exception as exc:
+                logging.getLogger(__name__).debug("Best-effort training-metric unregister failed for %r: %s", metric, exc)
+        obs._training_metrics = None
+
+
+@pytest.mark.unit
+class TestTrainingSessionsCompletedCounter:
+    """Gap 1 — terminal-transition counter for SLO 3.3."""
+
+    def setup_method(self):
+        _reset_training_metrics()
+
+    def teardown_method(self):
+        _reset_training_metrics()
+
+    def _value(self, status: str) -> float:
+        m = _ensure_training_metrics()["sessions_completed_total"]
+        return m.labels(status=status)._value.get()
+
+    def test_each_status_increments_counter(self):
+        """Every closed-set status increments by exactly 1 per call."""
+        for status in (TRAINING_SESSION_STATUS_SUCCESS, TRAINING_SESSION_STATUS_FAILURE, TRAINING_SESSION_STATUS_CANCELLED):
+            before = self._value(status)
+            inc_training_session_completed(status)
+            after = self._value(status)
+            assert after - before == pytest.approx(1.0), f"counter for status={status!r} did not increment by 1"
+
+    def test_repeated_increments_accumulate(self):
+        """Multiple terminal transitions accumulate correctly."""
+        before = self._value(TRAINING_SESSION_STATUS_SUCCESS)
+        for _ in range(5):
+            inc_training_session_completed(TRAINING_SESSION_STATUS_SUCCESS)
+        after = self._value(TRAINING_SESSION_STATUS_SUCCESS)
+        assert after - before == pytest.approx(5.0)
+
+    def test_invalid_status_raises_value_error(self):
+        """R1.1 cardinality discipline: open-set values are rejected."""
+        with pytest.raises(ValueError, match="invalid training-session status"):
+            inc_training_session_completed("rolled_back")  # not in the closed set
+
+    def test_label_set_is_exactly_three_values(self):
+        """The closed set is exactly {success, failure, cancelled}."""
+        from api.observability import _TRAINING_SESSION_STATUSES
+
+        assert _TRAINING_SESSION_STATUSES == frozenset({"success", "failure", "cancelled"})
+
+
+@pytest.mark.unit
+class TestTrainingStepDurationHistogram:
+    """Gap 2 — train-step duration histogram for SLO 3.4."""
+
+    EXPECTED_UPPER_BOUNDS = [0.05, 0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, float("inf")]
+
+    def setup_method(self):
+        _reset_training_metrics()
+
+    def teardown_method(self):
+        _reset_training_metrics()
+
+    def test_buckets_match_constant(self):
+        """Histogram is wired to the R5.4-pre bucket layout."""
+        from api.observability import _TRAINING_STEP_DURATION_BUCKETS
+
+        assert list(_TRAINING_STEP_DURATION_BUCKETS) == self.EXPECTED_UPPER_BOUNDS
+        hist = _ensure_training_metrics()["step_duration_seconds"]
+        # ``_upper_bounds`` includes the implicit ``+inf`` upper edge.
+        assert hist._upper_bounds == self.EXPECTED_UPPER_BOUNDS
+
+    def test_help_string_carries_slo_marker(self):
+        """The HELP line points at SLO 3.4 and does NOT carry the R4.1 tentative suffix."""
+        hist = _ensure_training_metrics()["step_duration_seconds"]
+        assert "SLO 3.4" in hist._documentation
+        assert "tentative pending R5.1" not in hist._documentation
+        assert "(R4.1 buckets tentative pending R5.1)" not in hist._documentation
+
+    def test_observation_lands_in_expected_bucket(self):
+        """A 0.7 s sample increments the (0.5, 1.0] bucket exactly.
+
+        ``prometheus_client``'s internal ``_buckets`` array stores a
+        non-cumulative count per bucket (the WIRE-format cumulative
+        view is computed at scrape time). A 0.7 s observation sits in
+        the half-open interval (0.5, 1.0] and so increments the bucket
+        whose upper bound is 1.0 — and ONLY that bucket.
+        """
+        observe_training_step_duration("output", 0.7)
+
+        hist = _ensure_training_metrics()["step_duration_seconds"]
+        labelled = hist.labels(phase="output")
+        bucket_counts = {ub: bucket.get() for ub, bucket in zip(hist._upper_bounds, labelled._buckets)}
+
+        assert bucket_counts[1.0] == 1, f"sample of 0.7 must land in the le=1.0 bucket: counts={bucket_counts}"
+        for ub, count in bucket_counts.items():
+            if ub == 1.0:
+                continue
+            assert count == 0, f"unexpected count {count} in bucket le={ub} — only le=1.0 should fire for a 0.7 s sample"
+
+        # The cumulative contract IS still observable via _sum and the
+        # final +inf observation count: every observation contributes
+        # to _sum exactly once.
+        assert labelled._sum.get() == pytest.approx(0.7)
+
+    def test_phase_label_supports_output(self):
+        """The histogram is keyed by phase; output is the R5.4-pre seed value."""
+        observe_training_step_duration("output", 0.123)
+        hist = _ensure_training_metrics()["step_duration_seconds"]
+        # Sum of observations should be 0.123 within float epsilon.
+        assert hist.labels(phase="output")._sum.get() == pytest.approx(0.123)
+
+
+@pytest.mark.unit
+class TestWorkerRegistryCollector:
+    """Gap 3 — worker -> Prometheus bridge collector."""
+
+    def _build_registry_with_two_workers(self):
+        """Populate a fake registry: w1 fully-instrumented, w2 heartbeat-only."""
+        from api.workers.registry import WorkerRegistry
+
+        reg = WorkerRegistry(heartbeat_timeout=30.0)
+        # w1 — fully-instrumented worker (R4.4 fields populated).
+        reg.register("w1", capabilities={"gpu": "rtx-4090"})
+        reg.heartbeat(
+            "w1",
+            in_flight_tasks=0,
+            tasks_completed=42,
+            last_task_duration_seconds=0.85,
+            recent_task_durations_seconds=[0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4],
+            gpu_utilization_pct=72.5,
+        )
+        # w2 — minimal worker (only the registration constructor's
+        # default last_heartbeat is set; R4.4 fields stay None / []).
+        reg.register("w2", capabilities={"gpu": None})
+        return reg
+
+    def _samples_by_metric(self, collector):
+        """Run collect() and bucket the samples by their metric name."""
+        out: dict[str, list] = {}
+        for fam in collector.collect():
+            out.setdefault(fam.name, []).extend(fam.samples)
+        return out
+
+    def test_collect_emits_expected_metric_names(self):
+        """All five families are present in a single scrape."""
+        from api.workers.metrics import WorkerRegistryCollector
+
+        reg = self._build_registry_with_two_workers()
+        collector = WorkerRegistryCollector(reg)
+        samples = self._samples_by_metric(collector)
+
+        assert "juniper_cascor_worker_heartbeat_age_seconds" in samples
+        assert "juniper_cascor_worker_last_task_duration_seconds" in samples
+        assert "juniper_cascor_worker_gpu_utilization_pct" in samples
+        assert "juniper_cascor_worker_recent_task_duration_seconds_p50" in samples
+        assert "juniper_cascor_worker_recent_task_duration_seconds_p95" in samples
+
+    def test_heartbeat_age_emitted_for_every_worker(self):
+        """Every worker has a populated last_heartbeat — both must appear."""
+        from api.workers.metrics import WorkerRegistryCollector
+
+        reg = self._build_registry_with_two_workers()
+        # Inject a fixed time source 5 s after registration so the age
+        # is non-zero and deterministic.
+        registration_now = max(w.last_heartbeat for w in reg.get_all_workers())
+        collector = WorkerRegistryCollector(reg, time_source=lambda: registration_now + 5.0)
+
+        samples = self._samples_by_metric(collector)
+        ages = {s.labels["worker_id"]: s.value for s in samples["juniper_cascor_worker_heartbeat_age_seconds"]}
+        assert set(ages.keys()) == {"w1", "w2"}
+        # Both should be approximately 5 s old (clock-injected).
+        for wid, age in ages.items():
+            assert age == pytest.approx(5.0, abs=1.0), f"heartbeat age for {wid} unexpected: {age}"
+
+    def test_unset_fields_are_omitted_not_zero_emitted(self):
+        """w2 has no R4.4 fields populated — its series must NOT appear."""
+        from api.workers.metrics import WorkerRegistryCollector
+
+        reg = self._build_registry_with_two_workers()
+        collector = WorkerRegistryCollector(reg)
+        samples = self._samples_by_metric(collector)
+
+        for metric_name in (
+            "juniper_cascor_worker_last_task_duration_seconds",
+            "juniper_cascor_worker_gpu_utilization_pct",
+            "juniper_cascor_worker_recent_task_duration_seconds_p50",
+            "juniper_cascor_worker_recent_task_duration_seconds_p95",
+        ):
+            worker_ids = {s.labels["worker_id"] for s in samples[metric_name]}
+            assert "w2" not in worker_ids, f"{metric_name}: w2 unset field was zero-emitted (forbidden)"
+            assert "w1" in worker_ids, f"{metric_name}: w1 (fully instrumented) is missing"
+
+    def test_w1_last_task_and_gpu_values_match(self):
+        """Fully-instrumented worker emits the actual reported values."""
+        from api.workers.metrics import WorkerRegistryCollector
+
+        reg = self._build_registry_with_two_workers()
+        collector = WorkerRegistryCollector(reg)
+        samples = self._samples_by_metric(collector)
+
+        last = {s.labels["worker_id"]: s.value for s in samples["juniper_cascor_worker_last_task_duration_seconds"]}
+        gpu = {s.labels["worker_id"]: s.value for s in samples["juniper_cascor_worker_gpu_utilization_pct"]}
+
+        assert last["w1"] == pytest.approx(0.85)
+        assert gpu["w1"] == pytest.approx(72.5)
+
+    def test_recent_p50_p95_within_window(self):
+        """Percentiles fall inside the [min, max] of the recent durations window."""
+        from api.workers.metrics import WorkerRegistryCollector
+
+        reg = self._build_registry_with_two_workers()
+        collector = WorkerRegistryCollector(reg)
+        samples = self._samples_by_metric(collector)
+
+        p50 = {s.labels["worker_id"]: s.value for s in samples["juniper_cascor_worker_recent_task_duration_seconds_p50"]}
+        p95 = {s.labels["worker_id"]: s.value for s in samples["juniper_cascor_worker_recent_task_duration_seconds_p95"]}
+
+        # Window for w1 is [0.5..1.4] in 0.1 increments. Median is
+        # ~0.95 (statistics.quantiles inclusive of 10 samples). p95 is
+        # near the upper end (~1.36).
+        assert 0.5 <= p50["w1"] <= 1.4
+        assert 0.5 <= p95["w1"] <= 1.4
+        assert p95["w1"] >= p50["w1"]
+
+    def test_single_sample_window_omits_percentiles(self):
+        """Window with <2 samples skips p50/p95 emission for that worker."""
+        from api.workers.metrics import WorkerRegistryCollector
+        from api.workers.registry import WorkerRegistry
+
+        reg = WorkerRegistry()
+        reg.register("solo", capabilities={})
+        reg.heartbeat("solo", recent_task_durations_seconds=[0.5])  # only one sample
+
+        collector = WorkerRegistryCollector(reg)
+        samples = self._samples_by_metric(collector)
+
+        worker_ids = {s.labels["worker_id"] for s in samples["juniper_cascor_worker_recent_task_duration_seconds_p50"]}
+        assert "solo" not in worker_ids, "single-sample window must NOT emit p50 (degenerate quantile)"
+
+    def test_collector_is_robust_to_registry_failure(self):
+        """A broken registry surfaces as an empty scrape, not an exception."""
+        from api.workers.metrics import WorkerRegistryCollector
+
+        class _BrokenRegistry:
+            def get_all_workers(self):
+                raise RuntimeError("simulated registry corruption")
+
+        collector = WorkerRegistryCollector(_BrokenRegistry())
+        samples = self._samples_by_metric(collector)
+        # All families exist; all are empty — no crash, no zero-emit.
+        for fam_samples in samples.values():
+            assert fam_samples == [], "broken registry leaked samples; expected empty scrape"
+
+
+@pytest.mark.unit
+class TestLifecycleManagerTerminalCounterIntegration:
+    """End-to-end: monitored_fit() bumps the counter at each terminal transition.
+
+    These tests drive synthetic terminal transitions through the
+    monkey-patched ``network.fit`` wrapper rather than running real
+    cascor training (which would require a torch-capable test
+    environment — see the prior R5.1b PR's note about the JuniperCascor
+    conda env's torch ImportError under Py3.14 free-threading).
+    """
+
+    def setup_method(self):
+        _reset_training_metrics()
+
+    def teardown_method(self):
+        _reset_training_metrics()
+
+    def _counter_value(self, status: str) -> float:
+        m = _ensure_training_metrics()["sessions_completed_total"]
+        return m.labels(status=status)._value.get()
+
+    def _build_manager_with_fake_network(self, fit_outcome: str):
+        """Return a manager whose ``network.fit`` synthesizes a terminal outcome.
+
+        ``fit_outcome`` is one of:
+          - ``"success"`` — fit returns normally and stop_event stays clear.
+          - ``"cancelled"`` — fit returns normally but stop_event is set
+            before the wrapper checks (simulating a stop_training()
+            arriving mid-flight).
+          - ``"failure"`` — fit raises ``RuntimeError``.
+        """
+        from api.lifecycle.manager import TrainingLifecycleManager
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+
+        # _install_monitoring_hooks ran inside create_network; the
+        # monkey-patched network.fit is now ``monitored_fit``. Replace
+        # the captured ``original_fit`` so it produces our synthetic
+        # outcome WITHOUT running the real cascor training path.
+        original_fit_marker = mgr._original_methods["fit"]
+
+        def _fake_fit(x, y, x_val=None, y_val=None, **kwargs):
+            if fit_outcome == "failure":
+                raise RuntimeError("synthetic training failure")
+            if fit_outcome == "cancelled":
+                # Simulate stop_training() landing mid-fit.
+                mgr._stop_requested.set()
+            return None
+
+        # Splice the fake into the slot where monitored_fit() captured
+        # the original. monitored_fit holds ``original_fit`` via
+        # closure, so we have to rebuild the closure: easiest is to
+        # reinstall hooks against a network whose .fit IS the fake.
+        mgr._restore_original_methods()
+        mgr._monitoring_active = False
+
+        # Replace network.fit with the fake, then re-install hooks so
+        # monitored_fit wraps the fake as the new "original_fit".
+        mgr.network.fit = _fake_fit
+        mgr._install_monitoring_hooks()
+
+        # Mark unused for type checkers — the marker is incidental.
+        del original_fit_marker
+        return mgr
+
+    def test_success_bumps_success_counter(self):
+        import torch
+
+        mgr = self._build_manager_with_fake_network("success")
+        before = self._counter_value(TRAINING_SESSION_STATUS_SUCCESS)
+        x = torch.zeros(2, 2)
+        y = torch.zeros(2, 2)
+        mgr.network.fit(x, y)
+        after = self._counter_value(TRAINING_SESSION_STATUS_SUCCESS)
+        assert after - before == pytest.approx(1.0)
+
+    def test_failure_bumps_failure_counter(self):
+        import torch
+
+        mgr = self._build_manager_with_fake_network("failure")
+        before = self._counter_value(TRAINING_SESSION_STATUS_FAILURE)
+        x = torch.zeros(2, 2)
+        y = torch.zeros(2, 2)
+        with pytest.raises(RuntimeError, match="synthetic training failure"):
+            mgr.network.fit(x, y)
+        after = self._counter_value(TRAINING_SESSION_STATUS_FAILURE)
+        assert after - before == pytest.approx(1.0)
+
+    def test_cancelled_bumps_cancelled_counter(self):
+        import torch
+
+        mgr = self._build_manager_with_fake_network("cancelled")
+        before = self._counter_value(TRAINING_SESSION_STATUS_CANCELLED)
+        x = torch.zeros(2, 2)
+        y = torch.zeros(2, 2)
+        mgr.network.fit(x, y)
+        after = self._counter_value(TRAINING_SESSION_STATUS_CANCELLED)
+        assert after - before == pytest.approx(1.0)
+
+
+@pytest.mark.unit
+class TestLifecycleStepDurationCallback:
+    """The output-phase epoch callback emits a histogram sample on the second invocation."""
+
+    def setup_method(self):
+        _reset_training_metrics()
+
+    def teardown_method(self):
+        _reset_training_metrics()
+
+    def test_two_back_to_back_callbacks_observe_one_sample(self):
+        """First callback seeds the timer; second emits the delta as a sample."""
+        from api.lifecycle.manager import TrainingLifecycleManager
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+
+        # Pull the injected callback out of the network attribute set
+        # by monitored_fit. monitored_fit hasn't been called yet — but
+        # the callback only flows through fit's setup. Instead, drive
+        # the fit() wrapper with a fake that runs the callback twice
+        # then returns successfully.
+        def _fake_fit(x, y, x_val=None, y_val=None, **kwargs):
+            cb = mgr.network._output_epoch_callback
+            cb(epoch=1, epochs=2, loss=0.5)
+            time.sleep(0.06)  # land in the (0.05, 0.1] bucket
+            cb(epoch=2, epochs=2, loss=0.4)
+            return None
+
+        # Re-install hooks around our fake fit (matches the
+        # terminal-counter integration tests above).
+        mgr._restore_original_methods()
+        mgr._monitoring_active = False
+        mgr.network.fit = _fake_fit
+        mgr._install_monitoring_hooks()
+
+        import torch
+
+        mgr.network.fit(torch.zeros(2, 2), torch.zeros(2, 2))
+
+        hist = _ensure_training_metrics()["step_duration_seconds"]
+        labelled = hist.labels(phase="output")
+        # ``_sum`` is the cumulative observation total — should be >0
+        # because exactly one sample was emitted (the second callback
+        # observes the delta from the first).
+        observed_sum = labelled._sum.get()
+        assert observed_sum > 0.0, "no train-step duration sample emitted"
+        # ``_buckets`` is non-cumulative in modern prometheus_client.
+        # Across all buckets the observation count must total exactly 1.
+        total_count = sum(bucket.get() for bucket in labelled._buckets)
+        assert total_count == 1, f"expected exactly 1 sample emitted across all buckets, got {total_count}"


### PR DESCRIPTION
## Summary

Closes the three instrumentation gaps that R5.1's SLO catalog
([juniper-deploy#48](https://github.com/pcalnon/juniper-deploy/pull/48))
flagged as unbinable. R5.4 (burn-rate alerts in juniper-deploy) is
gated on this PR landing.

### Gap 1 — `juniper_cascor_training_sessions_completed_total{status}` (counter)

Closed-set `status` label values per R1.1 cardinality discipline:
`success` / `failure` / `cancelled`. Bumped exactly once per terminal
FSM transition by the lifecycle manager's `monitored_fit` wrapper:
- `mark_completed` path → `success`
- `Command.STOP` mid-fit path → `cancelled`
- exception path → `failure`

**Binds SLO 3.3** ([juniper-deploy#48](https://github.com/pcalnon/juniper-deploy/pull/48)
SLO_CATALOG §3.3): training-session success ratio.

```promql
sum(rate(juniper_cascor_training_sessions_completed_total{status="success"}[5m]))
  / sum(rate(juniper_cascor_training_sessions_completed_total[5m]))
```

### Gap 2 — `juniper_cascor_training_step_duration_seconds{phase}` (histogram)

Buckets `(0.05, 0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, +inf)` target SLO
3.4 (p95 < 5 s). Emitted at the **api-lifecycle layer** via the existing
per-epoch output callback using `time.perf_counter` deltas. The `phase`
label is currently always `"output"` because only the output-phase
epoch callback is instrumented; candidate / input phase emission is on
the R5.4 follow-up queue.

**Born SLO-aligned** — HELP string carries the SLO 3.4 callout and does
NOT carry the R4.1 "tentative pending R5.1" suffix. Per-fit timer is
reset by `monitored_fit` so observations don't leak across fit()
invocations.

Histogram-buckets rationale doc updated:
- §1.1 — train-step boundary discussion (api-lifecycle vs. neural-net layer)
- §6 — per-boundary rationale for the new metric
- §7 / §8 — renumbered (was §6 / §7)

**Binds SLO 3.4** ([juniper-deploy#48](https://github.com/pcalnon/juniper-deploy/pull/48)
SLO_CATALOG §3.4).

### Gap 3 — `api.workers.metrics.WorkerRegistryCollector` (bridge)

Duck-typed `prometheus_client` collector that snapshots the in-process
`WorkerRegistry` on every scrape and emits per-worker gauges:

| Metric | Emitted when |
|--------|--------------|
| `juniper_cascor_worker_heartbeat_age_seconds{worker_id}` | always (every registration has a populated `last_heartbeat`) |
| `juniper_cascor_worker_last_task_duration_seconds{worker_id}` | only when worker reports the field |
| `juniper_cascor_worker_gpu_utilization_pct{worker_id}` | only when worker reports the field |
| `juniper_cascor_worker_recent_task_duration_seconds_p50/p95{worker_id}` | only when window has ≥2 samples |

**Gauge-omission strategy:** unset / `None` fields are NOT zero-emitted
— Prometheus interprets a missing series as "no data" which is the
correct semantic. Single-registration with the cascor `REGISTRY` at
lifespan startup (R1.4 discipline); unregistered at shutdown so the
test harness re-creating the app doesn't trip the duplicated-metric
guard.

**Closes the R4.4 bridge gap** that
[juniper-deploy#46 (R5.3 dashboard)](https://github.com/pcalnon/juniper-deploy/pull/46)
and [juniper-deploy#48 (R5.1 SLO catalog)](https://github.com/pcalnon/juniper-deploy/pull/48)
both flagged as the missing Prometheus surface for the heartbeat-freshness
and worker-task-duration internal SLIs and the operator dashboard.

## Files touched

**Production code**
- `src/api/observability.py` — counter, histogram, helper functions, closed-set status constants and bucket constant
- `src/api/lifecycle/manager.py` — counter increment at three terminal transitions; histogram observation in `_output_training_callback` with per-fit timer reset
- `src/api/workers/metrics.py` — new `WorkerRegistryCollector` module
- `src/api/app.py` — register / unregister the bridge collector in lifespan (extracted to helpers for C901 budget)

**Documentation**
- `notes/observability/HISTOGRAM_BUCKETS_RATIONALE_2026-05-02.md` — §1 inventory updated, §1.1 boundary choice added, §6 new metric rationale, renumbered downstream sections

**Tests**
- `src/tests/unit/api/test_metrics_r5_4_pre.py` — counter, histogram, bridge collector, and lifecycle integration

## Test plan

- [x] All pre-commit hooks pass on touched files (black, isort, flake8 incl. C901, mypy, bandit)
- [x] Inline isolated harness exercises the counter (each status increments by 1, invalid status raises)
- [x] Inline isolated harness exercises the histogram (0.7 s sample lands in `le=1.0` bucket; HELP carries SLO 3.4 marker; no R4.1 suffix)
- [x] Inline isolated harness exercises the bridge collector (5 families emitted; w2 unset fields omitted; both workers in heartbeat_age; single-sample window omits p50/p95; broken registry → empty scrape)
- [ ] CI exercises the full pytest suite — local pytest blocked by the JuniperCascor conda env's torch / Py3.14 free-threading ImportError (pre-existing constraint, see project memory)
- [ ] Verify the new metrics appear on a live `/metrics` scrape after deploy
- [ ] Follow-up PR (out of scope here): wire the new metrics into the R5.3 operator dashboards
- [ ] Follow-up PR ([juniper-deploy](https://github.com/pcalnon/juniper-deploy)): R5.4 burn-rate alerts on SLO 3.3 / 3.4 + the new internal SLIs

## Out of scope

- R5.1 SLO catalog (juniper-deploy#48) — already merged; this PR makes its bindings real but does not modify the catalog itself
- R5.3 dashboard wiring — a follow-up R5.3-followup PR can wire these in once the metrics are live
- `WorkerRegistration` dataclass shape — the bridge READS, doesn't restructure
- pyproject.toml version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)