### PR TITLE
feat(network): PATCH /v1/network/weights with shape + NaN validation (Phase 6E CAN-015h-1)

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -2224,6 +2224,175 @@ class TrainingLifecycleManager:
             return {}
 
     # ------------------------------------------------------------------
+    # CAN-015h-1: PATCH /v1/network/weights — surgical weight edit
+    # ------------------------------------------------------------------
+
+    # Sentinel values returned to the route layer so the route can map
+    # them to the right HTTP status. Plain string codes keep the
+    # lifecycle-↔-route boundary serializable for tests without
+    # requiring HTTPException to escape into the lifecycle layer.
+    _PATCH_OK: str = "ok"
+    _PATCH_FSM_REJECTED: str = "fsm_rejected"
+    _PATCH_NO_NETWORK: str = "no_network"
+    _PATCH_BAD_TARGET: str = "bad_target"
+    _PATCH_SHAPE_MISMATCH: str = "shape_mismatch"
+    _PATCH_NAN_INF: str = "nan_inf"
+    _PATCH_HIDDEN_UNIT_OUT_OF_RANGE: str = "hidden_unit_out_of_range"
+
+    def patch_weights(
+        self,
+        target: str,
+        field: str,
+        values: Any,
+        hidden_unit_index: Optional[int] = None,
+        dtype: str = "float32",
+    ) -> Dict[str, Any]:
+        """CAN-015h-1: surgically rewrite a single parameter group.
+
+        Returns a dict ``{"status": <code>, "detail": <str>}`` where
+        ``status`` is one of the ``_PATCH_*`` sentinels. The route
+        layer maps these to HTTP statuses (200 / 400 / 404 / 409 /
+        422) — see ``routes/network.py``.
+
+        FSM gate: requires INVESTIGATING (entered via ``/restore``).
+        Any other state returns ``_PATCH_FSM_REJECTED``.
+
+        Validation contract per the design plan:
+
+        - ``values`` must match the target tensor's shape exactly.
+          Partial updates are rejected with ``_PATCH_SHAPE_MISMATCH``.
+          Rationale: forces canopy to be explicit; prevents subtle
+          off-by-one bugs at the wire layer.
+        - NaN / Inf values are rejected with ``_PATCH_NAN_INF``.
+        - ``dtype`` is float32 by default. float64 inputs are auto-
+          cast (lossless when fitting in float32 range; the
+          plan-time concern about precision-losing casts is
+          captured by the NaN check post-cast).
+
+        Side-effects after a successful patch:
+
+        - The touched parameter is reassigned with a fresh tensor
+          carrying the new values, with ``requires_grad`` matching
+          the pre-patch attribute (so optimizer wiring elsewhere
+          doesn't toggle).
+        - The output-layer optimizer's state for the touched
+          parameter group is **zeroed** (Adam ``m`` and ``v``
+          buffers reset). Stale momentum from pre-patch weights is
+          meaningless after the rewrite.
+        """
+        if self.network is None:
+            return {"status": self._PATCH_NO_NETWORK, "detail": "No network created"}
+
+        if not self.state_machine.is_investigating():
+            return {
+                "status": self._PATCH_FSM_REJECTED,
+                "detail": f"patch_weights requires INVESTIGATING state (currently {self.state_machine.status.name})",
+            }
+
+        if target not in ("output", "hidden_unit"):
+            return {"status": self._PATCH_BAD_TARGET, "detail": f"unknown target: {target!r}"}
+        if field not in ("weights", "bias"):
+            return {"status": self._PATCH_BAD_TARGET, "detail": f"unknown field: {field!r}"}
+
+        # Resolve the tensor we're rewriting + a setter. The setter is
+        # a closure so we do not have to special-case the assignment
+        # logic at each branch — and the optimizer-state zero-out
+        # below uses the same closure to find the parameter group.
+        try:
+            new_tensor = self._build_patch_tensor(values, dtype)
+        except (TypeError, ValueError) as e:
+            return {"status": self._PATCH_NAN_INF, "detail": f"invalid tensor data: {e}"}
+
+        # NaN/Inf check after dtype cast (catches values that would
+        # otherwise become Inf when promoted to float32).
+        if not torch.isfinite(new_tensor).all():
+            return {"status": self._PATCH_NAN_INF, "detail": "values contain NaN or Inf"}
+
+        if target == "hidden_unit":
+            if hidden_unit_index is None or hidden_unit_index < 0 or hidden_unit_index >= len(self.network.hidden_units):
+                return {
+                    "status": self._PATCH_HIDDEN_UNIT_OUT_OF_RANGE,
+                    "detail": f"hidden_unit_index={hidden_unit_index} out of range (have {len(self.network.hidden_units)} units)",
+                }
+            current = self.network.hidden_units[hidden_unit_index][field]
+            if tuple(current.shape) != tuple(new_tensor.shape):
+                return {
+                    "status": self._PATCH_SHAPE_MISMATCH,
+                    "detail": f"shape mismatch: hidden_unit[{hidden_unit_index}].{field} expects {tuple(current.shape)}, got {tuple(new_tensor.shape)}",
+                }
+            # Zero the optimizer state BEFORE reassignment because the
+            # optimizer's state dict is keyed by tensor identity —
+            # ``current`` is the live key, ``new_tensor`` won't be
+            # found until a new optimizer is constructed against it.
+            self._zero_optimizer_state_for(current)
+            self.network.hidden_units[hidden_unit_index][field] = new_tensor
+        else:
+            attr = "output_weights" if field == "weights" else "output_bias"
+            current = getattr(self.network, attr)
+            if tuple(current.shape) != tuple(new_tensor.shape):
+                return {
+                    "status": self._PATCH_SHAPE_MISMATCH,
+                    "detail": f"shape mismatch: {attr} expects {tuple(current.shape)}, got {tuple(new_tensor.shape)}",
+                }
+            # Zero the optimizer state BEFORE reassignment (see above).
+            self._zero_optimizer_state_for(current)
+            requires_grad = bool(getattr(current, "requires_grad", False))
+            if requires_grad:
+                new_tensor.requires_grad_(True)
+            setattr(self.network, attr, new_tensor)
+
+        return {"status": self._PATCH_OK, "detail": "ok"}
+
+    @staticmethod
+    def _build_patch_tensor(values: Any, dtype: str) -> "torch.Tensor":
+        """Coerce a JSON-decoded ``values`` payload into a float32 tensor.
+
+        Raises ``ValueError`` on shape-irregular nested lists. The
+        NaN/Inf check is performed by the caller after this returns
+        so dtype-cast-induced infinities are also caught.
+        """
+        torch_dtype = torch.float64 if dtype == "float64" else torch.float32
+        try:
+            tensor = torch.tensor(values, dtype=torch_dtype)
+        except (TypeError, RuntimeError, ValueError) as e:
+            raise ValueError(f"could not coerce values to tensor: {e}") from e
+        # Force float32 on the wire side so storage and downstream
+        # forward-pass dtypes stay uniform with the existing network.
+        return tensor.to(dtype=torch.float32)
+
+    def _zero_optimizer_state_for(self, parameter) -> None:
+        """Zero out the optimizer's momentum/variance buffers for a
+        single parameter, if the network exposes a step-LR optimizer
+        whose ``state`` keys include the parameter object identity.
+
+        Best-effort: if the optimizer is None, missing state, or
+        keyed differently, the function is a no-op. The patched
+        weights still take effect; only the optimizer's stale
+        momentum survives, and the next training step will overwrite
+        it within a few iterations regardless.
+        """
+        optimizer = getattr(self.network, "output_optimizer", None)
+        if optimizer is None:
+            return
+        state = getattr(optimizer, "state", None)
+        if not isinstance(state, dict):
+            return
+        param_state = state.get(parameter)
+        if not isinstance(param_state, dict):
+            return
+        for key, val in list(param_state.items()):
+            if not isinstance(val, torch.Tensor):
+                continue
+            # Skip 0-d tensors (Adam's ``step`` counter is stored as a
+            # scalar tensor in newer PyTorch versions). Only the
+            # running-statistic buffers (``exp_avg``, ``exp_avg_sq``,
+            # etc.) carry the bias from pre-patch gradients and need
+            # zeroing.
+            if val.dim() == 0:
+                continue
+            param_state[key] = torch.zeros_like(val)
+
+    # ------------------------------------------------------------------
     # Decision boundary
     # ------------------------------------------------------------------
 

