### PR TITLE
fix(replay): drop set_range overwrite leaking time_index into range dict

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -1913,10 +1913,15 @@ class TrainingLifecycleManager:
             end = params.get("end")
             if start is None or end is None:
                 raise ValueError("range requires both 'start' and 'end' parameters")
-            range_result = session.set_range(int(start), int(end))
-            summary = session.state_summary()
-            summary["range"] = range_result
-            return summary
+            session.set_range(int(start), int(end))
+            # state_summary() already reflects the new range (set_range mutated
+            # self.range_start/self.range_end) and any re-clamped time_index.
+            # Don't overlay set_range's return value — it includes a
+            # ``time_index`` field that breaks the documented
+            # ``range == {"start", "end"}`` contract asserted by
+            # test_replay_control_seek_speed_range and
+            # test_state_summary_includes_all_fields.
+            return session.state_summary()
         elif action_lower == "stop":
             return self.stop_replay()
         else:


### PR DESCRIPTION
## Summary

Single-line bug fix in ``TrainingLifecycleManager.replay_control`` for the ``range`` action. ``set_range``'s return value (which intentionally includes ``time_index`` for direct callers) was being splatted over the ``range`` sub-dict in the ``state_summary``, breaking the documented ``range == {\"start\", \"end\"}`` shape that other tests already validate.

## Failing test on main

```
unit/api/test_lifecycle_manager.py::TestReplayLifecycleIntegration::test_replay_control_seek_speed_range

AssertionError: assert {'end': 4, 'start': 1, 'time_index': 3}
                        == {'end': 4, 'start': 1}
```

## Root cause

``src/api/lifecycle/manager.py:1916-1918`` (pre-fix):

```python
range_result = session.set_range(int(start), int(end))
summary = session.state_summary()
summary[\"range\"] = range_result
```

The session's ``set_range`` returns ``{\"start\", \"end\", \"time_index\"}`` (its own contract — covered by ``test_set_range_clamps_and_re_clamps_time_index``). ``state_summary`` returns ``range: {\"start\", \"end\"}`` (its contract — covered by ``test_state_summary_includes_all_fields``). The overwrite collapses the latter into the former, so the route response leaks ``time_index`` inside ``range`` even though the canonical place for it is at the top level of the summary.

## Fix

Drop the overwrite. ``set_range`` mutates ``self.range_start`` / ``self.range_end`` in-place under the session lock (and re-clamps ``self.time_index``), so the subsequent ``session.state_summary()`` call already reflects the new range with the correct two-key shape and the post-clamp ``time_index`` under its own top-level key.

```python
session.set_range(int(start), int(end))
return session.state_summary()
```

## Verification

- ``unit/api/test_lifecycle_manager.py::TestReplayLifecycleIntegration::test_replay_control_seek_speed_range`` — now passes
- Adjacent contracts unaffected:
  - ``test_set_range_clamps_and_re_clamps_time_index`` — still asserts the 3-key shape from direct ``session.set_range()`` calls
  - ``test_state_summary_includes_all_fields`` — still asserts the 2-key shape from ``state_summary()``
- Full ``-m unit`` suite under JuniperCascor1 (regular CPython 3.13): exit 0, no failures or errors

## Test plan

- [x] Failing test passes
- [x] Adjacent contract tests unchanged and still passing
- [x] Full unit suite passes (exit 0)
- [ ] CI integration leg also clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)