### PR TITLE
fix(ws): idempotent Counter registration in control_stream._get_command_counter

### DIFF
--- a/src/api/websocket/control_stream.py
+++ b/src/api/websocket/control_stream.py
@@ -57,17 +57,37 @@ _command_received_counter = None
 
 
 def _get_command_counter():
-    """Lazily create the command received counter when metrics are available."""
+    """Lazily create the command received counter when metrics are available.
+
+    Idempotent against the global ``prometheus_client.REGISTRY``: if a
+    test fixture (or in-process re-init) has nulled the module-level
+    cache while leaving the underlying Counter registered, re-fetch
+    the existing collector instead of raising
+    ``ValueError: Duplicated timeseries``. Same shape as the
+    ``_register_or_reuse`` helper in
+    ``src/api/observability.py:_ensure_training_metrics``.
+    """
     global _command_received_counter
     if _command_received_counter is None:
         try:
-            from prometheus_client import Counter
+            from prometheus_client import REGISTRY, Counter
 
-            _command_received_counter = Counter(
-                "cascor_ws_control_command_received_total",
-                "WebSocket control commands received",
-                ["command"],
-            )
+            metric_name = "cascor_ws_control_command_received_total"
+            try:
+                _command_received_counter = Counter(
+                    metric_name,
+                    "WebSocket control commands received",
+                    ["command"],
+                )
+            except ValueError:
+                # Already registered — adopt the existing collector.
+                # ``prometheus_client`` registers under both the bare name
+                # and the suffixed sample names (``_total``, ``_created``);
+                # lookup with the name we passed returns the same object.
+                existing = REGISTRY._names_to_collectors.get(metric_name)
+                if existing is None:
+                    raise
+                _command_received_counter = existing
         except ImportError:
             _command_received_counter = False  # sentinel: prometheus not available
     return _command_received_counter


### PR DESCRIPTION
## Summary

``src/api/websocket/control_stream.py:_get_command_counter()`` constructed ``Counter(\"cascor_ws_control_command_received_total\", ...)`` directly with no idempotency guard. Same family as the recent fixes for canopy ``_ensure_canopy_metrics``, juniper-data ``_ensure_dataset_metrics``, and juniper-observability ``PrometheusMiddleware`` / ``set_build_info``.

A test fixture that nulls the module-level cache without also unregistering from REGISTRY (or any in-process re-init) would crash the next call with ``ValueError: Duplicated timeseries``.

## Fix

Wrap the construction in try/except and adopt the existing collector on duplicate. Mirrors the existing ``_register_or_reuse`` helper in ``src/api/observability.py:_ensure_training_metrics``; inlined here rather than importing across modules to keep the websocket path self-contained.

Production behaviour unchanged on the first call.

## Verification

- WS control / Phase D tests pass
- No new metrics or labels — only the construction path changed

## Companion PRs

Part of a fleet sweep — the same defensive guard ships in juniper-ml#214 (set_build_info Info), juniper-cascor-client (forthcoming), juniper-canopy (forthcoming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)