### PR TITLE
fix(utils): load_dataset uses torch.load(weights_only=True), not yaml (BUG-CC-12)

### DIFF
--- a/src/tests/unit/test_utils_coverage.py
+++ b/src/tests/unit/test_utils_coverage.py
@@ -2,7 +2,6 @@
 """
 Tests for utils/utils.py to increase code coverage.
 """
-import io
 import os
 import sys
 import tempfile
@@ -226,23 +225,67 @@ class TestCheckObjectPickleability:
 
 
 class TestLoadDataset:
-    """Tests for load_dataset function (lines 90-92)."""
+    """Tests for load_dataset function.
 
-    def test_load_dataset_from_yaml_file_object(self):
-        """Test loading dataset from a file-like object with YAML content."""
-        yaml_content = "x: [1, 2, 3]\ny: [4, 5, 6]"
-        file_obj = io.StringIO(yaml_content)
-        x, y = load_dataset(file_obj)
-        assert x == [1, 2, 3]
-        assert y == [4, 5, 6]
+    Pre-BUG-CC-12 fix this read files as YAML, which never
+    round-tripped a real ``save_dataset`` payload. Tests now exercise
+    the corrected ``torch.load(weights_only=True)`` path against real
+    ``save_dataset`` output.
+    """
 
-    def test_load_dataset_with_nested_data(self):
-        """Test loading dataset with nested structure."""
-        yaml_content = "x:\n  - [1, 2]\n  - [3, 4]\ny:\n  - [0, 1]\n  - [1, 0]"
-        file_obj = io.StringIO(yaml_content)
-        x, y = load_dataset(file_obj)
-        assert x == [[1, 2], [3, 4]]
-        assert y == [[0, 1], [1, 0]]
+    def test_load_dataset_round_trip(self):
+        """save_dataset → load_dataset returns the same tensors."""
+        x = torch.randn(10, 3)
+        y = torch.randint(0, 2, (10,))
+
+        with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+            temp_file = f.name
+
+        try:
+            save_dataset(x, y, temp_file)
+            loaded_x, loaded_y = load_dataset(temp_file)
+            torch.testing.assert_close(loaded_x, x)
+            torch.testing.assert_close(loaded_y, y)
+        finally:
+            if os.path.exists(temp_file):
+                os.unlink(temp_file)
+
+    def test_load_dataset_returns_tensors(self):
+        """The returned values are torch.Tensor, not lists or numpy."""
+        x = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        y = torch.tensor([0.0, 1.0])
+
+        with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+            temp_file = f.name
+
+        try:
+            save_dataset(x, y, temp_file)
+            loaded_x, loaded_y = load_dataset(temp_file)
+            assert isinstance(loaded_x, torch.Tensor)
+            assert isinstance(loaded_y, torch.Tensor)
+        finally:
+            if os.path.exists(temp_file):
+                os.unlink(temp_file)
+
+    def test_load_dataset_accepts_pathlib(self):
+        """``file_path`` works with pathlib.Path as well as str."""
+        from pathlib import Path
+
+        x = torch.randn(5, 2)
+        y = torch.randint(0, 2, (5,))
+
+        with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+            temp_file = f.name
+        path_obj = Path(temp_file)
+
+        try:
+            save_dataset(x, y, path_obj)
+            loaded_x, loaded_y = load_dataset(path_obj)
+            torch.testing.assert_close(loaded_x, x)
+            torch.testing.assert_close(loaded_y, y)
+        finally:
+            if os.path.exists(temp_file):
+                os.unlink(temp_file)
 
 
 class TestDisplayProgressNegativeEpoch:

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -43,7 +43,8 @@
 #####################################################################################################################################################################################################
 
 # from typing import Tuple, Dict, Any
-from typing import Dict, Tuple
+import os
+from typing import Dict, Tuple, Union
 
 try:
     import columnar as col
