### PR TITLE
fix(ws): broadcast full topology on cascade_add (not count-only stub)

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -1594,13 +1594,19 @@ class TrainingLifecycleManager:
                         correlation=actual_correlation,
                     )
                 if manager_ref._ws_manager is not None:
-                    topology_data = {
-                        "hidden_units": new_hidden,
-                        "input_size": getattr(manager_ref.network, "input_size", 0),
-                        "output_size": getattr(manager_ref.network, "output_size", 0),
-                        "event": "cascade_add",
-                    }
-                    manager_ref._ws_manager.broadcast_from_thread(create_topology_message(topology_data))
+                    # The cascade_add ``topology`` broadcast must carry the
+                    # full serialized network — hidden_units as a list of
+                    # per-unit dicts (weights/bias/activation) plus
+                    # output_weights/output_bias — so canopy's
+                    # _transform_topology can render the new hidden node and
+                    # its cascade connections. A count-only stub here
+                    # previously caused canopy to render 0 hidden units after
+                    # every cascade growth (the WS frame overrode REST and
+                    # `len(int)` raised inside the transform's isinstance
+                    # check, collapsing the topology to inputs+outputs only).
+                    full_topology = manager_ref.get_topology()
+                    if full_topology is not None:
+                        manager_ref._ws_manager.broadcast_from_thread(create_topology_message(full_topology))
 
             # Post-call: return to output phase after grow completes
             sm.set_phase(TrainingPhase.OUTPUT)

--- a/src/tests/unit/api/test_monitoring_hooks.py
+++ b/src/tests/unit/api/test_monitoring_hooks.py
@@ -121,6 +121,75 @@ class TestMonitoringHooks:
         call_args = ws_mgr.broadcast_from_thread.call_args[0][0]
         assert call_args["type"] == "cascade_add"
 
+    def test_cascade_add_topology_broadcast_carries_full_serialized_network(self):
+        """After cascade growth, the WS ``topology`` broadcast must carry the
+        full serialized network — ``hidden_units`` as a list of per-unit dicts
+        plus ``output_weights``/``output_bias`` — not a count-only stub.
+
+        Regression: a count-only stub (``hidden_units: int``) was previously
+        broadcast on cascade_add. Canopy's ``_transform_topology`` saw
+        ``isinstance(int, list) is False`` and silently rendered 0 hidden
+        units, so the Network Topology view never updated as the cascade
+        grew. The fix is to broadcast ``manager.get_topology()`` directly.
+        """
+        from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
+
+        original_grow = CascadeCorrelationNetwork.grow_network
+
+        def fake_grow_one_unit(self_network, *args, **kwargs):
+            # Append a structurally-valid hidden unit so get_topology()
+            # serializes a list-shaped payload.
+            self_network.hidden_units.append(
+                {
+                    "weights": torch.tensor([0.10, 0.20, 0.30]),
+                    "bias": torch.tensor(0.05),
+                    "activation_fn": torch.sigmoid,
+                }
+            )
+            return None
+
+        CascadeCorrelationNetwork.grow_network = fake_grow_one_unit
+        try:
+            manager = TrainingLifecycleManager()
+            manager.create_network(input_size=2, output_size=2)
+
+            ws_mgr = MagicMock()
+            manager.set_ws_manager(ws_mgr)
+
+            # Trigger the wrapped grow path
+            manager.network.grow_network()
+
+            # Find the topology broadcast among all broadcast calls
+            topology_calls = [
+                call_args[0][0]
+                for call_args in ws_mgr.broadcast_from_thread.call_args_list
+                if isinstance(call_args[0][0], dict) and call_args[0][0].get("type") == "topology"
+            ]
+            assert len(topology_calls) >= 1, "expected at least one ``topology`` broadcast after cascade_add"
+
+            payload = topology_calls[-1]["data"]
+            # The whole point of the fix: hidden_units must be a list, not an int
+            hidden_units = payload.get("hidden_units")
+            assert isinstance(hidden_units, list), (
+                f"hidden_units must be a list (was {type(hidden_units).__name__}: {hidden_units!r}). "
+                "A count-only stub corrupts canopy's topology view."
+            )
+            assert len(hidden_units) >= 1, "expected at least one serialized hidden unit"
+
+            unit = hidden_units[0]
+            for required in ("id", "weights", "bias", "activation"):
+                assert required in unit, f"hidden unit missing {required!r}: {unit}"
+            assert isinstance(unit["weights"], list), "weights must be serialized as a list"
+
+            # Canopy's _transform_topology iterates output_weights to build
+            # input→output and hidden→output edges. Both must be present.
+            assert "output_weights" in payload
+            assert "output_bias" in payload
+            assert "input_size" in payload
+            assert "output_size" in payload
+        finally:
+            CascadeCorrelationNetwork.grow_network = original_grow
+
     def test_ws_callbacks_broadcast_on_candidate_progress(self):
         """Candidate progress callback broadcasts candidate_progress via WebSocket."""
         manager = TrainingLifecycleManager()

