### PR TITLE
ci(workflow): force gitleaks-action onto Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,6 +485,12 @@ jobs:
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # gitleaks-action v2.3.9 ships as a Node.js 20 action.
+          # GitHub forces Node 24 on 2026-06-02; opt in now to eliminate
+          # the deprecation warning and ensure continued operation past
+          # the cutover. Drop this once gitleaks-action publishes a
+          # release pinned to node24 (upstream PR #215).
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
         # gitleaks-action v2.3.9 has no `fail` input (passing it triggers
         # "Unexpected input(s) 'fail'" in CI). The action exits non-zero
         # on leaks by default, which is the behavior we want.


### PR DESCRIPTION
## Summary
Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` to the gitleaks-action env block.

## Why
GitHub forces Node.js 20 actions onto Node.js 24 on **2026-06-02**. gitleaks-action v2.3.9 has no Node.js 24 release (upstream PR #215 in flight). The documented escape hatch eliminates the deprecation warning now and protects against the upcoming cutover. Drop the override once an upstream node24-pinned release ships.

## Test plan
- [ ] CI green
- [ ] `Node.js 20 actions are deprecated` warning gone from Security Scans output

🤖 Generated with [Claude Code](https://claude.com/claude-code)