--- a/src/api/models/network.py
+++ b/src/api/models/network.py
@@ -94,3 +94,38 @@ class NetworkInfo(BaseModel):
     max_hidden_units: int
     learning_rate: float
     uuid: str = ""
+
+
+# ---------------------------------------------------------------------
+# CAN-015h-1: PATCH /v1/network/weights request body
+# ---------------------------------------------------------------------
+
+
+class PatchWeightsRequest(BaseModel):
+    """Body for ``PATCH /v1/network/weights`` (CAN-015h-1).
+
+    Targets one of the network's mutable parameter groups:
+
+    - ``target="output"``: rewrites the entire output-layer
+      ``weights`` matrix or ``bias`` vector. ``hidden_unit_index``
+      must be ``None``.
+    - ``target="hidden_unit"``: rewrites a specific hidden unit's
+      ``weights`` vector or ``bias`` scalar.
+      ``hidden_unit_index`` is required and must be a valid index
+      into the current ``hidden_units`` list.
+
+    The caller must include the **exact** shape — partial updates
+    are rejected with 400 (see lifecycle's ``patch_weights``).
+    Rationale per the design plan: forces the canopy UI to be
+    explicit and prevents subtle off-by-one bugs in the wire
+    layer. NaN/Inf values are rejected with 422.
+
+    Plan: ``notes/PHASE_6E_DEFERRED_CAN-015GH_DESIGN.md`` §"Endpoint
+    design / 1. PATCH /v1/network/weights" (juniper-ml).
+    """
+
+    target: Literal["output", "hidden_unit"] = Field(description="Which parameter group to patch")
+    field: Literal["weights", "bias"] = Field(description="Which field on the target to patch")
+    values: list = Field(description="New values, shape must match target exactly")
+    hidden_unit_index: int | None = Field(default=None, ge=0, description="Required iff target == 'hidden_unit'")
+    dtype: Literal["float32", "float64"] = Field(default="float32", description="Source dtype; cast to float32 internally")

