### PR TITLE
ci(workflow): silence two action-deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,7 +417,10 @@ jobs:
         uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5  # v4.0.1
         with:
           miniforge-version: latest
-          auto-activate-base: true
+          # auto-activate-base was renamed to auto-activate in v4 of the
+          # action. Miniforge uses `base` as its default env, so no
+          # explicit activate-environment is needed.
+          auto-activate: true
           python-version: ${{ env.PYTHON_TEST_VERSION }}
 
       - name: Install dependencies
@@ -474,8 +477,9 @@ jobs:
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          fail: true
+        # gitleaks-action v2.3.9 has no `fail` input (passing it triggers
+        # "Unexpected input(s) 'fail'" in CI). The action exits non-zero
+        # on leaks by default, which is the behavior we want.
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0


### PR DESCRIPTION
## Summary
- **Drop \`fail: true\` from gitleaks-action** — the input doesn't exist on v2.3.9 and triggers \`Unexpected input(s) 'fail', valid inputs are ['']\`. The action exits non-zero on leaks by default.
- **Rename \`auto-activate-base\` → \`auto-activate\`** in setup-miniconda — the v4 parameter rename. Miniforge defaults its env to \`base\`, so no \`activate-environment\` value needed.

## Out of scope
gitleaks-action@v2.3.9 still runs on Node.js 20, which GitHub is forcing to Node.js 24 on 2026-06-02. Bumping the SHA should happen across all five Juniper repos that share this pin (cascor, data, data-client, canopy, plus any others using the same secret-detection step) — left for a separate ecosystem PR.

## Test plan
- [ ] CI green on this PR
- [ ] \`Unexpected input(s) 'fail'\` warning gone from Security Scans output
- [ ] \`auto-activate-base is deprecated\` warning gone from Dependency Documentation output

🤖 Generated with [Claude Code](https://claude.com/claude-code)