### PR TITLE
ci(async-audit): Phase 4 — enforce async-route audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,16 +128,16 @@ jobs:
           python scripts/check_doc_links.py --exclude templates --exclude history
 
   # ═══════════════════════════════════════════════════════════════════════════════════════════════
-  # Async-route audit (Phase 2 — soft-fail visibility).
+  # Async-route audit (Phase 4 — enforced).
   # Catches the BUG-JD-10 bug class (sync-blocking calls inside async def
-  # route handlers). `continue-on-error: true` so violations surface as
-  # PR annotations without blocking merge. Phase 4 will flip this off.
+  # route handlers). Hard-fails on any new violation. The only intentional
+  # sync surface (``src/api/service_launcher.py``, an orchestration helper)
+  # carries a per-file-ignore in pyproject.toml [tool.ruff.lint.per-file-ignores].
   # See juniper-ml notes/ASYNC_ROUTE_AUDIT_HOOK_MIGRATION_PLAN.md §4.
   # ═══════════════════════════════════════════════════════════════════════════════════════════════
   async-route-audit:
-    name: Async-route audit (BUG-JD-10 class, soft-fail)
+    name: Async-route audit (BUG-JD-10 class)
     runs-on: ubuntu-latest
-    continue-on-error: true
 
     steps:
       - name: Checkout Code

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -129,13 +129,11 @@ repos:
         files: ^src/
 
   # ═══════════════════════════════════════════════════════════════════════════
-  # Async-route audit (Phase 2 — soft-fail visibility).
+  # Async-route audit (Phase 4 — enforced).
   # See juniper-ml notes/ASYNC_ROUTE_AUDIT_HOOK_MIGRATION_PLAN.md.
-  # `--exit-zero` keeps violations as warnings (won't block commits).
-  # CI lane in .github/workflows/ci.yml runs the same check with
-  # `continue-on-error: true` so PRs see annotations without blocking
-  # merge. Phase 4 will drop both `--exit-zero` and `continue-on-error`.
-  # Per-file-ignores live in pyproject.toml [tool.ruff].
+  # Hard-fails on any new ASYNC* violation. ``service_launcher.py`` (the
+  # only file with intentional sync calls in an async context) carries a
+  # per-file-ignore in pyproject.toml [tool.ruff.lint.per-file-ignores].
   # ═══════════════════════════════════════════════════════════════════════════
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.2
@@ -143,7 +141,7 @@ repos:
       - id: ruff
         alias: ruff-async-audit
         name: Async-route audit (BUG-JD-10 class)
-        args: [--select, ASYNC, --exit-zero]
+        args: [--select, ASYNC]
         files: ^src/.*\.py$
         stages: [pre-commit, manual]
 


### PR DESCRIPTION
## Summary

Phase 4 of the async-route audit migration (juniper-ml [ASYNC_ROUTE_AUDIT_HOOK_MIGRATION_PLAN.md](https://github.com/pcalnon/juniper-ml/blob/main/notes/ASYNC_ROUTE_AUDIT_HOOK_MIGRATION_PLAN.md) §4). Drops the soft-fail flags so any new BUG-JD-10-class violation hard-fails.

Second of four Phase 4 PRs: data (#98) → **cascor** → canopy → worker.

## Changes

**``.github/workflows/ci.yml``**
- Remove ``continue-on-error: true`` from the ``async-route-audit`` job.
- Rename job from "Async-route audit (BUG-JD-10 class, soft-fail)" → "Async-route audit (BUG-JD-10 class)".
- Update header comment from "Phase 2 — soft-fail visibility" → "Phase 4 — enforced".
- (The ruff command already lacks ``--exit-zero`` — that was tightened in fb1b5d4 during the Phase 2 lessons-learned cycle.)

**``.pre-commit-config.yaml``**
- Remove ``--exit-zero`` from the ``ruff-async-audit`` hook so violations block commits locally.
- Update header comment.

## Verification

- [x] ``ruff check --select ASYNC src/`` exits clean (only ``src/api/service_launcher.py`` is silenced via per-file-ignore in pyproject.toml — orchestration helper, not a route handler)
- [ ] CI ``async-route-audit`` job goes green on this PR

## Test plan

- [ ] CI green on this PR with the enforced lane
- [ ] Branch protection rules updated to require the lane (separate manual step in repo settings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)