--- a/src/api/routes/network.py
+++ b/src/api/routes/network.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, HTTPException, Request
 logger = logging.getLogger("juniper_cascor.api.routes.network")
 
 from api.models.common import success_response
-from api.models.network import NetworkCreateRequest
+from api.models.network import NetworkCreateRequest, PatchWeightsRequest
 
 router = APIRouter(prefix="/network", tags=["network"])
 
@@ -71,3 +71,51 @@ async def get_stats(request: Request) -> dict:
     if not lifecycle.has_network():
         raise HTTPException(status_code=404, detail="No network created")
     return success_response(lifecycle.get_statistics())
+
+
+@router.patch("/weights")
+async def patch_weights(request: Request, body: PatchWeightsRequest) -> dict:
+    """CAN-015h-1: surgically rewrite a single parameter group.
+
+    FSM-gated to ``Investigating`` (entered via ``/restore``).
+    Returns 200 + the post-patch network info on success; status
+    codes per the design plan §"Endpoint design / 1. PATCH":
+
+    - 200 — patch applied
+    - 400 — shape mismatch / unknown target / unknown field
+    - 404 — no network created / hidden_unit_index out of range
+    - 409 — FSM not Investigating
+    - 422 — NaN/Inf or untensorable values
+
+    Plan: ``notes/PHASE_6E_DEFERRED_CAN-015GH_DESIGN.md`` §"Endpoint
+    design / 1. PATCH /v1/network/weights" (juniper-ml).
+    """
+    lifecycle = _get_lifecycle(request)
+    result = lifecycle.patch_weights(
+        target=body.target,
+        field=body.field,
+        values=body.values,
+        hidden_unit_index=body.hidden_unit_index,
+        dtype=body.dtype,
+    )
+    status = result.get("status")
+    detail = result.get("detail", "patch failed")
+
+    if status == lifecycle._PATCH_OK:
+        info = lifecycle.get_network_info()
+        info["operation"] = "patch_weights"
+        info["fsm_state"] = lifecycle.state_machine.status.name
+        return success_response(info)
+    if status == lifecycle._PATCH_NO_NETWORK:
+        raise HTTPException(status_code=404, detail=detail)
+    if status == lifecycle._PATCH_FSM_REJECTED:
+        raise HTTPException(status_code=409, detail=detail)
+    if status == lifecycle._PATCH_HIDDEN_UNIT_OUT_OF_RANGE:
+        raise HTTPException(status_code=404, detail=detail)
+    if status == lifecycle._PATCH_NAN_INF:
+        raise HTTPException(status_code=422, detail=detail)
+    if status in (lifecycle._PATCH_BAD_TARGET, lifecycle._PATCH_SHAPE_MISMATCH):
+        raise HTTPException(status_code=400, detail=detail)
+    # Defensive — unmapped sentinel from the lifecycle layer.
+    logger.error("patch_weights: unmapped status %r", status)
+    raise HTTPException(status_code=500, detail="patch_weights returned an unexpected status")

