### PR TITLE
audit(d2+d5): document command_handler headroom acceptance + pin resume_replayed_events buckets

### DIFF
--- a/notes/observability/HISTOGRAM_BUCKETS_RATIONALE_2026-05-02.md
+++ b/notes/observability/HISTOGRAM_BUCKETS_RATIONALE_2026-05-02.md
@@ -239,6 +239,51 @@ A future R5.1 SLO catalog may still split the metric per command-class
 if a single layout proves insufficient — that would be a metric-rename
 event, not just a re-bucket, and is out of scope for R5.1b.
 
+### 5.4 D.2 audit follow-up (2026-05-04): tight breach-detection headroom — accepted
+
+The post-METRICS-MON observability audit (juniper-ml#195) finding
+**D.2** (P2) flagged that the `juniper-deploy/notes/SLO_CATALOG_2026-05-03.md`
+§4.4 SLO target (`p95 < 50 ms`) sits **one bucket below the `+inf`
+cap** (the `0.1` boundary, i.e. 100 ms) in the current
+`_WS_SUB_MS_LATENCY_BUCKETS` layout. With only the `0.05` and `0.1`
+boundaries straddling the SLO target, a healthy slow-command regime
+that drifts from 40 ms → 80 ms is bucketed identically to a regression
+that drifts from 80 ms → 200 ms — both increment the `0.1` (and
+implicitly `+inf`) buckets. Quantile-precision for breach detection
+in that 50 ms → 200 ms band is degraded.
+
+**Decision (2026-05-04): accepted as-is for now; re-evaluate at the
+30-day soak-window calibration (R5.1c).**
+
+Rationale:
+1. **Adding `0.025` and `0.2` boundaries now is premature.** The R5.1
+   SLO catalog itself flags every target as "initial — to revisit
+   after 30-day soak". If the soak data shifts the target to e.g.
+   `p95 < 25 ms` or `p95 < 100 ms`, the optimal additional boundaries
+   change accordingly. Choosing them now risks doing the work twice.
+2. **The shared `_WS_SUB_MS_LATENCY_BUCKETS` constant backs both
+   `command_handler_seconds` AND `broadcast_send_duration_seconds`.**
+   Splitting the constant to widen one without affecting the other is
+   a metric-rationale change with broader blast radius than the audit
+   finding warrants today.
+3. **Operational impact during soak is bounded.** The R5.4 burn-rate
+   alerts ship in log-only severity per catalog §2.6 (paging gated
+   on the soak-window calibration); fast-burn alerts on this metric
+   are explicitly informational pending soak. So the breach-detection
+   precision gap maps to "informational alerts have noisier
+   slow-fraction estimates," not to "operators miss real breaches."
+
+**Plan for R5.1c (post-soak):** if the calibrated SLO target stays in
+the 25–100 ms band, propose `_WS_SUB_MS_LATENCY_BUCKETS_V2` adding
+`0.025` and `0.2` boundaries — with the constant rename so the
+re-bucket is a clearly-tracked event in the rationale doc and tests.
+If the calibrated target lands outside that band, re-evaluate the
+boundary choices from scratch.
+
+**Tracking:** audit-doc D.2 row is closed by this acceptance note. The
+re-bucket itself, if needed, becomes a small future cascor sub-track
+sized for the R5.1c PR window.
+
 ---
 
 ## 6. `juniper_cascor_training_step_duration_seconds`

--- a/src/tests/unit/api/test_metrics_obs_wire_02.py
+++ b/src/tests/unit/api/test_metrics_obs_wire_02.py
@@ -167,6 +167,25 @@ class TestResumeRequestsAndReplayedEmission:
         assert after_count - before_count == 1
         assert hist._sum.get() == pytest.approx(7)
 
+    def test_replayed_events_histogram_buckets_pinned(self):
+        # Audit-doc D.5: pin ``cascor_ws_resume_replayed_events``
+        # ``_upper_bounds`` against the ``_WS_RESUME_REPLAY_BUCKETS``
+        # constant so future bucket-layout changes produce a
+        # deterministic test failure rather than silently re-bucketing
+        # the operational regimes documented in the rationale doc §7.
+        # Mirrors the cascor R5.4-pre + R5.1b bucket-pin assertion
+        # pattern (see ``test_metrics_r5_4_pre.py``).
+        from api.observability import _WS_RESUME_REPLAY_BUCKETS
+
+        hist = obs._ensure_ws_metrics()["resume_replayed_events"]
+        # ``prometheus_client.Histogram`` appends an implicit ``+inf``
+        # upper edge to whatever ``buckets=`` tuple it was constructed
+        # with.  Assert the layout matches the constant + the implicit
+        # ``+inf`` sentinel so a future re-bucket has to update both
+        # the constant and this test in lockstep.
+        expected = tuple(_WS_RESUME_REPLAY_BUCKETS) + (float("inf"),)
+        assert hist._upper_bounds == expected
+
     def test_handle_resume_emits_malformed_outcome(self):
         """Missing ``last_seq`` triggers the malformed_resume arm."""
         from api.websocket.training_stream import _handle_resume


### PR DESCRIPTION
## Summary

Closes audit-doc juniper-ml#195 findings **D.2** (P2) + **D.5** (P3) ahead of the 30-day soak-window calibration. Pure doc + 1 new test method.

### D.2 — `command_handler_seconds` tight headroom: ACCEPTED for now

The catalog §4.4 SLO target (\`p95 < 50 ms\`) sits one bucket below the \`+inf\` cap (100 ms) in \`_WS_SUB_MS_LATENCY_BUCKETS\`. The audit flagged this as TIGHT — a healthy 40 ms → 80 ms drift bucketed identically to a regression at 80 ms → 200 ms.

**Decision (in rationale doc §5.4): accept as-is, re-evaluate at R5.1c.**

Rationale:
1. R5.1 catalog targets are "initial — to revisit after 30-day soak"; if soak data shifts the target, the optimal additional boundaries change accordingly.
2. The shared \`_WS_SUB_MS_LATENCY_BUCKETS\` constant backs both \`command_handler_seconds\` AND \`broadcast_send_duration_seconds\` — splitting it now is a broader-blast-radius change than D.2 warrants.
3. R5.4 burn-rate alerts on this metric ship in log-only severity per catalog §2.6; fast-burn alerts are explicitly informational pending soak.

Plan for R5.1c documented in §5.4: if the calibrated target stays in the 25–100 ms band, propose \`_WS_SUB_MS_LATENCY_BUCKETS_V2\` adding 0.025 + 0.2 boundaries.

### D.5 — bucket-pin test for `cascor_ws_resume_replayed_events`

New \`test_replayed_events_histogram_buckets_pinned\` in \`test_metrics_obs_wire_02.py\` asserting the histogram's \`_upper_bounds\` matches \`_WS_RESUME_REPLAY_BUCKETS + (float("inf"),)\`. Mirrors R5.4-pre / R5.1b pattern. Future re-buckets must touch both the constant AND this test in lockstep.

The other half of D.5 (\`cascor_inference_duration_seconds\`) is moot — that metric was removed by OBS-WIRE-01 (juniper-cascor#204).

## Validation

- Pre-commit: PASS (black, isort, flake8, bandit on tests; markdown excluded)
- pytest: blocked locally by JuniperCascor env's torch / Py3.14 free-threading issue (documented project memory); CI will run the new test
- Diff: 2 files, +64 / -0

## Audit progress

26 of 27 findings closed after this merges (~96%). Remaining: §4.2 \`pending_tasks\` gauge + E.6 WorkerRegistry size cap = 250 — both queued as sequential cascor sub-tracks per the user's plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)