--- a/src/tests/unit/api/test_monitoring_hooks.py
+++ b/src/tests/unit/api/test_monitoring_hooks.py
@@ -160,20 +160,13 @@ class TestMonitoringHooks:
             manager.network.grow_network()
 
             # Find the topology broadcast among all broadcast calls
-            topology_calls = [
-                call_args[0][0]
-                for call_args in ws_mgr.broadcast_from_thread.call_args_list
-                if isinstance(call_args[0][0], dict) and call_args[0][0].get("type") == "topology"
-            ]
+            topology_calls = [call_args[0][0] for call_args in ws_mgr.broadcast_from_thread.call_args_list if isinstance(call_args[0][0], dict) and call_args[0][0].get("type") == "topology"]
             assert len(topology_calls) >= 1, "expected at least one ``topology`` broadcast after cascade_add"
 
             payload = topology_calls[-1]["data"]
             # The whole point of the fix: hidden_units must be a list, not an int
             hidden_units = payload.get("hidden_units")
-            assert isinstance(hidden_units, list), (
-                f"hidden_units must be a list (was {type(hidden_units).__name__}: {hidden_units!r}). "
-                "A count-only stub corrupts canopy's topology view."
-            )
+            assert isinstance(hidden_units, list), f"hidden_units must be a list (was {type(hidden_units).__name__}: {hidden_units!r}). " "A count-only stub corrupts canopy's topology view."
             assert len(hidden_units) >= 1, "expected at least one serialized hidden unit"
 
             unit = hidden_units[0]


### PR DESCRIPTION
## Summary

The `topology` WS frame emitted after cascade growth was a metadata stub (`hidden_units` as int count). Canopy's `_transform_topology` expects a list of hidden-unit dicts; `isinstance(int, list) is False` silently collapsed the result to inputs+outputs only and zero hidden nodes, so the Network Topology view in canopy never updated as the cascade grew.

Replace the stub with `manager.get_topology()` — the same serializer the REST `/v1/network/topology` endpoint uses — so the WS frame carries `hidden_units: [{id, weights, bias, activation}, ...]` plus `output_weights` / `output_bias`. Existing `_topology_lock` is held by `get_topology()`, so threadsafety is preserved.

## Symptom (pre-fix)

Network Topology tab header showed `Hidden Units: 0` and `Total Connections: 4` (= 2 inputs × 2 outputs) even after the cascade had grown. The sidebar `Network Information` panel correctly showed `Hidden Units: 1` because it reads `len(network.hidden_units)` from `/api/status`, which is unaffected by this WS path.

Companion canopy PR adds defense-in-depth: pcalnon/juniper-canopy#fix/topology-ws-broadcast-completeness.

## Test plan

- [x] New `test_cascade_add_topology_broadcast_carries_full_serialized_network` in `src/tests/unit/api/test_monitoring_hooks.py` — exercises the monitored `grow_network` wrapper end-to-end and asserts the broadcast `data.hidden_units` is a list, each unit carries `weights`/`bias`/`activation`, and `output_weights` / `output_bias` are present so canopy's transform can build hidden→output edges.
- [x] All 1259 existing `tests/unit/api/` tests pass (including the existing `test_ws_callbacks_broadcast_on_cascade_add` for the separate `cascade_add`-typed broadcast).
- [ ] Live observation in canopy after merge — Network Topology tab should reflect new hidden nodes within one fast-update tick of cascade growth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)