--- a/src/tests/unit/api/test_patch_weights.py
+++ b/src/tests/unit/api/test_patch_weights.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python
+"""Unit tests for the lifecycle's patch_weights method (CAN-015h-1).
+
+Covers:
+- FSM gate: any non-Investigating state returns _PATCH_FSM_REJECTED.
+- Target/field validation: unknown target or unknown field rejected.
+- Output-layer patching: weights and bias both rewritable; shape
+  mismatch rejected; NaN/Inf rejected; requires_grad preserved.
+- Hidden-unit patching: weights and bias both rewritable;
+  out-of-range index rejected; shape mismatch rejected.
+- Optimizer-state zero-out: when an Adam state exists for the
+  parameter, momentum/variance buffers are reset.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
+
+from api.lifecycle.manager import TrainingLifecycleManager  # noqa: E402
+from api.lifecycle.state_machine import TrainingStatus  # noqa: E402
+from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork  # noqa: E402
+from cascade_correlation.cascade_correlation_config.cascade_correlation_config import (  # noqa: E402
+    CascadeCorrelationConfig,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _make_lifecycle_with_network(num_hidden=2):
+    """Build a lifecycle + network and force-enter Investigating state.
+
+    The patch endpoint requires INVESTIGATING (entered via /restore in
+    production); for unit tests we set ``state_machine._status``
+    directly so we don't have to round-trip through a snapshot.
+    """
+    config = CascadeCorrelationConfig.create_simple_config(
+        input_size=2,
+        output_size=1,
+        learning_rate=0.1,
+        max_hidden_units=5,
+        random_seed=42,
+        init_output_weights="zero",
+    )
+    network = CascadeCorrelationNetwork(config=config)
+    # Add hidden units via the helper from h-0 so output_weights is widened.
+    for i in range(num_hidden):
+        prev_in = network.output_weights.shape[0]
+        network._install_hidden_unit(
+            weights=torch.randn(2 + i, dtype=torch.float32),
+            bias=torch.tensor([0.0], dtype=torch.float32),
+            activation_fn=network.activation_fn,
+            correlation=0.5,
+        )
+        network._resize_output_layer_for_new_units(num_added=1, prev_input_size=prev_in)
+
+    lifecycle = TrainingLifecycleManager()
+    lifecycle.network = network
+    lifecycle.state_machine._status = TrainingStatus.INVESTIGATING
+    return lifecycle
+
+
+# =============================================================================
+# FSM gate
+# =============================================================================
+
+
+class TestPatchWeightsFSMGate:
+    @pytest.mark.parametrize(
+        "status",
+        [
+            TrainingStatus.STOPPED,
+            TrainingStatus.STARTED,
+            TrainingStatus.PAUSED,
+            TrainingStatus.COMPLETED,
+            TrainingStatus.FAILED,
+            TrainingStatus.RESUME_READY,
+            TrainingStatus.REPLAYING,
+        ],
+    )
+    def test_non_investigating_states_rejected(self, status):
+        lc = _make_lifecycle_with_network(num_hidden=1)
+        lc.state_machine._status = status
+        result = lc.patch_weights(target="output", field="weights", values=lc.network.output_weights.detach().tolist())
+        assert result["status"] == lc._PATCH_FSM_REJECTED
+
+    def test_investigating_state_allowed(self):
+        lc = _make_lifecycle_with_network(num_hidden=1)
+        # Already in INVESTIGATING from fixture
+        result = lc.patch_weights(target="output", field="weights", values=lc.network.output_weights.detach().tolist())
+        assert result["status"] == lc._PATCH_OK
+
+
+# =============================================================================
+# Target / field / index validation
+# =============================================================================
+
+
+class TestPatchWeightsValidation:
+    def test_no_network_rejected(self):
+        lc = TrainingLifecycleManager()
+        lc.state_machine._status = TrainingStatus.INVESTIGATING
+        result = lc.patch_weights(target="output", field="weights", values=[[0.0]])
+        assert result["status"] == lc._PATCH_NO_NETWORK
+
+    def test_unknown_target_rejected(self):
+        lc = _make_lifecycle_with_network()
+        result = lc.patch_weights(target="invalid", field="weights", values=[[0.0]])
+        assert result["status"] == lc._PATCH_BAD_TARGET
+
+    def test_unknown_field_rejected(self):
+        lc = _make_lifecycle_with_network()
+        result = lc.patch_weights(target="output", field="invalid", values=[[0.0]])
+        assert result["status"] == lc._PATCH_BAD_TARGET
+
+    def test_hidden_unit_index_required_for_hidden_target(self):
+        lc = _make_lifecycle_with_network(num_hidden=2)
+        unit_w = lc.network.hidden_units[0]["weights"].detach().tolist()
+        result = lc.patch_weights(target="hidden_unit", field="weights", values=unit_w, hidden_unit_index=None)
+        assert result["status"] == lc._PATCH_HIDDEN_UNIT_OUT_OF_RANGE
+
+    def test_hidden_unit_index_out_of_range_rejected(self):
+        lc = _make_lifecycle_with_network(num_hidden=2)
+        unit_w = lc.network.hidden_units[0]["weights"].detach().tolist()
+        result = lc.patch_weights(target="hidden_unit", field="weights", values=unit_w, hidden_unit_index=99)
+        assert result["status"] == lc._PATCH_HIDDEN_UNIT_OUT_OF_RANGE
+
+    def test_shape_mismatch_rejected(self):
+        lc = _make_lifecycle_with_network()
+        wrong_shape = [[1.0, 2.0, 3.0]]  # output_weights is [in+hid, out=1] not [1, 3]
+        result = lc.patch_weights(target="output", field="weights", values=wrong_shape)
+        assert result["status"] == lc._PATCH_SHAPE_MISMATCH
+
+    def test_nan_value_rejected(self):
+        lc = _make_lifecycle_with_network()
+        shape = lc.network.output_weights.shape
+        bad_values = torch.full(shape, float("nan")).tolist()
+        result = lc.patch_weights(target="output", field="weights", values=bad_values)
+        assert result["status"] == lc._PATCH_NAN_INF
+
+    def test_inf_value_rejected(self):
+        lc = _make_lifecycle_with_network()
+        shape = lc.network.output_weights.shape
+        bad_values = torch.full(shape, float("inf")).tolist()
+        result = lc.patch_weights(target="output", field="weights", values=bad_values)
+        assert result["status"] == lc._PATCH_NAN_INF
+
+    def test_unparsable_values_rejected(self):
+        lc = _make_lifecycle_with_network()
+        # Ragged nested list — can't form a tensor.
+        result = lc.patch_weights(target="output", field="weights", values=[[1, 2], [3]])
+        assert result["status"] == lc._PATCH_NAN_INF
+
+
+# =============================================================================
+# Output-layer patches
+# =============================================================================
+
+
+class TestPatchOutputLayer:
+    def test_output_weights_rewrite(self):
+        lc = _make_lifecycle_with_network(num_hidden=1)
+        shape = lc.network.output_weights.shape
+        new_values = torch.full(shape, 0.42).tolist()
+        result = lc.patch_weights(target="output", field="weights", values=new_values)
+        assert result["status"] == lc._PATCH_OK
+        np.testing.assert_array_almost_equal(
+            lc.network.output_weights.detach().numpy(),
+            torch.full(shape, 0.42).numpy(),
+        )
+
+    def test_output_weights_preserves_requires_grad(self):
+        lc = _make_lifecycle_with_network(num_hidden=1)
+        # output_weights starts with requires_grad=True after _install_hidden_unit.
+        assert lc.network.output_weights.requires_grad is True
+        new_values = torch.zeros_like(lc.network.output_weights).tolist()
+        result = lc.patch_weights(target="output", field="weights", values=new_values)
+        assert result["status"] == lc._PATCH_OK
+        assert lc.network.output_weights.requires_grad is True
+
+    def test_output_bias_rewrite(self):
+        lc = _make_lifecycle_with_network()
+        new_bias = torch.tensor([1.234], dtype=torch.float32).tolist()
+        result = lc.patch_weights(target="output", field="bias", values=new_bias)
+        assert result["status"] == lc._PATCH_OK
+        np.testing.assert_array_almost_equal(lc.network.output_bias.detach().numpy(), [1.234])
+
+
+# =============================================================================
+# Hidden-unit patches
+# =============================================================================
+
+
+class TestPatchHiddenUnit:
+    def test_hidden_unit_weights_rewrite(self):
+        lc = _make_lifecycle_with_network(num_hidden=2)
+        original_shape = lc.network.hidden_units[1]["weights"].shape
+        new_values = torch.full(original_shape, 0.5).tolist()
+        result = lc.patch_weights(target="hidden_unit", field="weights", values=new_values, hidden_unit_index=1)
+        assert result["status"] == lc._PATCH_OK
+        np.testing.assert_array_almost_equal(
+            lc.network.hidden_units[1]["weights"].detach().numpy(),
+            torch.full(original_shape, 0.5).numpy(),
+        )
+
+    def test_hidden_unit_bias_rewrite(self):
+        lc = _make_lifecycle_with_network(num_hidden=2)
+        original_shape = lc.network.hidden_units[0]["bias"].shape
+        new_bias = torch.full(original_shape, 0.7).tolist()
+        result = lc.patch_weights(target="hidden_unit", field="bias", values=new_bias, hidden_unit_index=0)
+        assert result["status"] == lc._PATCH_OK
+        np.testing.assert_array_almost_equal(
+            lc.network.hidden_units[0]["bias"].detach().numpy(),
+            torch.full(original_shape, 0.7).numpy(),
+        )
+
+    def test_hidden_unit_shape_mismatch(self):
+        lc = _make_lifecycle_with_network(num_hidden=2)
+        # Unit 1's weights are [in+1] = [3] but pass [5] → mismatch.
+        result = lc.patch_weights(
+            target="hidden_unit",
+            field="weights",
+            values=[1.0, 2.0, 3.0, 4.0, 5.0],
+            hidden_unit_index=1,
+        )
+        assert result["status"] == lc._PATCH_SHAPE_MISMATCH
+
+
+# =============================================================================
+# Optimizer state zero-out
+# =============================================================================
+
+
+class TestOptimizerStateZeroOut:
+    def test_zeros_adam_state_for_patched_parameter(self):
+        lc = _make_lifecycle_with_network(num_hidden=1)
+        # Build a fake Adam-shaped optimizer state keyed by the
+        # CURRENT output_weights tensor (the one that's about to be
+        # replaced). Zero-out runs against this key BEFORE the
+        # reassignment per the lifecycle implementation.
+        param = lc.network.output_weights
+        fake_optimizer = MagicMock()
+        fake_optimizer.state = {
+            param: {
+                "step": torch.tensor(42),
+                "exp_avg": torch.full_like(param, 0.5),
+                "exp_avg_sq": torch.full_like(param, 0.25),
+            }
+        }
+        lc.network.output_optimizer = fake_optimizer
+
+        new_values = torch.full_like(param, 0.1).tolist()
+        result = lc.patch_weights(target="output", field="weights", values=new_values)
+        assert result["status"] == lc._PATCH_OK
+
+        # ``param`` is still a Python reference to the old tensor.
+        zero_state = fake_optimizer.state[param]
+        assert torch.all(zero_state["exp_avg"] == 0)
+        assert torch.all(zero_state["exp_avg_sq"] == 0)
+        # Step counter is preserved (only running statistics are bias-affected).
+        assert int(zero_state["step"]) == 42
+
+    def test_zeros_adam_state_for_hidden_unit(self):
+        lc = _make_lifecycle_with_network(num_hidden=2)
+        # State keyed by the hidden-unit weight tensor.
+        unit_w = lc.network.hidden_units[1]["weights"]
+        fake_optimizer = MagicMock()
+        fake_optimizer.state = {
+            unit_w: {
+                "exp_avg": torch.full_like(unit_w, 0.3),
+                "exp_avg_sq": torch.full_like(unit_w, 0.1),
+            }
+        }
+        lc.network.output_optimizer = fake_optimizer
+
+        new_values = torch.zeros_like(unit_w).tolist()
+        result = lc.patch_weights(target="hidden_unit", field="weights", values=new_values, hidden_unit_index=1)
+        assert result["status"] == lc._PATCH_OK
+        zero_state = fake_optimizer.state[unit_w]
+        assert torch.all(zero_state["exp_avg"] == 0)
+        assert torch.all(zero_state["exp_avg_sq"] == 0)
+
+    def test_no_optimizer_attribute_is_noop(self):
+        lc = _make_lifecycle_with_network()
+        # No output_optimizer attribute set — patch must still succeed.
+        if hasattr(lc.network, "output_optimizer"):
+            delattr(lc.network, "output_optimizer")
+        new_values = torch.zeros_like(lc.network.output_weights).tolist()
+        result = lc.patch_weights(target="output", field="weights", values=new_values)
+        assert result["status"] == lc._PATCH_OK
+
+    def test_optimizer_state_missing_for_param_is_noop(self):
+        lc = _make_lifecycle_with_network()
+        # Optimizer exists but doesn't track this parameter — must
+        # not raise. (Real-world: parameter was added after
+        # optimizer was built, e.g. cascade-grow without re-init.)
+        fake_optimizer = MagicMock()
+        fake_optimizer.state = {}
+        lc.network.output_optimizer = fake_optimizer
+        new_values = torch.zeros_like(lc.network.output_weights).tolist()
+        result = lc.patch_weights(target="output", field="weights", values=new_values)
+        assert result["status"] == lc._PATCH_OK


### PR DESCRIPTION
## Summary

First mutation endpoint of **CAN-015h**. Wires the post-restore \`Investigating\` FSM state to a surgical-rewrite endpoint that canopy's network-editor panel (h-5) consumes.

Plan reference: [\`notes/PHASE_6E_DEFERRED_CAN-015GH_DESIGN.md\`](https://github.com/pcalnon/juniper-ml/blob/main/notes/PHASE_6E_DEFERRED_CAN-015GH_DESIGN.md) §\"Endpoint design / 1. PATCH /v1/network/weights\" (juniper-ml).

## API surface

\`\`\`http
PATCH /v1/network/weights
Content-Type: application/json

{
  \"target\": \"output\" | \"hidden_unit\",
  \"field\": \"weights\" | \"bias\",
  \"values\": [[...], [...]],
  \"hidden_unit_index\": 3,        // required iff target == \"hidden_unit\"
  \"dtype\": \"float32\"             // optional; default float32
}
\`\`\`

Status codes:

- **200** — patch applied
- **400** — shape mismatch / unknown target or field
- **404** — no network created / hidden_unit_index out of range
- **409** — FSM not Investigating
- **422** — NaN/Inf or untensorable values

## Lifecycle (\`api/lifecycle/manager.py\`)

- **\`patch_weights\` returns a sentinel-status dict** so the route layer can map errors to HTTP statuses cleanly without HTTPException leaking into the lifecycle layer.
- **FSM gate**: rejects from any state other than \`INVESTIGATING\` (entered via \`/restore\`).
- **Validation**: exact-shape match, NaN/Inf rejection (including post-cast Inf detection), ragged-list catch via tensor-coerce failure path.
- **Optimizer-state zero-out**: runs **before** the parameter reassignment because the optimizer's state dict is keyed by tensor identity. Skips 0-d scalar tensors (Adam's \`step\` counter is stored as a scalar in newer PyTorch); zeros n-d running-statistic buffers (\`exp_avg\`, \`exp_avg_sq\`).
- **Best-effort**: missing optimizer / missing state / non-dict state are all silent no-ops.

## Tests (\`test_patch_weights.py\`, 27 tests)

- **FSM gate** parametrized over all 7 non-Investigating states.
- **Validation**: no-network, unknown target/field, missing \`hidden_unit_index\`, out-of-range index, shape mismatch, NaN, Inf, unparsable values.
- **Output-layer patches**: weights rewrite, \`requires_grad\` preserved, bias rewrite.
- **Hidden-unit patches**: weights rewrite, bias rewrite, shape mismatch.
- **Optimizer-state zero-out**: output_weights case + hidden-unit case + step counter preserved + missing optimizer is no-op + missing state for param is no-op.

## Validation

- [x] 27 new + 138 existing lifecycle/install_hidden_unit tests = **165 passed** in JuniperCascor1.
- [x] Pre-commit hooks pass (black, isort, flake8, mypy, bandit).
- 122 pre-existing failures in \`test_api_security\` / \`test_websocket_manager\` / \`test_control_stream_*\` — verified identical pre/post change.

## Out of scope

- **h-2**: POST \`/v1/network/hidden-units\` with cascade rebuild (next PR).
- **h-3**: DELETE \`/v1/network/hidden-units/{idx}\` with cascade rebuild.
- **h-4 through h-6**: canopy adapter + Network Editor panel.

## Test plan

- [x] Unit tests pass
- [x] Pre-commit clean
- [ ] Reviewer: confirm the sentinel-status pattern feels right vs. raising exceptions inside the lifecycle. The choice keeps the lifecycle layer HTTP-agnostic so it stays test-friendly without FastAPI fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)