### PR TITLE
docs(observability): cross-reference register_or_reuse helpers (Phase 3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -668,6 +668,15 @@ python -m snapshots.snapshot_cli list ./snapshots/
 
 **Line Length**: 512 for all linters (black, isort, flake8).
 
+**Prometheus Collectors**: Use the canonical helpers from `juniper-observability` (`>=0.2.0`) for any new `Counter` / `Gauge` / `Histogram` / `Summary` / `Info` / `Enum`:
+
+- `register_or_reuse(factory, name, *args, **kwargs)` — adopt-existing on duplicate (the default for almost every call site; preserves accumulated samples across in-process re-init).
+- `register_fresh(...)` — drop-and-recreate (only when args genuinely differ; the legacy local `_register_or_reuse` shape).
+- `register_info_or_update(name, description, **labels)` — sugar for the `Info` two-step register-then-`.info({...})` pattern.
+- `lazy_register_or_reuse(...)` — for the lazy-init-with-`None`-sentinel pattern.
+
+Tests touching these collectors should use `juniper_observability.testing.reset_prometheus_registry`. Existing examples: `src/api/observability.py:_ensure_training_metrics` / `_ensure_ws_metrics` (22+ call sites via the `_register_or_reuse` alias) and `src/api/websocket/control_stream.py:_get_command_counter`. See [the design doc in juniper-ml](https://github.com/pcalnon/juniper-ml/blob/main/notes/observability/REGISTER_OR_REUSE_HELPER_DESIGN_2026-05-05.md) for the rationale.
+
 ---
 
 ## Testing Infrastructure


### PR DESCRIPTION
## Summary

Adds a brief "Prometheus Collectors" entry to the Programming Conventions section of AGENTS.md pointing newcomers at the canonical helpers in juniper-observability >= 0.2.0 plus the testing fixture. Notes that ``register_fresh`` is the shape that matches the legacy local ``_register_or_reuse`` (drop-and-recreate semantics) for any new call site that genuinely wants different bucket boundaries on re-init.

Closes Phase 3 of the migration plan in [`juniper-ml/notes/observability/REGISTER_OR_REUSE_HELPER_DESIGN_2026-05-05.md`](https://github.com/pcalnon/juniper-ml/blob/main/notes/observability/REGISTER_OR_REUSE_HELPER_DESIGN_2026-05-05.md).

Documentation only; no code changes. Cross-reference points at the in-tree migration examples from PR #233 (``_ensure_training_metrics`` / ``_ensure_ws_metrics`` via the ``_register_or_reuse`` alias, and ``control_stream._get_command_counter``).

🤖 Generated with [Claude Code](https://claude.com/claude-code)