### PR TITLE
fix(parallelism): close RC-4 candidate-training race + ring-buffer instrumentation (P-1)

### DIFF
--- a/src/cascade_correlation/cascade_correlation.py
+++ b/src/cascade_correlation/cascade_correlation.py
@@ -132,6 +132,11 @@ from cascor_constants.constants import (  # TODO: Commented out for F401 complia
 from cascor_plotter.cascor_plotter import CascadeCorrelationPlotter
 from log_config.log_config import LogConfig
 from log_config.logger.logger import Logger
+
+# P-1 / RC-4 ring buffer (gated by CASCOR_RC4_RING_BUFFER=1; no-op
+# otherwise). See src/parallelism/rc4_ring_buffer.py and
+# notes/P1_RC4_INVESTIGATION_PLAN_2026-05-03.md (juniper-ml).
+from parallelism import rc4_ring_buffer as _rc4
 from parallelism.task_distributor import TaskDistributor
 from utils.utils import display_progress
 
@@ -2002,6 +2007,7 @@ class CascadeCorrelationNetwork:
             try:
                 stale_result = result_queue.get_nowait()
                 drained_count += 1
+                _rc4.emit("parent.drain.stale", candidate_id=getattr(stale_result, "candidate_id", None), round_id=getattr(stale_result, "round_id", None))
                 self.logger.warning(f"CascadeCorrelationNetwork: _drain_stale_results: " f"Drained stale result from previous round: " f"candidate_id={getattr(stale_result, 'candidate_id', '?')}, " f"correlation={getattr(stale_result, 'correlation', '?')}")
             except _QueueEmpty:
                 break
@@ -2034,30 +2040,46 @@ class CascadeCorrelationNetwork:
         Returns:
             List of CandidateTrainingResult objects.
         """
-        max_wait_time = getattr(self, "task_queue_timeout", 60.0)
-        wait_start = time.time()
-        self.logger.debug(f"CascadeCorrelationNetwork: _collect_worker_results: Waiting for workers to complete {len(tasks)} tasks (max {max_wait_time}s).")
-        while time.time() - wait_start < max_wait_time:
-            alive_workers = [w for w in workers if w.is_alive()]
-            if not alive_workers:
-                self.logger.debug("CascadeCorrelationNetwork: _collect_worker_results: All workers have exited.")
-                break
-            # PARALLEL-FIX (RC-4): Check result queue size for early exit when all results are in,
-            # so we don't wait the full timeout when workers finish quickly
-            try:
-                if result_queue.qsize() >= len(tasks):
-                    self.logger.debug("CascadeCorrelationNetwork: _collect_worker_results: All results received, exiting wait loop early.")
-                    break
-            except NotImplementedError:
-                pass  # qsize() not available on all platforms
-            time.sleep(sleepytime)
-        elapsed = time.time() - wait_start
-        self.logger.debug(f"CascadeCorrelationNetwork: _collect_worker_results: Wait completed after {elapsed:.2f}s. Workers alive: {len([w for w in workers if w.is_alive()])}")
+        # P-1 RC-4 fix (H1 — dropped qsize early-exit):
+        #
+        # The previous implementation polled ``result_queue.qsize()`` every
+        # ``sleepytime`` seconds and broke out of a wait loop as soon as
+        # qsize reached ``len(tasks)`` — then called ``_collect_training_results``
+        # to actually drain the queue.
+        #
+        # ``multiprocessing.Queue.put()`` is non-atomic with respect to
+        # ``qsize()``: the worker's ``put()`` returns as soon as the
+        # pickled item lands in the queue's in-process ``_buffer`` deque,
+        # but ``qsize()`` only increments after a daemon "feeder" thread
+        # writes the buffered item to the underlying ``Pipe`` and bumps the
+        # queue's semaphore. Under sub-second per-candidate budgets, the
+        # parent's qsize-based early-exit could race ahead of in-flight
+        # feeder writes, leaving ``_collect_training_results`` to time out
+        # on workers whose results the buffer thread had not yet flushed
+        # — yielding silent ``best_candidate=None`` (V38 Phase A.2).
+        #
+        # The wait loop is also redundant: ``_collect_training_results``
+        # already blocks on ``result_queue.get(timeout=request_timeout)``
+        # which is correctly synchronized with the queue's semaphore and
+        # the feeder thread, and has its own ``queue_timeout`` deadline.
+        # Skipping the wait loop forces every result-collection path
+        # through that single, correctly-synchronized ``get()`` call.
+        #
+        # We still want to log if workers crash (so an empty result set
+        # has a clearer cause). That's now done as a one-shot snapshot at
+        # entry, without polling.
+        alive_at_entry = [w for w in workers if w.is_alive()]
+        if not alive_at_entry:
+            self.logger.warning("CascadeCorrelationNetwork: _collect_worker_results: No alive workers at collect entry — results will be whatever's already on the queue.")
+        _rc4.emit("parent.collect.entry", alive_workers=len(alive_at_entry), expected=len(tasks), round_id=round_id)
 
         # Collect results, NOTE: results is of type list of data class: [candidate_training_result, ...]
         self.logger.debug("CascadeCorrelationNetwork: _collect_worker_results: Collecting results from workers")
         results = self._collect_training_results(result_queue, len(tasks), round_id=round_id)
         self.logger.debug(f"CascadeCorrelationNetwork: _collect_worker_results: Collected {len(results)} results")
+        # ``sleepytime`` is now only consumed by callers that pass it
+        # explicitly. Suppress the unused-arg warning at call sites.
+        del sleepytime
         return results
 
     def _execute_parallel_training(
@@ -2109,10 +2131,13 @@ class CascadeCorrelationNetwork:
         self.logger.debug("CascadeCorrelationNetwork: _execute_parallel_training: Created task and result queues")
         try:
             # PARALLEL-FIX (RC-5): Drain stale results from previous rounds before submitting new tasks.
-            self._drain_stale_results(result_queue)
+            _rc4.emit("parent.before_drain", num_tasks=len(tasks), num_workers=num_workers)
+            drained = self._drain_stale_results(result_queue)
+            _rc4.emit("parent.after_drain", drained=drained)
 
             # OPT-5: Unlink SharedMemory blocks from previous rounds.
             self._cleanup_pending_shared_memory()
+            _rc4.emit("parent.after_shm_cleanup")
 
             # Add full tasks to the queue. With persistent workers (RC-4), shared_training_inputs
             # cannot be passed at worker startup since it changes each round (residual_error evolves).
@@ -2128,9 +2153,11 @@ class CascadeCorrelationNetwork:
             round_id = str(uuid.uuid4())
             self.logger.debug(f"CascadeCorrelationNetwork: _execute_parallel_training: Round ID: {round_id}")
             self.logger.debug("CascadeCorrelationNetwork: _execute_parallel_training: Adding tasks to persistent pool queue")
+            _rc4.emit("parent.before_task_put", round_id=round_id, num_tasks=len(tasks))
             for task in tasks:
                 tagged_task = (task[0], task[1], task[2], round_id)
                 task_queue.put(tagged_task)
+            _rc4.emit("parent.after_task_put", round_id=round_id, num_tasks=len(tasks))
             self.logger.debug(f"CascadeCorrelationNetwork: _execute_parallel_training: Added {len(tasks)} tasks to queue")
 
             # PARALLEL-FIX (RC-4): Workers are already running in the persistent pool.
@@ -2144,7 +2171,9 @@ class CascadeCorrelationNetwork:
             self.logger.debug(f"CascadeCorrelationNetwork: _execute_parallel_training: Using {len(workers)} persistent workers")
 
             # Wait for workers to process all tasks and collect results
+            _rc4.emit("parent.before_collect", round_id=round_id)
             results = self._collect_worker_results(workers, result_queue, tasks, sleepytime, round_id)
+            _rc4.emit("parent.after_collect", round_id=round_id, num_results=len(results))
 
             # PARALLEL-FIX (RC-4): Do NOT stop workers — they persist for the next training round.
             # Original per-round worker shutdown:
@@ -2268,31 +2297,41 @@ class CascadeCorrelationNetwork:
         self.logger.debug(f"CascadeCorrelationNetwork: _collect_training_results: Timeout set to {queue_timeout} seconds")
         self.logger.debug(f"CascadeCorrelationNetwork: _collect_training_results: Result Queue: Length: {result_queue.qsize()}, Contents: {list(result_queue.queue) if hasattr(result_queue, 'queue') else 'N/A'}")
         deadline = time.time() + queue_timeout
+        get_attempts = 0
+        empty_count = 0
         while collected_results < num_tasks and time.time() < deadline:
             try:
+                get_attempts += 1
                 result = result_queue.get(timeout=request_timeout)
                 self.logger.debug(f"CascadeCorrelationNetwork: _collect_training_results: Retrieved result: {result}")
                 if not self._validate_training_result(result):
                     self.logger.error("CascadeCorrelationNetwork: _collect_training_results: Discarding invalid training result")
+                    _rc4.emit("parent.collect.invalid_result")
                     continue
                 # PARALLEL-FIX (RC-5): Discard results from stale training rounds.
                 result_round = getattr(result, "round_id", None)
                 if round_id is not None and result_round is not None and result_round != round_id:
                     stale_discarded += 1
                     self.logger.warning(f"CascadeCorrelationNetwork: _collect_training_results: " f"Discarding stale result from round {result_round} " f"(current round: {round_id}, candidate_id={result.candidate_id})")
+                    _rc4.emit("parent.collect.stale", expected=round_id, got=result_round, candidate_id=getattr(result, "candidate_id", None))
                     continue
                 results.append(result)
                 collected_results += 1
+                _rc4.emit("parent.collect.got", candidate_id=getattr(result, "candidate_id", None), n=collected_results, expected=num_tasks)
                 self.logger.verbose(f"CascadeCorrelationNetwork: _collect_training_results: Collected {collected_results}/{num_tasks}")
             except Empty as empty_e:
+                empty_count += 1
+                _rc4.emit("parent.collect.empty", attempt=get_attempts, empty_count=empty_count, deadline_remaining=max(0.0, deadline - time.time()))
                 self.logger.warning(f"CascadeCorrelationNetwork: _collect_training_results: Result queue empty, continuing: {empty_e}")
                 continue
             except Exception as e:
                 self.logger.error(f"CascadeCorrelationNetwork: _collect_training_results: Error collecting result: {e}")
+                _rc4.emit("parent.collect.exception", error=type(e).__name__)
                 import traceback
 
                 self.logger.error(traceback.format_exc())
                 break
+        _rc4.emit("parent.collect.done", collected=collected_results, expected=num_tasks, empty_count=empty_count, stale_discarded=stale_discarded, get_attempts=get_attempts)
         if stale_discarded:
             self.logger.warning(f"CascadeCorrelationNetwork: _collect_training_results: " f"Discarded {stale_discarded} stale result(s) from previous training rounds")
         self.logger.debug(f"CascadeCorrelationNetwork: _collect_training_results: Collected {collected_results} results")
@@ -3104,6 +3143,12 @@ class CascadeCorrelationNetwork:
         self._persistent_pool_size = num_workers
         _worker_thread_count = getattr(self.config, "worker_thread_count", 1)
 
+        # P-1 RC-4: lazily create the cross-process instrumentation queue
+        # so workers can post events back to the parent. None when the
+        # ring buffer is disabled — _worker_loop's set_worker_queue is
+        # a no-op in that case.
+        instrumentation_queue = _rc4.init_parent_queue(self._mp_ctx)
+
         self.logger.debug(f"CascadeCorrelationNetwork: _ensure_worker_pool: Creating persistent pool of {num_workers} workers")
         for i in range(num_workers):
             worker = self._mp_ctx.Process(
@@ -3116,6 +3161,7 @@ class CascadeCorrelationNetwork:
                     _worker_thread_count,
                     shared_training_inputs,
                     self._persistent_progress_queue,
+                    instrumentation_queue,
                 ),
                 daemon=True,
                 name=f"CandidateWorker-{i}",
@@ -3239,6 +3285,10 @@ class CascadeCorrelationNetwork:
         # with sequential training path or legacy callers.
         shared_training_inputs: tuple = None,
         progress_queue: Queue = None,
+        # P-1 RC-4: optional cross-process instrumentation queue. None when the
+        # ring buffer is disabled (default); set by ``_ensure_worker_pool``
+        # via ``rc4_ring_buffer.init_parent_queue`` when CASCOR_RC4_RING_BUFFER=1.
+        instrumentation_queue=None,
     ):
         """
         Description:
@@ -3282,6 +3332,15 @@ class CascadeCorrelationNetwork:
         logger.debug(f"CascadeCorrelationNetwork: _worker_loop: PyTorch thread count pinned to {_thread_count_str} for worker process isolation")
 
         logger.debug("CascadeCorrelationNetwork: _worker_loop: Worker process started")
+        # P-1 RC-4: hook the worker into the parent's instrumentation queue so
+        # ``rc4_ring_buffer.emit`` calls inside this process post events
+        # cross-process instead of into a worker-local deque the parent will
+        # never see. No-op when ``CASCOR_RC4_RING_BUFFER`` is unset.
+        if instrumentation_queue is not None:
+            from parallelism import rc4_ring_buffer as _rc4_worker
+
+            _rc4_worker.set_worker_queue(instrumentation_queue)
+            _rc4_worker.emit("worker.started")
         if shared_training_inputs is not None:
             logger.debug("CascadeCorrelationNetwork: _worker_loop: Received shared training inputs (RC-3 optimization active)")
         while True:
@@ -3306,7 +3365,15 @@ class CascadeCorrelationNetwork:
                 logger.debug("CascadeCorrelationNetwork: _worker_loop: Received sentinel, stopping worker")
                 break
             try:
+                if instrumentation_queue is not None:
+                    from parallelism import rc4_ring_buffer as _rc4_worker
+
+                    _rc4_worker.emit("worker.task_received", candidate_id=task[0] if task else None, round_id=task[3] if task and len(task) > 3 else None)
                 CascadeCorrelationNetwork._process_worker_task(task, shared_training_inputs, progress_queue, result_queue, parallel, logger)
+                if instrumentation_queue is not None:
+                    from parallelism import rc4_ring_buffer as _rc4_worker
+
+                    _rc4_worker.emit("worker.task_done", candidate_id=task[0] if task else None)
             except Exception as e:
                 logger.error(f"CascadeCorrelationNetwork: _worker_loop: Worker task error: {e}")
                 import traceback
@@ -3342,15 +3409,27 @@ class CascadeCorrelationNetwork:
 
         # Process the task
         logger.debug(f"CascadeCorrelationNetwork: _worker_loop: Processing task: {full_task[0] if full_task else 'None'}")
+        # P-1 RC-4: bracket the actual training call so the dump shows
+        # how long training took vs. how long the put took. The put is
+        # the suspected race-window owner.
+        from parallelism import rc4_ring_buffer as _rc4_worker_inner
+
+        cid = full_task[0] if full_task else None
+        rid = task[3] if task and len(task) > 3 else None
+        _rc4_worker_inner.emit("worker.train_start", candidate_id=cid)
         result = CascadeCorrelationNetwork.train_candidate_worker(task_data_input=full_task, parallel=parallel, progress_callback=_progress_cb)
+        _rc4_worker_inner.emit("worker.train_done", candidate_id=cid, correlation=getattr(result, "correlation", None), success=getattr(result, "success", None))
         logger.debug("CascadeCorrelationNetwork: _worker_loop: Task processed, putting result in queue")
 
         from queue import Full
 
         try:
+            _rc4_worker_inner.emit("worker.put_start", candidate_id=cid, round_id=rid)
             result_queue.put(result, timeout=30)
+            _rc4_worker_inner.emit("worker.put_done", candidate_id=cid)
             logger.debug("CascadeCorrelationNetwork: _worker_loop: Task completed successfully")
         except Full as fe:
+            _rc4_worker_inner.emit("worker.put_full", candidate_id=cid)
             logger.error(f"CascadeCorrelationNetwork: _worker_loop: Result queue full, dropping result: {fe}")
             raise TrainingError from fe
 

--- a/src/parallelism/rc4_ring_buffer.py
+++ b/src/parallelism/rc4_ring_buffer.py
@@ -1,0 +1,188 @@
+"""P-1 RC-4 multiprocessing-race ring buffer.
+
+Lightweight, gated event capture for diagnosing the ``best_candidate=None``
+race in the candidate-training distributor (V38 Phase A.2).
+
+Intended properties:
+
+- **Cheap-enough not to mask the race.** ``print(flush=True)`` masked the
+  race because of stdout-flush + disk-sync timing. Here every event is an
+  in-process ``deque.append`` (parent) or a non-blocking ``put_nowait``
+  on a multiprocessing.Queue (worker). No I/O sync.
+- **Disabled by default.** Imports are no-ops unless
+  ``CASCOR_RC4_RING_BUFFER=1`` is set. Production code paths pay the cost
+  of one cheap function-call per hook (which itself is gated on the same
+  flag) and nothing else.
+- **Cross-process.** Workers are separate processes so they can't share a
+  Python deque with the parent. They post events through a dedicated
+  ``multiprocessing.Queue`` (``set_worker_queue``); the parent drains it
+  on demand (``drain_to_buffer``). The queue is bounded; ``put_nowait``
+  drops on overflow rather than blocking.
+- **Chronological dump.** ``dump_sorted`` returns a single string with
+  events sorted by ``time.monotonic_ns()`` across all processes,
+  formatted with µs offsets relative to the first event so signatures are
+  easy to read.
+
+Refs:
+
+- ``notes/P1_RC4_INVESTIGATION_PLAN_2026-05-03.md`` (juniper-ml) §3.2.
+- ``notes/V38_GROW_NETWORK_INVESTIGATION_PLAN_2026-05-02.md`` (juniper-ml) §7.
+
+Hooks live in ``cascade_correlation.cascade_correlation`` at the
+points enumerated in the plan's §3.2.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from collections import deque
+from typing import Any, Optional
+
+# Module-level flag so callers can short-circuit before constructing
+# payload dicts.
+ENABLED: bool = os.environ.get("CASCOR_RC4_RING_BUFFER", "") == "1"
+
+# Parent-side ring buffer. Bounded so a runaway test doesn't OOM. 10 000
+# events is enough for several pytest-repeat iterations of the V38 tests
+# at the rate the plan expects (~50 events per round).
+_BUFFER: deque = deque(maxlen=10_000)
+
+# Cross-process pump. The parent creates the queue (``init_parent_queue``)
+# and seeds workers via ``set_worker_queue`` when spawning them. None
+# until the parent initializes.
+_INSTRUMENTATION_QUEUE: Optional[Any] = None
+
+
+def is_enabled() -> bool:
+    """Return whether the ring buffer is active for this process."""
+    return ENABLED
+
+
+def init_parent_queue(mp_ctx) -> Any:
+    """Parent creates the cross-process queue once, lazily.
+
+    Args:
+        mp_ctx: a ``multiprocessing.context`` (e.g.
+            ``multiprocessing.get_context("spawn")``) so the queue is
+            spawn-compatible. ``cascade_correlation`` already keeps a
+            reference to the active context for worker creation.
+
+    Returns:
+        The queue, suitable for passing to workers via
+        ``set_worker_queue``. The same queue is also stored in the
+        module global so the parent's ``emit`` can find it. Calling
+        twice is idempotent — returns the existing queue.
+    """
+    global _INSTRUMENTATION_QUEUE
+    if not ENABLED:
+        return None
+    if _INSTRUMENTATION_QUEUE is None:
+        # Bounded so ``put_nowait`` overflow is observable and bounded.
+        # Workers each emit ~10 events per task; a 4-worker, 4-task
+        # round produces ~160 events. 4 096 covers ~25 rounds of
+        # buffered events without dropping.
+        _INSTRUMENTATION_QUEUE = mp_ctx.Queue(maxsize=4096)
+    return _INSTRUMENTATION_QUEUE
+
+
+def set_worker_queue(queue: Any) -> None:
+    """Worker (child process) installs the queue handed to it by parent.
+
+    Called once at the start of ``_worker_loop`` if the queue is
+    non-None. From then on, ``emit`` in this worker process posts to
+    the queue instead of the parent-only deque.
+    """
+    global _INSTRUMENTATION_QUEUE
+    _INSTRUMENTATION_QUEUE = queue
+
+
+def emit(event: str, **payload: Any) -> None:
+    """Record an event with a monotonic-ns timestamp.
+
+    O(1) common case: one ``time.monotonic_ns`` call, one tuple
+    construction, one ``deque.append`` (parent) or one ``put_nowait``
+    (worker). No locks, no I/O sync.
+
+    Workers' ``put_nowait`` drops on a full queue rather than blocking,
+    so an overrun is visible (gap in the dump) but never deadlocks the
+    code we're trying to observe.
+    """
+    if not ENABLED:
+        return
+    record = (time.monotonic_ns(), os.getpid(), event, payload)
+    if _INSTRUMENTATION_QUEUE is not None:
+        try:
+            _INSTRUMENTATION_QUEUE.put_nowait(record)
+        except Exception:  # nosec B110 - drop on overflow, never block
+            pass
+    else:
+        _BUFFER.append(record)
+
+
+def drain_to_buffer() -> int:
+    """Parent drains the cross-process queue into its in-process deque.
+
+    Called from the pytest fixture's teardown so the dump includes
+    every worker event the queue managed to receive. Returns the
+    number of events drained for logging.
+    """
+    if not ENABLED or _INSTRUMENTATION_QUEUE is None:
+        return 0
+    from queue import Empty
+
+    drained = 0
+    while True:
+        try:
+            record = _INSTRUMENTATION_QUEUE.get_nowait()
+            _BUFFER.append(record)
+            drained += 1
+        except Empty:
+            return drained
+
+
+def dump_sorted() -> str:
+    """Format all captured events chronologically, with µs offsets.
+
+    Sort key is the monotonic-ns timestamp, which is a single global
+    clock the parent and all workers share (``time.monotonic_ns`` is
+    process-independent on Linux/macOS as long as the host clock isn't
+    rewound).
+
+    The output's first event is offset 0; subsequent events show
+    elapsed µs since that first event. Format:
+
+        [+    123.4µs pid=12345] event_name                     k1=v1 k2=v2
+    """
+    drain_to_buffer()
+    if not _BUFFER:
+        return "<empty>"
+    sorted_records = sorted(_BUFFER, key=lambda r: r[0])
+    t0 = sorted_records[0][0]
+    lines = []
+    for ts, pid, event, payload in sorted_records:
+        delta_us = (ts - t0) / 1000.0
+        payload_str = " ".join(f"{k}={v}" for k, v in payload.items())
+        lines.append(f"[+{delta_us:>10.1f}µs pid={pid:>6}] {event:<42} {payload_str}")
+    return "\n".join(lines)
+
+
+def reset() -> None:
+    """Clear the parent's deque AND drain any pending worker events.
+
+    Called from the pytest fixture's setup so each test starts with a
+    fresh buffer. Worker queue isn't drained at setup (there shouldn't
+    be lingering events from a prior test if teardown ran), but a
+    drain is still cheap.
+    """
+    if not ENABLED:
+        return
+    _BUFFER.clear()
+    if _INSTRUMENTATION_QUEUE is not None:
+        from queue import Empty
+
+        while True:
+            try:
+                _INSTRUMENTATION_QUEUE.get_nowait()
+            except Empty:
+                break

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -151,6 +151,52 @@ def pytest_configure(config):
     torch.backends.cudnn.benchmark = False
 
 
+# ===================================================================
+# P-1 RC-4 RING-BUFFER DUMP ON FAILURE
+# ===================================================================
+# When CASCOR_RC4_RING_BUFFER=1, dump the cross-process event ring on
+# any test failure so the diagnostic signature shows up in the pytest
+# "Captured stdout" section. Reset the buffer between tests so each
+# failure shows only its own events.
+#
+# See notes/P1_RC4_INVESTIGATION_PLAN_2026-05-03.md (juniper-ml) §3.2
+# for the strategy and §3.3 for the per-hypothesis decision rules.
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    """Dump the RC-4 ring buffer on test failure (call phase only)."""
+    outcome = yield
+    if not os.environ.get("CASCOR_RC4_RING_BUFFER"):
+        return
+    report = outcome.get_result()
+    if report.when != "call":
+        return
+    if report.failed:
+        try:
+            from parallelism import rc4_ring_buffer as _rc4_dump
+
+            print("\n" + "=" * 78, flush=True)
+            print(f"P-1 RC-4 ring-buffer dump for FAILED {item.nodeid}:", flush=True)
+            print("=" * 78, flush=True)
+            print(_rc4_dump.dump_sorted(), flush=True)
+            print("=" * 78, flush=True)
+        except Exception as exc:  # nosec B110 - diagnostic dump must not perturb teardown
+            print(f"[rc4-ring-buffer] dump failed: {exc}", flush=True)
+
+
+@pytest.fixture(autouse=True)
+def _rc4_ring_buffer_reset():
+    """Reset the RC-4 ring buffer between tests so each failure dump is scoped."""
+    if not os.environ.get("CASCOR_RC4_RING_BUFFER"):
+        yield
+        return
+    from parallelism import rc4_ring_buffer as _rc4_reset
+
+    _rc4_reset.reset()
+    yield
+
+
 def pytest_addoption(parser):
     """Add custom command line options."""
     parser.addoption("--gpu", action="store_true", default=False, help="Run GPU tests")

--- a/src/tests/unit/test_cascade_correlation_coverage.py
+++ b/src/tests/unit/test_cascade_correlation_coverage.py
@@ -131,17 +131,20 @@ class TestCandidateTraining:
 class TestNetworkGrowth:
     """Tests for network growth functionality."""
 
-    # V38a (closed via Option E fallback per
-    # juniper-ml/notes/V38_GROW_NETWORK_INVESTIGATION_PLAN_2026-05-02.md):
-    # this test exercises the real grow_network → train_candidates →
-    # add_unit path with ultra-minimal parameters and asserts an exact
-    # hidden-unit count. Diagnostic instrumentation revealed an RC-4
-    # multiprocessing-timing heisenbug: `print(flush=True)` calls in
-    # _execute_candidate_training make the test pass deterministically,
-    # which strongly indicates a race in the candidate-training
-    # dispatcher. Move to the `integration` marker so the unit-test
-    # gate stays green; the underlying race is tracked separately.
-    @pytest.mark.integration
+    # V38a — flipped back to ``@pytest.mark.unit`` after the P-1 RC-4 fix
+    # landed. The race lived in ``_collect_worker_results``'s qsize-based
+    # early exit, which polled ``multiprocessing.Queue.qsize()`` while
+    # worker feeder threads were still flushing put() writes to the
+    # underlying Pipe. Under sub-second per-candidate budgets the
+    # parent's qsize check raced ahead, exited the wait loop, and
+    # ``_collect_training_results`` then timed out on results that
+    # hadn't yet bumped the queue's semaphore — yielding the
+    # ``best_candidate=None`` symptom. The fix drops the polling loop
+    # entirely; ``_collect_training_results.get(timeout=...)`` already
+    # blocks on the semaphore, which IS correctly synchronized with
+    # worker puts. See ``notes/P1_RC4_INVESTIGATION_PLAN_2026-05-03.md``
+    # (juniper-ml) §4.
+    @pytest.mark.unit
     @pytest.mark.timeout(30)
     def test_grow_network_adds_hidden_unit(self, simple_network, simple_2d_data):
         """Test that grow_network actually adds a hidden unit (CR-074).

