### PR TITLE
audit(4.2): wire juniper_cascor_pending_tasks gauge via WorkerRegistryCollector

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -58,7 +58,12 @@ def _log_startup_task_exception(task: asyncio.Task) -> None:
         logger.error("Startup task %s failed: %s", task.get_name(), exc, exc_info=exc)
 
 
-def _register_worker_metrics_collector(app: FastAPI, settings: Settings, worker_registry: WorkerRegistry) -> None:
+def _register_worker_metrics_collector(
+    app: FastAPI,
+    settings: Settings,
+    worker_registry: WorkerRegistry,
+    worker_coordinator: WorkerCoordinator,
+) -> None:
     """Register the worker -> Prometheus bridge collector at startup.
 
     METRICS-MON R5.4-pre: closes the gap flagged by R5.1
@@ -71,6 +76,12 @@ def _register_worker_metrics_collector(app: FastAPI, settings: Settings, worker_
     Extracted from the lifespan handler purely for cyclomatic-complexity
     discipline (flake8 C901 budget) — the initialization itself is
     one-shot and unconditional given ``metrics_enabled``.
+
+    Audit-doc §4.2 (2026-05-04): the coordinator is now also wired so
+    the collector can emit ``juniper_cascor_pending_tasks`` on each
+    scrape. Closes the catalog §4.2 SLI gap and lifts the
+    ``CascorPendingTasksSaturated`` alert's ``absent_over_time(...) == 0``
+    inertness guard (juniper-deploy/prometheus/alert_rules.yml).
     """
     if not settings.metrics_enabled:
         return
@@ -79,7 +90,10 @@ def _register_worker_metrics_collector(app: FastAPI, settings: Settings, worker_
 
     from api.workers.metrics import WorkerRegistryCollector
 
-    worker_metrics_collector = WorkerRegistryCollector(worker_registry)
+    worker_metrics_collector = WorkerRegistryCollector(
+        worker_registry,
+        coordinator=worker_coordinator,
+    )
     REGISTRY.register(worker_metrics_collector)
     app.state.worker_metrics_collector = worker_metrics_collector
     logger.info("Worker -> Prometheus bridge collector registered")
@@ -188,7 +202,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     lifecycle.set_worker_coordinator(worker_coordinator)
     logger.info("Worker registry and coordinator initialized")
 
-    _register_worker_metrics_collector(app, settings, worker_registry)
+    _register_worker_metrics_collector(app, settings, worker_registry, worker_coordinator)
 
     # Worker Security (Phase 4) — conditionally initialize based on feature flags
     _init_worker_security(app, settings, worker_coordinator)

--- a/src/api/workers/coordinator.py
+++ b/src/api/workers/coordinator.py
@@ -359,6 +359,20 @@ class WorkerCoordinator:
         with self._lock:
             return len(self._unassigned_tasks) > 0
 
+    def pending_tasks_count(self) -> int:
+        """Return the current number of pending (in-flight) tasks.
+
+        Snapshot read under :attr:`_lock`. Used by the
+        :class:`api.workers.metrics.WorkerRegistryCollector` to emit the
+        ``juniper_cascor_pending_tasks`` gauge on every Prometheus
+        scrape (audit-doc §4.2). Counts every task in
+        :attr:`_pending_tasks` regardless of round-id, status, or
+        assignment — the dict tracks all tasks the coordinator considers
+        in-flight (unassigned + dispatched-but-not-yet-completed).
+        """
+        with self._lock:
+            return len(self._pending_tasks)
+
     def cancel_round(self) -> None:
         """Cancel the current round and clear all pending tasks."""
         with self._lock:

--- a/src/api/workers/metrics.py
+++ b/src/api/workers/metrics.py
@@ -64,6 +64,7 @@ from typing import TYPE_CHECKING, Callable, Iterable
 if TYPE_CHECKING:
     from prometheus_client.core import Metric
 
+    from api.workers.coordinator import WorkerCoordinator
     from api.workers.registry import WorkerRegistry
 
 logger = logging.getLogger("juniper_cascor.api.workers.metrics")
@@ -77,6 +78,13 @@ _METRIC_GPU_UTILIZATION_PCT: str = "juniper_cascor_worker_gpu_utilization_pct"
 _METRIC_RECENT_DURATION_P50: str = "juniper_cascor_worker_recent_task_duration_seconds_p50"
 _METRIC_RECENT_DURATION_P95: str = "juniper_cascor_worker_recent_task_duration_seconds_p95"
 _METRIC_HEARTBEAT_AGE: str = "juniper_cascor_worker_heartbeat_age_seconds"
+
+# Audit-doc §4.2: bridge the coordinator's in-flight task count to the
+# Prometheus surface so the catalog §4.2 SLI ("queue-depth saturation")
+# can compute and the matching ``CascorPendingTasksSaturated`` alert
+# rule (juniper-deploy/prometheus/alert_rules.yml) lifts its
+# ``absent_over_time(...) == 0`` guard.
+_METRIC_PENDING_TASKS: str = "juniper_cascor_pending_tasks"
 
 
 class WorkerRegistryCollector:
@@ -92,6 +100,16 @@ class WorkerRegistryCollector:
         registry: The cascor :class:`WorkerRegistry` to snapshot. The
             collector keeps a reference and re-reads it on every
             scrape; it does NOT copy on construction.
+        coordinator: Optional :class:`WorkerCoordinator`. When provided
+            (the normal cascor app wiring), the collector additionally
+            emits ``juniper_cascor_pending_tasks`` on each scrape using
+            the coordinator's ``pending_tasks_count()`` accessor (audit-
+            doc §4.2 / juniper-deploy alert ``CascorPendingTasksSaturated``).
+            When ``None`` (test fixtures, lightweight harnesses), the
+            pending-tasks gauge is silently skipped — preserving
+            R1.4 single-registration discipline and avoiding a
+            misleading zero-emission for callers that intentionally
+            don't have a coordinator wired.
         time_source: Optional callable returning the current wall-clock
             time as a float (defaults to :func:`time.time`). Injected
             for deterministic unit tests.
