### PR TITLE
obs-wire-01: wire 5 cascor metric emission sites + lazy-init race fix

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -20,7 +20,7 @@ import torch
 
 from api.lifecycle.monitor import TrainingMonitor, TrainingState
 from api.lifecycle.state_machine import Command, TrainingPhase, TrainingStateMachine
-from api.observability import TRAINING_SESSION_STATUS_CANCELLED, TRAINING_SESSION_STATUS_FAILURE, TRAINING_SESSION_STATUS_SUCCESS, inc_training_session_completed, observe_training_step_duration
+from api.observability import TRAINING_SESSION_STATUS_CANCELLED, TRAINING_SESSION_STATUS_FAILURE, TRAINING_SESSION_STATUS_SUCCESS, dec_training_sessions, inc_training_session_completed, inc_training_sessions, observe_training_step_duration, record_training_epoch, set_hidden_units, set_training_accuracy, set_training_loss
 from cascor_constants.constants_api import _PROJECT_API_DRAIN_THREAD_JOIN_TIMEOUT, _PROJECT_API_LIFECYCLE_DEFAULT_CANDIDATE_PATIENCE, _PROJECT_API_LIFECYCLE_DEFAULT_EPOCHS_MAX, _PROJECT_API_LIFECYCLE_DEFAULT_MAX_HIDDEN_UNITS, _PROJECT_API_LIFECYCLE_DEFAULT_MAX_ITERATIONS, _PROJECT_API_NETWORK_INPUT_SIZE_DEFAULT, _PROJECT_API_NETWORK_LEARNING_RATE_DEFAULT, _PROJECT_API_NETWORK_OUTPUT_SIZE_DEFAULT, _PROJECT_API_PROGRESS_QUEUE_GET_TIMEOUT, _PROJECT_API_PROGRESS_QUEUE_WAIT_TIMEOUT
 
 
@@ -1325,7 +1325,12 @@ class TrainingLifecycleManager:
             prev = _step_timer["prev"]
             if prev is not None:
                 try:
-                    observe_training_step_duration("output", now - prev)
+                    # OBS-WIRE-01 (A.6): the ``phase`` label was dropped
+                    # from the histogram — it was effectively a constant
+                    # ``"output"`` and the SLI regex never matched the
+                    # other two values. See observability.py for the
+                    # metric-definition comment.
+                    observe_training_step_duration(now - prev)
                 except Exception:
                     # Defensive: never let metrics emission break the
                     # train loop. The metric is best-effort by design.
@@ -1347,6 +1352,19 @@ class TrainingLifecycleManager:
 
             # Inject output training callback (Approach B — attribute fallback)
             manager_ref.network._output_epoch_callback = _output_training_callback
+
+            # OBS-WIRE-01 (A.1): mark the session active. Paired with
+            # the ``dec_training_sessions`` call in the ``finally``
+            # block below so the gauge stays balanced across normal,
+            # cancelled, and exception-failure terminal paths. The
+            # gauge gates three SLO alerts (TrainingStalled,
+            # TrainingLossNotDecreasing, LowCandidateCorrelation) which
+            # silently never fired pre-OBS-WIRE-01 because the gauge
+            # was perpetually zero.
+            try:
+                inc_training_sessions()
+            except Exception:
+                manager_ref.logger.debug("inc_training_sessions emission failed", exc_info=True)
 
             try:
                 result = original_fit(x, y, x_val=x_val, y_val=y_val, **kwargs)
@@ -1388,6 +1406,15 @@ class TrainingLifecycleManager:
                 inc_training_session_completed(TRAINING_SESSION_STATUS_FAILURE)
                 raise
             finally:
+                # OBS-WIRE-01 (A.1): always decrement, even on the
+                # exception path, so the active-sessions gauge stays
+                # balanced and the alerts that gate on
+                # ``... > 0`` (TrainingStalled etc.) actually drop
+                # back to zero when no training is in flight.
+                try:
+                    dec_training_sessions()
+                except Exception:
+                    manager_ref.logger.debug("dec_training_sessions emission failed", exc_info=True)
                 monitor.on_training_end()
 
         self.network.fit = monitored_fit
@@ -1624,6 +1651,40 @@ class TrainingLifecycleManager:
                     validation_loss=val_loss_list[i] if i < len(val_loss_list) else None,
                     validation_accuracy=val_accuracy_list[i] if i < len(val_accuracy_list) else None,
                 )
+                # OBS-WIRE-01 (A.2): bump the per-phase epoch counter
+                # exactly once per newly-emitted history row. Counters
+                # MUST NOT be throttled (rate() would under-count by
+                # the throttle factor); we emit one increment per row
+                # here, mirroring the high-water-mark advance.
+                try:
+                    record_training_epoch(phase="output")
+                    if i < len(val_loss_list):
+                        # Validation pass also constitutes a "training
+                        # epoch" from the SLI perspective. Keep the
+                        # phase distinction so the validation-vs-train
+                        # ratio stays observable.
+                        record_training_epoch(phase="validation")
+                except Exception:
+                    self.logger.debug("record_training_epoch emission failed", exc_info=True)
+
+            # OBS-WIRE-01 (A.2): set the loss / accuracy / hidden-units
+            # gauges from the latest history row. Gauges are last-value
+            # observations, so a single set() per drain is sufficient
+            # — the per-row emit-loop above advances the underlying
+            # counter; here we only need the terminal sample. ``last``
+            # is the index of the newest entry (current_len - 1).
+            last = current_len - 1
+            try:
+                set_training_loss(phase="output", loss_type="train", value=float(train_loss_list[last]))
+                if last < len(train_accuracy_list) and train_accuracy_list[last] is not None:
+                    set_training_accuracy(phase="output", value=float(train_accuracy_list[last]))
+                if last < len(val_loss_list) and val_loss_list[last] is not None:
+                    set_training_loss(phase="output", loss_type="validation", value=float(val_loss_list[last]))
+                if last < len(val_accuracy_list) and val_accuracy_list[last] is not None:
+                    set_training_accuracy(phase="validation", value=float(val_accuracy_list[last]))
+                set_hidden_units(int(hidden_units_count))
+            except Exception:
+                self.logger.debug("training gauge emission failed", exc_info=True)
 
             # Advance the high-water-mark before releasing the lock — this is
             # the second half of the formerly-split section.