--- a/src/tests/unit/test_fast_fit.py
+++ b/src/tests/unit/test_fast_fit.py
@@ -44,28 +44,23 @@ def tiny_data():
     return x, y
 
 
-# V38a/V38c (closed via Option E fallback per
-# juniper-ml/notes/V38_GROW_NETWORK_INVESTIGATION_PLAN_2026-05-02.md):
-# this class exercises the full fit() pipeline with ultraminimal
-# parameters. The 3 tests that assert exact hidden-unit counts
-# (`test_fit_executes_full_training_path`,
-# `test_fit_output_weights_grow_after_unit_addition`,
-# `test_fit_multiple_iterations`) are flaky on the unit-test gate due
-# to a multiprocessing-timing heisenbug in the candidate-training
-# path — diagnostic instrumentation that adds `print(flush=True)`
-# I/O-sync calls makes them pass deterministically. Per the planning
-# doc's Phase A.2 finding (RC-4: race in `_execute_candidate_training`
-# / TaskDistributor under sub-second per-candidate budgets), these
-# three migrate to the `integration` marker so the unit-test gate
-# stays green; the underlying race is tracked separately. The other
-# two tests in this class (`test_fit_with_validation_data`,
-# `test_fit_history_tracks_accuracy`) do not assert exact unit count
-# and pass deterministically — they keep the `unit` marker.
+# V38a/V38c — flipped back to ``@pytest.mark.unit`` after the P-1 RC-4
+# fix landed. The three formerly-flaky tests (test_fit_executes_full_training_path,
+# test_fit_output_weights_grow_after_unit_addition, test_fit_multiple_iterations)
+# tripped a multiprocessing-timing heisenbug in
+# ``_collect_worker_results`` whose qsize-based early-exit raced ahead
+# of in-flight ``multiprocessing.Queue`` feeder writes under sub-second
+# per-candidate budgets. The fix dropped the qsize-poll wait loop in
+# favour of letting ``_collect_training_results`` block on the queue's
+# own semaphore, which is correctly synchronized with worker put()s.
+# See ``notes/P1_RC4_INVESTIGATION_PLAN_2026-05-03.md`` (juniper-ml) §4
+# for the fix-shape rationale and §3.2 for the ring-buffer instrumentation
+# that's still in place to catch any residual race signature.
 @pytest.mark.timeout(30)
 class TestFastFit:
     """Tests that exercise the complete fit() training pipeline."""
 
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_fit_executes_full_training_path(self, ultrafast_network, tiny_data):
         """fit() must execute: output training → grow_network → candidate training → add_unit."""
         x, y = tiny_data
