### PR TITLE
ci: drop CVE-2026-3219 workaround, bump pip>=26.1.1

### DIFF
--- a/.github/workflows/ci-protocol.yml
+++ b/.github/workflows/ci-protocol.yml
@@ -56,7 +56,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install package + test extras
-        run: pip install --upgrade pip && pip install -e ".[test]"
+        run: pip install --upgrade "pip>=26.1.1" && pip install -e ".[test]"
 
       - name: Run unit tests with coverage
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Install pre-commit
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip>=26.1.1"
           pip install pre-commit
 
       - name: Cache pre-commit hooks
@@ -173,7 +173,7 @@ jobs:
           echo "║       Juniper Cascor - Install Dependencies                ║"
           echo "║       Python ${{ matrix.python-version }} on ${{ matrix.os }}              ║"
           echo "╚════════════════════════════════════════════════════════════╝"
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip>=26.1.1"
           # METRICS-MON R3.7: torch wheel resolution differs by OS.
           # Linux uses the CPU-only PyTorch index to avoid pulling CUDA
           # wheels; macOS finds its native wheels via the default PyPI
@@ -268,7 +268,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip>=26.1.1"
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           # juniper-data-client requires Python >=3.12 and is not yet on PyPI
           python -c "import sys; sys.exit(0 if sys.version_info >= (3,12) else 1)" && \
@@ -329,7 +329,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip>=26.1.1"
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           # juniper-data-client requires Python >=3.12 and is not yet on PyPI
           python -c "import sys; sys.exit(0 if sys.version_info >= (3,12) else 1)" && \
@@ -386,7 +386,7 @@ jobs:
 
       - name: Install build tools
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip>=26.1.1"
           pip install build
 
       - name: Build package
@@ -437,7 +437,7 @@ jobs:
           echo "╔════════════════════════════════════════════════════════════╗"
           echo "║       Juniper Cascor - Install Dependencies (Dep Docs)    ║"
           echo "╚════════════════════════════════════════════════════════════╝"
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip>=26.1.1"
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           # juniper-data-client requires Python >=3.12 and is not yet on PyPI
           python -c "import sys; sys.exit(0 if sys.version_info >= (3,12) else 1)" && \
@@ -497,7 +497,7 @@ jobs:
 
       - name: Install security tools
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip>=26.1.1"
           pip install "bandit[sarif]" pip-audit
 
       - name: Create reports directory
@@ -537,9 +537,7 @@ jobs:
           pip install torch numpy h5py pyyaml matplotlib
           pip freeze > reports/security/pip-freeze.txt
           # CRIT-005: Fail on high/critical vulnerabilities instead of just warning.
-          # --ignore-vuln CVE-2026-3219: pip 26.0.1 on the runner image has
-          # no fix available as of 2026-04-29.
-          pip-audit -r reports/security/pip-freeze.txt --strict --desc on --ignore-vuln CVE-2026-3219 \
+          pip-audit -r reports/security/pip-freeze.txt --strict --desc on \
             || (echo "::error::Critical/High vulnerabilities found in dependencies" && exit 1)
 
       - name: Upload Security Reports

--- a/.github/workflows/scheduled-tests.yml
+++ b/.github/workflows/scheduled-tests.yml
@@ -73,7 +73,7 @@ jobs:
           echo "╔════════════════════════════════════════════════════════════╗"
           echo "║       Juniper Cascor - Install Dependencies                ║"
           echo "╚════════════════════════════════════════════════════════════╝"
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip>=26.1.1"
           # Install CPU-only PyTorch first (CI doesn't need CUDA)
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           # Install project deps via editable install to keep source-tree
@@ -140,7 +140,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip>=26.1.1"
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           pip install -e ".[all]"
 
@@ -196,7 +196,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip>=26.1.1"
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           pip install -e ".[all]"
 
@@ -251,7 +251,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip>=26.1.1"
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           pip install -e ".[all]"
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip>=26.1.1"
           pip install "bandit[sarif]" pip-audit
           pip install torch numpy h5py pyyaml matplotlib
 
@@ -48,14 +48,9 @@ jobs:
           bandit -r src --exclude src/tests --skip B101,B301,B311,B403 --confidence-level medium --severity-level medium
 
       - name: Run pip-audit (Dependency Vulnerabilities)
-        # --ignore-vuln CVE-2026-3219: pip 26.0.1 (pre-installed on the
-        # GitHub Actions runner image) is flagged for the concatenated
-        # tar/ZIP confusion issue. As of 2026-04-29 there is no fixed
-        # pip release. Re-evaluate and remove this flag when pip
-        # publishes a fix.
         run: |
           pip freeze > reports/security/pip-freeze.txt
-          pip-audit -r reports/security/pip-freeze.txt --strict --desc on --ignore-vuln CVE-2026-3219
+          pip-audit -r reports/security/pip-freeze.txt --strict --desc on
 
       - name: Upload Security Reports
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1


### PR DESCRIPTION
## Summary

pip 26.1.1 is now released and no longer flagged for CVE-2026-3219 (concatenated tar/ZIP confusion). Verified against pip 26.1.1 with pip-audit: no known vulnerabilities.

## Changes

- All `pip install --upgrade pip` calls in CI now require `pip>=26.1.1`, guarding against runner images that ship an older vulnerable pip.
- Removed `--ignore-vuln CVE-2026-3219` from `ci.yml` (security job) and `security-scan.yml`, plus the explanatory comment blocks.

## Test plan
- [x] pip 26.1.1 verified clean against pip-audit locally
- [ ] CI pip-audit passes without `--ignore-vuln CVE-2026-3219`
- [ ] Scheduled `security-scan.yml` passes on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)