### PR TITLE
fix(api): apply numpy-scalar coercion at the response envelope (CAN-015h follow-up to #219)

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -20,6 +20,7 @@ import torch
 
 from api.lifecycle.monitor import TrainingMonitor, TrainingState
 from api.lifecycle.state_machine import Command, TrainingPhase, TrainingStateMachine
+from api.models.common import coerce_native_scalars as _common_coerce_native_scalars
 from api.observability import TRAINING_SESSION_STATUS_CANCELLED, TRAINING_SESSION_STATUS_FAILURE, TRAINING_SESSION_STATUS_SUCCESS, dec_training_sessions, inc_training_session_completed, inc_training_sessions, observe_training_step_duration, record_training_epoch, set_hidden_units, set_training_accuracy, set_training_loss
 from cascor_constants.constants_api import _PROJECT_API_DRAIN_THREAD_JOIN_TIMEOUT, _PROJECT_API_LIFECYCLE_DEFAULT_CANDIDATE_PATIENCE, _PROJECT_API_LIFECYCLE_DEFAULT_EPOCHS_MAX, _PROJECT_API_LIFECYCLE_DEFAULT_MAX_HIDDEN_UNITS, _PROJECT_API_LIFECYCLE_DEFAULT_MAX_ITERATIONS, _PROJECT_API_NETWORK_INPUT_SIZE_DEFAULT, _PROJECT_API_NETWORK_LEARNING_RATE_DEFAULT, _PROJECT_API_NETWORK_OUTPUT_SIZE_DEFAULT, _PROJECT_API_PROGRESS_QUEUE_GET_TIMEOUT, _PROJECT_API_PROGRESS_QUEUE_WAIT_TIMEOUT
 
@@ -61,41 +62,13 @@ def _write_activation_function_name(network: Any, value: str) -> None:
     network._init_activation_function()
 
 
-def _coerce_native_scalars(value: Any) -> Any:
-    """Coerce numpy scalar types to Python natives, recursively.
-
-    pydantic-core's JSON serializer rejects ``numpy.int64`` /
-    ``numpy.float64`` with ``PydanticSerializationError: Unable to
-    serialize unknown type: <class 'numpy.int64'>``. After
-    ``load_snapshot`` the network's scalar attributes come back from
-    HDF5 as numpy scalars (h5py's default for attribute reads), so any
-    response payload that includes those values would fail
-    serialization with an opaque 400 (the cascor ``value_error_handler``
-    strips the detail).
-
-    Walks dicts and lists/tuples; pass-throughs anything that doesn't
-    expose ``.item()``. Used at the API surface (e.g.
-    ``get_training_params``) so the rest of the code can keep working
-    with numpy values internally.
-    """
-    if isinstance(value, dict):
-        return {k: _coerce_native_scalars(v) for k, v in value.items()}
-    if isinstance(value, (list, tuple)):
-        coerced = [_coerce_native_scalars(v) for v in value]
-        return type(value)(coerced) if isinstance(value, tuple) else coerced
-    item = getattr(value, "item", None)
-    if callable(item):
-        # numpy scalars and 0-d numpy arrays expose ``.item()``
-        # returning a Python native. Plain str/int/float/bool/None
-        # don't have it, so they pass through unchanged.
-        try:
-            return item()
-        except (ValueError, TypeError):
-            # Defensive: any object whose ``.item()`` doesn't behave
-            # like a numpy scalar's (e.g. takes args, raises) falls
-            # through unchanged.
-            return value
-    return value
+# ``_coerce_native_scalars`` previously lived here as a private helper;
+# it's been promoted to ``api.models.common.coerce_native_scalars`` and
+# applied at the response envelope so every route is covered (not just
+# routes that thread through ``get_training_params``). The local alias
+# is kept so existing internal callers don't have to be edited in this
+# PR — they can move to the public name as a follow-up.
+_coerce_native_scalars = _common_coerce_native_scalars
 
 
 class _WeightHistoryRecorder:

--- a/src/api/models/common.py
+++ b/src/api/models/common.py
@@ -8,6 +8,41 @@ from pydantic import BaseModel, Field
 _API_VERSION: str = "0.4.0"
 
 
+def coerce_native_scalars(value: Any) -> Any:
+    """Coerce numpy scalar types to Python natives, recursively.
+
+    pydantic-core's JSON serializer rejects ``numpy.int64`` /
+    ``numpy.float64`` with ``PydanticSerializationError: Unable to
+    serialize unknown type: <class 'numpy.int64'>``. After
+    ``load_snapshot`` (and other code paths that read scalars back
+    from h5py / numpy arrays), the network's scalar attributes come
+    back as numpy scalars rather than Python natives. Applied at the
+    response envelope so every route's payload is JSON-clean
+    regardless of whether the route author knew to coerce per-field.
+
+    Walks dicts and lists/tuples; passes through anything that
+    doesn't expose ``.item()``. Plain Python scalars (str/int/float/
+    bool/None) don't have ``.item()`` so they're untouched.
+    """
+    if isinstance(value, dict):
+        return {k: coerce_native_scalars(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        coerced = [coerce_native_scalars(v) for v in value]
+        return type(value)(coerced) if isinstance(value, tuple) else coerced
+    item = getattr(value, "item", None)
+    if callable(item):
+        # numpy scalars and 0-d numpy arrays expose ``.item()``
+        # returning a Python native.
+        try:
+            return item()
+        except (ValueError, TypeError):
+            # Defensive: any object whose ``.item()`` doesn't behave
+            # like a numpy scalar's (e.g. takes args, raises) falls
+            # through unchanged.
+            return value
+    return value
+
+
 class Meta(BaseModel):
     """Response metadata."""
 
@@ -48,8 +83,18 @@ class ErrorResponse(BaseModel):
 
 
 def success_response(data: Any = None) -> dict:
-    """Create a success response envelope."""
-    return ResponseEnvelope(status="success", data=data).model_dump()
+    """Create a success response envelope.
+
+    ``data`` is run through ``coerce_native_scalars`` so any
+    numpy.int64 / numpy.float64 / 0-d ndarray scalars upstream
+    (typically from h5py-deserialized network attributes after a
+    snapshot restore) become Python natives before pydantic-core
+    serializes the envelope to JSON. Without this, those endpoints
+    return 400 ``VALIDATION_ERROR`` with a stripped detail because
+    ``PydanticSerializationError`` is a ``ValueError`` subclass and
+    the cascor app's ``value_error_handler`` catches it.
+    """
+    return ResponseEnvelope(status="success", data=coerce_native_scalars(data)).model_dump()
 
 
 def error_response(code: str, message: str, detail: str | None = None) -> dict:

--- a/src/tests/unit/api/test_success_response_coercion.py
+++ b/src/tests/unit/api/test_success_response_coercion.py
@@ -1,0 +1,132 @@
+"""Unit tests for ``success_response`` envelope-level numpy coercion.
+
+Pins the behaviour that ``success_response`` coerces numpy scalars in
+``data`` so every cascor route returns a JSON-serializable envelope —
+not just the routes that thread through ``get_training_params``.
+Catches the pre-existing bug class where post-restore endpoints
+(``GET /v1/network``, ``PATCH /v1/network/weights``,
+``POST /v1/snapshots/{id}/restore``, etc.) returned 400
+``VALIDATION_ERROR`` because pydantic-core couldn't serialize
+``numpy.int64`` / ``numpy.float64`` carried through from h5py reads.
+"""
+
+import json
+import os
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
+
+from api.models.common import coerce_native_scalars, error_response, success_response  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+class TestSuccessResponseCoercesData:
+    """The envelope's ``data`` block must round-trip through JSON even
+    when callers hand it raw numpy scalars (typical post-restore)."""
+
+    def test_numpy_int64_data_is_serializable(self):
+        envelope = success_response({"hidden_units": np.int64(2)})
+        # ``json.dumps`` is the actual transport — if this raises, the
+        # response would 500 in production with no useful detail.
+        encoded = json.dumps(envelope)
+        decoded = json.loads(encoded)
+        assert decoded["data"]["hidden_units"] == 2
+        assert type(decoded["data"]["hidden_units"]) is int
+
+    def test_numpy_float64_data_is_serializable(self):
+        envelope = success_response({"learning_rate": np.float64(0.01)})
+        encoded = json.dumps(envelope)
+        decoded = json.loads(encoded)
+        assert decoded["data"]["learning_rate"] == pytest.approx(0.01)
+        assert type(decoded["data"]["learning_rate"]) is float
+
+    def test_nested_numpy_scalars(self):
+        # Mirrors the actual unified-response payload shape after
+        # /v1/snapshots/{id}/restore.
+        payload = {
+            "operation": "restore",
+            "fsm_state": "Investigating",
+            "training_params": {
+                "max_hidden_units": np.int64(2),
+                "learning_rate": np.float64(0.01),
+            },
+            "time_index": {
+                "snapshot_window": {
+                    "start_epoch": 0,
+                    "end_epoch": np.int64(50),
+                },
+            },
+        }
+        envelope = success_response(payload)
+        encoded = json.dumps(envelope)
+        decoded = json.loads(encoded)
+        assert decoded["data"]["training_params"]["max_hidden_units"] == 2
+        assert decoded["data"]["time_index"]["snapshot_window"]["end_epoch"] == 50
+
+    def test_list_with_numpy_scalars(self):
+        envelope = success_response({"epochs": [np.int64(1), np.int64(2), 3]})
+        encoded = json.dumps(envelope)
+        decoded = json.loads(encoded)
+        assert decoded["data"]["epochs"] == [1, 2, 3]
+
+    def test_envelope_shape_unchanged(self):
+        envelope = success_response({"x": np.int64(1)})
+        # Same envelope shape as before — coercion is invisible to
+        # well-behaved (Python-native) callers.
+        assert envelope["status"] == "success"
+        assert "data" in envelope
+        assert "meta" in envelope
+        assert "timestamp" in envelope["meta"]
+        assert "version" in envelope["meta"]
+
+
+class TestSuccessResponseUnchangedForNativeData:
+    """Pre-existing callers that already pass Python natives must see
+    no behaviour change."""
+
+    def test_dict_passes_through(self):
+        envelope = success_response({"x": 1, "y": "hello", "z": True})
+        assert envelope["data"] == {"x": 1, "y": "hello", "z": True}
+
+    def test_list_passes_through(self):
+        envelope = success_response([1, 2, 3])
+        assert envelope["data"] == [1, 2, 3]
+
+    def test_none_passes_through(self):
+        envelope = success_response(None)
+        assert envelope["data"] is None
+
+    def test_default_no_data(self):
+        envelope = success_response()
+        assert envelope["data"] is None
+
+
+class TestErrorResponseUntouched:
+    """``error_response`` doesn't carry user-supplied data so it
+    intentionally doesn't auto-coerce; pin that fact so a future
+    refactor doesn't quietly start coercing error details too."""
+
+    def test_error_response_shape(self):
+        envelope = error_response("VALIDATION_ERROR", "bad input", "x must be int")
+        assert envelope["status"] == "error"
+        assert envelope["error"]["code"] == "VALIDATION_ERROR"
+        assert envelope["error"]["message"] == "bad input"
+        assert envelope["error"]["detail"] == "x must be int"
+
+
+class TestCoerceHelperPublic:
+    """``coerce_native_scalars`` is now public in ``api.models.common``;
+    the same behavioural contract applies as the previously-private
+    helper in ``lifecycle/manager.py``. ``test_coerce_native_scalars.py``
+    covers the deep matrix; this is just the one-line re-import sanity
+    check."""
+
+    def test_helper_is_importable_from_common(self):
+        # Smoke test: the import worked at module load. Verify the
+        # function still does what it says.
+        assert coerce_native_scalars(np.int64(7)) == 7
+        assert type(coerce_native_scalars(np.int64(7))) is int


### PR DESCRIPTION
## Summary

#219 patched a single call site (\`get_training_params\`), but the
underlying bug class — pydantic-core rejecting numpy scalars in
response payloads → 400 \`VALIDATION_ERROR\` with stripped detail —
affected more endpoints than that fix covered.

Hardening pass turned up at least:

| Endpoint | Pre-#219 | Post-#219 | Post-this-PR |
|---|---|---|---|
| \`POST /v1/snapshots/{id}/restore\` | 400 | 200 | 200 |
| \`POST /v1/snapshots/{id}/resume\` | 400 | 200 | 200 |
| \`POST /v1/snapshots/{id}/retrain\` | 400 | 200 | 200 |
| \`GET /v1/network\` (post-restore) | 400 | **400** | 200 |
| \`PATCH /v1/network/weights\` (post-restore) | 400 | **400** | 200 |

Both \`GET /v1/network\` and \`PATCH /v1/network/weights\` are
user-visible from the canopy Network Editor in service mode, so
this is in the same impact bucket as #219.

## Fix

Move the coercion up the stack so every route is covered.

- Promoted \`_coerce_native_scalars\` from \`api/lifecycle/manager.py\`
  (private, added by #219) to \`api/models/common.py\` as
  **\`coerce_native_scalars\`** (public).
- \`success_response(data)\` now runs \`data\` through the helper
  before returning the envelope. Every route's payload is
  JSON-clean regardless of whether the route author knew to coerce
  per-field.
- Kept a local \`_coerce_native_scalars\` alias in
  \`lifecycle/manager.py\` so existing internal callers don't have
  to be edited in this PR (the \`get_training_params\` wrapper
  added by #219 keeps working unchanged — both belt and braces).

## Why apply at the envelope rather than per-field

**Defence in depth.** Post-restore numpy scalars can leak into
payloads via paths that aren't obvious at the route layer (e.g.
nested inside \`hidden_units[*].bias\` from the topology builder).
Trying to enumerate every code path is fragile. The envelope is
the narrow waist where every successful response passes through,
and the helper is a no-op for already-Python-native data so the
cost is negligible.

## Test plan

- [x] \`test_success_response_coercion.py\` — 11 cases covering
      envelope shape preservation, numpy int/float at various
      nesting depths, passthrough for native data, \`error_response\`
      intentionally untouched, and a smoke test for the public
      import location.
- [x] Existing 20 cases in \`test_coerce_native_scalars.py\` still
      pass via the alias; total 31 cases green.
- [x] Pre-commit hooks pass.
- [x] Manual reproduction confirms \`GET /v1/network\` and
      \`PATCH /v1/network/weights\` flip 400 → 200 post-restore.
- [x] CI green.

## Pairs with

This is the fourth fix surfaced while landing the Phase 6E
hardening pass. Once this lands, the CAN-015h round-trip
integration test (which has been blocked on this serialization
issue) can finally land too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)