### PR TITLE
ci(P-4): bump pre-commit isort pin 5.13.2 → 8.0.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -119,7 +119,7 @@ repos:
   # Python Import Sorting - isort
   # ═══════════════════════════════════════════════════════════════════════════
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 8.0.1
     hooks:
       - id: isort
         name: Sort imports with isort


### PR DESCRIPTION
Aligns this repo's pre-commit isort pin with the local-Juniper-conda baseline (8.0.1) and juniper-canopy (8.0.1).

Closes the local-vs-pre-commit drift that caused two unnecessary CI iterations during V38 (juniper-ml notes/POST_V38_OPEN_ISSUES_PLAN_2026-05-03.md P-4).

`pre-commit run isort --all-files` clean — pure pin bump, no reformat.