### PR TITLE
audit(e6): WorkerRegistry size cap = 250 + WS handshake rejection plumbing

### DIFF
--- a/src/api/websocket/worker_stream.py
+++ b/src/api/websocket/worker_stream.py
@@ -21,7 +21,7 @@ from fastapi import WebSocket, WebSocketDisconnect
 from api.websocket.manager import ws_authenticate
 from api.workers.coordinator import WorkerCoordinator
 from api.workers.protocol import BinaryFrame, MessageType, WorkerProtocol
-from api.workers.registry import WorkerRegistry
+from api.workers.registry import WorkerRegistry, WorkerRegistryFullError
 
 logger = logging.getLogger("juniper_cascor.api.websocket.worker_stream")
 
@@ -175,7 +175,28 @@ async def _handle_registration(websocket: WebSocket, registry: WorkerRegistry) -
     capabilities = msg["capabilities"]
     worker_id = f"worker-{uuid.uuid4().hex[:12]}"
 
-    registry.register(worker_id, capabilities, client_name=client_name)
+    try:
+        registry.register(worker_id, capabilities, client_name=client_name)
+    except WorkerRegistryFullError as exc:
+        # Audit-doc E.6: the registry has hit its capacity cap. Reject
+        # the handshake cleanly with a structured error frame and a
+        # dedicated close code so operators (and future tests) can
+        # distinguish "saturation" from generic 4008 "invalid
+        # registration" failures.
+        logger.warning(
+            "Worker handshake rejected — registry at capacity (client_name=%s): %s",
+            client_name,
+            exc,
+        )
+        await websocket.send_json(
+            WorkerProtocol.build_error(
+                "Worker registry at capacity",
+                details=str(exc),
+            )
+        )
+        await websocket.close(code=4013, reason="Worker registry at capacity")
+        return None
+
     logger.info("Worker registered with server ID %s (client_name=%s)", worker_id, client_name)
 
     await websocket.send_json(

--- a/src/api/workers/registry.py
+++ b/src/api/workers/registry.py
@@ -13,6 +13,28 @@ from typing import Any
 logger = logging.getLogger("juniper_cascor.api.workers.registry")
 
 
+# Audit-doc juniper-ml#195 finding E.6: cap the registry size so a
+# misbehaving worker pool (or a malicious / runaway client storm)
+# cannot grow ``_workers`` unbounded. 250 is a deliberate ceiling
+# chosen as the user's "for now" expectation — well above any realistic
+# Juniper deployment fleet size today and below a memory-meaningful
+# threshold for the per-registration deque + heartbeat state. Revisit
+# alongside any large-fleet sizing exercise.
+_DEFAULT_MAX_WORKERS: int = 250
+
+
+class WorkerRegistryFullError(RuntimeError):
+    """Raised by :meth:`WorkerRegistry.register` when the registry is at capacity.
+
+    Distinct from generic :class:`RuntimeError` so callers (chiefly the
+    websocket worker handshake handler) can catch this specific case
+    and emit a structured "registry full" close frame to the client
+    rather than an opaque server-error response. Re-registrations of
+    an existing ``worker_id`` do NOT raise — they replace the existing
+    entry and the dict size stays unchanged.
+    """
+
+
 @dataclass
 class WorkerRegistration:
     """Tracks a single connected worker.
@@ -132,17 +154,34 @@ class WorkerRegistry:
     and querying available workers. All public methods are thread-safe.
     """
 
-    def __init__(self, heartbeat_timeout: float = 30.0) -> None:
+    def __init__(
+        self,
+        heartbeat_timeout: float = 30.0,
+        *,
+        max_workers: int = _DEFAULT_MAX_WORKERS,
+    ) -> None:
+        if max_workers <= 0:
+            raise ValueError(f"max_workers must be positive, got {max_workers!r}")
         self._workers: dict[str, WorkerRegistration] = {}
         self._lock = Lock()
         self._heartbeat_timeout = heartbeat_timeout
-        logger.info("WorkerRegistry initialized (heartbeat_timeout=%.1fs)", heartbeat_timeout)
+        self._max_workers = max_workers
+        logger.info(
+            "WorkerRegistry initialized (heartbeat_timeout=%.1fs, max_workers=%d)",
+            heartbeat_timeout,
+            max_workers,
+        )
 
     @property
     def worker_count(self) -> int:
         """Number of currently registered workers."""
         with self._lock:
             return len(self._workers)
+
+    @property
+    def max_workers(self) -> int:
+        """Configured registry capacity (audit-doc E.6)."""
+        return self._max_workers
 
     @property
     def available_worker_count(self) -> int:
@@ -171,10 +210,28 @@ class WorkerRegistry:
 
         Returns:
             The new WorkerRegistration.
+
+        Raises:
+            WorkerRegistryFullError: If the registry is at capacity
+                (:attr:`max_workers`) AND the registration is for a NEW
+                ``worker_id``. Re-registrations of an existing ID do
+                NOT raise (the dict size is unchanged) — they replace
+                the existing entry and emit the usual warning.
         """
         with self._lock:
-            if worker_id in self._workers:
+            is_replacement = worker_id in self._workers
+            if is_replacement:
                 logger.warning("Worker %s re-registering (replacing existing connection)", worker_id)
+            elif len(self._workers) >= self._max_workers:
+                # Audit-doc E.6: refuse new registrations once the cap
+                # is reached. Re-registrations bypass this check above.
+                logger.warning(
+                    "WorkerRegistry rejected new registration: at cap %d (client_name=%s, proposed_id=%s)",
+                    self._max_workers,
+                    client_name or "<none>",
+                    worker_id,
+                )
+                raise WorkerRegistryFullError(f"WorkerRegistry at capacity ({self._max_workers}); " f"reject new worker {worker_id!r}")
             reg = WorkerRegistration(worker_id=worker_id, capabilities=capabilities, client_name=client_name)
             self._workers[worker_id] = reg
             logger.info(

--- a/src/tests/unit/api/test_worker_registry.py
+++ b/src/tests/unit/api/test_worker_registry.py
@@ -355,3 +355,114 @@ class TestWorkerRegistry:
         count = registry.clear()
         assert count == 2
         assert registry.worker_count == 0
+
+
+@pytest.mark.unit
+class TestWorkerRegistrySizeCapAuditE6:
+    """Audit-doc juniper-ml#195 finding E.6 — registry size cap.
+
+    The registry was previously unbounded; a misbehaving worker pool
+    or a malicious / runaway client storm could grow ``_workers``
+    without limit. This test class pins the cap behavior end-to-end:
+
+      * Default cap is 250.
+      * Reaching the cap raises :class:`WorkerRegistryFullError` for a
+        new ``worker_id``.
+      * Re-registering an existing ``worker_id`` at the cap is allowed
+        (the dict size stays unchanged).
+      * Custom ``max_workers`` constructor kwarg is honored.
+      * Non-positive caps are rejected at construction time.
+      * The exception class is distinct so the WS handshake handler
+        can catch it specifically.
+    """
+
+    def test_default_cap_is_250(self):
+        from api.workers.registry import _DEFAULT_MAX_WORKERS
+
+        assert _DEFAULT_MAX_WORKERS == 250
+        registry = WorkerRegistry()
+        assert registry.max_workers == 250
+
+    def test_constructor_validates_max_workers(self):
+        with pytest.raises(ValueError, match="max_workers must be positive"):
+            WorkerRegistry(max_workers=0)
+        with pytest.raises(ValueError, match="max_workers must be positive"):
+            WorkerRegistry(max_workers=-1)
+
+    def test_register_rejects_new_worker_at_cap(self):
+        from api.workers.registry import WorkerRegistryFullError
+
+        registry = WorkerRegistry(max_workers=3)
+        registry.register("w1", {})
+        registry.register("w2", {})
+        registry.register("w3", {})
+        assert registry.worker_count == 3
+
+        with pytest.raises(WorkerRegistryFullError, match=r"at capacity \(3\)"):
+            registry.register("w4", {})
+
+        # The 4th attempt did NOT pollute the dict.
+        assert registry.worker_count == 3
+        assert "w4" not in {w.worker_id for w in registry.get_all_workers()}
+
+    def test_re_register_at_cap_is_allowed(self):
+        """Re-registering an existing worker_id keeps dict size unchanged → no raise."""
+        registry = WorkerRegistry(max_workers=2)
+        registry.register("w1", {"gpu": "rtx-4090"})
+        registry.register("w2", {"gpu": "a100"})
+        # At cap. Re-register w1 with new capabilities — replacement,
+        # not new entry.
+        replaced = registry.register("w1", {"gpu": "rtx-5090"})
+        assert replaced.capabilities == {"gpu": "rtx-5090"}
+        assert registry.worker_count == 2
+
+    def test_deregister_below_cap_re_enables_new_registration(self):
+        """After deregistering, the freed slot accepts a new worker."""
+        from api.workers.registry import WorkerRegistryFullError
+
+        registry = WorkerRegistry(max_workers=2)
+        registry.register("w1", {})
+        registry.register("w2", {})
+        with pytest.raises(WorkerRegistryFullError):
+            registry.register("w3", {})
+
+        registry.deregister("w1")
+        assert registry.worker_count == 1
+
+        # Now w3 fits.
+        registry.register("w3", {})
+        assert registry.worker_count == 2
+
+    def test_custom_cap_independent_of_default(self):
+        """A registry with max_workers=500 accepts up to 500 (smoke test, capped at 5)."""
+        registry = WorkerRegistry(max_workers=500)
+        assert registry.max_workers == 500
+        # Smoke: the first 5 registrations fit; default-cap=250 logic
+        # would not affect us.
+        for i in range(5):
+            registry.register(f"w{i}", {})
+        assert registry.worker_count == 5
+
+    def test_full_error_is_runtime_error_subclass(self):
+        """Catchable as RuntimeError for callers that don't import the specific class."""
+        from api.workers.registry import WorkerRegistryFullError
+
+        assert issubclass(WorkerRegistryFullError, RuntimeError)
+
+    def test_clear_resets_capacity_state(self):
+        """After clear(), the registry can fully repopulate to the cap."""
+        from api.workers.registry import WorkerRegistryFullError
+
+        registry = WorkerRegistry(max_workers=2)
+        registry.register("w1", {})
+        registry.register("w2", {})
+        with pytest.raises(WorkerRegistryFullError):
+            registry.register("w3", {})
+
+        cleared = registry.clear()
+        assert cleared == 2
+
+        # All slots free again.
+        registry.register("w1", {})
+        registry.register("w2", {})
+        assert registry.worker_count == 2


### PR DESCRIPTION
## Summary

Closes audit-doc juniper-ml#195 finding **E.6** (P3) — last remaining post-METRICS-MON observability residual. The user chose **250** as the "for now" cap.

## Changes

| Layer | File | Change |
|-------|------|--------|
| Registry | \`src/api/workers/registry.py\` | New \`_DEFAULT_MAX_WORKERS = 250\` constant + \`WorkerRegistryFullError(RuntimeError)\` exception class + \`max_workers\` kwarg + \`max_workers\` property + cap enforcement in \`register()\` |
| WS handshake | \`src/api/websocket/worker_stream.py\` | \`_handle_registration\` catches \`WorkerRegistryFullError\` and rejects cleanly with structured error frame + close code 4013 |
| Tests | \`src/tests/unit/api/test_worker_registry.py\` | New \`TestWorkerRegistrySizeCapAuditE6\` class (8 methods) covering default cap, validation, at-cap rejection, replacement bypass, freed-slot recovery, custom cap, exception subclass contract, post-clear repopulation |

## Design notes

- **Re-registrations bypass the cap.** When an existing \`worker_id\` re-registers (the existing code path that emits the "replacing existing connection" warning), the dict size stays unchanged — so no cap check applies. Only NEW worker_ids hit the cap.
- **Why a custom exception class?** \`RuntimeError\` is too broad — the WS handshake handler needs to distinguish "registry full" from generic server errors so it can emit the dedicated 4013 close code. The class subclasses \`RuntimeError\` so callers that don't import it specifically can still catch it generically.
- **Close code 4013** is unused elsewhere in the WS code (existing codes: 4001 auth, 4003 origin, 4004 not-init, 4005-4008 message validation, 4029 rate-limited). Capacity-exceeded gets its own slot.

## Validation

- pre-commit: PASS (black reformatted registry.py cosmetically; isort, flake8, mypy, bandit all green)
- pytest: blocked locally by JuniperCascor env's torch / Py3.14 free-threading issue (documented project memory); CI will run the 8 new test methods.

## Audit completion

**27 of 27 audit findings closed (~100%) once this merges.**

End of the post-METRICS-MON audit-driven sub-track program. The 30-day SLO calibration milestone (~2026-06-03) is the next natural checkpoint, at which point R5.1c soak-window data will inform whether the conservative initial targets get ratified or adjusted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)