### PR TITLE
refactor(observability): migrate to juniper-observability register_or_reuse (Phase 2c)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     # configure_sentry, get_prometheus_app, set_build_info, and the
     # R1.1/R1.2/R1.3 contract constants). Pinned at the first stable
     # release; consumers should never resolve back to the alpha line.
-    "juniper-observability>=0.1.1",
+    "juniper-observability>=0.2.0",
     # METRICS-MON R2.2.2 / seed-05: WebSocket frame schemas (envelope
     # Pydantic models for /ws/training and /ws/control + WorkerMessageType
     # StrEnum + BinaryFrame numpy codec for /ws/v1/workers). The cascor

--- a/src/api/observability.py
+++ b/src/api/observability.py
@@ -171,38 +171,27 @@ _TRAINING_STEP_DURATION_BUCKETS: tuple = (
 )
 
 
-def _register_or_reuse(cls, name: str, *args, **kwargs):
-    """Construct a Prometheus collector idempotently against the default registry.
-
-    The lazy ``_ensure_*_metrics`` singletons cache module-globals as
-    Python references. Tests sometimes clear those globals (to force a
-    fresh ``_ensure`` path) without unregistering the underlying
-    collectors from ``prometheus_client.REGISTRY``. The next ``cls(name,
-    ...)`` then raises ``ValueError: Duplicated timeseries`` because the
-    metric name is still bound in the registry even though our cache
-    forgot the Python reference.
-
-    Catch that specific case, look the existing collector up by name,
-    unregister it, and retry — yielding a fresh collector that reflects
-    the current call's labels/buckets without depending on stale state.
-    Other ``ValueError`` causes (genuinely invalid name, etc.) are
-    re-raised unchanged.
-    """
-    from prometheus_client import REGISTRY
-
-    try:
-        return cls(name, *args, **kwargs)
-    except ValueError as exc:
-        if "Duplicated timeseries" not in str(exc):
-            raise
-        # Find the orphaned collector by name and unregister it. The
-        # ``_collector_to_names`` mapping is the same lookup ``register``
-        # itself uses for the duplicate check.
-        for collector, names in list(REGISTRY._collector_to_names.items()):
-            if name in names:
-                REGISTRY.unregister(collector)
-                break
-        return cls(name, *args, **kwargs)
+# Idempotent collector registration helper. The original local
+# implementation (cascor PR ?? from before juniper-observability 0.2.0)
+# used drop-and-recreate semantics: on a duplicate, unregister the
+# existing collector and retry the construction so the latest call's
+# labels/buckets win at the cost of discarding any accumulated samples.
+#
+# Phase 2c migration (juniper-ml#216 / juniper-observability 0.2.0):
+# the call sites below were already calling ``_register_or_reuse(cls,
+# name, *args, **kwargs)`` with identical args every time (lazy-init
+# singleton dict pattern), so the drop-and-recreate semantics never
+# meaningfully differed from adopt-existing for production. The
+# canonical helper is ``juniper_observability.register_or_reuse`` which
+# adopts the existing collector — preserving accumulated samples across
+# in-process re-init (test fixtures rebuilding the app, dev autoreload).
+# Aliased here as ``_register_or_reuse`` so the 22+ call sites in this
+# module remain stable.
+#
+# Use ``juniper_observability.register_fresh`` instead at any future
+# call site that genuinely wants the drop-and-recreate behaviour
+# (test fixture exercising different bucket boundaries, etc.).
+from juniper_observability import register_or_reuse as _register_or_reuse
 
 
 def _ensure_training_metrics() -> dict:

--- a/src/api/websocket/control_stream.py
+++ b/src/api/websocket/control_stream.py
@@ -68,9 +68,8 @@ def _get_command_counter():
     global _command_received_counter
     if _command_received_counter is None:
         try:
-            from prometheus_client import Counter
-
             from juniper_observability import register_or_reuse
