### PR TITLE
fix(lifecycle): normalise _pause_event in reset() (BUG-CC-#5)

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -1912,8 +1912,13 @@ class TrainingLifecycleManager:
         return {"status": "resumed", "timestamp": time.time()}
 
     def reset(self) -> Dict[str, Any]:
-        """Reset training state."""
-        self._stop_requested.set()
+        """Reset training state.
+
+        Normalises the control-event pair via ``_reset_event_state`` so a
+        subsequent ``start_training`` does not inherit a stale
+        ``_pause_event.clear()`` from a prior pause (BUG-CC-#5).
+        """
+        self._reset_event_state()
         self._last_emitted_history_len = 0
         self.state_machine.handle_command(Command.RESET)
         self.training_monitor.clear_metrics()
@@ -1925,6 +1930,16 @@ class TrainingLifecycleManager:
         )
         self._broadcast_training_state(force=True)
         return {"status": "reset", "timestamp": time.time()}
+
+    def _reset_event_state(self) -> None:
+        """Single source of truth for control-event normalisation.
+
+        Post-condition: ``_stop_requested`` is set (signals any in-flight
+        training thread to stop) and ``_pause_event`` is set (no synthetic
+        pause inherited by the next ``start_training`` call).
+        """
+        self._stop_requested.set()
+        self._pause_event.set()
 
     # ------------------------------------------------------------------
     # Status & metrics

--- a/src/tests/integration/api/test_lifecycle_event_invariants.py
+++ b/src/tests/integration/api/test_lifecycle_event_invariants.py
@@ -1,0 +1,139 @@
+"""Regression tests for BUG-CC-#5: control-event normalisation in reset().
+
+Before the fix, ``reset()`` set ``_stop_requested`` but did not re-set
+``_pause_event``.  If the user paused before stopping, the next
+``start_training()`` call would inherit a stale ``_pause_event.clear()``
+and the training loop would synthetically pause after a single iteration.
+
+The fix introduces ``TrainingLifecycleManager._reset_event_state()`` as the
+single source of truth for control-event normalisation, called from
+``reset()``.  These tests pin the contract.
+"""
+
+import itertools
+
+import pytest
+
+from api.lifecycle.manager import TrainingLifecycleManager
+from api.lifecycle.state_machine import Command
+
+
+@pytest.fixture
+def mgr():
+    """Fresh lifecycle manager (no network, no executor, no training thread).
+
+    Sufficient for testing the event-state contract because ``reset()`` and
+    ``_reset_event_state()`` touch only ``_pause_event``, ``_stop_requested``,
+    the FSM, the training-state object, and the broadcast hook — all of which
+    are live after ``__init__``.
+    """
+    return TrainingLifecycleManager()
+
+
+# ---------------------------------------------------------------------------
+# Helper-contract: _reset_event_state() normalises from any prior state.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("pause_set,stop_set", list(itertools.product([False, True], repeat=2)))
+def test_reset_event_state_normalises_from_any_prior_state(mgr, pause_set, stop_set):
+    """For every combination of prior event states, post-condition holds."""
+    if pause_set:
+        mgr._pause_event.set()
+    else:
+        mgr._pause_event.clear()
+    if stop_set:
+        mgr._stop_requested.set()
+    else:
+        mgr._stop_requested.clear()
+
+    mgr._reset_event_state()
+
+    assert mgr._pause_event.is_set(), "post: _pause_event must be set"
+    assert mgr._stop_requested.is_set(), "post: _stop_requested must be set"
+
+
+# ---------------------------------------------------------------------------
+# Focused regression: the exact user-reported sequence.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_reset_after_pause_leaves_pause_event_set(mgr):
+    """User scenario: pause -> stop -> reset must leave _pause_event set.
+
+    Pre-fix this asserted False (the bug).  Drives the FSM directly to avoid
+    needing a real training thread / network for the test to be meaningful.
+    """
+    # Mirror the start path's event manipulations + advance FSM.
+    mgr._stop_requested.clear()
+    mgr._pause_event.set()
+    assert mgr.state_machine.handle_command(Command.START)
+
+    # User pauses — pause_training() clears _pause_event.
+    mgr.pause_training()
+    assert not mgr._pause_event.is_set(), "guard: pause must clear _pause_event"
+
+    # User stops — stop_training() sets _stop_requested but does not touch pause.
+    mgr.stop_training()
+    assert not mgr._pause_event.is_set(), "guard: stop must not re-set _pause_event"
+
+    # User resets — fix is here.
+    mgr.reset()
+
+    assert mgr._pause_event.is_set(), (
+        "BUG-CC-#5 regression: reset() must normalise _pause_event so the next "
+        "start_training() does not inherit a stale clear()"
+    )
+    assert mgr._stop_requested.is_set()
+
+
+# ---------------------------------------------------------------------------
+# Broader coverage: every legal sequence ending in reset() leaves events set.
+# ---------------------------------------------------------------------------
+
+
+_COMMANDS = ["pause", "resume", "stop", "reset"]
+
+
+def _apply(mgr, cmd):
+    """Apply a command; swallow RuntimeError raised for FSM-illegal transitions."""
+    method = {
+        "pause": mgr.pause_training,
+        "resume": mgr.resume_training,
+        "stop": mgr.stop_training,
+        "reset": mgr.reset,
+    }[cmd]
+    try:
+        method()
+    except RuntimeError:
+        # Invalid transition (e.g. resume when not paused) — fine for invariant testing.
+        pass
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "seq",
+    [
+        seq
+        for n in range(1, 4)
+        for seq in itertools.product(_COMMANDS, repeat=n)
+        if seq[-1] == "reset"
+    ],
+)
+def test_after_reset_pause_event_is_set(mgr, seq):
+    """No matter what command sequence preceded a final reset(), _pause_event is set.
+
+    Pre-stages the FSM into STARTED so pause/resume are not all rejected at the
+    front door; mirrors what start_training() does to the event pair.
+    """
+    mgr._stop_requested.clear()
+    mgr._pause_event.set()
+    assert mgr.state_machine.handle_command(Command.START)
+
+    for cmd in seq:
+        _apply(mgr, cmd)
+
+    assert mgr._pause_event.is_set(), f"_pause_event left cleared after sequence {seq}"
+    assert mgr._stop_requested.is_set(), f"_stop_requested left cleared after sequence {seq}"


