### PR TITLE
feat(network): DELETE /v1/network/hidden-units/{idx} with cascade rebuild (Phase 6E CAN-015h-3) [stacked on #200]

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -2515,6 +2515,90 @@ class TrainingLifecycleManager:
         }
 
     # ------------------------------------------------------------------
+    # CAN-015h-3: DELETE /v1/network/hidden-units/{idx} — manual remove
+    # ------------------------------------------------------------------
+
+    _REMOVE_OK: str = "ok"
+    _REMOVE_FSM_REJECTED: str = "fsm_rejected"
+    _REMOVE_NO_NETWORK: str = "no_network"
+    _REMOVE_OUT_OF_RANGE: str = "out_of_range"
+
+    def remove_hidden_unit_manual(self, idx: int) -> Dict[str, Any]:
+        """CAN-015h-3: remove the hidden unit at ``idx``.
+
+        Cascade-rebuild semantics:
+
+        - Unit ``idx`` is removed.
+        - Each subsequent unit ``j > idx`` had a weight at position
+          ``input_size + idx`` that referenced the removed unit's
+          output. That single weight is dropped from each subsequent
+          unit's weight vector. After the surgery, what was unit
+          ``j`` is now unit ``j - 1`` with weight vector length
+          ``input_size + (j - 1)`` — consistent with its new
+          cascade position.
+        - The corresponding column ``input_size + idx`` of
+          ``output_weights`` is removed; ``output_weights`` reshapes
+          to ``[in + num_units - 1, out]``.
+        - The optimizer is dropped (Adam state tensors no longer
+          match the new parameter shapes).
+
+        Returns sentinel-status dict. ``idx`` out of range returns
+        404 (not 409) per the design plan.
+        """
+        if self.network is None:
+            return {"status": self._REMOVE_NO_NETWORK, "detail": "No network created"}
+        if not self.state_machine.is_investigating():
+            return {
+                "status": self._REMOVE_FSM_REJECTED,
+                "detail": f"remove_hidden_unit_manual requires INVESTIGATING state (currently {self.state_machine.status.name})",
+            }
+        n = len(self.network.hidden_units)
+        if not isinstance(idx, int) or idx < 0 or idx >= n:
+            return {
+                "status": self._REMOVE_OUT_OF_RANGE,
+                "detail": f"hidden_unit_index={idx} out of range (have {n} units)",
+            }
+
+        input_size = self.network.input_size
+        col_to_drop = input_size + idx
+
+        # 1. For each subsequent unit, drop its weight at index col_to_drop.
+        #    Unit j > idx has weight vector length input_size + j; after
+        #    surgery the new length is input_size + (j - 1) which matches
+        #    its new cascade position post-shift.
+        for j in range(idx + 1, n):
+            unit = self.network.hidden_units[j]
+            old_weights = unit["weights"].detach()
+            keep_mask = torch.ones(old_weights.shape[0], dtype=torch.bool)
+            keep_mask[col_to_drop] = False
+            unit["weights"] = old_weights[keep_mask].clone().detach()
+
+        # 2. Remove the unit from the hidden_units list.
+        del self.network.hidden_units[idx]
+
+        # 3. Surgically remove the corresponding column from output_weights.
+        old_output = self.network.output_weights.detach()
+        keep_rows = torch.ones(old_output.shape[0], dtype=torch.bool)
+        keep_rows[col_to_drop] = False
+        new_output = old_output[keep_rows].clone().detach()
+        was_grad = bool(getattr(self.network.output_weights, "requires_grad", False))
+        self.network.output_weights = new_output
+        if was_grad:
+            self.network.output_weights.requires_grad_(True)
+        # output_bias is independent of unit count — leave untouched.
+
+        # 4. Drop the optimizer (Adam state shapes invalid after column drop).
+        if hasattr(self.network, "output_optimizer"):
+            self.network.output_optimizer = None
+
+        return {
+            "status": self._REMOVE_OK,
+            "detail": "ok",
+            "removed_index": idx,
+            "num_hidden_units": len(self.network.hidden_units),
+        }
+
+    # ------------------------------------------------------------------
     # Decision boundary
     # ------------------------------------------------------------------
 