--- a/src/api/observability.py
+++ b/src/api/observability.py
@@ -28,6 +28,7 @@ in juniper-ml.
 
 import logging
 import os
+import threading
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
@@ -40,7 +41,7 @@ from juniper_observability import get_prometheus_app, request_id_var, set_build_
 # resolves it through the historical import path.
 from juniper_observability.sentry import _strip_sensitive_headers  # noqa: F401 — re-exported for backwards compat
 
-from cascor_constants.constants_logging.constants_logging import _LOGGER_LOG_FILE_BACKUP_COUNT, _LOGGER_LOG_FILE_MAX_BYTES, _LOGGER_PROMETHEUS_LATENCY_BUCKETS, _LOGGER_SENTRY_TRACES_SAMPLE_RATE
+from cascor_constants.constants_logging.constants_logging import _LOGGER_LOG_FILE_BACKUP_COUNT, _LOGGER_LOG_FILE_MAX_BYTES, _LOGGER_SENTRY_TRACES_SAMPLE_RATE
 
 _SERVICE_NAME_DEFAULT: str = "juniper-cascor"
 _NAMESPACE_DEFAULT: str = "juniper_cascor"
@@ -134,6 +135,17 @@ def configure_sentry(dsn: str | None, service_name: str, version: str) -> None:
 # prometheus_client at import time (it is an optional dependency).
 # ---------------------------------------------------------------------------
 
+# OBS-WIRE-01 (E.1): module-level locks guarding the lazy-init dicts.
+# Prior to OBS-WIRE-01 the ``if _xxx_metrics is None:`` branches in
+# ``_ensure_training_metrics`` / ``_ensure_ws_metrics`` were not lock-
+# protected. Two concurrent first-callers could both enter the
+# ``is None`` branch; the second would hit ``Duplicated timeseries``,
+# ``_register_or_reuse`` would unregister the live collector, and the
+# first caller's reference would be orphaned. The locks make the
+# check-and-init pair atomic so exactly one caller registers.
+_training_metrics_lock = threading.Lock()
+_ws_metrics_lock = threading.Lock()
+
 _training_metrics: dict | None = None
 
 # METRICS-MON R5.4-pre: bucket layout for the train-step duration
@@ -194,9 +206,22 @@ def _register_or_reuse(cls, name: str, *args, **kwargs):
 
 
 def _ensure_training_metrics() -> dict:
-    """Create training-related Prometheus metrics on first access."""
+    """Create training-related Prometheus metrics on first access.
+
+    OBS-WIRE-01 (E.1): the check-and-init is wrapped in
+    ``_training_metrics_lock`` so concurrent first-callers cannot both
+    enter the ``is None`` branch and orphan a collector via the
+    ``_register_or_reuse`` recovery path.
+    """
     global _training_metrics
-    if _training_metrics is None:
+    # Fast path — the lock is only needed during the one-time init.
+    if _training_metrics is not None:
+        return _training_metrics
+    with _training_metrics_lock:
+        # Double-checked: another thread may have completed init while
+        # we waited on the lock.
+        if _training_metrics is not None:
+            return _training_metrics
         from prometheus_client import Counter, Gauge, Histogram
 
         _training_metrics = {
@@ -248,35 +273,30 @@ def _ensure_training_metrics() -> dict:
                 "juniper_cascor_candidate_correlation",
                 "Best candidate unit correlation with residual error",
             ),
-            "inference_requests_total": _register_or_reuse(
-                Counter,
-                "juniper_cascor_inference_requests_total",
-                "Total inference requests processed",
-            ),
-            "inference_duration_seconds": _register_or_reuse(
-                Histogram,
-                "juniper_cascor_inference_duration_seconds",
-                # METRICS-MON R4.1: bucket layout is **tentative pending
-                # R5.1**. Per-boundary SLO rationale in
-                # ``notes/observability/HISTOGRAM_BUCKETS_RATIONALE_2026-05-02.md``.
-                "Inference latency in seconds (R4.1 buckets tentative pending R5.1)",
-                buckets=_LOGGER_PROMETHEUS_LATENCY_BUCKETS,
-            ),
-            # METRICS-MON R5.4-pre: train-step duration histogram born
-            # SLO-aligned (no "tentative pending R5.1" suffix). Buckets
-            # target SLO 3.4 (p95 < 5s); see SLO_CATALOG §3.4 in
-            # juniper-deploy and §6 of
-            # ``notes/observability/HISTOGRAM_BUCKETS_RATIONALE_2026-05-02.md``
-            # for per-boundary rationale and the train-step boundary
-            # choice. The metric measures wall-clock around one
-            # forward+backward+update cycle (an "epoch" at the
-            # api-lifecycle level — see §1 / §6 of the rationale doc for
-            # the boundary discussion).
+            # OBS-WIRE-01 (A.5): the ``juniper_cascor_inference_*``
+            # family was removed because cascor exposes no inference
+            # endpoint — predictions are produced by downstream
+            # consumers (canopy / data services), not by this service.
+            # The previously-defined Counter and Histogram had zero
+            # production callers. See PR body for the wire-vs-remove
+            # rationale.
+            #
+            # OBS-WIRE-01 (A.6): the ``phase`` label was dropped from
+            # ``juniper_cascor_training_step_duration_seconds``. Pre-
+            # OBS-WIRE-01 the only emission site (lifecycle/manager.py
+            # output-phase callback) hard-coded ``phase="output"`` so
+            # the regex ``phase=~"input|candidate|output"`` in the SLI
+            # PromQL only ever matched a single value. The label
+            # carried no signal and was misleading; keeping it would
+            # have required adding analogous emission sites at the
+            # candidate / input phases (option (b) of the audit), which
+            # is not warranted while cascade-correlation has only an
+            # output-phase epoch loop. See PR body for the
+            # juniper-deploy SLI / alert follow-up.
             "step_duration_seconds": _register_or_reuse(
                 Histogram,
                 "juniper_cascor_training_step_duration_seconds",
                 "Buckets target SLO 3.4 (p95 < 5s); see SLO_CATALOG §3.4 in juniper-deploy.",
-                ["phase"],
                 buckets=_TRAINING_STEP_DURATION_BUCKETS,
             ),
         }
@@ -341,15 +361,11 @@ def dec_training_sessions() -> None:
     _ensure_training_metrics()["sessions_active"].dec()
 
 