### PR DESCRIPTION
## Summary

Fixes the user-reported "training auto-pauses after one iteration following Stop+Reset" bug (BUG-CC-#5).

`reset()` previously set `_stop_requested` but did **not** re-set `_pause_event`. If the user had paused before stopping, the cleared `_pause_event` survived `reset()` and poisoned the next `start_training()` — the cascade-correlation inner loops would block on the next `_pause_event.wait()` after a single iteration, producing the observed "pauses after one iteration" symptom.

This PR introduces `TrainingLifecycleManager._reset_event_state()` as the single source of truth for control-event normalisation and routes `reset()` through it. The change eliminates the asymmetric event handling that caused the bug and forecloses the future-drift class flagged in the plan (R5.3).

This is **PR-1** of the frontend-remediation plan series. Spec: [`juniper-canopy/notes/FRONTEND_ISSUES_PLAN_2026-05-09.md`](https://github.com/pcalnon/juniper-canopy/blob/main/notes/FRONTEND_ISSUES_PLAN_2026-05-09.md) §4.

## Implementation (per plan §4.4 A+B+C)

- **A** (one-line semantic fix): `reset()` now calls `_reset_event_state()` which sets both events.
- **B** (helper to prevent future drift): new `_reset_event_state()` method documents the post-condition contract.
- **C** (regression coverage): new `src/tests/integration/api/test_lifecycle_event_invariants.py` (26 tests).

## Verification

- New invariant suite: 26/26 pass post-fix; 10/26 fail pre-fix (verified by stash-then-run).
- Existing lifecycle suite: 192 unit tests (`test_lifecycle_*.py`) + 56 integration api tests — all green.

## Test plan

- [x] `pytest src/tests/integration/api/test_lifecycle_event_invariants.py --integration` — 26 passed
- [x] `pytest src/tests/unit/api/test_lifecycle_*.py --integration` — 192 passed
- [x] `pytest src/tests/integration/api/ --integration` — 56 passed
- [x] Pre-fix sanity: stash the manager.py change, rerun new suite → 10 fail with the expected `_pause_event left cleared after sequence …` assertion
- [ ] Manual canopy-side smoke: pause → stop → reset → start, observe continuous training (deferred to PR-1 merge + canopy hookup)

## Files changed

- `src/api/lifecycle/manager.py` (+17/-2): `reset()` docstring + `_reset_event_state()` helper.
- `src/tests/integration/api/test_lifecycle_event_invariants.py` (+138, new): contract test + focused regression + parametrized sequence sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)