@@ -101,9 +119,11 @@ class WorkerRegistryCollector:
         self,
         registry: "WorkerRegistry",
         *,
+        coordinator: "WorkerCoordinator | None" = None,
         time_source: Callable[[], float] = time.time,
     ) -> None:
         self._registry = registry
+        self._coordinator = coordinator
         self._now = time_source
 
     def collect(self) -> Iterable["Metric"]:  # noqa: D401 — prometheus_client interface
@@ -196,6 +216,23 @@ class WorkerRegistryCollector:
         yield gpu_utilization
         yield recent_p50
         yield recent_p95
+
+        # Audit-doc §4.2: pending-tasks gauge. Emit only when a
+        # coordinator was wired at construction; missing-coordinator is
+        # treated as "no data" (gauge omitted) rather than zero-emit so
+        # the alert rule's ``absent_over_time(...) == 0`` guard keeps
+        # working in test fixtures + lightweight harnesses that don't
+        # construct a coordinator.
+        if self._coordinator is not None:
+            pending_tasks = GaugeMetricFamily(
+                _METRIC_PENDING_TASKS,
+                "Number of in-flight tasks tracked by the worker coordinator (unassigned + dispatched-but-not-yet-completed).",
+            )
+            try:
+                pending_tasks.add_metric([], float(self._coordinator.pending_tasks_count()))
+                yield pending_tasks
+            except Exception:
+                logger.exception("WorkerRegistryCollector failed to read coordinator.pending_tasks_count() — skipping gauge emission")
 
 
 def _percentiles(samples: list[float]) -> tuple[float, float]:

--- a/src/tests/unit/api/test_metrics_r5_4_pre.py
+++ b/src/tests/unit/api/test_metrics_r5_4_pre.py
@@ -446,3 +446,110 @@ class TestLifecycleStepDurationCallback:
         # Across all buckets the observation count must total exactly 1.
         total_count = sum(bucket.get() for bucket in hist._buckets)
         assert total_count == 1, f"expected exactly 1 sample emitted across all buckets, got {total_count}"