--- a/src/api/routes/network.py
+++ b/src/api/routes/network.py
@@ -174,3 +174,48 @@ async def add_hidden_unit(request: Request, body: AddHiddenUnitRequest) -> dict:
         raise HTTPException(status_code=400, detail=detail)
     logger.error("add_hidden_unit_manual: unmapped status %r", status)
     raise HTTPException(status_code=500, detail="add_hidden_unit_manual returned an unexpected status")
+
+
+@router.delete("/hidden-units/{idx}")
+async def delete_hidden_unit(request: Request, idx: int) -> dict:
+    """CAN-015h-3: remove the hidden unit at ``idx`` with cascade rebuild.
+
+    FSM-gated to ``Investigating``. Subsequent units shift down by
+    one, and each has its weight at the deleted unit's input
+    position dropped (so the cascade-input width matches the new
+    cascade position). The output layer's corresponding column is
+    removed; the optimizer is dropped.
+
+    Status codes:
+
+    - 200 — unit removed; response body carries
+      ``removed_index``, ``num_hidden_units``, ``operation``,
+      ``fsm_state``.
+    - 404 — no network created OR ``idx`` out of range.
+    - 409 — FSM not Investigating.
+
+    Plan: ``notes/PHASE_6E_DEFERRED_CAN-015GH_DESIGN.md`` §"Endpoint
+    design / 3. DELETE /v1/network/hidden-units/{idx}" (juniper-ml).
+    """
+    lifecycle = _get_lifecycle(request)
+    result = lifecycle.remove_hidden_unit_manual(idx=idx)
+    status = result.get("status")
+    detail = result.get("detail", "remove failed")
+
+    if status == lifecycle._REMOVE_OK:
+        info = lifecycle.get_network_info()
+        info.update(
+            {
+                "operation": "remove_hidden_unit",
+                "fsm_state": lifecycle.state_machine.status.name,
+                "removed_index": result.get("removed_index"),
+                "num_hidden_units": result.get("num_hidden_units"),
+            }
+        )
+        return success_response(info)
+    if status in (lifecycle._REMOVE_NO_NETWORK, lifecycle._REMOVE_OUT_OF_RANGE):
+        raise HTTPException(status_code=404, detail=detail)
+    if status == lifecycle._REMOVE_FSM_REJECTED:
+        raise HTTPException(status_code=409, detail=detail)
+    logger.error("remove_hidden_unit_manual: unmapped status %r", status)
+    raise HTTPException(status_code=500, detail="remove_hidden_unit_manual returned an unexpected status")