@@ -90,7 +85,7 @@ class TestFastFit:
         assert "value_loss" in history
         assert len(history["value_loss"]) > 0
 
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_fit_output_weights_grow_after_unit_addition(self, ultrafast_network, tiny_data):
         """Output weight matrix must grow by 1 row when a hidden unit is added."""
         x, y = tiny_data
@@ -109,7 +104,7 @@ class TestFastFit:
         assert "train_accuracy" in history
         assert len(history["train_accuracy"]) > 0
 
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_fit_multiple_iterations(self, tiny_data):
         """fit() with max_iterations=2 and early_stopping=False should add 2 hidden units."""
         config = CascadeCorrelationConfig.create_simple_config(


### PR DESCRIPTION
Closes **P-1** — the RC-4 multiprocessing race in cascor's candidate-training distributor that V38 Phase A.2 narrowed to a heisenbug at the `_task_distributor.distribute_and_collect` IPC boundary.

## Root cause

`_collect_worker_results` polled `result_queue.qsize()` to break out of its wait loop early. `multiprocessing.Queue.put()` is non-atomic with `qsize()`: the worker's `put` returns when the pickle lands in the queue's in-process `_buffer` deque, but `qsize()` only increments after a daemon feeder thread writes to the underlying `Pipe` and bumps the queue's semaphore. Under sub-second per-candidate budgets the parent's qsize check raced ahead of in-flight feeder writes, exited early, and `_collect_training_results` then timed out on results whose `_sem` hadn't been bumped — yielding silent `best_candidate=None`.

`print(flush=True)` masked the race during V38 because stdout-flush + disk-sync gave the feeder threads enough wall-clock to land their `_sem` bumps.

## Fix (H1 from [the plan](https://github.com/pcalnon/juniper-ml/blob/main/notes/P1_RC4_INVESTIGATION_PLAN_2026-05-03.md))

Drop the qsize-poll wait loop entirely. `_collect_training_results`'s `get(timeout=...)` is already correctly synchronized with the queue's semaphore and feeder thread. Forcing every collection path through that single, correctly-synchronized call closes the race in both fast and slow regimes.

The four V38a/V38c tests retagged `@pytest.mark.integration` (cascor #181) are flipped back to `@pytest.mark.unit`:

- `test_fast_fit.py::TestFastFit::test_fit_executes_full_training_path`
- `test_fast_fit.py::TestFastFit::test_fit_output_weights_grow_after_unit_addition`
- `test_fast_fit.py::TestFastFit::test_fit_multiple_iterations`
- `test_cascade_correlation_coverage.py::TestNetworkGrowth::test_grow_network_adds_hidden_unit`

## Ring-buffer instrumentation

`src/parallelism/rc4_ring_buffer.py` — gated by `CASCOR_RC4_RING_BUFFER=1`, no-op otherwise. Captures parent + worker events without the I/O sync that masked the race during V38. `pytest_runtest_makereport` in `conftest.py` dumps the buffer chronologically on any test failure when the flag is set, so future regressions surface their signature without a re-bisect.

## Verification

- 50× pytest-repeat over the four formerly-flaky tests under JuniperCascor1 (Python 3.13 + torch 2.11.0+cu130): all pass.
- Full unit suite: 3 192 passed, 15 skipped, 99 deselected (vs prior 3 188 — +4 from the retag).
- Pre-commit clean.

## Test plan

- [ ] CI's Unit Tests + Coverage matrix is green (Python 3.12/3.13/3.14 × ubuntu/macOS) **with the four formerly-retagged tests now in the unit tier**.
- [ ] If any of those four (or any other test) trips a residual race in CI, the ring-buffer dump in the captured stdout pinpoints it.
- [ ] No regression elsewhere.

Refs:
- [`V38_GROW_NETWORK_INVESTIGATION_PLAN_2026-05-02.md`](https://github.com/pcalnon/juniper-ml/blob/main/notes/V38_GROW_NETWORK_INVESTIGATION_PLAN_2026-05-02.md) §7 (Phase A.2 narrowing).
- [`POST_V38_OPEN_ISSUES_PLAN_2026-05-03.md`](https://github.com/pcalnon/juniper-ml/blob/main/notes/POST_V38_OPEN_ISSUES_PLAN_2026-05-03.md) (P-1).
- [`P1_RC4_INVESTIGATION_PLAN_2026-05-03.md`](https://github.com/pcalnon/juniper-ml/blob/main/notes/P1_RC4_INVESTIGATION_PLAN_2026-05-03.md) §4 (fix-shape ranking).