### PR TITLE
test(replay): align range-dict assertions with PR #195's contract (P-8)

### DIFF
--- a/src/tests/unit/api/test_lifecycle_manager.py
+++ b/src/tests/unit/api/test_lifecycle_manager.py
@@ -1393,11 +1393,15 @@ class TestReplayLifecycleIntegration:
                 state = mgr.replay_control("speed", value=2.5)
                 assert state["speed"] == 2.5
                 state = mgr.replay_control("range", start=1, end=4)
-                # P-2 cluster B (PR #183): the ``range`` action now merges
-                # ``set_range``'s return dict (with re-clamped ``time_index``)
-                # into ``state_summary``, matching the contract asserted by
-                # ``test_replay_control_range`` over the HTTP route surface.
-                assert state["range"] == {"start": 1, "end": 4, "time_index": 3}
+                # PR #195 finalised the contract: ``range`` is just
+                # ``{start, end}``; the (possibly re-clamped) ``time_index``
+                # is exposed as a top-level field on the same response,
+                # not nested inside ``range``. ``set_range`` mutates
+                # ``self.range_*`` and clamps ``self.time_index`` in-place
+                # under the lock, so ``state_summary`` already reflects
+                # both atomically.
+                assert state["range"] == {"start": 1, "end": 4}
+                assert state["time_index"] == 3
             finally:
                 mgr.stop_replay()
         mgr.shutdown()

--- a/src/tests/unit/api/test_snapshot_route_coverage.py
+++ b/src/tests/unit/api/test_snapshot_route_coverage.py
@@ -764,7 +764,12 @@ class TestReplaySnapshot:
             self._install_replay_session(lifecycle, "snap-range", length=5)
             response = client.post("/v1/snapshots/snap-range/replay/control", json={"action": "range", "start": 1, "end": 4})
             assert response.status_code == 200
-            assert response.json()["data"]["result"]["range"] == {"start": 1, "end": 4, "time_index": 1}
+            # PR #195: ``range`` carries only ``{start, end}``. The post-clamp
+            # ``time_index`` lives at the top level of the result payload
+            # (state_summary's own field), not nested inside ``range``.
+            result = response.json()["data"]["result"]
+            assert result["range"] == {"start": 1, "end": 4}
+            assert result["time_index"] == 1
         finally:
             self._teardown_replay_session(lifecycle)
 


### PR DESCRIPTION
PR #195 reverted the production code to keep `range == {start, end}` and surface `time_index` as a top-level state_summary field, but didn't update the two tests that asserted the old three-key shape. Cascor main has been red since #195 merged.

This PR updates both tests to the new contract:
- `state["range"] == {"start", "end"}` (no `time_index`)
- `state["time_index"]` asserted separately as a top-level field

No production-code changes — assertion shape only.

Refs juniper-ml notes/POST_V38_OPEN_ISSUES_PLAN_2026-05-03.md (P-8 follow-up to P-2 cluster B / PR #195).