@@ -54,7 +55,6 @@ except ImportError:
     col = None
 import numpy as np
 import torch
-import yaml
 
 from log_config.logger.logger import Logger
 
@@ -62,11 +62,13 @@ from log_config.logger.logger import Logger
 def save_dataset(
     x: torch.Tensor,
     y: torch.Tensor,
-    file_path: str,
+    file_path: Union[str, "os.PathLike[str]"],
 ) -> None:
     """
     Description:
-        Save a dataset to a file.
+        Save a dataset to a file. Writes a torch checkpoint
+        containing ``{"x": x, "y": y}``; round-trips through
+        ``load_dataset``.
     Args:
         x: Input features tensor
         y: Target tensor
@@ -75,19 +77,29 @@ def save_dataset(
     torch.save({"x": x, "y": y}, file_path)
 
 
-def load_dataset(file_path: str) -> Tuple[torch.Tensor, torch.Tensor]:
+def load_dataset(file_path: Union[str, "os.PathLike[str]"]) -> Tuple[torch.Tensor, torch.Tensor]:
     """
     Description:
-        Load a dataset from a file.
+        Load a dataset from a file written by ``save_dataset``.
     Args:
-        file_path: Path to the saved dataset
+        file_path: Path to the saved dataset (the same path passed
+            to ``save_dataset``).
     Returns:
         Tuple containing:
             - x: Input features tensor
             - y: Target tensor
+
+    Notes:
+        Inverts ``save_dataset`` (which writes via ``torch.save``).
+        Pre-fix this function read the file as YAML (BUG-CC-12,
+        2026-05-05 audit), which never round-tripped a real
+        ``torch.save`` payload — the active path was a half-finished
+        format swap that only compiled because no production caller
+        exercised it. Now uses ``torch.load(weights_only=True)`` so
+        only safe primitive types can resolve from the saved
+        checkpoint (the torch ≥ 2.6 default; required from 2.8).
     """
-    data = yaml.safe_load(file_path.read())
-    # data = torch.load(file_path)
+    data = torch.load(file_path, map_location="cpu", weights_only=True)
     return (data["x"], data["y"])
 
 


### PR DESCRIPTION
## Summary

\`utils.load_dataset\` was supposed to invert \`utils.save_dataset\`
(which writes via \`torch.save\`), but the active path was
\`yaml.safe_load(file_path.read())\` — a half-finished format swap
that never round-tripped a real \`torch.save\` payload. The two
functions had not been an inverse pair since the swap landed.

Surfaced by the 2026-05-05 roadmap audit
(\`notes/ROADMAP_AUDIT_2026-05-05.md\` §4.1, BUG-CC-12).

## Root cause

The existing tests passed because they fed YAML strings directly
into \`load_dataset\` and never round-tripped through
\`save_dataset\`. A type-hint mismatch (\`file_path: str\` vs.
\`.read()\` call) meant the function could only be called with a
file-like object — not the string path the signature advertised.

## Fix

- \`load_dataset\` now uses
  \`torch.load(file_path, map_location=\"cpu\", weights_only=True)\`.
- \`weights_only=True\` is the torch ≥ 2.6 default and required from
  torch 2.8; it restricts the unpickler to safe primitive types.
- \`file_path\` type hint widened to \`Union[str, os.PathLike[str]]\`.
- \`yaml\` import removed (this was its only caller).

## Test plan

Replaced two YAML-string tests (which encoded the broken behaviour)
with three round-trip cases:

- [x] \`test_load_dataset_round_trip\` — save_dataset → load_dataset
      returns equal tensors via \`torch.testing.assert_close\`.
- [x] \`test_load_dataset_returns_tensors\` — result is real
      \`torch.Tensor\` instances (the YAML path lost type fidelity).
- [x] \`test_load_dataset_accepts_pathlib\` — \`pathlib.Path\` works.
- [x] 49 cases pass in \`test_utils_coverage.py\` post-fix.
- [x] Pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)