### PR TITLE
fix: pre-commit B014 + obs-wire-01 validation-loss gauge index (P-9, P-23)

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -1678,10 +1678,21 @@ class TrainingLifecycleManager:
                 set_training_loss(phase="output", loss_type="train", value=float(train_loss_list[last]))
                 if last < len(train_accuracy_list) and train_accuracy_list[last] is not None:
                     set_training_accuracy(phase="output", value=float(train_accuracy_list[last]))
-                if last < len(val_loss_list) and val_loss_list[last] is not None:
-                    set_training_loss(phase="output", loss_type="validation", value=float(val_loss_list[last]))
-                if last < len(val_accuracy_list) and val_accuracy_list[last] is not None:
-                    set_training_accuracy(phase="validation", value=float(val_accuracy_list[last]))
+                # P-23: validation history is typically shorter than the
+                # training history (validation may run every K epochs).
+                # Indexing the validation lists with the training-side
+                # ``last = current_len - 1`` skips the gauge update
+                # whenever the latest training epoch had no validation
+                # pass — the test
+                # ``test_drain_emits_loss_accuracy_hidden_units_and_counter``
+                # exercises that case. Gauges are "most recent
+                # observation", so emit the last validation entry
+                # whenever any exists. Single-conditional form keeps the
+                # function under flake8 C901's complexity cap.
+                if val_loss_list and val_loss_list[-1] is not None:
+                    set_training_loss(phase="output", loss_type="validation", value=float(val_loss_list[-1]))
+                if val_accuracy_list and val_accuracy_list[-1] is not None:
+                    set_training_accuracy(phase="validation", value=float(val_accuracy_list[-1]))
                 set_hidden_units(int(hidden_units_count))
             except Exception:
                 self.logger.debug("training gauge emission failed", exc_info=True)

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -895,9 +895,11 @@ def _reap_multiprocessing_children(timeout: float = 2.0) -> None:
                 pass
             try:
                 os.waitpid(pid, 0)
-            except (ChildProcessError, OSError) as exc:
-                # Best-effort teardown: the process may already be reaped or
-                # not waitable in this context; ignore to avoid shutdown noise.
+            except OSError as exc:
+                # ``ChildProcessError`` is a subclass of ``OSError``, so
+                # ``OSError`` alone matches both. Best-effort teardown: the
+                # process may already be reaped or not waitable in this
+                # context; ignore to avoid shutdown noise.
                 _ = exc
             _forkserver._forkserver_pid = None
             _forkserver._forkserver_address = None

--- a/src/tests/unit/api/test_monitoring_hooks.py
+++ b/src/tests/unit/api/test_monitoring_hooks.py
@@ -331,10 +331,15 @@ class TestMonitoringHooks:
                     "correlation": 0.66,
                 }
             )
-            # Give the drain thread a chance to discover the queue and consume progress
+            # Give the drain thread a chance to discover the queue and consume progress.
+            # P-25: bumped 0.15s → 0.5s after macOS-3.12 leg observed an empty
+            # progress_events list at 0.15s. The drain thread polls every ~50 ms but
+            # macOS thread scheduling under spawn-mode multiprocessing setup adds
+            # variance; 0.5s gives ~10 poll cycles of headroom and still keeps the
+            # whole test under 1s on linux runners.
             import time
 
-            time.sleep(0.15)
+            time.sleep(0.5)
             return {"ok": True}
 
         CascadeCorrelationNetwork.grow_network = fake_grow


### PR DESCRIPTION
Two CI fixes blocking cascor main:

**P-9** — Pre-commit B014: `except (ChildProcessError, OSError)` is redundant since ChildProcessError inherits from OSError. From PR #205. Drop ChildProcessError.

**P-23** — Validation-loss/accuracy gauge stays at 0.0 when val history is shorter than train history (typical case — val runs every K epochs). The condition `last < len(val_loss_list)` evaluates false when the latest train epoch had no validation pass. Gauges are most-recent-observation; emit the last validation entry whenever any exists.

Surfaced together because P-9 unblocks pre-commit which unblocks unit-tests which surfaces P-23.