--- a/src/tests/unit/api/test_remove_hidden_unit_manual.py
+++ b/src/tests/unit/api/test_remove_hidden_unit_manual.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python
+"""Unit tests for remove_hidden_unit_manual (CAN-015h-3).
+
+Cascade-rebuild semantics are subtle — the test surface specifically
+asserts:
+
+- Removing the **tail** unit is structurally identical to truncating
+  output_weights at the last row.
+- Removing a **middle** unit drops the corresponding column from
+  ``output_weights`` AND drops the corresponding weight from each
+  subsequent unit's weight vector. After the surgery, every unit's
+  weight vector length matches its new cascade position.
+- The forward-pass shape invariant holds post-delete: a fresh call
+  to ``_compute_hidden_outputs`` succeeds without raising.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
+
+from api.lifecycle.manager import TrainingLifecycleManager  # noqa: E402
+from api.lifecycle.state_machine import TrainingStatus  # noqa: E402
+from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork  # noqa: E402
+from cascade_correlation.cascade_correlation_config.cascade_correlation_config import (  # noqa: E402
+    CascadeCorrelationConfig,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _make_lifecycle(num_hidden=3, in_size=2, out_size=1):
+    config = CascadeCorrelationConfig.create_simple_config(
+        input_size=in_size,
+        output_size=out_size,
+        learning_rate=0.1,
+        max_hidden_units=10,
+        random_seed=42,
+        init_output_weights="zero",
+    )
+    network = CascadeCorrelationNetwork(config=config)
+    for i in range(num_hidden):
+        prev_in = network.output_weights.shape[0]
+        # Deterministic weights so we can verify the post-delete
+        # state by inspection.
+        weights = torch.arange(in_size + i, dtype=torch.float32) * 0.1 + i
+        network._install_hidden_unit(
+            weights=weights,
+            bias=torch.tensor([float(i)], dtype=torch.float32),
+            activation_fn=network.activation_fn,
+            correlation=0.5 * (i + 1),
+        )
+        network._resize_output_layer_for_new_units(num_added=1, prev_input_size=prev_in)
+    lifecycle = TrainingLifecycleManager()
+    lifecycle.network = network
+    lifecycle.state_machine._status = TrainingStatus.INVESTIGATING
+    return lifecycle
+
+
+# =============================================================================
+# FSM gate + range
+# =============================================================================
+
+
+class TestRemoveFSMGate:
+    @pytest.mark.parametrize(
+        "status",
+        [
+            TrainingStatus.STOPPED,
+            TrainingStatus.STARTED,
+            TrainingStatus.PAUSED,
+            TrainingStatus.COMPLETED,
+            TrainingStatus.FAILED,
+            TrainingStatus.RESUME_READY,
+            TrainingStatus.REPLAYING,
+        ],
+    )
+    def test_non_investigating_rejected(self, status):
+        lc = _make_lifecycle(num_hidden=2)
+        lc.state_machine._status = status
+        result = lc.remove_hidden_unit_manual(idx=0)
+        assert result["status"] == lc._REMOVE_FSM_REJECTED
+
+
+class TestRemoveValidation:
+    def test_no_network_rejected(self):
+        lc = TrainingLifecycleManager()
+        lc.state_machine._status = TrainingStatus.INVESTIGATING
+        result = lc.remove_hidden_unit_manual(idx=0)
+        assert result["status"] == lc._REMOVE_NO_NETWORK
+
+    def test_negative_idx_rejected(self):
+        lc = _make_lifecycle(num_hidden=2)
+        result = lc.remove_hidden_unit_manual(idx=-1)
+        assert result["status"] == lc._REMOVE_OUT_OF_RANGE
+
+    def test_idx_at_count_rejected(self):
+        lc = _make_lifecycle(num_hidden=2)
+        result = lc.remove_hidden_unit_manual(idx=2)
+        assert result["status"] == lc._REMOVE_OUT_OF_RANGE
+
+    def test_remove_when_empty_rejected(self):
+        lc = _make_lifecycle(num_hidden=0)
+        result = lc.remove_hidden_unit_manual(idx=0)
+        assert result["status"] == lc._REMOVE_OUT_OF_RANGE
+
+
+# =============================================================================
+# Tail removal
+# =============================================================================
+
+
+class TestRemoveTail:
+    def test_remove_tail_succeeds(self):
+        lc = _make_lifecycle(num_hidden=3, in_size=2)
+        result = lc.remove_hidden_unit_manual(idx=2)  # last unit
+        assert result["status"] == lc._REMOVE_OK
+        assert result["removed_index"] == 2
+        assert result["num_hidden_units"] == 2
+        assert len(lc.network.hidden_units) == 2
+        # output_weights was [in+3, out=1] = [5, 1]; now [4, 1].
+        assert lc.network.output_weights.shape == (4, 1)
+
+    def test_tail_remove_preserves_remaining_units_unchanged(self):
+        lc = _make_lifecycle(num_hidden=3, in_size=2)
+        prev_unit_0_w = lc.network.hidden_units[0]["weights"].detach().clone()
+        prev_unit_1_w = lc.network.hidden_units[1]["weights"].detach().clone()
+        lc.remove_hidden_unit_manual(idx=2)
+        # Unit 0 weights unchanged (it never referenced the removed unit).
+        np.testing.assert_array_equal(
+            lc.network.hidden_units[0]["weights"].detach().numpy(),
+            prev_unit_0_w.numpy(),
+        )
+        # Unit 1 weights unchanged (referenced the removed unit's INPUT,
+        # which was at index 2+1=3 — but unit 1's weight vector has
+        # length 3, not 4, so it never referenced the removed unit).
+        np.testing.assert_array_equal(
+            lc.network.hidden_units[1]["weights"].detach().numpy(),
+            prev_unit_1_w.numpy(),
+        )
+
+
+# =============================================================================
+# Middle removal — cascade rebuild
+# =============================================================================
+
+
+class TestRemoveMiddle:
+    def test_remove_middle_drops_subsequent_unit_weights(self):
+        # 3 units, in_size=2:
+        #   unit 0 weights: length 2  -> [in_0, in_1]
+        #   unit 1 weights: length 3  -> [in_0, in_1, h_0]
+        #   unit 2 weights: length 4  -> [in_0, in_1, h_0, h_1]
+        # Remove unit 1 (idx=1):
+        #   col_to_drop = input_size + idx = 2 + 1 = 3
+        #   unit 0 unchanged (length 2; index 3 is out of bounds — skipped)
+        #   unit 2 (now becomes new unit 1): drop weight at index 3,
+        #     so its weights become length 3. But length 3 = input_size + 1
+        #     which matches its new cascade position. Good.
+        lc = _make_lifecycle(num_hidden=3, in_size=2)
+        prev_unit_2_w = lc.network.hidden_units[2]["weights"].detach().clone()
+        result = lc.remove_hidden_unit_manual(idx=1)
+        assert result["status"] == lc._REMOVE_OK
+        assert len(lc.network.hidden_units) == 2
+
+        # The "new unit 1" is what was unit 2. Its weights should be
+        # the original unit 2's weights with index 3 dropped (i.e.,
+        # entries [0, 1, 2] preserved, entry 3 dropped).
+        new_unit_1_w = lc.network.hidden_units[1]["weights"].detach()
+        expected_w = torch.cat([prev_unit_2_w[:3], prev_unit_2_w[4:]])  # only 4 entries; drop idx 3
+        np.testing.assert_array_almost_equal(new_unit_1_w.numpy(), expected_w.numpy())
+        # Length matches new cascade position: input_size(2) + 1 = 3.
+        assert new_unit_1_w.shape == (3,)
+
+    def test_remove_first_drops_correct_column(self):
+        # 3 units. Remove unit 0 (col_to_drop = 2):
+        #   unit 0 deleted.
+        #   unit 1 (new unit 0): had weights [in_0, in_1, h_0]; drop h_0
+        #     (index 2). New weights: length 2 = input_size + 0. Good.
+        #   unit 2 (new unit 1): had weights [in_0, in_1, h_0, h_1]; drop h_0
+        #     (index 2). New weights: length 3 = input_size + 1. Good.
+        lc = _make_lifecycle(num_hidden=3, in_size=2)
+        prev_unit_1_w = lc.network.hidden_units[1]["weights"].detach().clone()
+        prev_unit_2_w = lc.network.hidden_units[2]["weights"].detach().clone()
+        result = lc.remove_hidden_unit_manual(idx=0)
+        assert result["status"] == lc._REMOVE_OK
+        assert len(lc.network.hidden_units) == 2
+
+        new_unit_0_w = lc.network.hidden_units[0]["weights"].detach()
+        # Was prev_unit_1_w with index 2 dropped → length 2.
+        np.testing.assert_array_almost_equal(
+            new_unit_0_w.numpy(), prev_unit_1_w[[0, 1]].numpy()
+        )
+        new_unit_1_w = lc.network.hidden_units[1]["weights"].detach()
+        # Was prev_unit_2_w with index 2 dropped → length 3.
+        np.testing.assert_array_almost_equal(
+            new_unit_1_w.numpy(),
+            torch.cat([prev_unit_2_w[:2], prev_unit_2_w[3:]]).numpy(),
+        )
+
+    def test_post_delete_forward_pass_succeeds(self):
+        # The cascade-input shape invariant must hold post-delete:
+        # _compute_hidden_outputs() should run without raising.
+        lc = _make_lifecycle(num_hidden=3, in_size=2)
+        lc.remove_hidden_unit_manual(idx=1)
+        x = torch.randn(4, 2)
+        # Smoke test: must not raise.
+        outputs = lc.network._compute_hidden_outputs(x)
+        # Shape: [batch, input_size + num_hidden_after] = [4, 4]
+        assert outputs.shape == (4, 2 + len(lc.network.hidden_units))
+
+
+# =============================================================================
+# Output weights surgery
+# =============================================================================
+
+
+class TestRemoveOutputWeights:
+    def test_output_weights_column_dropped(self):
+        lc = _make_lifecycle(num_hidden=3, in_size=2)
+        # Stamp a recognizable pattern: row k has value k+10.
+        with torch.no_grad():
+            for k in range(lc.network.output_weights.shape[0]):
+                lc.network.output_weights[k, :] = k + 10
+        lc.remove_hidden_unit_manual(idx=1)  # col_to_drop = 3
+        rows = lc.network.output_weights.detach().numpy().flatten()
+        # Should be values 10, 11, 12, 14 (skip 13 which was the dropped unit).
+        np.testing.assert_array_almost_equal(rows, [10.0, 11.0, 12.0, 14.0])
+
+    def test_optimizer_dropped(self):
+        lc = _make_lifecycle(num_hidden=2)
+        lc.network.output_optimizer = MagicMock()
+        result = lc.remove_hidden_unit_manual(idx=0)
+        assert result["status"] == lc._REMOVE_OK
+        assert lc.network.output_optimizer is None
+
+    def test_requires_grad_preserved(self):
+        lc = _make_lifecycle(num_hidden=2)
+        # output_weights starts with requires_grad=True.
+        assert lc.network.output_weights.requires_grad is True
+        lc.remove_hidden_unit_manual(idx=0)
+        assert lc.network.output_weights.requires_grad is True


### PR DESCRIPTION
## Summary

Third (final cascor-side) mutation endpoint of **CAN-015h**. **Stacked on #200** (h-2). Removes the hidden unit at \`idx\` with surgical cascade rebuild.

Plan reference: [\`notes/PHASE_6E_DEFERRED_CAN-015GH_DESIGN.md\`](https://github.com/pcalnon/juniper-ml/blob/main/notes/PHASE_6E_DEFERRED_CAN-015GH_DESIGN.md) §\"Endpoint design / 3. DELETE /v1/network/hidden-units/{idx}\" (juniper-ml).

## The cascade-rebuild surgery (the point of this PR)

Each hidden unit \`j\` has a weight vector of length \`input_size + j\`. Unit \`j\`'s weight at position \`input_size + i\` (for \`i < j\`) is the connection from unit \`i\`'s output. When we remove unit \`idx\`, every subsequent unit's connection to the deleted unit's output must be dropped:

1. Unit \`j > idx\` had its connection at position \`input_size + idx\`. **Drop that single weight from \`j\`'s weight vector.**
2. After the surgery, what was unit \`j\` is now unit \`j - 1\` with a weight vector of length \`input_size + (j - 1)\` — consistent with its new cascade position.
3. The corresponding column \`input_size + idx\` of \`output_weights\` is removed.

The forward-pass shape invariant holds post-delete — verified by \`test_post_delete_forward_pass_succeeds\`.

### Approach choice

This is more invasive than h-2's tail-only append. The plan's intent was clearly \"middle deletion supported.\" Two alternatives were rejected:

- **Catastrophic rebuild** (drop all subsequent units): too destructive — user mental model is \"remove this one unit,\" not \"destroy half the network.\"
- **Tail-only delete** (V1 restriction matching h-2's tail-only add): conservative but loses the most useful UX case — deleting a known-bad middle unit.

## API surface

\`\`\`http
DELETE /v1/network/hidden-units/{idx}
\`\`\`

Status codes: **200** (removed) / **404** (no network OR \`idx\` out of range, per the design plan) / **409** (FSM not Investigating).

## Tests (\`test_remove_hidden_unit_manual.py\`, 19 tests)

- **FSM gate** parametrized over all 7 non-Investigating states.
- **Validation**: no-network, negative idx, \`idx==count\`, empty network.
- **Tail removal**: structurally identical to truncating the last row; remaining units' weights unchanged.
- **Middle removal**: cascade-rebuild surgery covers removing unit 0 (everything shifts), removing unit 1 (middle of 3), and the **forward-pass shape invariant** post-delete.
- **Output weights surgery**: column dropped (verified by stamping a recognizable pattern and checking which entries survive); optimizer dropped; \`requires_grad\` preserved.

## Validation

- [x] 19 new + h-2's 21 + h-1's 27 + 138 sibling lifecycle tests = **205 passed** in JuniperCascor1.
- [x] Pre-commit hooks pass (black, isort, flake8, mypy, bandit).

## CAN-015h cascor side complete

After h-1 / h-2 / h-3 land, the cascor backend exposes the full mutation surface:

- \`PATCH /v1/network/weights\` (h-1)
- \`POST /v1/network/hidden-units\` (h-2)
- \`DELETE /v1/network/hidden-units/{idx}\` (h-3)

All FSM-gated to \`Investigating\`. Canopy editor panel + adapter (h-4 through h-6) build on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)