-def record_inference(duration: float) -> None:
-    """Record an inference request.
-
-    Args:
-        duration: Inference duration in seconds.
-    """
-    m = _ensure_training_metrics()
-    m["inference_requests_total"].inc()
-    m["inference_duration_seconds"].observe(duration)
+# OBS-WIRE-01 (A.5): ``record_inference`` removed alongside the
+# ``juniper_cascor_inference_*`` metric family. Cascor has no inference
+# endpoint, so the helper was dead. Restore it (and the metric
+# definitions above) if a future PR adds ``POST /v1/predict`` or
+# similar.
 
 
 # METRICS-MON R5.4-pre: closed-set status values for the
@@ -388,7 +404,7 @@ def inc_training_session_completed(status: str) -> None:
     _ensure_training_metrics()["sessions_completed_total"].labels(status=status).inc()
 
 
-def observe_training_step_duration(phase: str, duration: float) -> None:
+def observe_training_step_duration(duration: float) -> None:
     """Record a single train-step duration observation.
 
     METRICS-MON R5.4-pre: measures wall-clock around one
@@ -396,12 +412,14 @@ def observe_training_step_duration(phase: str, duration: float) -> None:
     duration < 5 s) — see juniper-deploy notes/SLO_CATALOG_2026-05-03.md
     §3.4 and §6 of the cascor histogram-buckets rationale doc.
 
+    OBS-WIRE-01 (A.6): the ``phase`` label was dropped — see the
+    metric-definition comment in ``_ensure_training_metrics`` above.
+
     Args:
-        phase: Training phase — "output", "candidate", or "input".
         duration: Step duration in seconds (typically a
             ``time.perf_counter`` delta).
     """
-    _ensure_training_metrics()["step_duration_seconds"].labels(phase=phase).observe(duration)
+    _ensure_training_metrics()["step_duration_seconds"].observe(duration)
 
 
 # ---------------------------------------------------------------------------