+
+
+@pytest.mark.unit
+class TestPendingTasksGaugeAudit_4_2:
+    """Audit-doc §4.2 — ``juniper_cascor_pending_tasks`` bridge gauge.
+
+    The pre-existing :class:`api.workers.coordinator.WorkerCoordinator`
+    tracks in-flight tasks in an internal ``_pending_tasks`` dict that
+    was JSON-only (no Prometheus surface) until this audit follow-up.
+    The corresponding ``CascorPendingTasksSaturated`` alert
+    (juniper-deploy/prometheus/alert_rules.yml) carried an
+    ``absent_over_time(...) == 0`` inertness guard while the bridge
+    was missing.
+
+    These tests exercise the wire-up:
+      * ``pending_tasks_count()`` accessor on the coordinator.
+      * The optional ``coordinator=`` kwarg on
+        :class:`api.workers.metrics.WorkerRegistryCollector`.
+      * The ``juniper_cascor_pending_tasks`` gauge emission when wired.
+      * Backward-compat: missing-coordinator path stays silent
+        (preserves the alert's inertness guard for test fixtures).
+    """
+
+    def _samples_by_metric(self, collector):
+        out: dict[str, list] = {}
+        for fam in collector.collect():
+            out.setdefault(fam.name, []).extend(fam.samples)
+        return out
+
+    def _build_coordinator_with_n_pending(self, n: int):
+        """Inject ``n`` pending tasks into a freshly-constructed coordinator.
+
+        The coordinator's full ``submit_tasks`` flow requires a round-id
+        and websocket dispatch; for a unit test we inject directly into
+        ``_pending_tasks`` under the lock to avoid the integration
+        surface. The accessor doesn't care about task shape, only count.
+        """
+        from api.workers.coordinator import WorkerCoordinator
+        from api.workers.registry import WorkerRegistry
+
+        reg = WorkerRegistry(heartbeat_timeout=30.0)
+        coord = WorkerCoordinator(registry=reg)
+        with coord._lock:  # noqa: SLF001 — test poke under the same lock
+            for i in range(n):
+                coord._pending_tasks[f"task-{i}"] = object()  # type: ignore[assignment]
+        return coord, reg
+
+    def test_pending_tasks_count_returns_dict_size(self):
+        """Direct accessor: returns ``len(_pending_tasks)`` under the lock."""
+        coord, _reg = self._build_coordinator_with_n_pending(7)
+        assert coord.pending_tasks_count() == 7
+
+    def test_pending_tasks_count_zero_when_empty(self):
+        """No tasks pending → 0 (not None / not raises)."""
+        coord, _reg = self._build_coordinator_with_n_pending(0)
+        assert coord.pending_tasks_count() == 0
+
+    def test_collector_emits_pending_tasks_when_coordinator_wired(self):
+        """When ``coordinator=`` is set, the gauge appears in collect() output."""
+        from api.workers.metrics import WorkerRegistryCollector
+
+        coord, reg = self._build_coordinator_with_n_pending(3)
+        collector = WorkerRegistryCollector(reg, coordinator=coord)
+        samples = self._samples_by_metric(collector)
+
+        assert "juniper_cascor_pending_tasks" in samples, "pending_tasks gauge must appear when coordinator is wired"
+        gauge_samples = samples["juniper_cascor_pending_tasks"]
+        # Single unlabelled sample.
+        assert len(gauge_samples) == 1
+        assert gauge_samples[0].labels == {}
+        assert gauge_samples[0].value == 3.0
+
+    def test_collector_omits_pending_tasks_when_no_coordinator(self):
+        """Without ``coordinator=``, the gauge is silently skipped (back-compat)."""
+        from api.workers.metrics import WorkerRegistryCollector
+        from api.workers.registry import WorkerRegistry
+
+        reg = WorkerRegistry(heartbeat_timeout=30.0)
+        collector = WorkerRegistryCollector(reg)  # NO coordinator
+        samples = self._samples_by_metric(collector)
+
+        assert "juniper_cascor_pending_tasks" not in samples, "pending_tasks gauge must be omitted when no coordinator wired — " "preserves the alert rule's absent_over_time(...) == 0 inertness " "guard for test fixtures + lightweight harnesses"
+
+    def test_collector_skips_gauge_on_coordinator_exception(self):
+        """If the coordinator raises during count read, scrape continues."""
+        from api.workers.metrics import WorkerRegistryCollector
+        from api.workers.registry import WorkerRegistry
+
+        class _BrokenCoordinator:
+            def pending_tasks_count(self) -> int:
+                raise RuntimeError("simulated coordinator failure")
+
+        reg = WorkerRegistry(heartbeat_timeout=30.0)
+        collector = WorkerRegistryCollector(reg, coordinator=_BrokenCoordinator())
+        samples = self._samples_by_metric(collector)
+
+        # Other gauges still emit; the pending_tasks gauge is skipped
+        # (logged but not raised — matches the per-snapshot try/except
+        # pattern in the rest of collect()).
+        assert "juniper_cascor_pending_tasks" not in samples
+
+    def test_pending_tasks_count_drops_to_zero_after_cancel_round(self):
+        """Wire-up regression: cancel_round() clears _pending_tasks → gauge drops."""
+        coord, _reg = self._build_coordinator_with_n_pending(5)
+        assert coord.pending_tasks_count() == 5
+        coord.cancel_round()
+        assert coord.pending_tasks_count() == 0


