### PR TITLE
ci(async-audit): enable Phase 2 — soft-fail visibility for async-route audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,37 @@ jobs:
           python scripts/check_doc_links.py --exclude templates --exclude history
 
   # ═══════════════════════════════════════════════════════════════════════════════════════════════
+  # Async-route audit (Phase 2 — soft-fail visibility).
+  # Catches the BUG-JD-10 bug class (sync-blocking calls inside async def
+  # route handlers). `continue-on-error: true` so violations surface as
+  # PR annotations without blocking merge. Phase 4 will flip this off.
+  # See juniper-ml notes/ASYNC_ROUTE_AUDIT_HOOK_MIGRATION_PLAN.md §4.
+  # ═══════════════════════════════════════════════════════════════════════════════════════════════
+  async-route-audit:
+    name: Async-route audit (BUG-JD-10 class, soft-fail)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_TEST_VERSION }}
+
+      - name: Install ruff
+        run: pip install "ruff==0.15.6"
+
+      - name: Run async-route audit
+        run: |
+          echo "╔════════════════════════════════════════════════════════════╗"
+          echo "║       Juniper Cascor - Async-route audit (BUG-JD-10)      ║"
+          echo "╚════════════════════════════════════════════════════════════╝"
+          ruff check --select ASYNC --output-format=github src/
+
+  # ═══════════════════════════════════════════════════════════════════════════════════════════════
   # Unit Tests: Run unit tests with coverage enforcement
   # MED-009: Added Python version matrix for multi-version testing
   # Migrated from conda to pip for CI portability (polyrepo Phase 5)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -129,12 +129,13 @@ repos:
         files: ^src/
 
   # ═══════════════════════════════════════════════════════════════════════════
-  # Async-route audit (Phase 1 wiring, disabled state).
+  # Async-route audit (Phase 2 — soft-fail visibility).
   # See juniper-ml notes/ASYNC_ROUTE_AUDIT_HOOK_MIGRATION_PLAN.md.
-  # `stages: [manual]` keeps this from firing on regular commits.
-  # Run on demand:  pre-commit run --hook-stage manual ruff-async-audit
-  # Phase 2 flips to `stages: [pre-commit, manual]` and adds CI lane.
-  # Phase 4 hard-fails. Per-file-ignores live in pyproject.toml [tool.ruff].
+  # `--exit-zero` keeps violations as warnings (won't block commits).
+  # CI lane in .github/workflows/ci.yml runs the same check with
+  # `continue-on-error: true` so PRs see annotations without blocking
+  # merge. Phase 4 will drop both `--exit-zero` and `continue-on-error`.
+  # Per-file-ignores live in pyproject.toml [tool.ruff].
   # ═══════════════════════════════════════════════════════════════════════════
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.2
@@ -144,7 +145,7 @@ repos:
         name: Async-route audit (BUG-JD-10 class)
         args: [--select, ASYNC, --exit-zero]
         files: ^src/.*\.py$
-        stages: [manual]
+        stages: [pre-commit, manual]
 
   # ═══════════════════════════════════════════════════════════════════════════
   # Python Linting - Flake8 (Source Code)


### PR DESCRIPTION
## Summary

Phase 2 enable for juniper-cascor. Second of four Phase 2 PRs.

Same shape as the data PR ([data #94](https://github.com/pcalnon/juniper-data/pull/94)):

- Pre-commit \`stages: [manual]\` → \`[pre-commit, manual]\`
- New CI job \`async-route-audit\` with \`continue-on-error: true\`

## Effect

After the Phase 1 per-file-ignore on \`src/api/service_launcher.py\`
(orchestration helper), cascor has **zero visible violations**
post-Phase-2. The CI lane and pre-commit hook will catch any new
violations introduced by future code changes.

## Test plan

- [x] \`pre-commit run ruff-async-audit\` (without \`--hook-stage manual\`)
      runs and passes — hook now fires on regular commits.
- [x] CI job uses ruff 0.15.6 and \`--output-format=github\` for
      annotation rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)