### PR TITLE
fix(ci,tests): integration tests actually run + register critical mark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,7 +285,11 @@ jobs:
           echo "║       Juniper Cascor - Quick Integration Tests             ║"
           echo "╚════════════════════════════════════════════════════════════╝"
 
+          # --integration opts in to integration-marked tests; without it
+          # src/tests/conftest.py adds a skip marker to every integration
+          # test, which silently turned this entire job into a no-op.
           python -m pytest \
+            --integration \
             -m "integration and not slow" \
             src/tests/integration \
             --timeout=60 \
@@ -342,7 +346,11 @@ jobs:
           echo "║       Juniper Cascor - Integration Tests (Fast Only)       ║"
           echo "╚════════════════════════════════════════════════════════════╝"
 
+          # --integration opts in to integration-marked tests; without it
+          # src/tests/conftest.py adds a skip marker to every integration
+          # test, which silently turned this entire job into a no-op.
           python -m pytest \
+            --integration \
             -m "integration and not slow" \
             src/tests/integration \
             --verbose \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,6 +177,7 @@ markers = [
     "accuracy: Tests for accuracy calculation methods",
     "early_stopping: Tests for early stopping logic",
     "requires_juniper_data: Tests that require the juniper-data package to be installed",
+    "critical: Tests covering business-critical paths (used as a tag, not a selector)",
 ]
 timeout = 60
 # Thread-based timeout avoids SIGALRM interference with forkserver IPC


### PR DESCRIPTION
## Summary
- **Pass \`--integration\` in both Quick + Full Integration job invocations** so the conftest skip-gate at \`src/tests/conftest.py:224\` lets the tests actually execute.
- **Register \`critical\` marker** in \`[tool.pytest.ini_options].markers\` to silence \`PytestUnknownMarkWarning\` from \`src/tests/integration/api/test_ws_control_set_params.py:72\`.

## Why
Both Integration Tests jobs in the latest main CI run reported \`60 skipped, 21 deselected\` and finished in **~1.5s** — i.e. **zero tests executed**. \`conftest.py\` adds a skip marker to every integration-marked test unless \`--integration\` is passed on the command line. The CI invocation never passed it, so both jobs silently became no-ops since the gate was introduced.

The unit-test job runs against \`src/tests/unit\` with \`-m \"unit and not slow\"\`, so no spillover risk from passing \`--integration\` only in the integration jobs.

## Test plan
- [ ] CI green on this PR — and \`Quick Integration Tests\` + \`Full Integration Tests\` jobs report >0 tests run (will reveal any pre-existing integration test failures that were hidden by the silent skip)
- [ ] \`PytestUnknownMarkWarning\` for \`critical\` no longer appears in test output

🤖 Generated with [Claude Code](https://claude.com/claude-code)