### PR DESCRIPTION
## Summary

Closes audit-doc juniper-ml#195 finding **§4.2** (P3) — wires `juniper_cascor_pending_tasks` Gauge through the existing `WorkerRegistryCollector`, lifting the inertness guard on the `CascorPendingTasksSaturated` alert in juniper-deploy.

## Changes

| Layer | File | Change |
|-------|------|--------|
| Coordinator accessor | `src/api/workers/coordinator.py` | New `pending_tasks_count() -> int` — snapshot read of `len(_pending_tasks)` under `_lock` |
| Collector | `src/api/workers/metrics.py` | Optional `coordinator=` kwarg; `collect()` emits `juniper_cascor_pending_tasks` when wired |
| App wiring | `src/api/app.py` | Pass coordinator into `_register_worker_metrics_collector` |
| Tests | `src/tests/unit/api/test_metrics_r5_4_pre.py` | New `TestPendingTasksGaugeAudit_4_2` class — 6 methods covering accessor, gauge emission, back-compat path, broken-coordinator path, post-cancel_round drop |

## Design notes

- **Why extend `WorkerRegistryCollector` rather than create a separate collector?** Audit doc explicitly recommended extending the existing one. Single registration site, single lifecycle, no need to re-do the unregister-on-shutdown plumbing.
- **Backward compat (no-coordinator path)**: when `coordinator=None`, the gauge is silently SKIPPED (not zero-emitted). This preserves the alert's `absent_over_time(...) == 0` inertness guard for test fixtures + lightweight harnesses that intentionally don't construct a coordinator.
- **Unlabelled gauge**: matches the alert rule's selector (`juniper_cascor_pending_tasks{service="juniper-cascor"} > 10` — service label is auto-applied by Prometheus relabeling).
- **Best-effort emission**: if the coordinator raises during `pending_tasks_count()`, the exception is logged not raised; the rest of the scrape continues. Matches the existing per-snapshot try/except pattern in `collect()`.

## Validation

- pre-commit: PASS (black reformatted test file; isort, flake8, mypy, bandit all green)
- pytest: blocked locally by JuniperCascor env's torch / Py3.14 free-threading issue (documented project memory); CI will run the 6 new test methods

## Audit progress

**26 of 27 findings closed (~96%) once this merges.** Only E.6 (`WorkerRegistry` size cap = 250) remains — queued as the next sequential cascor sub-track per the user's plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)