+            from prometheus_client import Counter
 
             _command_received_counter = register_or_reuse(
                 Counter,

--- a/src/api/websocket/control_stream.py
+++ b/src/api/websocket/control_stream.py
@@ -59,35 +59,25 @@ _command_received_counter = None
 def _get_command_counter():
     """Lazily create the command received counter when metrics are available.
 
-    Idempotent against the global ``prometheus_client.REGISTRY``: if a
+    Idempotent via :func:`juniper_observability.register_or_reuse`: if a
     test fixture (or in-process re-init) has nulled the module-level
-    cache while leaving the underlying Counter registered, re-fetch
-    the existing collector instead of raising
-    ``ValueError: Duplicated timeseries``. Same shape as the
-    ``_register_or_reuse`` helper in
-    ``src/api/observability.py:_ensure_training_metrics``.
+    cache while leaving the underlying Counter registered, the helper
+    adopts the existing collector instead of raising
+    ``ValueError: Duplicated timeseries``.
     """
     global _command_received_counter
     if _command_received_counter is None:
         try:
-            from prometheus_client import REGISTRY, Counter
+            from prometheus_client import Counter
 
-            metric_name = "cascor_ws_control_command_received_total"
-            try:
-                _command_received_counter = Counter(
-                    metric_name,
-                    "WebSocket control commands received",
-                    ["command"],
-                )
-            except ValueError:
-                # Already registered — adopt the existing collector.
-                # ``prometheus_client`` registers under both the bare name
-                # and the suffixed sample names (``_total``, ``_created``);
-                # lookup with the name we passed returns the same object.
-                existing = REGISTRY._names_to_collectors.get(metric_name)
-                if existing is None:
-                    raise
-                _command_received_counter = existing
+            from juniper_observability import register_or_reuse
+
+            _command_received_counter = register_or_reuse(
+                Counter,
+                "cascor_ws_control_command_received_total",
+                "WebSocket control commands received",
+                ["command"],
+            )
         except ImportError:
             _command_received_counter = False  # sentinel: prometheus not available
     return _command_received_counter


### PR DESCRIPTION
## Summary

Phase 2c — final per-consumer migration of the plan in [`juniper-ml/notes/observability/REGISTER_OR_REUSE_HELPER_DESIGN_2026-05-05.md`](https://github.com/pcalnon/juniper-ml/blob/main/notes/observability/REGISTER_OR_REUSE_HELPER_DESIGN_2026-05-05.md).

## What changes

| File | Change |
|---|---|
| ``src/api/observability.py`` | Drop the local ``_register_or_reuse`` definition (~32 lines) and replace with ``from juniper_observability import register_or_reuse as _register_or_reuse``. The 22+ existing call sites in ``_ensure_training_metrics`` / ``_ensure_ws_metrics`` keep their exact same syntax via the alias. |
| ``src/api/websocket/control_stream.py`` | ``_get_command_counter`` swaps inline try/except for the imported helper. Net −15 lines. |
| ``pyproject.toml`` | ``juniper-observability>=0.1.1`` → ``>=0.2.0`` |

## Semantic note: drop-and-recreate vs adopt-existing

The original local ``_register_or_reuse`` used **drop-and-recreate** on a duplicate (unregister existing → retry construction → latest args win at the cost of discarded samples). The canonical ``juniper_observability.register_or_reuse`` uses **adopt-existing** (samples preserved, latest args silently ignored).

For all 22+ call sites in this module the args are identical every time (the lazy-init singleton dict pattern), so the two semantics produce indistinguishable output for production *and* for tests that start with a clean REGISTRY. Adopt-existing is strictly more correct for any scenario where a fixture clears the module-globals without scrubbing REGISTRY itself.

If a future call site needs drop-and-recreate, ``juniper_observability.register_fresh`` is available with the old semantics.

## Verification

Full ``-m unit`` cascor suite under JuniperCascor1: **3346 passed, 10 skipped, 0 failed**.

## Companion PRs

- juniper-data #95 (Phase 2a) — opened
- juniper-canopy #245 (Phase 2b) — opened
- juniper-cascor-client deliberately excluded from Phase 2 (would add pydantic + starlette transitive deps to a leaf library; PR #37 inline guard stays)

🤖 Generated with [Claude Code](https://claude.com/claude-code)