### PR TITLE
fix(ci): skip gitleaks on repository_dispatch events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,6 +482,16 @@ jobs:
           fetch-depth: 0
 
       - name: Run Gitleaks (Secrets Detection)
+        # gitleaks-action v2.3.9 explicitly rejects ``repository_dispatch``
+        # ("ERROR: The [repository_dispatch] event is not yet supported"),
+        # which kills the entire Security Scans job whenever the workflow
+        # is triggered by upstream-published events from juniper-data /
+        # juniper-cascor-worker. The push/PR triggers cover the
+        # human-driven entry points that actually need secret scanning;
+        # the dispatch trigger is for ecosystem-fanout test runs and
+        # doesn't introduce new commits to scan. Mirrors juniper-data /
+        # juniper-canopy.
+        if: github.event_name != 'repository_dispatch'
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Add \`if: github.event_name != 'repository_dispatch'\` to cascor's gitleaks-action step. Mirrors the guard already present in juniper-data and juniper-canopy.

## Why
After PR #229 (gitleaks-action Node.js 24 forcing) merged, cascor main went red on the Security Scans job:

\`\`\`
##[error]ERROR: The [repository_dispatch] event is not yet supported
\`\`\`

cascor subscribes to \`data-client-updated\` and \`cascor-worker-updated\` dispatch events. The ecosystem-merge cascade from this evening's six gitleaks PRs fired those events into cascor's CI, and gitleaks-action v2.3.9 explicitly rejects \`repository_dispatch\`. The push/PR triggers still cover human-driven entry points; the dispatch trigger is for ecosystem-fanout test runs and never introduces new commits.

The pre-existing bug went undetected because \`repository_dispatch\` rarely fires; this evening's batch of merges happened to fan out fast enough to trigger it.

## Test plan
- [ ] CI green on this PR (push event — gitleaks runs as before)
- [ ] Post-merge: any future \`repository_dispatch\`-triggered cascor CI run skips Gitleaks step cleanly without taking down Security Scans

🤖 Generated with [Claude Code](https://claude.com/claude-code)