### PR TITLE
ci(async-audit): wire async-route audit hook in disabled state (Phase 1)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -129,6 +129,24 @@ repos:
         files: ^src/
 
   # ═══════════════════════════════════════════════════════════════════════════
+  # Async-route audit (Phase 1 wiring, disabled state).
+  # See juniper-ml notes/ASYNC_ROUTE_AUDIT_HOOK_MIGRATION_PLAN.md.
+  # `stages: [manual]` keeps this from firing on regular commits.
+  # Run on demand:  pre-commit run --hook-stage manual ruff-async-audit
+  # Phase 2 flips to `stages: [pre-commit, manual]` and adds CI lane.
+  # Phase 4 hard-fails. Per-file-ignores live in pyproject.toml [tool.ruff].
+  # ═══════════════════════════════════════════════════════════════════════════
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.2
+    hooks:
+      - id: ruff
+        alias: ruff-async-audit
+        name: Async-route audit (BUG-JD-10 class)
+        args: [--select, ASYNC, --exit-zero]
+        files: ^src/.*\.py$
+        stages: [manual]
+
+  # ═══════════════════════════════════════════════════════════════════════════
   # Python Linting - Flake8 (Source Code)
   # LOW-001: Enabled C901 complexity warnings (removed from ignore list)
   # ═══════════════════════════════════════════════════════════════════════════

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,3 +242,37 @@ module = [
     "yaml.*",
 ]
 ignore_missing_imports = true
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Ruff — async-route audit only (Phase 1 wiring, disabled state).
+# Cascor's primary lint stack stays flake8 + black + isort + bandit + mypy.
+# Ruff is added solely for the ASYNC* ruleset (BUG-JD-10 class prevention),
+# enforced via a manual-stage pre-commit hook. See juniper-ml notes/
+# ASYNC_ROUTE_AUDIT_HOOK_MIGRATION_PLAN.md.
+# ═══════════════════════════════════════════════════════════════════════════
+[tool.ruff]
+# Note: ruff >=0.15 caps line-length at 320. Cascor's ecosystem
+# convention is 512, but since this ruff config is only used for the
+# ASYNC* ruleset (not formatting), the value doesn't affect output;
+# pinned at the 320 cap so the config parses without error.
+line-length = 320
+target-version = "py312"
+
+[tool.ruff.lint]
+# Empty `select` so regular `ruff check` is a no-op. The ASYNC* ruleset is
+# explicitly opted into via the pre-commit hook's `--select ASYNC` arg.
+# Phase 4 may flip this to `select = ["ASYNC"]` if we want the rules
+# applied during regular runs too.
+select = []
+
+[tool.ruff.lint.per-file-ignores]
+# Phase 0 enumeration (juniper-ml notes/ASYNC_ROUTE_VIOLATIONS_2026-05-06.md)
+# flagged 4 violations in this file. They're all intentional — the file is
+# a service orchestration helper that spawns subprocesses, polls health
+# endpoints, and writes log files. Sync I/O is the whole point of these
+# functions; the async wrapper is for orchestration concurrency, not
+# request handling. Per-file-ignored so the ruff-async-audit hook doesn't
+# surface them as Phase 3 cleanup candidates.
+# why: orchestration helper, not a route handler
+"src/api/service_launcher.py" = ["ASYNC109", "ASYNC210", "ASYNC220", "ASYNC230"]


### PR DESCRIPTION
## Summary

Phase 1 wiring of the async-route audit hook for juniper-cascor.
Second of four Phase 1 wiring PRs (data → **cascor** → canopy →
worker).

Cascor doesn't use ruff today — primary lint stack is flake8 +
black + isort + bandit + mypy. This PR adds ruff with the
\`ASYNC\` ruleset only, gated to a manual-stage pre-commit hook.

## What's added

\`\`\`toml
# pyproject.toml
[tool.ruff]
line-length = 320  # ruff >=0.15 cap
target-version = \"py312\"

[tool.ruff.lint]
select = []  # no-op for regular runs; ASYNC opted in via hook arg

[tool.ruff.lint.per-file-ignores]
\"src/api/service_launcher.py\" = [\"ASYNC109\", \"ASYNC210\", \"ASYNC220\", \"ASYNC230\"]
\`\`\`

\`\`\`yaml
# .pre-commit-config.yaml
- id: ruff
  alias: ruff-async-audit
  name: Async-route audit (BUG-JD-10 class)
  args: [--select, ASYNC, --exit-zero]
  files: ^src/.*\\.py\$
  stages: [manual]
\`\`\`

## Why per-file-ignore on service_launcher.py

Phase 0 enumeration ([juniper-ml \`ASYNC_ROUTE_VIOLATIONS_2026-05-06.md\`](https://github.com/pcalnon/juniper-ml/blob/main/notes/ASYNC_ROUTE_VIOLATIONS_2026-05-06.md)
§2.3) flagged 4 violations all in this single file. The file is
a **service orchestration helper** that spawns subprocesses, polls
health endpoints, and writes log files. The async wrapper is for
orchestration concurrency, not request handling — sync I/O is the
whole point of these functions. Per-file-ignored so Phase 3
cleanup work focuses on actual route-handler violations elsewhere.

## How to use

\`\`\`bash
pre-commit run --hook-stage manual ruff-async-audit --all-files
\`\`\`

## Test plan

- [x] Manual hook runs and passes (no violations after per-file-
      ignore is applied to service_launcher.py).
- [x] Regular \`pre-commit run\` does NOT fire the new hook.
- [x] \`pyproject.toml\` parses without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)