### PR TITLE
fix(tests): bucket-pin expected uses list[float] to match _upper_bounds

### DIFF
--- a/src/tests/unit/api/test_metrics_obs_wire_02.py
+++ b/src/tests/unit/api/test_metrics_obs_wire_02.py
@@ -180,10 +180,12 @@ class TestResumeRequestsAndReplayedEmission:
         hist = obs._ensure_ws_metrics()["resume_replayed_events"]
         # ``prometheus_client.Histogram`` appends an implicit ``+inf``
         # upper edge to whatever ``buckets=`` tuple it was constructed
-        # with.  Assert the layout matches the constant + the implicit
-        # ``+inf`` sentinel so a future re-bucket has to update both
-        # the constant and this test in lockstep.
-        expected = tuple(_WS_RESUME_REPLAY_BUCKETS) + (float("inf"),)
+        # with and exposes the result as a ``list[float]`` in
+        # ``_upper_bounds``.  Assert the layout matches the constant
+        # (cast to floats) + the implicit ``+inf`` sentinel so a future
+        # re-bucket has to update both the constant and this test in
+        # lockstep.
+        expected = [float(b) for b in _WS_RESUME_REPLAY_BUCKETS] + [float("inf")]
         assert hist._upper_bounds == expected
 
     def test_handle_resume_emits_malformed_outcome(self):


### PR DESCRIPTION
## Summary
- Change \`expected\` in \`test_replayed_events_histogram_buckets_pinned\` from \`tuple(...) + (float(\"inf\"),)\` to \`[float(b) for b in ...] + [float(\"inf\")]\`
- Unblocks \`main\` (red since PR #217 merged on 2026-05-05 — Unit Tests fail on all 4 platforms)

## Why
\`prometheus_client.Histogram\` exposes \`_upper_bounds\` as a \`list[float]\`, not a tuple. Python's \`==\` returns \`False\` between a list and a tuple even when their elements compare equal. Validated against prometheus_client 0.21.x:

\`\`\`
>>> Histogram(buckets=(0, 1, 5, 25, 100, 500, 1024))._upper_bounds
[0.0, 1.0, 5.0, 25.0, 100.0, 500.0, 1024.0, inf]
\`\`\`

The constant \`_WS_RESUME_REPLAY_BUCKETS\` in \`api/observability.py\` stays as a tuple of ints (the value passed to \`Histogram(buckets=...)\` — prometheus_client handles the cast).

## Test plan
- [x] Sanity-check: prometheus_client builds \`_upper_bounds\` as list[float] matching the new expected — verified outside cascor env (cascor's local conda env can't import torch under FT 3.14t)
- [ ] CI green on this PR
- [ ] \`main\` recovers post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)