### PR TITLE
feat(replay): emit weight payloads on sample-boundary events (Phase 6E CAN-015g, g-3) [retarget #187, stacked on #189]

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -304,6 +304,12 @@ class _ReplaySession:
         # eagerly even in the V1 case so consumers don't have to
         # branch on ``is None``.
         self.weight_cache = _WeightCache(weight_history, byte_budget=weight_cache_budget_bytes if weight_cache_budget_bytes is not None else _WeightCache.DEFAULT_BUDGET_BYTES)
+        # CAN-015g (g-3): O(1) reverse lookup from time_index (0-based
+        # epoch in the metric arrays) → sample_index (0-based into
+        # sample_indices). Populated only when the cache is available;
+        # the emitter checks membership to decide whether to attach a
+        # ``weights`` block to the synthetic event.
+        self._epoch_to_sample: Dict[int, int] = ({int(epoch): i for i, epoch in enumerate(self.weight_cache.sample_indices)} if self.weight_cache.available else {})
         # Playback state — guarded by the lock for cross-thread reads.
         self._lock = threading.Lock()
         self.time_index: int = 0
@@ -436,7 +442,20 @@ class _ReplaySession:
         Bypasses ``monitor.on_epoch_end`` (which would write to
         ``metrics_buffer``) and calls ``_trigger_callbacks`` directly
         so the WS broadcasters fire but live training state stays
-        untouched. Per the design's read-only-history guarantee."""
+        untouched. Per the design's read-only-history guarantee.
+
+        CAN-015g (g-3): when ``index`` lands on a sample-boundary
+        epoch (i.e. a position the serializer captured weight tensors
+        for) and the snapshot has weight history available, the
+        emitted event additionally carries a ``weights`` block with
+        base64-encoded float32 tensors. Sub-sample epochs carry
+        ``is_sample_boundary=False`` and no weight payload — canopy
+        holds the previously-received weights until a new boundary
+        arrives. V1 snapshots (no weight cache) emit identically to
+        the pre-g-3 shape (no ``is_sample_boundary`` field at all),
+        preserving backward compatibility for canopy clients that
+        pre-date the V2 protocol.
+        """
         if self._monitor is None:
             return
         if index < 0 or index >= self.length:
@@ -446,7 +465,7 @@ class _ReplaySession:
             series = self._history.get(key, [])
             return series[index] if index < len(series) else None
 
-        metrics = {
+        metrics: Dict[str, Any] = {
             "epoch": index + 1,  # 1-indexed for canopy display, matches on_epoch_end
             "loss": _series_at("train_loss"),
             "accuracy": _series_at("train_accuracy"),
@@ -456,6 +475,13 @@ class _ReplaySession:
             "replay": True,  # marker so subscribers can distinguish synthetic frames
             "snapshot_id": self.snapshot_id,
         }
+        if self.weight_cache.available:
+            sample_index = self._epoch_to_sample.get(index)
+            metrics["is_sample_boundary"] = sample_index is not None
+            if sample_index is not None:
+                payload = self.weights_at(sample_index)
+                if payload is not None:
+                    metrics["weights"] = self._encode_weight_payload(payload)
         try:
             self._monitor._trigger_callbacks(
                 "epoch_end",
@@ -468,6 +494,65 @@ class _ReplaySession:
             # Best-effort emission — a subscriber that raises mustn't
             # crash the playback thread.
             self.logger.exception("replay session: synthetic _trigger_callbacks raised")
+
+    @staticmethod
+    def _encode_weight_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+        """CAN-015g (g-3): base64-encode the per-sample weight tensors.
+
+        Wire format per ``notes/PHASE_6E_DEFERRED_CAN-015GH_DESIGN.md``
+        §"Synthetic epoch_end event (additive)". JSON-friendly
+        envelope (`{dtype, shape, data}`) keeps the payload trivially
+        decodable from canopy's clientside JS without binary WS frame
+        plumbing — that optimization is deferred per the plan's
+        "Out of scope" list pending profiling data.
+
+        Returns a fresh dict; the input cache payload is not mutated
+        because the cache may serve the same payload to multiple
+        subscribers across scrubber moves.
+        """
+        return {
+            "sample_index": payload["sample_index"],
+            "epoch": payload["epoch"],
+            "output_weights": _ReplaySession._encode_tensor(payload.get("output_weights")),
+            "output_bias": _ReplaySession._encode_tensor(payload.get("output_bias")),
+            "hidden_units": [
+                {
+                    "first_sample_index": int(unit.get("first_sample_index", 0)),
+                    "activation": str(unit.get("activation", "")),
+                    "weights": _ReplaySession._encode_tensor(unit.get("weights")),
+                    # Bias is a Python float in the cache payload; ship
+                    # as-is so canopy doesn't pay base64-decode cost on
+                    # a single scalar.
+                    "bias": float(unit.get("bias", 0.0)),
+                }
+                for unit in payload.get("hidden_units", [])
+            ],
+        }
+
+    @staticmethod
+    def _encode_tensor(arr) -> Optional[Dict[str, Any]]:
+        """Encode a numpy array as ``{dtype, shape, data: base64(...)}``.
+
+        Returns ``None`` when ``arr`` is ``None`` or has no shape — the
+        caller (encoder) treats absent tensors as "skip this field" so
+        a snapshot missing one of the optional weight components
+        (e.g. zero hidden units) doesn't fail emission outright.
+        """
+        if arr is None:
+            return None
+        if not hasattr(arr, "tobytes"):
+            return None
+        # Force float32 for wire-side determinism; the cache already
+        # stores float32 from g-1's writer but a future ragged-storage
+        # change might admit float64 — coerce defensively.
+        as_f32 = np.ascontiguousarray(arr, dtype=np.float32)
+        import base64 as _base64
+
+        return {
+            "dtype": "float32",
+            "shape": list(as_f32.shape),
+            "data": _base64.b64encode(as_f32.tobytes()).decode("ascii"),
+        }
 
     def _run(self) -> None:
         """Background thread driver. Sleeps for ``1/abs(speed)`` between

--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -309,7 +309,7 @@ class _ReplaySession:
         # sample_indices). Populated only when the cache is available;
         # the emitter checks membership to decide whether to attach a
         # ``weights`` block to the synthetic event.
-        self._epoch_to_sample: Dict[int, int] = ({int(epoch): i for i, epoch in enumerate(self.weight_cache.sample_indices)} if self.weight_cache.available else {})
+        self._epoch_to_sample: Dict[int, int] = {int(epoch): i for i, epoch in enumerate(self.weight_cache.sample_indices)} if self.weight_cache.available else {}
         # Playback state — guarded by the lock for cross-thread reads.
         self._lock = threading.Lock()
         self.time_index: int = 0

--- a/src/tests/unit/api/test_replay_weight_emission.py
+++ b/src/tests/unit/api/test_replay_weight_emission.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python
+"""Unit tests for synthetic-event weight emission (CAN-015g g-3).
+
+Covers:
+- Sample-boundary epochs emit ``is_sample_boundary=True`` + a
+  base64-encoded ``weights`` block.
+- Sub-sample epochs emit ``is_sample_boundary=False`` and **no**
+  ``weights`` field.
+- V1 snapshots (no weight cache) emit no ``is_sample_boundary``
+  field at all — preserves backward compatibility for canopy
+  clients pre-dating the V2 protocol.
+- The encoded tensor envelope round-trips correctly: base64 decode
+  → reshape via ``shape`` → matches the source array.
+- Hidden units are emitted with their per-sample slices and the
+  scalar bias is shipped as a float (no base64 overhead for
+  single-value fields).
+"""
+
+import base64
+import os
+import sys
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+# Add parent directories for imports (matches sibling test files).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
+
+from api.lifecycle.manager import _ReplaySession  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def _history(num_epochs=10):
+    return {
+        "train_loss": [1.0 - 0.05 * i for i in range(num_epochs)],
+        "value_loss": [1.1 - 0.05 * i for i in range(num_epochs)],
+        "train_accuracy": [0.5 + 0.04 * i for i in range(num_epochs)],
+        "value_accuracy": [0.5 + 0.04 * i for i in range(num_epochs)],
+    }
+
+
+def _weight_history(num_samples=3, num_hidden=2, in_size=2, out_size=1, sampling_interval=2):
+    """Build a synthetic weight_history.
+
+    ``sample_indices`` maps sample-index → epoch (matches the
+    convention captured in g-2's docs: epoch numbers are 0-based and
+    line up with the metric-array index used by ``_emit_frame``).
+    """
+    sample_indices = [i * sampling_interval for i in range(num_samples)]
+    output_weights = []
+    output_bias = []
+    for i in range(num_samples):
+        hid_at_sample = min(i, num_hidden)
+        output_weights.append(np.random.RandomState(i).randn(in_size + hid_at_sample, out_size).astype(np.float32))
+        output_bias.append(np.random.RandomState(i + 100).randn(out_size).astype(np.float32))
+    hidden_units = []
+    for unit_idx in range(num_hidden):
+        first_sample_index = unit_idx + 1  # sample-index, NOT epoch (g-2 convention)
+        unit_weights = []
+        unit_bias = []
+        for j in range(num_samples - first_sample_index):
+            unit_weights.append(np.random.RandomState(unit_idx * 10 + j).randn(in_size + unit_idx).astype(np.float32))
+            unit_bias.append(float(np.random.RandomState(unit_idx * 10 + j + 1).randn()))
+        hidden_units.append(
+            {
+                "first_sample_index": first_sample_index,
+                "activation": "tanh",
+                "weights": unit_weights,
+                "bias": unit_bias,
+            }
+        )
+    return {
+        "sampling_strategy": "adaptive",
+        "sampling_interval": sampling_interval,
+        "sample_indices": sample_indices,
+        "output_weights": output_weights,
+        "output_bias": output_bias,
+        "hidden_units": hidden_units,
+    }
+
+
+def _make_session(weight_history=None, num_epochs=10):
+    monitor = MagicMock()
+    monitor._trigger_callbacks = MagicMock()
+    session = _ReplaySession("snap-test", _history(num_epochs), monitor, weight_history=weight_history)
+    return session, monitor
+
+
+# =============================================================================
+# V1 backward-compat
+# =============================================================================
+
+
+class TestV1EmissionBackwardCompat:
+    """Snapshots without weight history must emit the pre-g-3 shape."""
+
+    def test_no_is_sample_boundary_field_on_v1(self):
+        session, monitor = _make_session(weight_history=None)
+        session._emit_frame(0)
+        assert monitor._trigger_callbacks.call_count == 1
+        metrics = monitor._trigger_callbacks.call_args.kwargs["metrics"]
+        assert "is_sample_boundary" not in metrics
+        assert "weights" not in metrics
+
+    def test_v1_metrics_unchanged(self):
+        session, monitor = _make_session(weight_history=None)
+        session._emit_frame(2)
+        metrics = monitor._trigger_callbacks.call_args.kwargs["metrics"]
+        assert metrics["epoch"] == 3  # 1-indexed
+        assert metrics["replay"] is True
+        assert metrics["snapshot_id"] == "snap-test"
+
+
+# =============================================================================
+# V2 sample-boundary detection
+# =============================================================================
+
+
+class TestSampleBoundaryDetection:
+    def test_boundary_epoch_emits_weights(self):
+        wh = _weight_history(num_samples=3, sampling_interval=2)  # samples at epochs 0, 2, 4
+        session, monitor = _make_session(weight_history=wh)
+        session._emit_frame(2)  # epoch index 2 == sample 1
+        metrics = monitor._trigger_callbacks.call_args.kwargs["metrics"]
+        assert metrics["is_sample_boundary"] is True
+        assert "weights" in metrics
+        assert metrics["weights"]["sample_index"] == 1
+
+    def test_non_boundary_epoch_marks_false_no_weights(self):
+        wh = _weight_history(num_samples=3, sampling_interval=2)  # samples at 0, 2, 4
+        session, monitor = _make_session(weight_history=wh)
+        session._emit_frame(1)  # not a sample boundary
+        metrics = monitor._trigger_callbacks.call_args.kwargs["metrics"]
+        assert metrics["is_sample_boundary"] is False
+        assert "weights" not in metrics
+
+    def test_first_epoch_boundary_emits(self):
+        # sample_indices[0] == 0 — the very first emission lands on a boundary.
+        wh = _weight_history(num_samples=3, sampling_interval=2)
+        session, monitor = _make_session(weight_history=wh)
+        session._emit_frame(0)
+        metrics = monitor._trigger_callbacks.call_args.kwargs["metrics"]
+        assert metrics["is_sample_boundary"] is True
+        assert metrics["weights"]["sample_index"] == 0
+
+    def test_emit_frame_skips_out_of_range(self):
+        wh = _weight_history(num_samples=3, sampling_interval=2)
+        session, monitor = _make_session(weight_history=wh)
+        session._emit_frame(99)
+        assert monitor._trigger_callbacks.call_count == 0
+
+
+# =============================================================================
+# Tensor envelope
+# =============================================================================
+
+
+class TestEncodedTensorEnvelope:
+    def test_output_weights_round_trip(self):
+        wh = _weight_history(num_samples=3, sampling_interval=2)
+        session, monitor = _make_session(weight_history=wh)
+        session._emit_frame(4)  # sample index 2
+        metrics = monitor._trigger_callbacks.call_args.kwargs["metrics"]
+        ow = metrics["weights"]["output_weights"]
+        assert ow["dtype"] == "float32"
+        assert ow["shape"] == list(wh["output_weights"][2].shape)
+        decoded = np.frombuffer(base64.b64decode(ow["data"]), dtype=np.float32).reshape(ow["shape"])
+        np.testing.assert_array_equal(decoded, wh["output_weights"][2])
+
+    def test_output_bias_round_trip(self):
+        wh = _weight_history(num_samples=3, sampling_interval=2)
+        session, monitor = _make_session(weight_history=wh)
+        session._emit_frame(2)  # sample index 1
+        metrics = monitor._trigger_callbacks.call_args.kwargs["metrics"]
+        ob = metrics["weights"]["output_bias"]
+        assert ob["dtype"] == "float32"
+        decoded = np.frombuffer(base64.b64decode(ob["data"]), dtype=np.float32).reshape(ob["shape"])
+        np.testing.assert_array_equal(decoded, wh["output_bias"][1])
+
+    def test_hidden_unit_weights_round_trip(self):
+        wh = _weight_history(num_samples=3, sampling_interval=2, num_hidden=2)
+        session, monitor = _make_session(weight_history=wh)
+        session._emit_frame(4)  # sample index 2 — both units present
+        metrics = monitor._trigger_callbacks.call_args.kwargs["metrics"]
+        hu = metrics["weights"]["hidden_units"]
+        assert len(hu) == 2
+        for emitted, source in zip(hu, wh["hidden_units"]):
+            # local_idx = sample_index(2) - first_sample_index of unit
+            local_idx = 2 - source["first_sample_index"]
+            arr = source["weights"][local_idx]
+            assert emitted["weights"]["dtype"] == "float32"
+            assert emitted["weights"]["shape"] == list(arr.shape)
+            decoded = np.frombuffer(base64.b64decode(emitted["weights"]["data"]), dtype=np.float32).reshape(emitted["weights"]["shape"])
+            np.testing.assert_array_equal(decoded, arr)
+            # Bias is a plain float, not an envelope
+            assert isinstance(emitted["bias"], float)
+            assert emitted["bias"] == pytest.approx(source["bias"][local_idx])
+
+    def test_units_not_yet_added_excluded(self):
+        wh = _weight_history(num_samples=3, sampling_interval=2, num_hidden=2)
+        # Unit 0 first_sample_index=1, unit 1 first_sample_index=2.
+        # At sample 0 neither unit is present.
+        session, monitor = _make_session(weight_history=wh)
+        session._emit_frame(0)
+        metrics = monitor._trigger_callbacks.call_args.kwargs["metrics"]
+        assert metrics["weights"]["hidden_units"] == []
+
+    def test_encode_tensor_handles_none_gracefully(self):
+        # Defensive: if the cache somehow returns a payload with None
+        # tensors (e.g. ragged storage in a future PR), the encoder
+        # must not crash the playback thread.
+        encoded = _ReplaySession._encode_tensor(None)
+        assert encoded is None
+
+
+# =============================================================================
+# Empty weight history
+# =============================================================================
+
+
+class TestEmptyWeightHistory:
+    """A weight_history dict with empty sample_indices behaves like V1."""
+
+    def test_empty_sample_indices_treated_as_v1(self):
+        wh = {
+            "sampling_strategy": "adaptive",
+            "sampling_interval": 2,
+            "sample_indices": [],
+            "output_weights": [],
+            "output_bias": [],
+            "hidden_units": [],
+        }
+        session, monitor = _make_session(weight_history=wh)
+        session._emit_frame(0)
+        metrics = monitor._trigger_callbacks.call_args.kwargs["metrics"]
+        # Cache.available is False when sample_indices is empty, so the
+        # emitter falls through the V1 branch — no is_sample_boundary
+        # field at all.
+        assert "is_sample_boundary" not in metrics
+        assert "weights" not in metrics


### PR DESCRIPTION
## Why this PR exists

Original g-3 PR was **#187**, marked MERGED but the merge commit landed in stacked parent \`feature/can-015g-2-replay-weight-cache\` rather than \`main\`. \`git merge-base --is-ancestor f5b7309 origin/main\` returns false. Same stacked-merge issue as #184 → fix shipped in **#189**.

This PR re-targets the same change by cherry-picking the original commit \`f5b7309\` onto **#189**'s branch. **No code changes** — diff is identical to what #187 carried.

## Validation

- [x] 41 tests pass on the retargeted branch (12 \`test_replay_weight_emission.py\` + 19 \`test_replay_weight_cache.py\` + 10 \`test_snapshot_weight_history.py\`) in JuniperCascor1
- [x] Cherry-pick auto-merged cleanly

## Original PR description

See **#187** for the complete description. TL;DR:

- \`_ReplaySession\` builds an O(1) \`_epoch_to_sample\` reverse lookup at init.
- \`_emit_frame\` extended: V2 path adds \`is_sample_boundary\` + base64-encoded \`weights\` block on boundary epochs; V1 path emits the unchanged pre-g-3 shape.
- Wire format: \`{dtype, shape, data: base64}\` envelopes; scalar bias as plain float.

🤖 Generated with [Claude Code](https://claude.com/claude-code)