@@ -434,9 +452,18 @@ _WS_SUB_MS_LATENCY_BUCKETS: tuple = (
 
 
 def _ensure_ws_metrics() -> dict:
-    """Create WebSocket-related Prometheus metrics on first access."""
+    """Create WebSocket-related Prometheus metrics on first access.
+
+    OBS-WIRE-01 (E.1): same lock-guarded check-and-init pattern used in
+    ``_ensure_training_metrics`` — see that function's docstring for
+    the rationale.
+    """
     global _ws_metrics
-    if _ws_metrics is None:
+    if _ws_metrics is not None:
+        return _ws_metrics
+    with _ws_metrics_lock:
+        if _ws_metrics is not None:
+            return _ws_metrics
         from prometheus_client import Counter, Gauge, Histogram
 
         _ws_metrics = {

--- a/src/api/websocket/control_stream.py
+++ b/src/api/websocket/control_stream.py
@@ -162,18 +162,38 @@ async def _handle_command_message(websocket: WebSocket, lifecycle, msg: dict, bu
         counter.labels(command=command).inc()
 
     timeout = _COMMAND_TIMEOUTS.get(command, 2.0)
+    # OBS-WIRE-01 (A.3): time only the dispatch — the
+    # ``asyncio.wait_for(asyncio.to_thread(...))`` span — NOT the
+    # surrounding parse/validate/ack-send work. This binds catalog
+    # SLI 4.4 (command-handler p95 < 50 ms). The send-ack call below
+    # is itself instrumented via the broadcast-send histogram from
+    # ``WebSocketManager._send_json``, so we don't double-count.
+    handler_start = time.perf_counter()
     try:
         result = await asyncio.wait_for(
             asyncio.to_thread(_execute_command, lifecycle, command, msg.get("params")),
             timeout=timeout,
         )
+        handler_duration = time.perf_counter() - handler_start
         await websocket.send_json(create_control_ack_message(command, "success", data=result, command_id=command_id))
     except asyncio.TimeoutError:
+        handler_duration = time.perf_counter() - handler_start
         logger.error("Command '%s' timed out after %ss", command, timeout)
         await websocket.send_json(create_control_ack_message(command, "error", error=f"Command timed out after {timeout}s", command_id=command_id))
     except Exception as e:
+        handler_duration = time.perf_counter() - handler_start
         logger.error("Command '%s' failed: %s", command, e)
         await websocket.send_json(create_control_ack_message(command, "error", error="Command execution failed", command_id=command_id))
+    # OBS-WIRE-01 (A.3): observe the command-handler histogram. Done
+    # outside the try/except chain so a single observation is emitted
+    # whether the handler completed, timed out, or raised — the
+    # SLO PromQL aggregates across all three.
+    try:
+        from api.observability import ws_observe_command_handler
+
+        ws_observe_command_handler(command, handler_duration)
+    except Exception:
+        logger.debug("ws_observe_command_handler emission failed", exc_info=True)
 
 
 async def _control_ping_loop(websocket: WebSocket, client_ip: str, hb_interval: float, hb_timeout: float, pong_received: asyncio.Event) -> None:

--- a/src/api/websocket/manager.py
+++ b/src/api/websocket/manager.py
@@ -478,7 +478,20 @@ class WebSocketManager:
         Applies a configurable send timeout (default 0.5s) to prevent slow
         clients from blocking broadcast fan-out (GAP-WS-07 quick-fix).
         Returns False on failure or timeout.
+
+        OBS-WIRE-01 (A.3): the per-connection send is timed with
+        ``time.perf_counter`` and observed into
+        ``cascor_ws_broadcast_send_duration_seconds`` (catalog SLI 4.3 —
+        broadcast fan-out p95 < 1 ms). Only the wait_for() span is
+        timed; serialization-for-bandwidth-accounting (``_account_send``)
+        is excluded so the histogram reflects pure socket-write latency.
         """
+        # OBS-WIRE-01 (A.3): start the broadcast-send timer. The metric
+        # ``type`` label is closed-set-by-convention — fall back to
+        # ``"unknown"`` if the message has no ``type`` field, matching
+        # the pattern in ``_account_send``.
+        msg_type = str(message.get("type") or "unknown")
+        send_start = time.perf_counter()
         try:
             await asyncio.wait_for(
                 websocket.send_json(message),
@@ -493,6 +506,18 @@ class WebSocketManager:
             with self._seq_lock:
                 self._send_failures += 1
             return False
+        finally:
+            # OBS-WIRE-01 (A.3): observe the broadcast-send histogram
+            # in ``finally`` so timeouts and exceptions still produce a
+            # sample (the slow / failed sends are exactly what we care
+            # about for SLI 4.3). Defensive try/except: prometheus_client
+            # may not be importable in some test environments.
+            try:
+                from api.observability import _ensure_ws_metrics
+
+                _ensure_ws_metrics()["broadcast_send_duration_seconds"].labels(type=msg_type).observe(time.perf_counter() - send_start)
+            except Exception:
+                logger.debug("broadcast_send_duration emission failed", exc_info=True)
         # GAP-WS-16: account bytes after a successful send. We re-serialize
         # to size the payload because Starlette's send_json hides the wire
         # bytes from us. The double-encode is cheap; if size estimation

--- a/src/cascade_correlation/cascade_correlation.py
+++ b/src/cascade_correlation/cascade_correlation.py
@@ -3428,6 +3428,20 @@ class CascadeCorrelationNetwork:
 
     #################################################################################################################################################################################################
     # Public Method to add a new hidden unit based on the correlation
+    def _emit_candidate_correlation(self, value) -> None:
+        """OBS-WIRE-01 (A.2): emit the best-candidate-correlation gauge.
+
+        Defensive: never let a metrics-emit failure break the training
+        loop. Kept as a method (not a free function) so unit tests can
+        ``patch.object`` it on a per-instance basis.
+        """
+        try:
+            from api.observability import set_candidate_correlation as _set_candidate_correlation
+
+            _set_candidate_correlation(float(value))
+        except Exception:
+            self.logger.debug("set_candidate_correlation emission failed", exc_info=True)
+
     def _install_hidden_unit(
         self,
         weights: torch.Tensor,
@@ -3748,6 +3762,12 @@ class CascadeCorrelationNetwork:
             residual_magnitude = residual_error.abs().mean().item()
             adaptive_threshold = max(1e-6, min(self.correlation_threshold, residual_magnitude * 0.01))
             best_correlation = training_results.best_candidate.get_correlation()
+            # OBS-WIRE-01 (A.2): emit the best-candidate correlation
+            # gauge. Sampled once per grow-iteration after the
+            # candidate pool finishes training. Extracted into a tiny
+            # helper to keep the grow_network branch count under the
+            # flake8 C901 ceiling.
+            self._emit_candidate_correlation(best_correlation)
             if best_correlation < adaptive_threshold:
                 self.logger.info(f"CascadeCorrelationNetwork: grow_network: No candidate met adaptive correlation threshold: {adaptive_threshold:.6f} (static: {self.correlation_threshold}, residual_mag: {residual_magnitude:.6f}), Best Correlation Achieved: {best_correlation:.6f}")
                 break

--- a/src/tests/unit/api/test_metrics_obs_wire_01.py
+++ b/src/tests/unit/api/test_metrics_obs_wire_01.py
@@ -1,0 +1,442 @@
+"""OBS-WIRE-01 regression tests.
+
+Closes 6 of 27 audit findings from
+``juniper-ml notes/code-review/OBSERVABILITY_AUDIT_AND_OUTSTANDING_ISSUES_2026-05-03.md``:
+
+- A.1: ``juniper_cascor_training_sessions_active`` gauge inc/dec
+- A.2: training_loss / epochs_total / candidate_correlation /
+  accuracy_ratio / hidden_units_total emission
+- A.3: ``cascor_ws_broadcast_send_duration_seconds`` and
+  ``cascor_ws_command_handler_seconds`` observation
+- A.5: removal of dead ``juniper_cascor_inference_*`` family
+- A.6: drop ``phase`` label from
+  ``juniper_cascor_training_step_duration_seconds``
+- E.1: lazy-init race in ``_ensure_training_metrics`` /
+  ``_ensure_ws_metrics``
+
+Each suite owns its own teardown so tests are order-independent.
+"""
+
+import logging
+import threading
+
+import pytest
+
+import api.observability as obs
+
+
+def _reset_training_metrics() -> None:
+    """Force lazy re-init so each test sees a fresh metric set."""
+    from prometheus_client import REGISTRY
+
+    if obs._training_metrics is not None:
+        for metric in list(obs._training_metrics.values()):
+            try:
+                REGISTRY.unregister(metric)
+            except Exception as exc:
+                logging.getLogger(__name__).debug("Best-effort training-metric unregister failed for %r: %s", metric, exc)
+        obs._training_metrics = None
+
+
+def _reset_ws_metrics() -> None:
+    """Force lazy re-init so each test sees a fresh ws-metric set."""
+    from prometheus_client import REGISTRY
+
+    if obs._ws_metrics is not None:
+        for metric in list(obs._ws_metrics.values()):
+            try:
+                REGISTRY.unregister(metric)
+            except Exception as exc:
+                logging.getLogger(__name__).debug("Best-effort ws-metric unregister failed for %r: %s", metric, exc)
+        obs._ws_metrics = None
+
+
+@pytest.mark.unit
+class TestActiveSessionsGaugeInLifecycleManager:
+    """A.1 — inc at session start, dec on every terminal path (incl. exception)."""
+
+    def setup_method(self):
+        _reset_training_metrics()
+
+    def teardown_method(self):
+        _reset_training_metrics()
+
+    def _gauge_value(self) -> float:
+        return obs._ensure_training_metrics()["sessions_active"]._value.get()
+
+    def _build_manager_with_fake_network(self, fit_outcome: str):
+        """Replica of the helper in ``test_metrics_r5_4_pre.py``."""
+        from api.lifecycle.manager import TrainingLifecycleManager
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+
+        def _fake_fit(x, y, x_val=None, y_val=None, **kwargs):
+            if fit_outcome == "failure":
+                raise RuntimeError("synthetic training failure")
+            if fit_outcome == "cancelled":
+                mgr._stop_requested.set()
+            return None
+
+        mgr._restore_original_methods()
+        mgr._monitoring_active = False
+        mgr.network.fit = _fake_fit
+        mgr._install_monitoring_hooks()
+        return mgr
+
+    def test_success_path_increments_then_decrements(self):
+        import torch
+
+        mgr = self._build_manager_with_fake_network("success")
+        before = self._gauge_value()
+        mgr.network.fit(torch.zeros(2, 2), torch.zeros(2, 2))
+        after = self._gauge_value()
+        # Inc(+1) then Dec(-1) → net zero.
+        assert after == pytest.approx(before)
+
+    def test_cancelled_path_decrements(self):
+        import torch
+
+        mgr = self._build_manager_with_fake_network("cancelled")
+        before = self._gauge_value()
+        mgr.network.fit(torch.zeros(2, 2), torch.zeros(2, 2))
+        after = self._gauge_value()
+        assert after == pytest.approx(before)
+
+    def test_exception_path_still_decrements(self):
+        """The try/finally invariant — failure must not leak the gauge."""
+        import torch
+
+        mgr = self._build_manager_with_fake_network("failure")
+        before = self._gauge_value()
+        with pytest.raises(RuntimeError, match="synthetic training failure"):
+            mgr.network.fit(torch.zeros(2, 2), torch.zeros(2, 2))
+        after = self._gauge_value()
+        # Most important assertion of this test: gauge balanced even on
+        # the exception path.
+        assert after == pytest.approx(before)
+
+
+@pytest.mark.unit
+class TestTrainingMetricsExtractAndRecord:
+    """A.2 — _extract_and_record_metrics emits epochs / loss / accuracy / hidden_units."""
+
+    def setup_method(self):
+        _reset_training_metrics()
+
+    def teardown_method(self):
+        _reset_training_metrics()
+
+    def _build_manager_with_synth_history(self, train_loss, train_acc, val_loss, val_acc, n_hidden):
+        """Build a manager whose network.history mimics a few completed epochs.
+
+        The manager is constructed via the normal ``create_network``
+        path (which installs monitoring hooks), then we synthesize the
+        ``history`` dict and ``hidden_units`` list directly so
+        ``_extract_and_record_metrics`` has data to drain.
+        """
+        from api.lifecycle.manager import TrainingLifecycleManager
+
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        mgr.network.history = {
+            "train_loss": list(train_loss),
+            "train_accuracy": list(train_acc),
+            "value_loss": list(val_loss),
+            "value_accuracy": list(val_acc),
+            "hidden_units_added": [],
+        }
+        mgr.network.hidden_units = [object()] * n_hidden
+        mgr._last_emitted_history_len = 0
+        return mgr
+
+    def test_drain_emits_loss_accuracy_hidden_units_and_counter(self):
+        mgr = self._build_manager_with_synth_history(
+            train_loss=[1.0, 0.5, 0.25],
+            train_acc=[0.6, 0.8, 0.95],
+            val_loss=[1.1, 0.6],  # only 2 validation rows
+            val_acc=[0.5, 0.75],
+            n_hidden=3,
+        )
+        epochs_total = obs._ensure_training_metrics()["epochs_total"]
+        loss_gauge = obs._ensure_training_metrics()["loss"]
+        accuracy_gauge = obs._ensure_training_metrics()["accuracy_ratio"]
+        hidden_gauge = obs._ensure_training_metrics()["hidden_units_total"]
+
+        epochs_before = epochs_total.labels(phase="output")._value.get()
+
+        mgr._extract_and_record_metrics()
+
+        # Counter advanced by 3 — one per history row drained.
+        epochs_after = epochs_total.labels(phase="output")._value.get()
+        assert epochs_after - epochs_before == pytest.approx(3.0)
+
+        # Loss gauge holds the LAST value (gauge contract).
+        assert loss_gauge.labels(phase="output", loss_type="train")._value.get() == pytest.approx(0.25)
+        # Validation loss gauge — last validation row was 0.6.
+        assert loss_gauge.labels(phase="output", loss_type="validation")._value.get() == pytest.approx(0.6)
+
+        # Accuracy gauge — last train_accuracy is 0.95.
+        assert accuracy_gauge.labels(phase="output")._value.get() == pytest.approx(0.95)
+        # Validation accuracy at phase="validation".
+        assert accuracy_gauge.labels(phase="validation")._value.get() == pytest.approx(0.75)
+
+        # Hidden units gauge reflects the network's current count.
+        assert hidden_gauge._value.get() == pytest.approx(3.0)
+
+    def test_drain_is_idempotent_without_new_data(self):
+        """Re-call without new history rows must not double-bump the counter."""
+        mgr = self._build_manager_with_synth_history(
+            train_loss=[1.0],
+            train_acc=[0.5],
+            val_loss=[],
+            val_acc=[],
+            n_hidden=1,
+        )
+        epochs_total = obs._ensure_training_metrics()["epochs_total"]
+        mgr._extract_and_record_metrics()
+        first = epochs_total.labels(phase="output")._value.get()
+        mgr._extract_and_record_metrics()
+        second = epochs_total.labels(phase="output")._value.get()
+        assert second == pytest.approx(first), "second drain emitted phantom epochs"
+
+
+@pytest.mark.unit
+class TestCandidateCorrelationGaugeWiring:
+    """A.2 — candidate_correlation gauge reachable via the helper.
+
+    The actual emission site lives inside ``cascade_correlation.py``'s
+    ``grow_network`` loop. Driving real cascade-correlation training
+    here would require a working torch environment (see project memory
+    re: JuniperCascor torch ImportError under Py3.14 free-threading).
+    Instead, exercise the import-and-emit path the production code uses
+    so a refactor that breaks the helper is caught at unit-test time.
+    """
+
+    def setup_method(self):
+        _reset_training_metrics()
+
+    def teardown_method(self):
+        _reset_training_metrics()
+
+    def test_helper_sets_gauge_value(self):
+        """The set_candidate_correlation helper writes to the right gauge."""
+        from api.observability import set_candidate_correlation
+
+        gauge = obs._ensure_training_metrics()["candidate_correlation"]
+        set_candidate_correlation(0.42)
+        assert gauge._value.get() == pytest.approx(0.42)
+        # Gauge contract: a second set() OVERWRITES, doesn't accumulate.
+        set_candidate_correlation(0.99)
+        assert gauge._value.get() == pytest.approx(0.99)
+
+
+@pytest.mark.unit
+class TestStepDurationPhaseLabelDropped:
+    """A.6 — phase label gone from ``juniper_cascor_training_step_duration_seconds``."""
+
+    def setup_method(self):
+        _reset_training_metrics()
+
+    def teardown_method(self):
+        _reset_training_metrics()
+
+    def test_metric_has_no_label_names(self):
+        hist = obs._ensure_training_metrics()["step_duration_seconds"]
+        assert hist._labelnames == ()
+
+    def test_helper_signature_takes_only_duration(self):
+        """A.6: ``observe_training_step_duration`` no longer accepts ``phase``."""
+        from api.observability import observe_training_step_duration
+
+        # Positional-only call with one arg should succeed.
+        observe_training_step_duration(0.05)
+        # And calling with the legacy two-arg shape should fail because
+        # the helper was simplified.
+        with pytest.raises(TypeError):
+            observe_training_step_duration("output", 0.05)  # type: ignore[call-arg]
+
+
+@pytest.mark.unit
+class TestInferenceMetricsRemoved:
+    """A.5 — the dead ``juniper_cascor_inference_*`` family is gone."""
+
+    def setup_method(self):
+        _reset_training_metrics()
+
+    def teardown_method(self):
+        _reset_training_metrics()
+
+    def test_inference_metrics_absent_from_dict(self):
+        m = obs._ensure_training_metrics()
+        assert "inference_requests_total" not in m
+        assert "inference_duration_seconds" not in m
+
+    def test_record_inference_helper_removed(self):
+        assert not hasattr(obs, "record_inference"), "record_inference should have been removed (A.5)"
+
+
+@pytest.mark.unit
+class TestBroadcastSendDurationWiring:
+    """A.3 — ``cascor_ws_broadcast_send_duration_seconds`` observed per send."""
+
+    def setup_method(self):
+        _reset_ws_metrics()
+
+    def teardown_method(self):
+        _reset_ws_metrics()
+
+    def test_send_json_observes_histogram(self):
+        """A successful _send_json call increments the histogram by exactly one observation."""
+        import asyncio
+
+        from api.websocket.manager import WebSocketManager
+
+        mgr = WebSocketManager()
+
+        # Fake WebSocket whose ``send_json`` is a no-op coroutine.
+        class _FakeWS:
+            async def send_json(self, msg):
+                return None
+
+        ws = _FakeWS()
+        hist = obs._ensure_ws_metrics()["broadcast_send_duration_seconds"]
+
+        before_count = sum(b.get() for b in hist.labels(type="state")._buckets)
+        result = asyncio.run(mgr._send_json(ws, {"type": "state", "payload": "hi"}))
+        assert result is True
+        after_count = sum(b.get() for b in hist.labels(type="state")._buckets)
+        assert after_count - before_count == 1
+
+    def test_send_json_observes_histogram_on_failure(self):
+        """Even when send fails, we still record the latency sample (slow/failed sends matter for SLI 4.3)."""
+        import asyncio
+
+        from api.websocket.manager import WebSocketManager
+
+        mgr = WebSocketManager()
+
+        class _BrokenWS:
+            async def send_json(self, msg):
+                raise RuntimeError("synthetic send failure")
+
+        ws = _BrokenWS()
+        hist = obs._ensure_ws_metrics()["broadcast_send_duration_seconds"]
+        before_count = sum(b.get() for b in hist.labels(type="state")._buckets)
+
+        result = asyncio.run(mgr._send_json(ws, {"type": "state", "payload": "hi"}))
+        assert result is False
+        after_count = sum(b.get() for b in hist.labels(type="state")._buckets)
+        assert after_count - before_count == 1, "failed sends must still produce a latency sample"
+
+    def test_unknown_message_type_falls_back(self):
+        """Messages without a ``type`` field land in the ``unknown`` bucket family (consistent with _account_send)."""
+        import asyncio
+
+        from api.websocket.manager import WebSocketManager
+
+        mgr = WebSocketManager()
+
+        class _FakeWS:
+            async def send_json(self, msg):
+                return None
+
+        ws = _FakeWS()
+        hist = obs._ensure_ws_metrics()["broadcast_send_duration_seconds"]
+        before_count = sum(b.get() for b in hist.labels(type="unknown")._buckets)
+        asyncio.run(mgr._send_json(ws, {"payload": "no-type-field"}))
+        after_count = sum(b.get() for b in hist.labels(type="unknown")._buckets)
+        assert after_count - before_count == 1
+
+
+@pytest.mark.unit
+class TestCommandHandlerHistogramWiring:
+    """A.3 — ``cascor_ws_command_handler_seconds`` observed per dispatch."""
+
+    def setup_method(self):
+        _reset_ws_metrics()
+
+    def teardown_method(self):
+        _reset_ws_metrics()
+
+    def test_helper_observes_histogram(self):
+        """``ws_observe_command_handler`` writes to the right histogram with the right label."""
+        from api.observability import ws_observe_command_handler
+
+        hist = obs._ensure_ws_metrics()["command_handler_seconds"]
+        before = sum(b.get() for b in hist.labels(command="start")._buckets)
+        ws_observe_command_handler("start", 0.012)
+        after = sum(b.get() for b in hist.labels(command="start")._buckets)
+        assert after - before == 1
+        # And the sum got the actual duration.
+        assert hist.labels(command="start")._sum.get() == pytest.approx(0.012)
+
+
+@pytest.mark.unit
+class TestLazyInitRaceFix:
+    """E.1 — concurrent first-callers don't orphan a collector.
+
+    Pre-OBS-WIRE-01: two threads could both enter the
+    ``if _xxx_metrics is None:`` branch; the second hit
+    ``Duplicated timeseries``, the recovery path unregistered the
+    live collector, and the first thread's reference was orphaned.
+
+    Post-OBS-WIRE-01: ``threading.Lock`` makes the check-and-init
+    atomic so exactly one thread registers and every caller sees the
+    same dict.
+    """
+
+    def setup_method(self):
+        _reset_training_metrics()
+        _reset_ws_metrics()
+
+    def teardown_method(self):
+        _reset_training_metrics()
+        _reset_ws_metrics()
+
+    def _race_ensure(self, ensure_fn, n_threads: int = 16):
+        """Drive ``n_threads`` concurrent first-callers and return their results."""
+        results = [None] * n_threads
+        barrier = threading.Barrier(n_threads)
+
+        def worker(idx: int) -> None:
+            barrier.wait()  # synchronize the entry instant
+            results[idx] = ensure_fn()
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        return results
+
+    def test_concurrent_callers_see_same_training_dict(self):
+        """All threads receive the same dict instance — no orphaned collectors."""
+        results = self._race_ensure(obs._ensure_training_metrics)
+        first = results[0]
+        assert first is not None
+        for other in results[1:]:
+            assert other is first, "concurrent first-callers received different dict instances (race not fixed)"
+
+    def test_concurrent_callers_see_same_ws_dict(self):
+        results = self._race_ensure(obs._ensure_ws_metrics)
+        first = results[0]
+        assert first is not None
+        for other in results[1:]:
+            assert other is first, "concurrent first-callers received different ws-dict instances (race not fixed)"
+
+    def test_collector_registered_in_global_registry_after_race(self):
+        """The collector is reachable in REGISTRY (no half-registered orphans)."""
+        from prometheus_client import REGISTRY
+
+        self._race_ensure(obs._ensure_training_metrics)
+        # The active-sessions Gauge name must be findable in the registry.
+        names: set[str] = set()
+        for _collector, collector_names in REGISTRY._collector_to_names.items():
+            names.update(collector_names)
+        assert "juniper_cascor_training_sessions_active" in names
+
+    def test_lock_present(self):
+        """E.1 contract: the locks are module-level threading.Lock instances."""
+        assert isinstance(obs._training_metrics_lock, type(threading.Lock()))
+        assert isinstance(obs._ws_metrics_lock, type(threading.Lock()))

--- a/src/tests/unit/api/test_metrics_r5_4_pre.py
+++ b/src/tests/unit/api/test_metrics_r5_4_pre.py
@@ -121,12 +121,15 @@ class TestTrainingStepDurationHistogram:
         view is computed at scrape time). A 0.7 s observation sits in
         the half-open interval (0.5, 1.0] and so increments the bucket
         whose upper bound is 1.0 — and ONLY that bucket.
+
+        OBS-WIRE-01 (A.6): the histogram no longer carries a ``phase``
+        label — see the metric-definition comment in
+        ``api.observability``.
         """
-        observe_training_step_duration("output", 0.7)
+        observe_training_step_duration(0.7)
 
         hist = _ensure_training_metrics()["step_duration_seconds"]
-        labelled = hist.labels(phase="output")
-        bucket_counts = {ub: bucket.get() for ub, bucket in zip(hist._upper_bounds, labelled._buckets)}
+        bucket_counts = {ub: bucket.get() for ub, bucket in zip(hist._upper_bounds, hist._buckets)}
 
         assert bucket_counts[1.0] == 1, f"sample of 0.7 must land in the le=1.0 bucket: counts={bucket_counts}"
         for ub, count in bucket_counts.items():
@@ -137,14 +140,17 @@ class TestTrainingStepDurationHistogram:
         # The cumulative contract IS still observable via _sum and the
         # final +inf observation count: every observation contributes
         # to _sum exactly once.
-        assert labelled._sum.get() == pytest.approx(0.7)
+        assert hist._sum.get() == pytest.approx(0.7)
 
-    def test_phase_label_supports_output(self):
-        """The histogram is keyed by phase; output is the R5.4-pre seed value."""
-        observe_training_step_duration("output", 0.123)
+    def test_phase_label_dropped(self):
+        """OBS-WIRE-01 (A.6): the histogram is unlabelled — no labelnames."""
         hist = _ensure_training_metrics()["step_duration_seconds"]
-        # Sum of observations should be 0.123 within float epsilon.
-        assert hist.labels(phase="output")._sum.get() == pytest.approx(0.123)
+        # ``Histogram._labelnames`` is the public-ish accessor for the
+        # declared label set; an empty tuple means the metric has no
+        # labels (post-A.6 contract).
+        assert hist._labelnames == (), f"expected no labels post-A.6, got {hist._labelnames!r}"
+        observe_training_step_duration(0.123)
+        assert hist._sum.get() == pytest.approx(0.123)
 
 
 @pytest.mark.unit
@@ -431,13 +437,12 @@ class TestLifecycleStepDurationCallback:
         mgr.network.fit(torch.zeros(2, 2), torch.zeros(2, 2))
 
         hist = _ensure_training_metrics()["step_duration_seconds"]
-        labelled = hist.labels(phase="output")
-        # ``_sum`` is the cumulative observation total — should be >0
-        # because exactly one sample was emitted (the second callback
-        # observes the delta from the first).
-        observed_sum = labelled._sum.get()
+        # OBS-WIRE-01 (A.6): the histogram is unlabelled — observations
+        # land directly on ``hist._sum`` / ``hist._buckets`` rather
+        # than the per-label child.
+        observed_sum = hist._sum.get()
         assert observed_sum > 0.0, "no train-step duration sample emitted"
         # ``_buckets`` is non-cumulative in modern prometheus_client.
         # Across all buckets the observation count must total exactly 1.
-        total_count = sum(bucket.get() for bucket in labelled._buckets)
+        total_count = sum(bucket.get() for bucket in hist._buckets)
         assert total_count == 1, f"expected exactly 1 sample emitted across all buckets, got {total_count}"

--- a/src/tests/unit/test_api_observability.py
+++ b/src/tests/unit/test_api_observability.py
@@ -525,12 +525,16 @@ class TestObservabilityShim_R5_1b:
                         logging.debug("Best-effort metric unregister failed in teardown for %r: %s", metric, exc)
                 setattr(obs, cache_attr, None)
 
-    def test_inference_duration_seconds_help_keeps_r4_1_marker(self):
+    def test_inference_metrics_were_removed_obs_wire_01(self):
+        """OBS-WIRE-01 (A.5): the ``juniper_cascor_inference_*`` family
+        was removed because cascor exposes no inference endpoint. Pin
+        the removal so a future revert lands a regression alongside it.
+        """
         from api.observability import _ensure_training_metrics
 
         metrics = _ensure_training_metrics()
-        hist = metrics["inference_duration_seconds"]
-        assert "(R4.1 buckets tentative pending R5.1)" in hist._documentation
+        assert "inference_requests_total" not in metrics
+        assert "inference_duration_seconds" not in metrics
 
     def test_resume_replayed_events_help_keeps_r4_1_marker(self):
         from api.observability import _ensure_ws_metrics


### PR DESCRIPTION
## Summary

Closes 6 of 27 audit findings (~22% of post-METRICS-MON outstanding work) from juniper-ml#195 (`OBSERVABILITY_AUDIT_AND_OUTSTANDING_ISSUES_2026-05-03.md`). The audit found that pre-METRICS-MON observability scaffolding had several metric helpers with zero production callers; dashboards / alerts / SLO catalog entries referenced them and silently showed flat zeros (or never fired).

## Findings closed (one-line resolution each)

| ID | Metric / issue | Resolution |
|----|----------------|------------|
| A.1 | `juniper_cascor_training_sessions_active` gauge | **Wired** `inc/dec` around `monitored_fit()` in `lifecycle/manager.py` with `try/finally` so the exception path still decrements |
| A.2 | `training_loss`, `training_epochs_total`, `training_accuracy_ratio`, `hidden_units_total`, `candidate_correlation` | **Wired** in `_extract_and_record_metrics()` (per-iteration drain) and `cascade_correlation.grow_network` (best-candidate per growth step) |
| A.3 | `cascor_ws_broadcast_send_duration_seconds`, `cascor_ws_command_handler_seconds` (catalog SLI 4.3 + 4.4) | **Wired** in `WebSocketManager._send_json` and `control_stream._handle_command_message`. Observations land in `finally` so timeouts/exceptions still produce samples |
| A.5 | `juniper_cascor_inference_*` family | **Removed** — cascor exposes no inference endpoint; the metric had zero callers and zero realistic call sites |
| A.6 | `phase` label on `juniper_cascor_training_step_duration_seconds` | **Dropped the label** (option a) — was effectively constant `"output"`; SLI regex never matched the other two values |
| E.1 | Lazy-init race in `_ensure_training_metrics` / `_ensure_ws_metrics` | **Wrapped** check-and-init in module-level `threading.Lock` instances with double-checked locking |

## Wire-vs-remove decisions

- **A.5 (inference)**: removed. `grep -rn "@router|@app|inference|/predict" src/api/` found no inference endpoint and no architectural plan to add one. Cascor is training-only; predictions happen downstream. Restoring is a 1-commit revert if `POST /v1/predict` ever lands.
- **A.2 (accuracy)**: wired. `cascade_correlation.fit` calls `calculate_accuracy(x_train, y_train)` and `get_accuracy(x_train, y_train)` and appends to `history["train_accuracy"]` / `history["value_accuracy"]`. Both flow through `_extract_and_record_metrics` so the gauges populate naturally.
- **A.6 (phase label)**: dropped. Option (b) (adding input/candidate emission sites) would have required identifying analogues in cascade-correlation training, but the algorithm has only an output-phase epoch loop in the lifecycle path. Dropping the constant label is simpler and removes the misleading regex.

## juniper-deploy follow-up needed

The A.6 label drop means `notes/SLO_CATALOG_2026-05-03.md` §3.4 PromQL and the corresponding burn-rate alert in `prometheus/alert_rules.yml` need their `phase=~"..."` filter removed. **This PR does NOT modify juniper-deploy** — that change is a separate PR against that repo.

## Per-finding test files and methods

All new tests live in `src/tests/unit/api/test_metrics_obs_wire_01.py` (18 tests / 8 classes):

- **A.1**: `TestActiveSessionsGaugeInLifecycleManager::test_success_path_increments_then_decrements`, `::test_cancelled_path_decrements`, `::test_exception_path_still_decrements`
- **A.2 (lifecycle)**: `TestTrainingMetricsExtractAndRecord::test_drain_emits_loss_accuracy_hidden_units_and_counter`, `::test_drain_is_idempotent_without_new_data`
- **A.2 (candidate corr)**: `TestCandidateCorrelationGaugeWiring::test_helper_sets_gauge_value`
- **A.3 (broadcast)**: `TestBroadcastSendDurationWiring::test_send_json_observes_histogram`, `::test_send_json_observes_histogram_on_failure`, `::test_unknown_message_type_falls_back`
- **A.3 (command)**: `TestCommandHandlerHistogramWiring::test_helper_observes_histogram`
- **A.5**: `TestInferenceMetricsRemoved::test_inference_metrics_absent_from_dict`, `::test_record_inference_helper_removed`
- **A.6**: `TestStepDurationPhaseLabelDropped::test_metric_has_no_label_names`, `::test_helper_signature_takes_only_duration`
- **E.1**: `TestLazyInitRaceFix::test_concurrent_callers_see_same_training_dict`, `::test_concurrent_callers_see_same_ws_dict`, `::test_collector_registered_in_global_registry_after_race`, `::test_lock_present`

Updated existing tests:
- `test_metrics_r5_4_pre.py` — A.6 phase-label drop reflected (4 methods)
- `test_api_observability.py` — pinned A.5 inference removal

## Test plan

- [x] `pre-commit run` on all touched files — passes (black, isort, flake8, bandit, mypy)
- [x] Local pytest of the 13 conftest-free OBS-WIRE-01 tests + 8 R5.4-pre regression + 2 R5.1b shim — all pass
- [ ] CI must run the 5 lifecycle-dependent tests (`TestActiveSessionsGaugeInLifecycleManager`, `TestTrainingMetricsExtractAndRecord`) which can't run locally because the JuniperCascor conda env's torch fails to import under Py3.14 free-threading (documented in project memory)
- [ ] Manual verification on a running cascor instance: `curl localhost:8201/metrics | grep -E "training_sessions_active|broadcast_send_duration|command_handler_seconds|candidate_correlation"` should show non-zero values during a training run

## References

- juniper-ml#195 — OBSERVABILITY_AUDIT_AND_OUTSTANDING_ISSUES_2026-05-03 (audit doc)
- juniper-cascor#188 — METRICS-MON R5.4-pre (the partial wire-up that surfaced this gap)

## Out of scope

- Canopy findings (A.4, C.1) — separate sister PR
- Audit finding A.9 (12 broad ws_* dead metrics) — separate cleanup PR after dashboards/alerts are reviewed for which to keep
- juniper-deploy modifications (catalog SLI 3.4 PromQL, alert rule phase filter)
- `worker_*` metrics — already wired by R5.4-pre
- Removing the 25-epoch throttle (R5.6 future sub-track)

Closes 6 of 27 audit findings (~22% of post-METRICS-MON outstanding work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)