### PR TITLE
feat(network): POST /v1/network/hidden-units with cascade rebuild (Phase 6E CAN-015h-2) [stacked on #199]

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -2393,6 +2393,128 @@ class TrainingLifecycleManager:
             param_state[key] = torch.zeros_like(val)
 
     # ------------------------------------------------------------------
+    # CAN-015h-2: POST /v1/network/hidden-units — manual unit append
+    # ------------------------------------------------------------------
+
+    _ADD_OK: str = "ok"
+    _ADD_FSM_REJECTED: str = "fsm_rejected"
+    _ADD_NO_NETWORK: str = "no_network"
+    _ADD_AT_CAP: str = "at_cap"
+    _ADD_BAD_ACTIVATION: str = "bad_activation"
+    _ADD_BAD_SHAPE: str = "bad_shape"
+    _ADD_NAN_INF: str = "nan_inf"
+
+    def add_hidden_unit_manual(
+        self,
+        weights: Any,
+        bias: float = 0.0,
+        activation: str = "Tanh",
+    ) -> Dict[str, Any]:
+        """CAN-015h-2: append a hidden unit at the cascade tail.
+
+        Companion to ``add_unit`` (training-loop cascade-grow), but
+        invoked manually from the canopy editor while the FSM is
+        Investigating. Reuses the h-0 helpers
+        (``_install_hidden_unit`` + ``_resize_output_layer_for_new_units``)
+        so the cascade-grow code path and the manual-append code
+        path can never drift apart on dict shape, history record
+        layout, or output-layer rebuild semantics.
+
+        Returns a sentinel-status dict like ``patch_weights``. Per
+        the design plan: the new output-layer column is forced to
+        **zero** (regardless of ``self.init_output_weights``)
+        because the user hasn't trained against this unit yet —
+        zero output column means zero contribution to predictions
+        until ``PATCH /v1/network/weights`` rewrites it.
+        """
+        if self.network is None:
+            return {"status": self._ADD_NO_NETWORK, "detail": "No network created"}
+        if not self.state_machine.is_investigating():
+            return {
+                "status": self._ADD_FSM_REJECTED,
+                "detail": f"add_hidden_unit_manual requires INVESTIGATING state (currently {self.state_machine.status.name})",
+            }
+        # max_hidden_units cap — same contract as the training-loop
+        # cascade-grow path (which raises rather than returning a
+        # sentinel; here we surface 409 to the route layer).
+        if len(self.network.hidden_units) >= getattr(self.network, "max_hidden_units", 0):
+            return {
+                "status": self._ADD_AT_CAP,
+                "detail": f"network is at max_hidden_units cap ({self.network.max_hidden_units})",
+            }
+        # Activation resolution against the network's registry. Pydantic
+        # at the route boundary already restricts to the supported
+        # Literal set, but we re-check here for direct lifecycle calls.
+        registry = getattr(self.network, "activation_functions_dict", {}) or {}
+        activation_fn = registry.get(activation)
+        if activation_fn is None:
+            return {
+                "status": self._ADD_BAD_ACTIVATION,
+                "detail": f"unknown activation: {activation!r} (registry keys: {sorted(registry.keys())})",
+            }
+        # Tensor coercion + NaN/Inf check (same path as patch_weights).
+        try:
+            weights_tensor = self._build_patch_tensor(weights, "float32")
+        except (TypeError, ValueError) as e:
+            return {"status": self._ADD_NAN_INF, "detail": f"invalid weights: {e}"}
+        if not torch.isfinite(weights_tensor).all():
+            return {"status": self._ADD_NAN_INF, "detail": "weights contain NaN or Inf"}
+        if not (isinstance(bias, (int, float)) and torch.isfinite(torch.tensor(float(bias))).item()):
+            return {"status": self._ADD_NAN_INF, "detail": "bias must be a finite scalar"}
+
+        # Shape check: weight vector length must match the current
+        # cascade-input width (= input_size + num_existing_hidden_units).
+        prev_input_size = self.network.output_weights.shape[0]
+        if weights_tensor.ndim != 1 or weights_tensor.shape[0] != prev_input_size:
+            return {
+                "status": self._ADD_BAD_SHAPE,
+                "detail": f"weights shape {tuple(weights_tensor.shape)} does not match expected [{prev_input_size}] (input_size + num_existing_hidden_units)",
+            }
+
+        # Install via the h-0 helper. Correlation is undefined for
+        # manual inserts — record 0.0 as a sentinel so downstream
+        # consumers (history viewer, replay) can distinguish manual
+        # from training-loop additions if needed.
+        self.network._install_hidden_unit(
+            weights=weights_tensor,
+            bias=torch.tensor([float(bias)], dtype=torch.float32),
+            activation_fn=activation_fn,
+            correlation=0.0,
+        )
+
+        # Resize the output layer with a forced zero-init so the
+        # appended unit's output column doesn't contribute to
+        # predictions until trained or patched. Save and restore
+        # ``init_output_weights`` so the network's persistent config
+        # stays whatever the user originally set.
+        original_init = self.network.init_output_weights
+        try:
+            self.network.init_output_weights = "zero"
+            self.network._resize_output_layer_for_new_units(
+                num_added=1,
+                prev_input_size=prev_input_size,
+            )
+        finally:
+            self.network.init_output_weights = original_init
+
+        # Optimizer state for the now-stale output_weights tensor is
+        # invalid (the parameter object was replaced by the resize
+        # AND the dimension itself changed). Best-effort drop of the
+        # optimizer; the next training pass will reconstruct it. We
+        # drop rather than zero-out because Adam's state tensors no
+        # longer match the new parameter shape.
+        if hasattr(self.network, "output_optimizer"):
+            self.network.output_optimizer = None
+
+        new_index = len(self.network.hidden_units) - 1
+        return {
+            "status": self._ADD_OK,
+            "detail": "ok",
+            "unit_index": new_index,
+            "num_hidden_units": len(self.network.hidden_units),
+        }
+
+    # ------------------------------------------------------------------
     # Decision boundary
     # ------------------------------------------------------------------
 

--- a/src/api/models/network.py
+++ b/src/api/models/network.py
@@ -129,3 +129,51 @@ class PatchWeightsRequest(BaseModel):
     values: list = Field(description="New values, shape must match target exactly")
     hidden_unit_index: int | None = Field(default=None, ge=0, description="Required iff target == 'hidden_unit'")
     dtype: Literal["float32", "float64"] = Field(default="float32", description="Source dtype; cast to float32 internally")
+
+
+# ---------------------------------------------------------------------
+# CAN-015h-2: POST /v1/network/hidden-units request body
+# ---------------------------------------------------------------------
+
+
+class AddHiddenUnitRequest(BaseModel):
+    """Body for ``POST /v1/network/hidden-units`` (CAN-015h-2).
+
+    Append a fresh hidden unit at the cascade tail. The new unit's
+    output-layer column is initialized to zero, so it contributes
+    nothing to predictions until the user re-trains or patches the
+    output layer (see h-1 → ``PATCH /v1/network/weights``).
+
+    V1 limits:
+
+    - ``position`` is **tail-only**. Insert-at-position is documented
+      in the design plan but deferred from V1 because the
+      connectivity-rewrite semantics are user-surprising and worth
+      shipping with explicit UI text. A future PR will add
+      ``position: int`` once that text exists.
+
+    Plan: ``notes/PHASE_6E_DEFERRED_CAN-015GH_DESIGN.md`` §"Endpoint
+    design / 2. POST /v1/network/hidden-units" (juniper-ml).
+    """
+
+    weights: list = Field(description="Weight vector, shape [input_size + num_existing_hidden_units]")
+    bias: float = Field(default=0.0, description="Bias scalar")
+    activation: Literal[
+        "Identity",
+        "Tanh",
+        "Sigmoid",
+        "ReLU",
+        "LeakyReLU",
+        "ELU",
+        "SELU",
+        "GELU",
+        "Softmax",
+        "Softplus",
+        "Hardtanh",
+        "Softshrink",
+        "Tanhshrink",
+        "tanh",
+        "sigmoid",
+        "relu",
+    ] = Field(default="Tanh", description="Activation function name (mirrors the network-create registry)")
+    position: Literal["tail"] = Field(default="tail", description="V1 supports tail-only; insert-at-position deferred")

--- a/src/api/routes/network.py
+++ b/src/api/routes/network.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, HTTPException, Request
 logger = logging.getLogger("juniper_cascor.api.routes.network")
 
 from api.models.common import success_response
-from api.models.network import NetworkCreateRequest, PatchWeightsRequest
+from api.models.network import AddHiddenUnitRequest, NetworkCreateRequest, PatchWeightsRequest
 
 router = APIRouter(prefix="/network", tags=["network"])
 
@@ -119,3 +119,58 @@ async def patch_weights(request: Request, body: PatchWeightsRequest) -> dict:
     # Defensive — unmapped sentinel from the lifecycle layer.
     logger.error("patch_weights: unmapped status %r", status)
     raise HTTPException(status_code=500, detail="patch_weights returned an unexpected status")
+
+
+@router.post("/hidden-units")
+async def add_hidden_unit(request: Request, body: AddHiddenUnitRequest) -> dict:
+    """CAN-015h-2: append a fresh hidden unit at the cascade tail.
+
+    FSM-gated to ``Investigating``. The new unit's output-layer
+    column is initialized to **zero** so it contributes nothing
+    until the user re-trains or patches the output layer.
+
+    Status codes:
+
+    - 200 — unit appended; response body carries the new
+      ``unit_index``, ``num_hidden_units``, ``operation``,
+      ``fsm_state``.
+    - 400 — bad shape (weight vector length does not match
+      input_size + num_existing_hidden_units).
+    - 404 — no network created.
+    - 409 — FSM not Investigating, or network at
+      ``max_hidden_units`` cap.
+    - 422 — NaN/Inf in weights or bias / unknown activation.
+
+    Plan: ``notes/PHASE_6E_DEFERRED_CAN-015GH_DESIGN.md`` §"Endpoint
+    design / 2. POST /v1/network/hidden-units" (juniper-ml).
+    """
+    lifecycle = _get_lifecycle(request)
+    result = lifecycle.add_hidden_unit_manual(
+        weights=body.weights,
+        bias=body.bias,
+        activation=body.activation,
+    )
+    status = result.get("status")
+    detail = result.get("detail", "add failed")
+
+    if status == lifecycle._ADD_OK:
+        info = lifecycle.get_network_info()
+        info.update(
+            {
+                "operation": "add_hidden_unit",
+                "fsm_state": lifecycle.state_machine.status.name,
+                "unit_index": result.get("unit_index"),
+                "num_hidden_units": result.get("num_hidden_units"),
+            }
+        )
+        return success_response(info)
+    if status == lifecycle._ADD_NO_NETWORK:
+        raise HTTPException(status_code=404, detail=detail)
+    if status in (lifecycle._ADD_FSM_REJECTED, lifecycle._ADD_AT_CAP):
+        raise HTTPException(status_code=409, detail=detail)
+    if status in (lifecycle._ADD_NAN_INF, lifecycle._ADD_BAD_ACTIVATION):
+        raise HTTPException(status_code=422, detail=detail)
+    if status == lifecycle._ADD_BAD_SHAPE:
+        raise HTTPException(status_code=400, detail=detail)
+    logger.error("add_hidden_unit_manual: unmapped status %r", status)
+    raise HTTPException(status_code=500, detail="add_hidden_unit_manual returned an unexpected status")

--- a/src/tests/unit/api/test_add_hidden_unit_manual.py
+++ b/src/tests/unit/api/test_add_hidden_unit_manual.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python
+"""Unit tests for add_hidden_unit_manual (CAN-015h-2)."""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
+
+from api.lifecycle.manager import TrainingLifecycleManager  # noqa: E402
+from api.lifecycle.state_machine import TrainingStatus  # noqa: E402
+from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork  # noqa: E402
+from cascade_correlation.cascade_correlation_config.cascade_correlation_config import (  # noqa: E402
+    CascadeCorrelationConfig,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _make_lifecycle(num_hidden=1, max_hidden_units=5):
+    """Build a network in INVESTIGATING with ``num_hidden`` units already installed."""
+    config = CascadeCorrelationConfig.create_simple_config(
+        input_size=2,
+        output_size=1,
+        learning_rate=0.1,
+        max_hidden_units=max_hidden_units,
+        random_seed=42,
+        init_output_weights="random",  # exercises the zero-init override
+    )
+    network = CascadeCorrelationNetwork(config=config)
+    for i in range(num_hidden):
+        prev_in = network.output_weights.shape[0]
+        network._install_hidden_unit(
+            weights=torch.randn(2 + i, dtype=torch.float32),
+            bias=torch.tensor([0.0], dtype=torch.float32),
+            activation_fn=network.activation_fn,
+            correlation=0.5,
+        )
+        network._resize_output_layer_for_new_units(num_added=1, prev_input_size=prev_in)
+    lifecycle = TrainingLifecycleManager()
+    lifecycle.network = network
+    lifecycle.state_machine._status = TrainingStatus.INVESTIGATING
+    return lifecycle
+
+
+# =============================================================================
+# FSM gate
+# =============================================================================
+
+
+class TestAddHiddenUnitFSMGate:
+    @pytest.mark.parametrize(
+        "status",
+        [
+            TrainingStatus.STOPPED,
+            TrainingStatus.STARTED,
+            TrainingStatus.PAUSED,
+            TrainingStatus.COMPLETED,
+            TrainingStatus.FAILED,
+            TrainingStatus.RESUME_READY,
+            TrainingStatus.REPLAYING,
+        ],
+    )
+    def test_non_investigating_rejected(self, status):
+        lc = _make_lifecycle(num_hidden=1)
+        lc.state_machine._status = status
+        prev_in = lc.network.output_weights.shape[0]
+        result = lc.add_hidden_unit_manual(weights=[0.0] * prev_in)
+        assert result["status"] == lc._ADD_FSM_REJECTED
+
+    def test_investigating_allowed(self):
+        lc = _make_lifecycle(num_hidden=1)
+        prev_in = lc.network.output_weights.shape[0]
+        result = lc.add_hidden_unit_manual(weights=[0.0] * prev_in)
+        assert result["status"] == lc._ADD_OK
+
+
+# =============================================================================
+# Validation
+# =============================================================================
+
+
+class TestAddHiddenUnitValidation:
+    def test_no_network_rejected(self):
+        lc = TrainingLifecycleManager()
+        lc.state_machine._status = TrainingStatus.INVESTIGATING
+        result = lc.add_hidden_unit_manual(weights=[0.0, 0.0])
+        assert result["status"] == lc._ADD_NO_NETWORK
+
+    def test_at_cap_rejected(self):
+        lc = _make_lifecycle(num_hidden=2, max_hidden_units=2)
+        prev_in = lc.network.output_weights.shape[0]
+        result = lc.add_hidden_unit_manual(weights=[0.0] * prev_in)
+        assert result["status"] == lc._ADD_AT_CAP
+
+    def test_unknown_activation_rejected(self):
+        lc = _make_lifecycle()
+        prev_in = lc.network.output_weights.shape[0]
+        result = lc.add_hidden_unit_manual(weights=[0.0] * prev_in, activation="exotic")
+        assert result["status"] == lc._ADD_BAD_ACTIVATION
+
+    def test_nan_weights_rejected(self):
+        lc = _make_lifecycle()
+        prev_in = lc.network.output_weights.shape[0]
+        result = lc.add_hidden_unit_manual(weights=[float("nan")] * prev_in)
+        assert result["status"] == lc._ADD_NAN_INF
+
+    def test_inf_bias_rejected(self):
+        lc = _make_lifecycle()
+        prev_in = lc.network.output_weights.shape[0]
+        result = lc.add_hidden_unit_manual(weights=[0.0] * prev_in, bias=float("inf"))
+        assert result["status"] == lc._ADD_NAN_INF
+
+    def test_shape_mismatch_rejected(self):
+        lc = _make_lifecycle(num_hidden=1)
+        # Expected length is 3 (in=2 + 1 hidden); pass length 5 → mismatch.
+        result = lc.add_hidden_unit_manual(weights=[0.0, 0.0, 0.0, 0.0, 0.0])
+        assert result["status"] == lc._ADD_BAD_SHAPE
+
+    def test_2d_weights_rejected(self):
+        lc = _make_lifecycle()
+        prev_in = lc.network.output_weights.shape[0]
+        result = lc.add_hidden_unit_manual(weights=[[0.0] * prev_in])
+        assert result["status"] == lc._ADD_BAD_SHAPE
+
+
+# =============================================================================
+# Successful append
+# =============================================================================
+
+
+class TestAddHiddenUnitSuccess:
+    def test_appends_unit_and_resizes(self):
+        lc = _make_lifecycle(num_hidden=1)
+        n_before = len(lc.network.hidden_units)
+        prev_in = lc.network.output_weights.shape[0]
+        result = lc.add_hidden_unit_manual(weights=[1.0] * prev_in, bias=0.5, activation="Tanh")
+        assert result["status"] == lc._ADD_OK
+        assert result["unit_index"] == n_before
+        assert result["num_hidden_units"] == n_before + 1
+        assert len(lc.network.hidden_units) == n_before + 1
+        # Output layer widened by exactly one row.
+        assert lc.network.output_weights.shape == (prev_in + 1, lc.network.output_size)
+
+    def test_new_output_column_is_zero(self):
+        # Even though network was constructed with init_output_weights="random",
+        # the manual-append path must force zero-init for the new column.
+        lc = _make_lifecycle(num_hidden=0)
+        prev_in = lc.network.output_weights.shape[0]
+        # Stamp a recognizable pattern into the existing output weights.
+        with torch.no_grad():
+            lc.network.output_weights.copy_(torch.full_like(lc.network.output_weights, 7.0))
+        result = lc.add_hidden_unit_manual(weights=[0.5, -0.5])
+        assert result["status"] == lc._ADD_OK
+        # New row (index prev_in) must be zero.
+        new_row = lc.network.output_weights[prev_in:, :].detach().numpy()
+        np.testing.assert_array_equal(new_row, np.zeros_like(new_row))
+        # Old rows must be preserved at the stamped pattern.
+        old_rows = lc.network.output_weights[:prev_in, :].detach().numpy()
+        np.testing.assert_array_almost_equal(old_rows, np.full_like(old_rows, 7.0))
+
+    def test_init_output_weights_config_preserved(self):
+        # The temporary "zero" override must restore the original setting.
+        lc = _make_lifecycle()
+        original = lc.network.init_output_weights
+        prev_in = lc.network.output_weights.shape[0]
+        lc.add_hidden_unit_manual(weights=[0.0] * prev_in)
+        assert lc.network.init_output_weights == original
+
+    def test_history_records_zero_correlation(self):
+        # Manual inserts have undefined correlation; sentinel 0.0.
+        lc = _make_lifecycle()
+        n_history_before = len(lc.network.history["hidden_units_added"])
+        prev_in = lc.network.output_weights.shape[0]
+        lc.add_hidden_unit_manual(weights=[0.0] * prev_in)
+        assert len(lc.network.history["hidden_units_added"]) == n_history_before + 1
+        assert lc.network.history["hidden_units_added"][-1]["correlation"] == 0.0
+
+    def test_optimizer_dropped_after_append(self):
+        lc = _make_lifecycle()
+        lc.network.output_optimizer = MagicMock()
+        prev_in = lc.network.output_weights.shape[0]
+        result = lc.add_hidden_unit_manual(weights=[0.0] * prev_in)
+        assert result["status"] == lc._ADD_OK
+        assert lc.network.output_optimizer is None
+
+    def test_two_sequential_appends(self):
+        lc = _make_lifecycle(num_hidden=0)
+        # First append: weights of length 2 (in_size).
+        r1 = lc.add_hidden_unit_manual(weights=[0.5, -0.5])
+        assert r1["status"] == lc._ADD_OK
+        assert r1["unit_index"] == 0
+        # Second append: weights of length 3 (in_size + 1).
+        r2 = lc.add_hidden_unit_manual(weights=[0.1, 0.2, 0.3])
+        assert r2["status"] == lc._ADD_OK
+        assert r2["unit_index"] == 1
+        assert lc.network.output_weights.shape == (4, lc.network.output_size)


### PR DESCRIPTION
## Summary

Second mutation endpoint of **CAN-015h**. **Stacked on #199** (h-1). Appends a fresh hidden unit at the cascade tail while the FSM is \`Investigating\`; reuses h-0's \`_install_hidden_unit\` and \`_resize_output_layer_for_new_units\` helpers so the manual-add path can never drift apart from the training-loop cascade-grow path.

Plan reference: [\`notes/PHASE_6E_DEFERRED_CAN-015GH_DESIGN.md\`](https://github.com/pcalnon/juniper-ml/blob/main/notes/PHASE_6E_DEFERRED_CAN-015GH_DESIGN.md) §\"Endpoint design / 2. POST /v1/network/hidden-units\" (juniper-ml).

## V1 limitation

\`position=\"tail\"\` only. Insert-at-position is documented in the plan but **deferred** here — the connectivity-rewrite semantics are user-surprising and worth shipping with explicit canopy UI text. A future PR will add \`position: int\` once that text exists. The Pydantic body type forces this at the boundary (\`position: Literal[\"tail\"]\`).

## API surface

\`\`\`http
POST /v1/network/hidden-units
Content-Type: application/json

{
  \"weights\": [...],                   // length = input_size + num_existing_hidden_units
  \"bias\": 0.0,
  \"activation\": \"Tanh\",
  \"position\": \"tail\"                 // V1: tail-only
}
\`\`\`

Status codes: **200** (appended) / **400** (shape mismatch) / **404** (no network) / **409** (FSM not Investigating, or at \`max_hidden_units\` cap) / **422** (NaN/Inf, unknown activation).

## Implementation highlights

- **Forced zero-init of the new output column** regardless of \`init_output_weights\` config. Rationale: the user hasn't trained against this unit, so a non-zero output contribution would be arbitrary. Save / restore \`init_output_weights\` so the network's persistent config stays whatever the user originally set.
- **Optimizer dropped to None** after append. Adam's state tensors no longer match the new parameter shape; next training pass rebuilds from scratch.
- **History records \`correlation=0.0\`** as a sentinel for manual inserts (training-loop adds carry the candidate's actual correlation; downstream consumers can distinguish if needed).
- **\`max_hidden_units\` cap surfaces 409** rather than raising \`ValidationError\` (training-loop contract). The manual endpoint should give canopy a friendly error code.

## Tests (\`test_add_hidden_unit_manual.py\`, 21 tests)

- **FSM gate** parametrized over all 7 non-Investigating states.
- **Validation**: no-network, at-cap, unknown activation, NaN weights, Inf bias, shape mismatch, 2-D weights rejected.
- **Successful append**: hidden_units grows by one, output_weights widened by one row, **new column is zero** (regardless of the original init config), original \`init_output_weights\` preserved, history records \`correlation=0.0\`, optimizer dropped, two sequential appends account correctly.

## Validation

- [x] 21 new + h-1's 27 + 138 sibling lifecycle tests = **186 passed** in JuniperCascor1.
- [x] Pre-commit hooks pass (black, isort, flake8, mypy, bandit).

## Out of scope

- **h-3**: DELETE \`/v1/network/hidden-units/{idx}\` (next PR — final cascor-side endpoint).
- **h-4 through h-6**: canopy adapter + Network Editor panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)