### PR TITLE
feat(replay): wire weight cache into _ReplaySession + extend control response (Phase 6E CAN-015g, g-2) [retarget #184]

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -61,6 +61,197 @@ def _write_activation_function_name(network: Any, value: str) -> None:
     network._init_activation_function()
 
 
+class _WeightCache:
+    """CAN-015g (Phase 6E follow-on, g-2): per-sample weight tensor cache.
+
+    Lifts the dict-of-numpy-arrays produced by g-1's
+    ``snapshot_serializer._load_weight_history`` into an LRU cache so
+    ``_ReplaySession`` can serve weight payloads to canopy without
+    re-walking the (potentially large) source dict on every scrubber
+    move. Plan: ``notes/PHASE_6E_DEFERRED_CAN-015GH_DESIGN.md`` §
+    "In-memory cache".
+
+    The "LRU eviction with byte budget" design lives here rather than
+    leaning on a generic library because:
+      • The byte cost of an entry is the sum of ``ndarray.nbytes`` for
+        every tensor in the sample (output + per-unit) — not something
+        a generic cache can introspect.
+      • The budget is a soft cap for fairness across long-running
+        sessions, not a hard limit; missing the budget by one sample
+        is preferable to evicting the just-requested entry.
+
+    All public methods are thread-safe (the cache is read by the
+    replay driver thread and written by the route response thread on
+    cache misses).
+    """
+
+    DEFAULT_BUDGET_BYTES: int = 256 * 1024 * 1024  # 256 MB; g-2 of plan
+
+    def __init__(self, weight_history: Optional[Dict[str, Any]], byte_budget: int = DEFAULT_BUDGET_BYTES):
+        self._wh = weight_history or {}
+        self._budget = max(1, int(byte_budget))
+        # OrderedDict for LRU: ``move_to_end`` on access, ``popitem(last=False)``
+        # for eviction. Key = sample_index (int).
+        from collections import OrderedDict as _OrderedDict
+
+        self._entries: "_OrderedDict[int, Dict[str, Any]]" = _OrderedDict()
+        self._sizes: Dict[int, int] = {}
+        self._total_bytes: int = 0
+        self._lock = threading.Lock()
+        self._hits: int = 0
+        self._misses: int = 0
+        self._evictions: int = 0
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    @property
+    def available(self) -> bool:
+        """True iff the underlying weight_history has any samples."""
+        return bool(self._wh.get("sample_indices"))
+
+    @property
+    def sample_indices(self) -> List[int]:
+        return list(self._wh.get("sample_indices", []))
+
+    @property
+    def num_samples(self) -> int:
+        return len(self._wh.get("sample_indices", []))
+
+    @property
+    def sampling_strategy(self) -> str:
+        return str(self._wh.get("sampling_strategy", ""))
+
+    @property
+    def sampling_interval(self) -> int:
+        return int(self._wh.get("sampling_interval", 0))
+
+    def stats(self) -> Dict[str, int]:
+        with self._lock:
+            return {
+                "hits": self._hits,
+                "misses": self._misses,
+                "evictions": self._evictions,
+                "entries": len(self._entries),
+                "bytes": self._total_bytes,
+                "budget_bytes": self._budget,
+            }
+
+    # ------------------------------------------------------------------
+    # Lookup
+    # ------------------------------------------------------------------
+
+    def get(self, sample_index: int) -> Optional[Dict[str, Any]]:
+        """Return the per-sample weight payload, or ``None`` if the
+        index is out of range / weights aren't available.
+
+        On a cache hit the entry is promoted to most-recently-used.
+        On a miss the payload is built from the source dict and
+        admitted (possibly evicting older entries to fit the budget).
+        """
+        if not self.available:
+            return None
+        if sample_index < 0 or sample_index >= self.num_samples:
+            return None
+
+        with self._lock:
+            if sample_index in self._entries:
+                self._entries.move_to_end(sample_index)
+                self._hits += 1
+                return self._entries[sample_index]
+            self._misses += 1
+
+        payload = self._build_payload(sample_index)
+        size = self._sizeof(payload)
+
+        with self._lock:
+            # Evict LRU entries until the new payload fits the budget.
+            # Always admit at least the current payload even if it alone
+            # exceeds the budget — the user explicitly asked for it.
+            while self._entries and (self._total_bytes + size) > self._budget:
+                evicted_key, _ = self._entries.popitem(last=False)
+                self._total_bytes -= self._sizes.pop(evicted_key, 0)
+                self._evictions += 1
+            self._entries[sample_index] = payload
+            self._sizes[sample_index] = size
+            self._total_bytes += size
+
+        return payload
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _build_payload(self, sample_index: int) -> Dict[str, Any]:
+        """Project the per-sample slice out of the source weight_history.
+
+        Layout matches what g-3 will emit in the synthetic ``epoch_end``
+        event's ``weights`` block — keeping it stable here lets g-3
+        forward this dict directly to subscribers.
+        """
+        output_weights = self._wh.get("output_weights", [])
+        output_bias = self._wh.get("output_bias", [])
+        hidden_units = self._wh.get("hidden_units", [])
+
+        ow = output_weights[sample_index] if sample_index < len(output_weights) else None
+        ob = output_bias[sample_index] if sample_index < len(output_bias) else None
+
+        # Hidden-unit per-sample slicing. Each unit's per-sample arrays
+        # are indexed relative to ``first_sample_index``, defined as the
+        # **0-based index into the global ``sample_indices`` list** at
+        # which this unit first appeared (NOT an epoch number). Skip
+        # units whose first sample is in the future. The convention is
+        # documented here because the data layout is otherwise opaque —
+        # g-3's emitter and any future consumers must use the same
+        # interpretation.
+        hu_payload = []
+        for unit in hidden_units:
+            first = int(unit.get("first_sample_index", 0))
+            if sample_index < first:
+                continue
+            local_idx = sample_index - first
+            unit_w = unit.get("weights", [])
+            unit_b = unit.get("bias", [])
+            if local_idx >= len(unit_w):
+                continue
+            hu_payload.append(
+                {
+                    "first_sample_index": first,
+                    "activation": unit.get("activation", ""),
+                    "weights": unit_w[local_idx],
+                    "bias": float(unit_b[local_idx]) if local_idx < len(unit_b) else 0.0,
+                }
+            )
+
+        return {
+            "sample_index": sample_index,
+            "epoch": int(self._wh.get("sample_indices", [sample_index])[sample_index]),
+            "output_weights": ow,
+            "output_bias": ob,
+            "hidden_units": hu_payload,
+        }
+
+    @staticmethod
+    def _sizeof(payload: Dict[str, Any]) -> int:
+        """Approximate the byte cost of a payload entry.
+
+        Sums ``ndarray.nbytes`` for every tensor referenced. Skips
+        Python overhead — close enough for budget-eviction decisions.
+        """
+        size = 0
+        for key in ("output_weights", "output_bias"):
+            arr = payload.get(key)
+            if hasattr(arr, "nbytes"):
+                size += int(arr.nbytes)
+        for unit in payload.get("hidden_units", []):
+            arr = unit.get("weights")
+            if hasattr(arr, "nbytes"):
+                size += int(arr.nbytes)
+            # bias is a Python float — negligible.
+        return size
+
+
 class _ReplaySession:
     """CAN-015c (Phase 6E Sprint B B-3): per-snapshot replay session.
 
@@ -92,7 +283,7 @@ class _ReplaySession:
     # at very low speeds.
     _MAX_TICK_SLEEP: float = 0.5
 
-    def __init__(self, snapshot_id: str, history: Dict[str, list], monitor) -> None:
+    def __init__(self, snapshot_id: str, history: Dict[str, list], monitor, weight_history: Optional[Dict[str, Any]] = None, weight_cache_budget_bytes: Optional[int] = None) -> None:
         self.snapshot_id = snapshot_id
         # Pre-extract the history arrays we know about so the loop
         # doesn't re-fetch every tick. Stored as plain lists (not
@@ -105,6 +296,14 @@ class _ReplaySession:
         # loop correctly idles.
         self.length: int = max((len(v) for v in self._history.values()), default=0)
         self._monitor = monitor
+        # CAN-015g (g-2): per-sample weight cache. Empty / absent
+        # weight_history (V1 snapshots, or networks where g-1
+        # serializer didn't load any samples) yields a cache that
+        # advertises ``available=False``; canopy then knows to disable
+        # the decision-boundary scrubber. The cache is constructed
+        # eagerly even in the V1 case so consumers don't have to
+        # branch on ``is None``.
+        self.weight_cache = _WeightCache(weight_history, byte_budget=weight_cache_budget_bytes if weight_cache_budget_bytes is not None else _WeightCache.DEFAULT_BUDGET_BYTES)
         # Playback state — guarded by the lock for cross-thread reads.
         self._lock = threading.Lock()
         self.time_index: int = 0
@@ -192,7 +391,7 @@ class _ReplaySession:
     def state_summary(self) -> Dict[str, Any]:
         """Snapshot of the current session state for the route response."""
         with self._lock:
-            return {
+            summary: Dict[str, Any] = {
                 "snapshot_id": self.snapshot_id,
                 "length": self.length,
                 "time_index": self.time_index,
@@ -200,6 +399,31 @@ class _ReplaySession:
                 "paused": self.paused,
                 "range": {"start": self.range_start, "end": self.range_end},
             }
+        # CAN-015g (g-2): expose weight-cache state so canopy knows
+        # whether decision-boundary playback is available and can
+        # render the scrubber accordingly. ``sample_epochs`` is the
+        # epoch number at each sample boundary — canopy uses these to
+        # snap the scrubber to the closest sample.
+        summary["weights_available"] = self.weight_cache.available
+        if self.weight_cache.available:
+            summary["weight_sampling"] = {
+                "strategy": self.weight_cache.sampling_strategy,
+                "interval": self.weight_cache.sampling_interval,
+                "num_samples": self.weight_cache.num_samples,
+                "sample_epochs": self.weight_cache.sample_indices,
+            }
+        return summary
+
+    def weights_at(self, sample_index: int) -> Optional[Dict[str, Any]]:
+        """Return the per-sample weight payload for ``sample_index``,
+        or ``None`` if the snapshot has no weight history or the
+        index is out of range.
+
+        Wrapper around the cache so callers (g-3's emitter, ad-hoc
+        ops queries) don't have to reach into ``self.weight_cache``
+        directly.
+        """
+        return self.weight_cache.get(sample_index)
 
     def _clamp_to_range(self, index: int) -> int:
         if self.range_end <= self.range_start:
@@ -1906,7 +2130,12 @@ class TrainingLifecycleManager:
 
         history = getattr(self.network, "history", None)
         history_dict = history if isinstance(history, dict) else {}
-        session = _ReplaySession(snapshot_id, history_dict, self.training_monitor)
+        # CAN-015g (g-2): pull the per-sample weight history that the
+        # g-1 serializer loaded onto the network. V1 snapshots have
+        # no such attribute (or it's None) — the cache then advertises
+        # weights_available=false to canopy via state_summary.
+        weight_history = getattr(self.network, "weight_history", None)
+        session = _ReplaySession(snapshot_id, history_dict, self.training_monitor, weight_history=weight_history)
         self._replay_session = session
         # Marker fields used by Resume / Restore are not relevant here.
         self._resume_point_epoch = None

--- a/src/tests/unit/api/test_replay_weight_cache.py
+++ b/src/tests/unit/api/test_replay_weight_cache.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python
+"""Unit tests for the per-sample weight cache in _ReplaySession (CAN-015g g-2).
+
+Covers:
+- Cache hit/miss semantics + LRU promotion ordering.
+- Byte-budget eviction (oldest entries evicted to fit new ones).
+- Backward compat: V1 snapshots (no weight_history) yield a cache
+  that advertises ``available=False`` and gates the extended
+  state_summary fields.
+- Per-sample payload shape: output_weights, output_bias, hidden_units
+  with first-sample-aware slicing.
+- ``state_summary`` extension exposes ``weights_available``,
+  ``weight_sampling.{strategy,interval,num_samples,sample_epochs}``.
+"""
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+# Add parent directories for imports (matches sibling test files).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
+
+from api.lifecycle.manager import _ReplaySession, _WeightCache  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def _make_weight_history(num_samples=5, in_size=2, out_size=1, num_hidden=2, sampling_interval=10):
+    """Synthetic weight_history payload (mirrors g-1 fixture)."""
+    sample_indices = [i * sampling_interval for i in range(num_samples)]
+    output_weights = []
+    output_bias = []
+    for i in range(num_samples):
+        hid_at_sample = min(i, num_hidden)
+        output_weights.append(np.random.RandomState(i).randn(in_size + hid_at_sample, out_size).astype(np.float32))
+        output_bias.append(np.random.RandomState(i + 100).randn(out_size).astype(np.float32))
+    hidden_units = []
+    for unit_idx in range(num_hidden):
+        # ``first_sample_index`` is the **index into ``sample_indices``**
+        # (0-based) at which this unit first appeared, NOT an epoch
+        # number. The cache uses it directly to slice the per-sample
+        # arrays. Unit ``unit_idx`` first appears at sample
+        # ``unit_idx + 1`` (so sample 0 has no units, sample 1 has unit
+        # 0 only, etc.).
+        first_sample_index = unit_idx + 1
+        unit_weights = []
+        unit_bias = []
+        for j in range(num_samples - first_sample_index):
+            unit_weights.append(np.random.RandomState(unit_idx * 10 + j).randn(in_size + unit_idx).astype(np.float32))
+            unit_bias.append(float(np.random.RandomState(unit_idx * 10 + j + 1).randn()))
+        hidden_units.append(
+            {
+                "first_sample_index": first_sample_index,
+                "activation": "tanh",
+                "weights": unit_weights,
+                "bias": unit_bias,
+            }
+        )
+    return {
+        "sampling_strategy": "adaptive",
+        "sampling_interval": sampling_interval,
+        "sample_indices": sample_indices,
+        "output_weights": output_weights,
+        "output_bias": output_bias,
+        "hidden_units": hidden_units,
+    }
+
+
+# =============================================================================
+# Cache standalone
+# =============================================================================
+
+
+class TestWeightCacheBasics:
+    def test_empty_weight_history_unavailable(self):
+        cache = _WeightCache(None)
+        assert cache.available is False
+        assert cache.num_samples == 0
+        assert cache.get(0) is None
+
+    def test_empty_dict_unavailable(self):
+        cache = _WeightCache({})
+        assert cache.available is False
+
+    def test_empty_sample_indices_unavailable(self):
+        cache = _WeightCache({"sample_indices": []})
+        assert cache.available is False
+
+    def test_populated_history_available(self):
+        cache = _WeightCache(_make_weight_history(num_samples=3))
+        assert cache.available is True
+        assert cache.num_samples == 3
+        assert cache.sampling_strategy == "adaptive"
+        assert cache.sampling_interval == 10
+
+    def test_get_returns_none_for_out_of_range_index(self):
+        cache = _WeightCache(_make_weight_history(num_samples=3))
+        assert cache.get(-1) is None
+        assert cache.get(3) is None
+        assert cache.get(100) is None
+
+
+class TestWeightCachePayloadShape:
+    def test_payload_contains_expected_keys(self):
+        wh = _make_weight_history(num_samples=4, num_hidden=2)
+        cache = _WeightCache(wh)
+        payload = cache.get(2)
+        assert payload is not None
+        assert payload["sample_index"] == 2
+        assert payload["epoch"] == 20  # sample_indices[2] = 2 * sampling_interval(10)
+        assert "output_weights" in payload
+        assert "output_bias" in payload
+        assert "hidden_units" in payload
+
+    def test_payload_skips_units_not_yet_added(self):
+        wh = _make_weight_history(num_samples=4, num_hidden=2)
+        # Units appear at samples 1 and 2 (first_sample_index = 10 and 20).
+        # At sample 0 no units are present.
+        cache = _WeightCache(wh)
+        payload = cache.get(0)
+        assert payload is not None
+        assert payload["hidden_units"] == []
+
+    def test_payload_includes_units_added_at_or_before_sample(self):
+        wh = _make_weight_history(num_samples=4, num_hidden=2)
+        cache = _WeightCache(wh)
+        payload = cache.get(2)
+        # Units 0 and 1 should both be present at sample 2.
+        assert len(payload["hidden_units"]) == 2
+        for unit in payload["hidden_units"]:
+            assert "weights" in unit
+            assert "bias" in unit
+            assert isinstance(unit["bias"], float)
+
+    def test_payload_output_tensors_match_source(self):
+        wh = _make_weight_history(num_samples=3)
+        cache = _WeightCache(wh)
+        payload = cache.get(1)
+        np.testing.assert_array_equal(payload["output_weights"], wh["output_weights"][1])
+        np.testing.assert_array_equal(payload["output_bias"], wh["output_bias"][1])
+
+
+# =============================================================================
+# LRU + budget
+# =============================================================================
+
+
+class TestWeightCacheLRU:
+    def test_hit_promotes_to_most_recently_used(self):
+        wh = _make_weight_history(num_samples=4)
+        cache = _WeightCache(wh)
+        # Fill cache: 0, 1, 2 (LRU order: 0 oldest)
+        cache.get(0)
+        cache.get(1)
+        cache.get(2)
+        # Touching 0 promotes it; eviction would now drop 1 first.
+        cache.get(0)
+        stats = cache.stats()
+        assert stats["entries"] == 3
+        assert stats["hits"] == 1
+        assert stats["misses"] == 3
+
+    def test_eviction_under_tight_budget(self):
+        wh = _make_weight_history(num_samples=5, num_hidden=2)
+        # Size against a sample where both hidden units are present so
+        # the per-sample byte cost is realistic. Budget allows one
+        # payload but not two.
+        sizing_cache = _WeightCache(wh)
+        per_sample = sizing_cache._sizeof(sizing_cache.get(4))
+        assert per_sample > 0
+        budget = per_sample + 1  # Fits one entry of this size, no slack for two.
+
+        cache = _WeightCache(wh, byte_budget=budget)
+        cache.get(2)
+        cache.get(3)
+        cache.get(4)  # Should evict 2 (oldest)
+        stats = cache.stats()
+        assert stats["evictions"] >= 1
+        # Re-fetch evicted entry — must re-build it (counts as miss)
+        miss_before = stats["misses"]
+        cache.get(2)
+        stats_after = cache.stats()
+        assert stats_after["misses"] > miss_before
+
+    def test_oversized_payload_still_admitted(self):
+        wh = _make_weight_history(num_samples=2)
+        # Budget below any single payload's size
+        cache = _WeightCache(wh, byte_budget=1)
+        payload = cache.get(0)
+        # Caller still gets the data even though admission blew the budget.
+        assert payload is not None
+        # Entry was admitted but next miss will evict it.
+        cache.get(1)
+        stats = cache.stats()
+        assert stats["evictions"] >= 1
+
+
+# =============================================================================
+# Stats
+# =============================================================================
+
+
+class TestWeightCacheStats:
+    def test_stats_initial_zeros(self):
+        cache = _WeightCache(_make_weight_history(num_samples=3))
+        stats = cache.stats()
+        assert stats["hits"] == 0
+        assert stats["misses"] == 0
+        assert stats["evictions"] == 0
+        assert stats["entries"] == 0
+        assert stats["bytes"] == 0
+
+    def test_stats_reflect_activity(self):
+        cache = _WeightCache(_make_weight_history(num_samples=3))
+        cache.get(0)
+        cache.get(0)  # hit
+        cache.get(1)
+        stats = cache.stats()
+        assert stats["misses"] == 2
+        assert stats["hits"] == 1
+        assert stats["entries"] == 2
+        assert stats["bytes"] > 0
+
+
+# =============================================================================
+# Integration with _ReplaySession
+# =============================================================================
+
+
+class TestReplaySessionWithWeightCache:
+    """The session wires the cache and surfaces it through state_summary."""
+
+    @staticmethod
+    def _history():
+        return {
+            "train_loss": [0.5, 0.4, 0.3, 0.2, 0.1],
+            "value_loss": [0.6, 0.5, 0.4, 0.3, 0.2],
+            "train_accuracy": [0.6, 0.7, 0.8, 0.85, 0.9],
+            "value_accuracy": [0.55, 0.65, 0.75, 0.8, 0.85],
+        }
+
+    def test_session_without_weight_history_advertises_unavailable(self):
+        from unittest.mock import MagicMock
+
+        monitor = MagicMock()
+        session = _ReplaySession("snap", self._history(), monitor)
+        assert session.weight_cache.available is False
+        summary = session.state_summary()
+        assert summary["weights_available"] is False
+        assert "weight_sampling" not in summary
+
+    def test_session_with_weight_history_exposes_sampling_block(self):
+        from unittest.mock import MagicMock
+
+        monitor = MagicMock()
+        wh = _make_weight_history(num_samples=4, sampling_interval=25)
+        session = _ReplaySession("snap", self._history(), monitor, weight_history=wh)
+        summary = session.state_summary()
+        assert summary["weights_available"] is True
+        assert summary["weight_sampling"] == {
+            "strategy": "adaptive",
+            "interval": 25,
+            "num_samples": 4,
+            "sample_epochs": [0, 25, 50, 75],
+        }
+
+    def test_weights_at_returns_payload(self):
+        from unittest.mock import MagicMock
+
+        monitor = MagicMock()
+        wh = _make_weight_history(num_samples=3)
+        session = _ReplaySession("snap", self._history(), monitor, weight_history=wh)
+        payload = session.weights_at(1)
+        assert payload is not None
+        assert payload["sample_index"] == 1
+
+    def test_weights_at_returns_none_when_unavailable(self):
+        from unittest.mock import MagicMock
+
+        monitor = MagicMock()
+        session = _ReplaySession("snap", self._history(), monitor)
+        assert session.weights_at(0) is None
+
+    def test_custom_budget_honored(self):
+        from unittest.mock import MagicMock
+
+        monitor = MagicMock()
+        wh = _make_weight_history(num_samples=3)
+        session = _ReplaySession("snap", self._history(), monitor, weight_history=wh, weight_cache_budget_bytes=1024)
+        assert session.weight_cache._budget == 1024


### PR DESCRIPTION
## Why this PR exists

Original g-2 PR was **#184** and is marked MERGED on GitHub, but its merge commit went into the stacked parent branch \`feature/can-015g-1-snapshot-weight-history\` (which itself merged via #180), not into \`main\` directly. \`git merge-base --is-ancestor 9ab05e0 origin/main\` returns false. Same stacked-PR pattern noted earlier with B-3 / B-4 in Sprint B.

This PR re-targets the same change against \`main\` via cherry-pick of the original commit \`9ab05e0\`. **No code changes** — diff is identical to what #184 carried.

## Validation

- [x] 29 tests pass on the retargeted branch (19 new \`test_replay_weight_cache.py\` + 10 \`test_snapshot_weight_history.py\` from g-1) in JuniperCascor1
- [x] Cherry-pick auto-merged cleanly (no conflicts)

## Original PR description

See **#184** for the complete description. TL;DR:

- New \`_WeightCache\` class — thread-safe LRU with 256MB byte budget.
- \`_ReplaySession.__init__\` accepts \`weight_history\` + \`weight_cache_budget_bytes\`.
- \`state_summary()\` extended with \`weights_available\` + \`weight_sampling\` block (strict superset of B-3 shape).
- \`weights_at(sample_index)\` accessor on the session.
- \`start_replay\` threads \`network.weight_history\` into the session.
- Documents the \`first_sample_index\` semantic (sample-list index, not epoch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)