### PR TITLE
feat(training): capture per-sample weight history during training (Phase 6E CAN-015g, g-6)

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -61,6 +61,399 @@ def _write_activation_function_name(network: Any, value: str) -> None:
     network._init_activation_function()
 
 
+class _WeightHistoryRecorder:
+    """CAN-015g (Phase 6E follow-on, g-6): training-loop weight history capture.
+
+    Populates ``network.weight_history`` during a training run so the
+    serializer's V2 path (g-1) actually has data to persist when the
+    user calls ``POST /v1/snapshots``. Without this, V2 replay only
+    works against ad-hoc test fixtures — production training would
+    still produce V1-only snapshots.
+
+    Plan: ``notes/PHASE_6E_DEFERRED_CAN-015GH_DESIGN.md`` §"Live
+    capture during training (g-6)".
+
+    Three trigger points:
+      1. **Every Nth epoch** — registered as a callback on
+         ``training_monitor.on_epoch_end``. ``N`` = network's
+         ``config.weight_history_sampling_interval`` (default 50;
+         set to 1 for every-epoch capture; set to 0 to disable the
+         periodic trigger and rely on cascade-add only).
+      2. **Cascade-grow events** — registered as a callback on
+         ``training_monitor.on_cascade_add``. Always captures
+         regardless of the periodic interval since these are the
+         narrative anchors per the parent design.
+      3. **Terminal capture** — call ``capture_terminal()`` from the
+         lifecycle's training-completion path so the last sample
+         reflects the truly-final weights even when training stops
+         mid-interval.
+
+    Memory ceiling: ``config.weight_history_max_samples`` (default
+    1000) is a soft cap. On overflow the recorder decimates
+    inter-cascade samples by 2× while always retaining cascade-add
+    samples (they're the visually-meaningful moments).
+
+    Idempotency: a single epoch can fire both Nth-epoch and
+    cascade-add triggers. The recorder dedupes by epoch number — a
+    sample for a given epoch is recorded at most once, with the
+    cascade-add capture winning if both fire (it has the latest
+    post-grow state).
+
+    Thread safety: capture runs in the training thread (the same
+    thread that fires ``on_epoch_end`` / ``on_cascade_add``). No
+    cross-thread coordination is needed because ``network.weight_history``
+    is only read by the lifecycle in (a) ``save_snapshot`` and
+    (b) replay-session loading — both of which fire while training
+    is paused or stopped per the FSM.
+    """
+
+    # Marker on a sample's metadata: ``True`` means this sample was
+    # captured at a cascade-add event and is exempt from decimation.
+    _CASCADE_FLAG_KEY = "_cascade_add"
+
+    def __init__(self, network, monitor, *, sampling_interval: Optional[int] = None, max_samples: Optional[int] = None) -> None:
+        self.network = network
+        self.monitor = monitor
+        config = getattr(network, "config", None)
+        self.sampling_interval: int = int(sampling_interval if sampling_interval is not None else getattr(config, "weight_history_sampling_interval", 50))
+        self.max_samples: int = int(max_samples if max_samples is not None else getattr(config, "weight_history_max_samples", 1000))
+        self.logger = logging.getLogger(__name__)
+        self._registered: bool = False
+        self._init_weight_history()
+
+    def _init_weight_history(self) -> None:
+        """Ensure ``network.weight_history`` exists with the expected shape.
+
+        Pre-g-6 networks won't have the attribute — initialize it
+        with the same dict layout the g-1 serializer reads. Idempotent
+        so reattaching the recorder mid-run doesn't clobber existing
+        samples.
+        """
+        wh = getattr(self.network, "weight_history", None)
+        if not isinstance(wh, dict):
+            self.network.weight_history = {
+                "sampling_strategy": "adaptive",
+                "sampling_interval": self.sampling_interval,
+                "sample_indices": [],
+                "output_weights": [],
+                "output_bias": [],
+                # Per-unit dicts: {first_sample_index, activation, weights[], bias[]}.
+                # See plan §"Hidden-unit slicing convention".
+                "hidden_units": [],
+                # Internal: epochs already captured (dedupe + decimation
+                # bookkeeping). Not consumed by the serializer.
+                "_captured_epochs": [],
+                "_cascade_epochs": set(),
+            }
+        else:
+            # Refresh the periodic interval so a runtime-tunable change
+            # via PATCH /v1/training/params lands on the next trigger.
+            wh["sampling_interval"] = self.sampling_interval
+            wh.setdefault("sampling_strategy", "adaptive")
+            wh.setdefault("sample_indices", [])
+            wh.setdefault("output_weights", [])
+            wh.setdefault("output_bias", [])
+            wh.setdefault("hidden_units", [])
+            wh.setdefault("_captured_epochs", [])
+            wh.setdefault("_cascade_epochs", set())
+
+    # ------------------------------------------------------------------
+    # Registration
+    # ------------------------------------------------------------------
+
+    def register(self) -> None:
+        """Subscribe to ``on_epoch_end`` and ``on_cascade_add`` events.
+
+        Idempotent — repeated calls are no-ops so multiple
+        ``start_training`` invocations don't double-register.
+        """
+        if self._registered or self.monitor is None:
+            return
+        self.monitor.register_callback("epoch_end", self._on_epoch_end)
+        self.monitor.register_callback("cascade_add", self._on_cascade_add)
+        self._registered = True
+
+    # ------------------------------------------------------------------
+    # Trigger callbacks
+    # ------------------------------------------------------------------
+
+    def _on_epoch_end(self, **kwargs) -> None:
+        """Periodic trigger: capture every Nth epoch.
+
+        Skipped silently when ``sampling_interval == 0`` (cascade-add
+        only mode). Best-effort — exceptions are logged but never
+        crash the training thread.
+        """
+        if self.sampling_interval <= 0:
+            return
+        epoch = kwargs.get("epoch")
+        if epoch is None:
+            return
+        try:
+            epoch_int = int(epoch)
+        except (TypeError, ValueError):
+            return
+        # Trigger on epoch numbers that are multiples of the interval
+        # (epoch=1 with interval=50 does NOT fire; epoch=50 does).
+        # Epoch 0 fires too — gives canopy the initial state.
+        if epoch_int % self.sampling_interval != 0:
+            return
+        try:
+            self._capture(epoch_int, is_cascade_add=False)
+        except Exception:
+            self.logger.exception("g-6: epoch_end capture raised; continuing")
+
+    def _on_cascade_add(self, **kwargs) -> None:
+        """Cascade-grow trigger: always capture.
+
+        Fires after a unit has been fully installed (matches the
+        existing ``hidden_units_added`` append point in
+        ``cascade_correlation.add_unit``). Uses the monitor's
+        ``current_epoch`` because the event payload doesn't carry it.
+        """
+        epoch = getattr(self.monitor, "current_epoch", None) if self.monitor is not None else None
+        if epoch is None:
+            return
+        try:
+            epoch_int = int(epoch)
+        except (TypeError, ValueError):
+            return
+        try:
+            self._capture(epoch_int, is_cascade_add=True)
+        except Exception:
+            self.logger.exception("g-6: cascade_add capture raised; continuing")
+
+    def capture_terminal(self) -> None:
+        """Final-epoch capture from the lifecycle's training-completion path.
+
+        Public so the caller can invoke it explicitly; uses the
+        monitor's ``current_epoch`` like ``_on_cascade_add`` and
+        marks the sample as cascade-equivalent (decimation-exempt)
+        so the terminal frame survives even on long runs that hit
+        the soft cap.
+        """
+        epoch = getattr(self.monitor, "current_epoch", None) if self.monitor is not None else None
+        if epoch is None:
+            return
+        try:
+            epoch_int = int(epoch)
+        except (TypeError, ValueError):
+            return
+        try:
+            self._capture(epoch_int, is_cascade_add=True)
+        except Exception:
+            self.logger.exception("g-6: terminal capture raised; continuing")
+
+    # ------------------------------------------------------------------
+    # Capture mechanics
+    # ------------------------------------------------------------------
+
+    def _capture(self, epoch: int, *, is_cascade_add: bool) -> None:
+        """Snapshot the network's current weights into ``weight_history``.
+
+        Dedupes by epoch — a second trigger at the same epoch
+        overwrites the previous sample's tensors (the cascade-add
+        capture wins because it sees the latest post-grow state).
+        Tensors are detached + ``cpu().numpy().copy()`` so the
+        history holds an independent snapshot the optimizer can't
+        mutate later.
+        """
+        self._init_weight_history()
+        wh = self.network.weight_history
+
+        captured = wh["_captured_epochs"]
+        cascade_epochs = wh["_cascade_epochs"]
+
+        if epoch in captured:
+            existing_idx = captured.index(epoch)
+            self._write_sample_at(existing_idx, epoch, is_cascade_add=is_cascade_add)
+            if is_cascade_add:
+                cascade_epochs.add(epoch)
+            return
+
+        # New sample — append.
+        captured.append(epoch)
+        wh["sample_indices"].append(epoch)
+        wh["output_weights"].append(self._copy_output_weights())
+        wh["output_bias"].append(self._copy_output_bias())
+        new_index = len(captured) - 1
+        # Hidden-unit per-sample slice: append a per-unit array entry.
+        self._append_hidden_unit_slices(new_index, captured)
+        if is_cascade_add:
+            cascade_epochs.add(epoch)
+
+        # Enforce the soft cap with cascade-aware decimation.
+        if self.max_samples > 0 and len(captured) > self.max_samples:
+            self._decimate(captured, cascade_epochs)
+
+    def _write_sample_at(self, index: int, epoch: int, *, is_cascade_add: bool) -> None:
+        """Overwrite an existing sample's tensors (dedupe path)."""
+        wh = self.network.weight_history
+        wh["output_weights"][index] = self._copy_output_weights()
+        wh["output_bias"][index] = self._copy_output_bias()
+        # Refresh per-unit slices for this sample only.
+        captured = wh["_captured_epochs"]
+        for unit_idx, unit_dict in enumerate(wh["hidden_units"]):
+            first = unit_dict["first_sample_index"]
+            local = index - first
+            if local < 0:
+                continue
+            unit_w, unit_b = self._copy_unit(unit_idx)
+            if unit_w is None:
+                continue
+            while len(unit_dict["weights"]) <= local:
+                unit_dict["weights"].append(unit_w)
+                unit_dict["bias"].append(unit_b)
+            unit_dict["weights"][local] = unit_w
+            unit_dict["bias"][local] = unit_b
+        # Ensure any newly-cascade-grown unit (added between this
+        # sample's first capture and the rewrite) gets a slot.
+        self._append_hidden_unit_slices(index, captured, rewrite=True)
+
+    def _append_hidden_unit_slices(self, sample_index: int, captured: list, rewrite: bool = False) -> None:
+        """Ensure every current hidden unit has a per-sample slice for ``sample_index``."""
+        wh = self.network.weight_history
+        units = getattr(self.network, "hidden_units", None) or []
+        for unit_idx, _ in enumerate(units):
+            if unit_idx >= len(wh["hidden_units"]):
+                # First time we've seen this unit — record its
+                # ``first_sample_index`` (sample-list index, NOT
+                # epoch — matches the g-2 cache convention).
+                activation = self._unit_activation_name(unit_idx)
+                wh["hidden_units"].append(
+                    {
+                        "first_sample_index": sample_index,
+                        "activation": activation,
+                        "weights": [],
+                        "bias": [],
+                    }
+                )
+            unit_dict = wh["hidden_units"][unit_idx]
+            first = unit_dict["first_sample_index"]
+            local = sample_index - first
+            if local < 0:
+                continue
+            unit_w, unit_b = self._copy_unit(unit_idx)
+            if unit_w is None:
+                continue
+            if rewrite and local < len(unit_dict["weights"]):
+                unit_dict["weights"][local] = unit_w
+                unit_dict["bias"][local] = unit_b
+            else:
+                while len(unit_dict["weights"]) <= local:
+                    # Pad with zeros if a prior sample skipped this
+                    # unit (shouldn't happen with the current trigger
+                    # set but defensive against future trigger types).
+                    unit_dict["weights"].append(unit_w)
+                    unit_dict["bias"].append(unit_b)
+
+    # ------------------------------------------------------------------
+    # Tensor copy helpers (training-thread, no autograd retention)
+    # ------------------------------------------------------------------
+
+    def _copy_output_weights(self):
+        ow = getattr(self.network, "output_weights", None)
+        return self._tensor_to_numpy(ow)
+
+    def _copy_output_bias(self):
+        ob = getattr(self.network, "output_bias", None)
+        return self._tensor_to_numpy(ob)
+
+    def _copy_unit(self, unit_idx: int):
+        units = getattr(self.network, "hidden_units", None) or []
+        if unit_idx >= len(units):
+            return None, None
+        unit = units[unit_idx]
+        w = unit.get("weights") if isinstance(unit, dict) else getattr(unit, "weights", None)
+        b = unit.get("bias") if isinstance(unit, dict) else getattr(unit, "bias", None)
+        w_np = self._tensor_to_numpy(w)
+        b_np = self._tensor_to_numpy(b)
+        if b_np is None:
+            return w_np, 0.0
+        # Per-unit bias is logically a scalar — flatten to a Python float
+        # so the (g-1) serializer's atleast_1d wrap path stays uniform.
+        return w_np, float(b_np.flat[0]) if b_np.size > 0 else 0.0
+
+    @staticmethod
+    def _tensor_to_numpy(t):
+        if t is None:
+            return None
+        # Torch tensor path — detach to drop autograd, cpu() to leave
+        # any device, numpy() + copy() so the buffer survives
+        # subsequent in-place updates by the optimizer.
+        try:
+            return np.ascontiguousarray(t.detach().cpu().numpy(), dtype=np.float32).copy()
+        except AttributeError:
+            try:
+                return np.ascontiguousarray(t, dtype=np.float32).copy()
+            except (TypeError, ValueError):
+                return None
+
+    def _unit_activation_name(self, unit_idx: int) -> str:
+        units = getattr(self.network, "hidden_units", None) or []
+        if unit_idx >= len(units):
+            return ""
+        unit = units[unit_idx]
+        if isinstance(unit, dict):
+            act = unit.get("activation_fn") or unit.get("activation")
+            if act is None:
+                return ""
+            name = getattr(act, "__name__", None) or str(act).__class__.__name__
+            return str(name)
+        return ""
+
+    # ------------------------------------------------------------------
+    # Decimation (memory ceiling)
+    # ------------------------------------------------------------------
+
+    def _decimate(self, captured: list, cascade_epochs: set) -> None:
+        """Halve the inter-cascade sample density when the soft cap is hit.
+
+        Drops every other non-cascade sample. Cascade-add samples
+        (and the terminal sample, if marked) are always retained
+        because they carry the narrative arc the user actually wants
+        to scrub through.
+        """
+        wh = self.network.weight_history
+        keep_mask: List[bool] = []
+        non_cascade_seen = 0
+        for epoch in captured:
+            if epoch in cascade_epochs:
+                keep_mask.append(True)
+            else:
+                # Drop every second non-cascade sample.
+                keep = (non_cascade_seen % 2) == 0
+                keep_mask.append(keep)
+                non_cascade_seen += 1
+
+        # Apply mask in-place to the parallel arrays.
+        new_captured = [e for e, k in zip(captured, keep_mask) if k]
+        new_indices = [v for v, k in zip(wh["sample_indices"], keep_mask) if k]
+        new_outputs = [v for v, k in zip(wh["output_weights"], keep_mask) if k]
+        new_biases = [v for v, k in zip(wh["output_bias"], keep_mask) if k]
+
+        # Drop the same indices from each hidden unit's per-sample arrays;
+        # adjust ``first_sample_index`` if that unit's first sample fell.
+        for unit_dict in wh["hidden_units"]:
+            old_first = unit_dict["first_sample_index"]
+            unit_keep = keep_mask[old_first:]
+            unit_dict["weights"] = [v for v, k in zip(unit_dict["weights"], unit_keep) if k]
+            unit_dict["bias"] = [v for v, k in zip(unit_dict["bias"], unit_keep) if k]
+            # Re-index ``first_sample_index`` to the new compacted list.
+            kept_before = sum(1 for k in keep_mask[:old_first] if k)
+            unit_dict["first_sample_index"] = kept_before
+
+        wh["_captured_epochs"] = new_captured
+        wh["sample_indices"] = new_indices
+        wh["output_weights"] = new_outputs
+        wh["output_bias"] = new_biases
+        # ``_cascade_epochs`` already only references retained epochs.
+
+        # Bump the *recorded* sampling_interval to reflect the
+        # decimation so loaders / canopy can interpret the gap.
+        wh["sampling_interval"] = max(1, wh.get("sampling_interval", self.sampling_interval) * 2)
+
+
 class _ReplaySession:
     """CAN-015c (Phase 6E Sprint B B-3): per-snapshot replay session.
 
@@ -334,6 +727,11 @@ class TrainingLifecycleManager:
 
         # Network creation params (for reset)
         self._network_params: Optional[Dict[str, Any]] = None
+
+        # CAN-015g (g-6): training-loop weight history recorder.
+        # Lazily attached on first ``start_training`` call; persists
+        # across re-trains so callbacks register exactly once.
+        self._weight_history_recorder: Optional["_WeightHistoryRecorder"] = None
 
         # WebSocket manager (set via set_ws_manager)
         self._ws_manager = None
@@ -732,6 +1130,15 @@ class TrainingLifecycleManager:
                 # Extract any remaining metrics after fit completes
                 manager_ref._extract_and_record_metrics()
 
+                # CAN-015g (g-6): capture the truly-final weights so
+                # the last sample reflects training's terminal state
+                # even when fit() exited mid-interval (e.g. early
+                # stopping mid-N). Wraps both the cancelled and
+                # completed paths because both are valid terminal
+                # states the user can replay against.
+                if manager_ref._weight_history_recorder is not None:
+                    manager_ref._weight_history_recorder.capture_terminal()
+
                 if stop_event.is_set():
                     sm.handle_command(Command.STOP)
                     state.update_state(status="Stopped", phase="Idle")
@@ -1016,6 +1423,28 @@ class TrainingLifecycleManager:
     # and rationale (Option 1 — filter at the start_training boundary).
     _FIT_KWARGS: frozenset = frozenset({"max_epochs", "epochs", "max_iterations", "early_stopping"})
 
+    def _attach_weight_history_recorder(self) -> None:
+        """CAN-015g (g-6): instantiate + register the weight history recorder.
+
+        Idempotent — call before each training run. The recorder
+        reads ``config.weight_history_sampling_interval`` /
+        ``config.weight_history_max_samples`` at attach time, so a
+        runtime PATCH /v1/training/params change before this point
+        affects subsequent samples (changes mid-run land at the next
+        ``register`` call when re-attached).
+        """
+        if self.network is None or self.training_monitor is None:
+            return
+        existing = self._weight_history_recorder
+        if existing is None or existing.network is not self.network:
+            self._weight_history_recorder = _WeightHistoryRecorder(self.network, self.training_monitor)
+        else:
+            # Re-init in case config tunables changed since last training run.
+            existing.sampling_interval = int(getattr(self.network.config, "weight_history_sampling_interval", existing.sampling_interval))
+            existing.max_samples = int(getattr(self.network.config, "weight_history_max_samples", existing.max_samples))
+            existing._init_weight_history()
+        self._weight_history_recorder.register()
+
     def start_training(
         self,
         x: Optional[torch.Tensor] = None,
@@ -1105,6 +1534,14 @@ class TrainingLifecycleManager:
             # start fit() before update_params lands.
             if network_kwargs:
                 self._apply_params_unlocked(network_kwargs)
+
+            # CAN-015g (g-6): attach the weight-history recorder before
+            # the training future runs so the first epoch_end /
+            # cascade_add events get captured. Lazy attach: the
+            # recorder reads ``config.weight_history_*`` so a runtime
+            # PATCH /v1/training/params change before this point lands
+            # in the recorder's snapshot of those values.
+            self._attach_weight_history_recorder()
 
             self._training_future = self._executor.submit(self._run_training, self._train_x, self._train_y, self._val_x, self._val_y, **fit_kwargs)
 

--- a/src/cascade_correlation/cascade_correlation_config/cascade_correlation_config.py
+++ b/src/cascade_correlation/cascade_correlation_config/cascade_correlation_config.py
@@ -205,6 +205,18 @@ class CascadeCorrelationConfig:
         task_reassignment_timeout: float = 120.0,
         # cascade_correlation_network_snapshots_dir: str = _HDF5_PROJECT_SNAPSHOTS_DIR,
         cascade_correlation_network_snapshots_dir: pathlib.Path = _CASCADE_CORRELATION_NETWORK_HDF5_PROJECT_SNAPSHOTS_DIR,
+        # CAN-015g (g-6): per-sample weight history capture during
+        # training. ``weight_history_sampling_interval`` is N for the
+        # every-Nth-epoch trigger (50 by default; 1 captures every
+        # epoch — Option A in the design's storage-strategy table; 0
+        # disables the periodic trigger so only cascade-add events
+        # are sampled — Option D). ``weight_history_max_samples`` is
+        # a soft cap on the in-memory history length before
+        # decimation kicks in (see plan §"Live capture during
+        # training (g-6)" / "Memory ceiling"); 0 means unbounded
+        # (use with care on long runs).
+        weight_history_sampling_interval: int = 50,
+        weight_history_max_samples: int = 1000,
         # UUID
         uuid: uuid.UUID = None,
     ):
@@ -290,6 +302,10 @@ class CascadeCorrelationConfig:
 
         # Snapshot directory
         self.cascade_correlation_network_snapshots_dir = cascade_correlation_network_snapshots_dir
+
+        # CAN-015g (g-6): per-sample weight history capture during training.
+        self.weight_history_sampling_interval = weight_history_sampling_interval
+        self.weight_history_max_samples = weight_history_max_samples
 
         # Optimizer configuration. CAN-010 / ENH-006 (A-2): forward
         # ``optimizer_type`` from the constructor kwargs so creation-time

--- a/src/tests/unit/api/test_weight_history_recorder.py
+++ b/src/tests/unit/api/test_weight_history_recorder.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python
+"""Unit tests for the training-loop weight history recorder (CAN-015g g-6).
+
+Covers:
+- Initialization: pre-g-6 networks (no ``weight_history`` attribute)
+  pick up the V2 capture surface seamlessly.
+- Trigger ordering: every-Nth-epoch, cascade-grow events, terminal
+  capture all populate the history correctly. Dedup by epoch when
+  multiple triggers fire at the same epoch.
+- Config tunables: ``sampling_interval=0`` disables the periodic
+  trigger; ``max_samples=0`` disables decimation.
+- Decimation: cascade-add samples are retained; inter-cascade are
+  decimated 2× when the cap is exceeded.
+- Hidden-unit slicing: ``first_sample_index`` is a sample-list index
+  (matches the g-2 cache convention).
+
+The recorder is exercised against a synthetic ``network`` mock so
+the tests don't drag in a full CascadeCorrelationNetwork instance —
+keeps the tests fast and isolates the recorder logic from any
+training-loop side effects.
+"""
+
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import torch
+
+# Add parent directories for imports.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
+
+from api.lifecycle.manager import _WeightHistoryRecorder  # noqa: E402
+from api.lifecycle.monitor import TrainingMonitor  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def _mock_network(num_hidden=0, in_size=2, out_size=1, sampling_interval=10, max_samples=100):
+    """Build a stand-in for a CascadeCorrelationNetwork.
+
+    Just exposes the attributes the recorder reads:
+    ``output_weights``, ``output_bias``, ``hidden_units``,
+    ``config.weight_history_sampling_interval``,
+    ``config.weight_history_max_samples``.
+    """
+    config = SimpleNamespace(
+        weight_history_sampling_interval=sampling_interval,
+        weight_history_max_samples=max_samples,
+    )
+    network = SimpleNamespace(
+        config=config,
+        output_weights=torch.zeros(in_size + num_hidden, out_size, dtype=torch.float32),
+        output_bias=torch.zeros(out_size, dtype=torch.float32),
+        hidden_units=[{"weights": torch.zeros(in_size + i, dtype=torch.float32), "bias": torch.zeros(1, dtype=torch.float32)} for i in range(num_hidden)],
+    )
+    return network
+
+
+def _real_monitor():
+    """Use the real TrainingMonitor so callbacks fire through ``_trigger_callbacks``."""
+    return TrainingMonitor()
+
+
+# =============================================================================
+# Initialization
+# =============================================================================
+
+
+class TestWeightHistoryRecorderInit:
+    def test_pre_g6_network_gets_weight_history_initialized(self):
+        net = _mock_network()
+        assert not hasattr(net, "weight_history")
+        recorder = _WeightHistoryRecorder(net, _real_monitor())
+        assert hasattr(net, "weight_history")
+        assert net.weight_history["sample_indices"] == []
+        assert net.weight_history["sampling_strategy"] == "adaptive"
+        assert net.weight_history["sampling_interval"] == 10
+        assert recorder.sampling_interval == 10
+        assert recorder.max_samples == 100
+
+    def test_existing_weight_history_preserved(self):
+        net = _mock_network()
+        net.weight_history = {
+            "sampling_strategy": "every_n",
+            "sampling_interval": 7,
+            "sample_indices": [0, 7],
+            "output_weights": [np.zeros((2, 1), dtype=np.float32)] * 2,
+            "output_bias": [np.zeros(1, dtype=np.float32)] * 2,
+            "hidden_units": [],
+            "_captured_epochs": [0, 7],
+            "_cascade_epochs": set(),
+        }
+        recorder = _WeightHistoryRecorder(net, _real_monitor())
+        # Existing samples are preserved; only sampling_interval is
+        # refreshed to the recorder's value (matches runtime PATCH).
+        assert net.weight_history["sample_indices"] == [0, 7]
+        assert recorder.sampling_interval == 10
+        assert net.weight_history["sampling_interval"] == 10  # refreshed
+
+    def test_constructor_overrides(self):
+        net = _mock_network(sampling_interval=10, max_samples=100)
+        recorder = _WeightHistoryRecorder(net, _real_monitor(), sampling_interval=5, max_samples=50)
+        assert recorder.sampling_interval == 5
+        assert recorder.max_samples == 50
+
+    def test_register_idempotent(self):
+        net = _mock_network()
+        monitor = _real_monitor()
+        recorder = _WeightHistoryRecorder(net, monitor)
+        recorder.register()
+        before = len(monitor.callbacks.get("epoch_end", []))
+        recorder.register()  # second call should NOT re-register
+        after = len(monitor.callbacks.get("epoch_end", []))
+        assert before == after
+
+
+# =============================================================================
+# Periodic trigger
+# =============================================================================
+
+
+class TestPeriodicTrigger:
+    def test_nth_epoch_captures(self):
+        net = _mock_network(sampling_interval=5)
+        monitor = _real_monitor()
+        recorder = _WeightHistoryRecorder(net, monitor)
+        recorder.register()
+        for epoch in range(0, 12):
+            monitor.on_epoch_end(epoch=epoch, loss=1.0, accuracy=0.5, learning_rate=0.1)
+        # Captures at 0, 5, 10
+        assert net.weight_history["sample_indices"] == [0, 5, 10]
+
+    def test_sampling_interval_zero_disables_periodic(self):
+        net = _mock_network(sampling_interval=0)
+        monitor = _real_monitor()
+        recorder = _WeightHistoryRecorder(net, monitor)
+        recorder.register()
+        for epoch in range(0, 20):
+            monitor.on_epoch_end(epoch=epoch, loss=1.0, accuracy=0.5, learning_rate=0.1)
+        assert net.weight_history["sample_indices"] == []
+
+    def test_capture_records_independent_copy(self):
+        net = _mock_network(sampling_interval=1)
+        monitor = _real_monitor()
+        recorder = _WeightHistoryRecorder(net, monitor)
+        recorder.register()
+        monitor.on_epoch_end(epoch=0, loss=1.0, accuracy=0.5, learning_rate=0.1)
+        # Mutate the network's weights — the captured sample must NOT change.
+        net.output_weights = net.output_weights + 999.0
+        np.testing.assert_array_equal(net.weight_history["output_weights"][0], np.zeros((2, 1), dtype=np.float32))
+
+
+# =============================================================================
+# Cascade-grow trigger
+# =============================================================================
+
+
+class TestCascadeAddTrigger:
+    def test_cascade_add_captures_at_current_epoch(self):
+        net = _mock_network(sampling_interval=0)  # only cascade-add fires
+        monitor = _real_monitor()
+        # Set monitor's current_epoch via on_epoch_end.
+        monitor.on_epoch_end(epoch=17, loss=1.0, accuracy=0.5, learning_rate=0.1)
+        recorder = _WeightHistoryRecorder(net, monitor)
+        recorder.register()
+        monitor.on_cascade_add(hidden_unit_index=0, correlation=0.9)
+        assert net.weight_history["sample_indices"] == [17]
+        assert 17 in net.weight_history["_cascade_epochs"]
+
+    def test_cascade_add_dedup_with_periodic(self):
+        net = _mock_network(sampling_interval=10)
+        monitor = _real_monitor()
+        recorder = _WeightHistoryRecorder(net, monitor)
+        recorder.register()
+        monitor.on_epoch_end(epoch=10, loss=1.0, accuracy=0.5, learning_rate=0.1)
+        monitor.on_cascade_add(hidden_unit_index=0, correlation=0.9)
+        # Single sample at epoch 10 — cascade marker set.
+        assert net.weight_history["sample_indices"] == [10]
+        assert 10 in net.weight_history["_cascade_epochs"]
+
+
+# =============================================================================
+# Terminal capture
+# =============================================================================
+
+
+class TestCaptureTerminal:
+    def test_terminal_captures_at_current_epoch(self):
+        net = _mock_network(sampling_interval=0)
+        monitor = _real_monitor()
+        monitor.on_epoch_end(epoch=99, loss=0.1, accuracy=0.95, learning_rate=0.1)
+        recorder = _WeightHistoryRecorder(net, monitor)
+        recorder.register()
+        recorder.capture_terminal()
+        assert net.weight_history["sample_indices"] == [99]
+        # Terminal samples are decimation-exempt (marked as cascade).
+        assert 99 in net.weight_history["_cascade_epochs"]
+
+
+# =============================================================================
+# Decimation
+# =============================================================================
+
+
+class TestDecimation:
+    def test_decimation_keeps_cascade_samples(self):
+        net = _mock_network(sampling_interval=1, max_samples=4)
+        monitor = _real_monitor()
+        recorder = _WeightHistoryRecorder(net, monitor)
+        recorder.register()
+        # Epochs 0..4 = 5 samples; cap is 4. Mark epoch 2 as cascade-add.
+        for epoch in range(0, 5):
+            monitor.on_epoch_end(epoch=epoch, loss=1.0, accuracy=0.5, learning_rate=0.1)
+            if epoch == 2:
+                monitor.on_cascade_add(hidden_unit_index=0, correlation=0.9)
+        # After exceeding cap at epoch 4: decimation keeps cascade
+        # epoch 2 unconditionally; non-cascade samples halve.
+        assert 2 in net.weight_history["sample_indices"]
+        # Final length must be ≤ original since decimation just ran.
+        assert len(net.weight_history["sample_indices"]) < 5
+
+    def test_max_samples_zero_disables_decimation(self):
+        net = _mock_network(sampling_interval=1, max_samples=0)
+        monitor = _real_monitor()
+        recorder = _WeightHistoryRecorder(net, monitor)
+        recorder.register()
+        for epoch in range(0, 50):
+            monitor.on_epoch_end(epoch=epoch, loss=1.0, accuracy=0.5, learning_rate=0.1)
+        assert len(net.weight_history["sample_indices"]) == 50
+
+    def test_decimation_doubles_recorded_interval(self):
+        net = _mock_network(sampling_interval=1, max_samples=2)
+        monitor = _real_monitor()
+        recorder = _WeightHistoryRecorder(net, monitor)
+        recorder.register()
+        for epoch in range(0, 4):
+            monitor.on_epoch_end(epoch=epoch, loss=1.0, accuracy=0.5, learning_rate=0.1)
+        # Decimation fired at least once — recorded interval doubled.
+        assert net.weight_history["sampling_interval"] >= 2
+
+
+# =============================================================================
+# Hidden-unit slicing
+# =============================================================================
+
+
+class TestHiddenUnitSlicing:
+    def test_first_sample_index_uses_sample_list_index(self):
+        net = _mock_network(num_hidden=0, sampling_interval=5)
+        monitor = _real_monitor()
+        recorder = _WeightHistoryRecorder(net, monitor)
+        recorder.register()
+        # Sample 0: no hidden units
+        monitor.on_epoch_end(epoch=0, loss=1.0, accuracy=0.5, learning_rate=0.1)
+        # Add a hidden unit, then sample 1 captures it.
+        net.hidden_units.append({"weights": torch.tensor([1.0, 2.0], dtype=torch.float32), "bias": torch.tensor([0.5], dtype=torch.float32)})
+        monitor.on_epoch_end(epoch=5, loss=0.9, accuracy=0.6, learning_rate=0.1)
+        # Cache convention: ``first_sample_index`` is an index into
+        # ``sample_indices``, NOT an epoch number. Unit appeared at
+        # sample list index 1 (epoch 5).
+        assert len(net.weight_history["hidden_units"]) == 1
+        unit = net.weight_history["hidden_units"][0]
+        assert unit["first_sample_index"] == 1
+        assert len(unit["weights"]) == 1
+        np.testing.assert_array_equal(unit["weights"][0], np.array([1.0, 2.0], dtype=np.float32))
+
+    def test_unit_bias_recorded_as_python_float(self):
+        net = _mock_network(num_hidden=1, sampling_interval=1)
+        net.hidden_units[0]["bias"] = torch.tensor([0.42], dtype=torch.float32)
+        monitor = _real_monitor()
+        recorder = _WeightHistoryRecorder(net, monitor)
+        recorder.register()
+        monitor.on_epoch_end(epoch=0, loss=1.0, accuracy=0.5, learning_rate=0.1)
+        unit = net.weight_history["hidden_units"][0]
+        assert isinstance(unit["bias"][0], float)
+        assert unit["bias"][0] == pytest.approx(0.42)
+
+
+# =============================================================================
+# Robustness
+# =============================================================================
+
+
+class TestRobustness:
+    def test_callback_swallows_exceptions(self):
+        net = _mock_network(sampling_interval=1)
+        monitor = _real_monitor()
+        recorder = _WeightHistoryRecorder(net, monitor)
+        recorder.register()
+        # Sabotage the network's output_weights so _tensor_to_numpy
+        # fails; recorder must not crash the monitor's emission path.
+        net.output_weights = "not a tensor"
+        monitor.on_epoch_end(epoch=0, loss=1.0, accuracy=0.5, learning_rate=0.1)
+        # Sample was appended (output_weights for it is None),
+        # the training thread did not raise.
+        assert net.weight_history["sample_indices"] == [0]
+
+    def test_terminal_without_monitor_state_is_noop(self):
+        net = _mock_network()
+        monitor = MagicMock()
+        monitor.current_epoch = None
+        recorder = _WeightHistoryRecorder(net, monitor)
+        recorder.capture_terminal()
+        assert net.weight_history["sample_indices"] == []


### PR DESCRIPTION
## Summary

Sixth PR of **CAN-015g** (Replay V2). Closes the V2 protocol's **write-side gap**: production training runs now actually populate \`network.weight_history\`, so saved snapshots carry the per-sample tensors that g-1's serializer persists, g-2's cache loads, and g-3's emitter emits.

Plan reference: [\`notes/PHASE_6E_DEFERRED_CAN-015GH_DESIGN.md\`](https://github.com/pcalnon/juniper-ml/blob/main/notes/PHASE_6E_DEFERRED_CAN-015GH_DESIGN.md) §\"Live capture during training (g-6)\" (added in juniper-ml #188).

## Discovery context

While implementing g-1/g-2/g-3 it surfaced that the cascor side could **play back** a \`weight_history\` but nothing in the training loop **populated** it — the protocol worked end-to-end against ad-hoc test fixtures only. g-6 closes the gap.

## Implementation

- **New \`_WeightHistoryRecorder\` class** in \`lifecycle/manager.py\`. Three triggers:
  - **Periodic**: every Nth epoch via \`training_monitor.on_epoch_end\`. \`N\` from \`config.weight_history_sampling_interval\` (default 50; \`N=1\` captures every epoch — Option A; \`N=0\` disables periodic — Option D).
  - **Cascade-grow**: every \`training_monitor.on_cascade_add\` event. Marked decimation-exempt.
  - **Terminal**: \`capture_terminal()\` from \`monitored_fit\`'s post-fit block (covers cancelled-by-stop and clean-completion paths).
- **Idempotent dedupe by epoch** — single epoch firing both Nth-epoch and cascade-add triggers records one sample (cascade-add wins).
- **Memory ceiling** via \`config.weight_history_max_samples\` (default 1000). On overflow, \`_decimate\` halves inter-cascade density while always retaining cascade-add samples; recorded \`sampling_interval\` doubles to reflect the on-disk gap.
- **Hidden-unit slicing matches the g-2 cache convention**: \`first_sample_index\` is a 0-based index into \`sample_indices\`, NOT an epoch number.
- **Tensor capture** uses \`.detach().cpu().numpy().copy()\` — drops autograd retention, produces buffers the optimizer can't mutate later.
- **Best-effort**: capture exceptions caught + logged but never crash the training thread.

## Wiring

- \`lifecycle/manager.py\`: new \`self._weight_history_recorder\` attribute, lazy attach via \`_attach_weight_history_recorder()\` from \`start_training\` just before submitting the future. Re-attach picks up runtime PATCH \`/v1/training/params\` changes.
- Terminal capture wired into \`monitored_fit\`'s post-fit block.

## Config

Two new tunables on \`CascadeCorrelationConfig\`:

| Field | Default | Purpose |
|---|---|---|
| \`weight_history_sampling_interval\` | 50 | N for the every-Nth-epoch trigger. \`1\` = every epoch (Option A). \`0\` = disable periodic (Option D — cascade-add only). |
| \`weight_history_max_samples\` | 1000 | Soft cap before decimation kicks in. \`0\` = unbounded. |

Both runtime-mutable via the existing PATCH \`/v1/training/params\` flow.

## Tests (\`test_weight_history_recorder.py\`, 17 tests)

- **Initialization**: pre-g-6 networks pick up V2 capture; existing \`weight_history\` preserved on re-attach (only \`sampling_interval\` refreshed); \`register()\` is idempotent.
- **Periodic trigger**: captures every Nth epoch; \`sampling_interval=0\` disables it; captured sample is an independent copy.
- **Cascade-add trigger**: captures at monitor's \`current_epoch\`; dedupes when same epoch fires both periodic + cascade-add.
- **Terminal capture**: marks sample as decimation-exempt.
- **Decimation**: cascade samples retained; \`max_samples=0\` disables; \`sampling_interval\` recorded value doubles after a decimation pass.
- **Hidden-unit slicing**: \`first_sample_index\` is a sample-list index; per-unit bias recorded as Python float.
- **Robustness**: capture exception in tensor copy doesn't crash the monitor; \`capture_terminal\` without monitor state is a no-op.

## Validation

- [x] 17 new + 165 existing lifecycle/serializer tests = **182 passed** in JuniperCascor1 (Python 3.13.13).
- [x] Pre-commit hooks pass (black, isort, flake8, mypy, bandit).

## Out of scope for g-6

- **Wall-clock benchmark** (≤ 5% overhead vs. baseline) — captured in the plan's risk register; will land as a perf regression test once the fast-slow mode test harness gets a benchmark fixture for it.
- **Decimation chaos test** (100k-epoch synthetic loop) — captured in the plan; deferred until the perf-test harness is wired.

## Test plan

- [x] Unit tests pass
- [x] Pre-commit clean
- [ ] Reviewer: confirm the trigger mix (every Nth + cascade + terminal) matches the plan's intent. The dedupe-by-epoch behavior is testable via \`test_cascade_add_dedup_with_periodic\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)