### PR TITLE
feat(params): candidate-pool PATCH schema + invariants (Issue #1, PR-4a)

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -71,6 +71,43 @@ def _write_activation_function_name(network: Any, value: str) -> None:
 _coerce_native_scalars = _common_coerce_native_scalars
 
 
+class InvalidCandidatePoolError(ValueError):
+    """Raised when a candidate-pool PATCH violates the §1.5 C2.1 invariant triple.
+
+    A subclass of ``ValueError`` so existing ``except ValueError`` handlers in
+    ``update_params`` and the PATCH route still see it; the PATCH route promotes
+    instances of this specific subclass to HTTP 422 (the message is the
+    human-readable violation string) while bare ``ValueError`` remains 404.
+    See ``FRONTEND_ISSUES_PLAN_2026-05-09.md §1.5 C2.1`` for the full truth table.
+    """
+
+
+def _validate_candidate_pool_triple(s: int, t: int, r: int, p: int) -> Optional[str]:
+    """Return ``None`` if (S, T, R, P) satisfy the §1.5 C2.1 invariant or a
+    human-readable violation string otherwise.
+
+    Bound to be called against the *post-merge* triple — never against the
+    per-key delta — because a multi-key PATCH that's only valid as a unit
+    (e.g. ``{S: 6, T: 4, R: 2}`` from a prior ``(S=2, T=2, R=0)``) must be
+    accepted in one shot.
+    """
+    if not (1 <= s <= p):
+        return f"selected_candidates {s} not in [1, candidate_pool_size={p}]"
+    if t < 0 or r < 0:
+        return f"top_candidates and random_candidates must be >= 0 (got T={t}, R={r})"
+    if t > s or r > s:
+        return f"each component must be <= selected_candidates (S={s}, T={t}, R={r})"
+    if t == 0 and r == 0:
+        return "top_candidates and random_candidates cannot both be 0"
+    if t == 0 and r != s:
+        return f"with top_candidates=0, random_candidates must equal S={s} (got R={r})"
+    if r == 0 and t != s:
+        return f"with random_candidates=0, top_candidates must equal S={s} (got T={t})"
+    if t > 0 and r > 0 and t + r != s:
+        return f"top_candidates+random_candidates must equal S={s} (got {t}+{r}={t + r})"
+    return None
+
+
 class _WeightHistoryRecorder:
     """CAN-015g (Phase 6E follow-on, g-6): training-loop weight history capture.
 
@@ -2070,6 +2107,14 @@ class TrainingLifecycleManager:
                 # snap counter resets each ``start_training``.
                 "auto_snap_best": self._auto_snap_best,
                 "auto_snap_min_epochs": self._auto_snap_min_epochs,
+                # FRONTEND_ISSUES_PLAN_2026-05-09 §1.5 C2 / Issue #1 — candidate-pool
+                # selection knobs. PR-4a stores them; PR-4b consumes them in
+                # ``_select_best_candidates`` and ``grow_network``.
+                "multi_candidate": getattr(self.network, "multi_candidate", False),
+                "candidate_selection": getattr(self.network, "candidate_selection", "top"),
+                "selected_candidates": getattr(self.network, "selected_candidates", 1),
+                "top_candidates": getattr(self.network, "top_candidates", 1),
+                "random_candidates": getattr(self.network, "random_candidates", 0),
             }
         )
 
@@ -2227,10 +2272,26 @@ class TrainingLifecycleManager:
             "activation_function_name",  # CAN-011 (Phase 6E Sprint A-3) — re-init on swap
             "auto_snap_best",  # CAS-006 (Phase 6E Sprint A-4) — lifecycle attribute
             "auto_snap_min_epochs",  # CAS-006 (Phase 6E Sprint A-4) — lifecycle attribute
+            # FRONTEND_ISSUES_PLAN_2026-05-09 §1.5 C2 — schema-only in PR-4a; selection
+            # logic in PR-4b. Plain network attributes (no nested setter required).
+            "multi_candidate",
+            "candidate_selection",
+            "selected_candidates",
+            "top_candidates",
+            "random_candidates",
         }
         nested_keys = {"optimizer_type", "activation_function_name"}
         lifecycle_keys = {"auto_snap_best", "auto_snap_min_epochs"}
         simple_keys = updatable_keys - nested_keys - lifecycle_keys
+
+        # FRONTEND_ISSUES_PLAN_2026-05-09 §1.5 C2.1 — validate the candidate-pool
+        # triple against the *post-merge* state so a multi-key PATCH that's only
+        # valid as a unit (e.g. {S=6, T=4, R=2} from a prior {S=2, T=2, R=0})
+        # is accepted in one shot. Raises ValueError → 422 if violated; nothing
+        # has been applied yet, so no rollback is needed for this branch.
+        triple_violation = self._validate_candidate_pool_post_merge(params)
+        if triple_violation is not None:
+            raise InvalidCandidatePoolError(triple_violation)
         applicable = {k: v for k, v in params.items() if k in simple_keys and hasattr(self.network, k)}
         old_values = {k: getattr(self.network, k) for k in applicable}
 
@@ -2300,6 +2361,25 @@ class TrainingLifecycleManager:
                     self.logger.exception("update_params rollback: revert of %s failed", key)
             raise
         return self.get_training_params()
+
+    def _validate_candidate_pool_post_merge(self, params: Dict[str, Any]) -> Optional[str]:
+        """Validate the §1.5 C2.1 candidate-pool invariant against the *post-merge*
+        triple — i.e. what (S, T, R, P) would be if every key in ``params``
+        landed.  Returns ``None`` on success or a violation string on failure.
+
+        Skipped when none of {selected_candidates, top_candidates,
+        random_candidates, candidate_pool_size} appears in ``params`` — the
+        ambient triple was already valid (it's an invariant of the network),
+        and validating an unrelated PATCH would be needlessly expensive.
+        """
+        triple_keys = {"selected_candidates", "top_candidates", "random_candidates", "candidate_pool_size"}
+        if not (triple_keys & params.keys()):
+            return None
+        s = params.get("selected_candidates", getattr(self.network, "selected_candidates", 1))
+        t = params.get("top_candidates", getattr(self.network, "top_candidates", 1))
+        r = params.get("random_candidates", getattr(self.network, "random_candidates", 0))
+        p = params.get("candidate_pool_size", getattr(self.network, "candidate_pool_size", 1))
+        return _validate_candidate_pool_triple(int(s), int(t), int(r), int(p))
 
     # ------------------------------------------------------------------
     # Topology & statistics

--- a/src/api/models/training.py
+++ b/src/api/models/training.py
@@ -120,6 +120,14 @@ class TrainingParams(BaseModel):
     # training when the metric is volatile.
     auto_snap_best: Optional[bool] = Field(None, description="Auto-save a snapshot whenever the model beats its best (validation) accuracy")
     auto_snap_min_epochs: Optional[int] = Field(None, ge=0, le=1_000_000, description="Suppress auto-snap until this many epochs have elapsed (default 50)")
+    # FRONTEND_ISSUES_PLAN_2026-05-09 §1.5 C2 / Issue #1 — see TrainingParamUpdateRequest
+    # for the full per-field rationale; mirrored here so the start-of-training override
+    # surface validates the same way as the runtime PATCH path (no dropped keys).
+    multi_candidate: Optional[bool] = Field(None, description="If True, promote multiple candidates per growth iteration (PR-4b will wire selection logic)")
+    candidate_selection: Optional[Literal["top", "random", "mixed"]] = Field(None, description="Strategy for choosing which trained candidates to promote")
+    selected_candidates: Optional[int] = Field(None, ge=1, le=256, description="Total candidates promoted per growth iteration (S in the C2.1 invariant triple)")
+    top_candidates: Optional[int] = Field(None, ge=0, le=256, description="Top-correlation slice of the promoted set (T)")
+    random_candidates: Optional[int] = Field(None, ge=0, le=256, description="Random slice of the promoted set (R)")
 
 
 class TrainingStartRequest(BaseModel):
@@ -202,3 +210,11 @@ class TrainingParamUpdateRequest(BaseModel):
     # CAS-006 (A-4): runtime-patchable counterparts to TrainingParams.auto_snap_*.
     auto_snap_best: Optional[bool] = Field(None, description="Auto-save a snapshot whenever the model beats its best (validation) accuracy")
     auto_snap_min_epochs: Optional[int] = Field(None, ge=0, le=1_000_000, description="Suppress auto-snap until this many epochs have elapsed")
+    # FRONTEND_ISSUES_PLAN_2026-05-09 §1.5 C2 / Issue #1 — candidate-pool selection knobs.
+    # Schema + post-merge invariant validation (C2.1) ship in PR-4a; the
+    # cascade_correlation.py selection-logic wiring lands in PR-4b.
+    multi_candidate: Optional[bool] = Field(None, description="If True, promote multiple candidates per growth iteration (PR-4b will wire this into selection)")
+    candidate_selection: Optional[Literal["top", "random", "mixed"]] = Field(None, description="Strategy for choosing which trained candidates to promote: top correlation, random, or a mix")
+    selected_candidates: Optional[int] = Field(None, ge=1, description="Total candidates promoted per growth iteration (S in the C2.1 invariant triple); must be in [1, candidate_pool_size]")
+    top_candidates: Optional[int] = Field(None, ge=0, description="Top-correlation slice of the promoted set (T in the C2.1 invariant triple)")
+    random_candidates: Optional[int] = Field(None, ge=0, description="Random slice of the promoted set (R in the C2.1 invariant triple)")

--- a/src/api/routes/training.py
+++ b/src/api/routes/training.py
@@ -5,6 +5,7 @@ import logging
 import torch
 from fastapi import APIRouter, HTTPException, Request
 
+from api.lifecycle.manager import InvalidCandidatePoolError
 from api.models.common import success_response
 from api.models.training import TrainingParamUpdateRequest, TrainingStartRequest
 
@@ -149,6 +150,11 @@ async def update_training_params(request: Request, body: TrainingParamUpdateRequ
     try:
         updated = lifecycle.update_params(body.model_dump(exclude_none=True))
         return success_response(updated)
+    except InvalidCandidatePoolError as e:
+        # FRONTEND_ISSUES_PLAN_2026-05-09 §1.5 C2.1 — surface the violation
+        # string in the JSON body so the canopy adapter can route it through
+        # the same `mismatches`/`skipped` toast machinery from C3.
+        raise HTTPException(status_code=422, detail=str(e))
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
 

--- a/src/cascade_correlation/cascade_correlation.py
+++ b/src/cascade_correlation/cascade_correlation.py
@@ -668,6 +668,15 @@ class CascadeCorrelationNetwork:
         self.input_size = self.config.input_size or _CASCADE_CORRELATION_NETWORK_INPUT_SIZE
         self.output_size = self.config.output_size or _CASCADE_CORRELATION_NETWORK_OUTPUT_SIZE
         self.candidate_pool_size = self.config.candidate_pool_size or _CASCADE_CORRELATION_NETWORK_CANDIDATE_POOL_SIZE
+        # FRONTEND_ISSUES_PLAN_2026-05-09 §1.5 C2 / Issue #1 — candidate-pool selection
+        # knobs. Defaults preserve current behavior (single top-correlation candidate
+        # per growth iteration). PR-4b will rewire ``_select_best_candidates`` to
+        # honour the multi/top/random triple; today these attributes are storage-only.
+        self.multi_candidate = bool(getattr(self.config, "multi_candidate", False) or False)
+        self.candidate_selection = getattr(self.config, "candidate_selection", None) or "top"
+        self.selected_candidates = getattr(self.config, "selected_candidates", None) or 1
+        self.top_candidates = getattr(self.config, "top_candidates", None) if getattr(self.config, "top_candidates", None) is not None else 1
+        self.random_candidates = getattr(self.config, "random_candidates", None) if getattr(self.config, "random_candidates", None) is not None else 0
 
         # Initialize training parameters
         self.learning_rate = self.config.learning_rate or _CASCADE_CORRELATION_NETWORK_LEARNING_RATE

--- a/src/tests/integration/api/test_candidate_pool_invariants.py
+++ b/src/tests/integration/api/test_candidate_pool_invariants.py
@@ -1,0 +1,179 @@
+"""End-to-end PATCH /v1/training/params tests for the candidate-pool triple.
+
+Pins the §1.5 C2.1 invariant against the real FastAPI route — covers schema
+acceptance, atomic post-merge validation, 422 surfacing, and per-field
+round-trip for each of the five new params (multi_candidate,
+candidate_selection, selected_candidates, top_candidates, random_candidates).
+
+The cascade_correlation.py selection-logic wiring is **not** validated here —
+that's PR-4b. PR-4a only ensures the storage and the invariant hold; the
+defaults preserve current single-top-candidate behavior.
+"""
+
+import threading
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.app import create_app
+from api.settings import Settings
+
+
+@pytest.fixture
+def client():
+    """Minimal TestClient mirroring test_api_full_lifecycle's daemon-shutdown."""
+    settings = Settings()
+    app = create_app(settings)
+    tc = TestClient(app)
+    tc.__enter__()
+    yield tc
+    lifecycle = getattr(app.state, "lifecycle", None)
+    if lifecycle:
+        lifecycle._stop_requested.set()
+        if getattr(lifecycle, "_executor", None):
+            lifecycle._executor.shutdown(wait=False, cancel_futures=True)
+    exit_thread = threading.Thread(target=lambda: tc.__exit__(None, None, None), daemon=True)
+    exit_thread.start()
+    exit_thread.join(timeout=5)
+
+
+def _create_network(client, *, candidate_pool_size: int = 8) -> None:
+    resp = client.post(
+        "/v1/network",
+        json={
+            "input_size": 2,
+            "output_size": 2,
+            "candidate_pool_size": candidate_pool_size,
+            "epochs_max": 5,
+            "candidate_epochs": 2,
+            "output_epochs": 2,
+            "patience": 1,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.integration
+class TestCandidatePoolInvariants:
+    """§1.5 C2.1 — exhaustive matrix over the post-merge invariant."""
+
+    @pytest.mark.parametrize(
+        "patch",
+        [
+            {"selected_candidates": 1, "top_candidates": 1, "random_candidates": 0},
+            {"selected_candidates": 4, "top_candidates": 4, "random_candidates": 0},
+            {"selected_candidates": 4, "top_candidates": 0, "random_candidates": 4},
+            {"selected_candidates": 6, "top_candidates": 4, "random_candidates": 2},
+        ],
+    )
+    def test_valid_triples_accepted(self, client, patch):
+        _create_network(client)
+        resp = client.patch("/v1/training/params", json=patch)
+        assert resp.status_code == 200, resp.text
+        applied = resp.json()["data"]
+        for k, v in patch.items():
+            assert applied[k] == v, f"PATCH applied but GET reports {applied[k]} for {k} (wanted {v})"
+
+    @pytest.mark.parametrize(
+        "patch,fragment",
+        [
+            ({"selected_candidates": 0, "top_candidates": 0, "random_candidates": 0}, "selected_candidates"),
+            ({"selected_candidates": 4, "top_candidates": 5, "random_candidates": 0}, "each component"),
+            ({"selected_candidates": 4, "top_candidates": 3, "random_candidates": 2}, "must equal S=4"),
+            ({"selected_candidates": 4, "top_candidates": 0, "random_candidates": 0}, "cannot both be 0"),
+            ({"selected_candidates": 4, "top_candidates": 0, "random_candidates": 3}, "with top_candidates=0"),
+            ({"selected_candidates": 4, "top_candidates": 3, "random_candidates": 0}, "with random_candidates=0"),
+        ],
+    )
+    def test_invalid_triples_rejected_422(self, client, patch, fragment):
+        _create_network(client)
+        resp = client.patch("/v1/training/params", json=patch)
+        # Pydantic catches non-negativity itself (ge=0 on the field), so a few
+        # of the above bypass the post-merge helper. Either 422 path is fine —
+        # we just need the invariant violation NOT to silently apply.
+        assert resp.status_code in (400, 422), f"expected 4xx, got {resp.status_code}: {resp.text}"
+        body = resp.json()
+        assert "detail" in body, body
+        assert fragment in str(body["detail"]), f"violation message {body['detail']!r} missing fragment {fragment!r}"
+
+    def test_atomic_multi_key_patch_accepted_in_one_shot(self, client):
+        """A PATCH that's only valid as a unit must not 422 on the first key.
+
+        Starting state: the constructor defaults (S=1, T=1, R=0). The single
+        PATCH below sets {S=6, T=4, R=2} — which is invalid if applied
+        per-key (S=6, T=1 inherits, R=0 inherits → fails T+R==S) but valid
+        as a post-merge unit.
+        """
+        _create_network(client)
+        resp = client.patch(
+            "/v1/training/params",
+            json={"selected_candidates": 6, "top_candidates": 4, "random_candidates": 2},
+        )
+        assert resp.status_code == 200, resp.text
+        applied = resp.json()["data"]
+        assert (applied["selected_candidates"], applied["top_candidates"], applied["random_candidates"]) == (6, 4, 2)
+
+    def test_pool_size_in_same_patch_validates_against_new_pool(self, client):
+        """PATCHing pool_size and S in the same call must validate against the
+        post-merge pool. Starting pool=2, new pool=8, S=6 — invalid against
+        the old pool, valid against the new."""
+        _create_network(client, candidate_pool_size=2)
+        resp = client.patch(
+            "/v1/training/params",
+            json={"candidate_pool_size": 8, "selected_candidates": 6, "top_candidates": 4, "random_candidates": 2},
+        )
+        assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.integration
+class TestCandidatePoolPerFieldRoundTrip:
+    """Each of the 5 new params individually round-trips through PATCH/GET."""
+
+    def test_multi_candidate_round_trip(self, client):
+        _create_network(client)
+        resp = client.patch("/v1/training/params", json={"multi_candidate": True})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["data"]["multi_candidate"] is True
+        resp = client.get("/v1/training/params")
+        assert resp.json()["data"]["multi_candidate"] is True
+
+    def test_candidate_selection_round_trip(self, client):
+        _create_network(client)
+        for value in ("top", "random", "mixed"):
+            resp = client.patch("/v1/training/params", json={"candidate_selection": value})
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["data"]["candidate_selection"] == value
+
+    def test_candidate_selection_rejects_unknown(self, client):
+        _create_network(client)
+        resp = client.patch("/v1/training/params", json={"candidate_selection": "lottery"})
+        assert resp.status_code == 422, resp.text  # pydantic Literal rejection
+
+    def test_selected_candidates_round_trip(self, client):
+        _create_network(client)
+        # Need to provide T+R=S to satisfy the invariant — pure-S patches with
+        # the inherited (T=1, R=0) only work when S=1.
+        resp = client.patch(
+            "/v1/training/params",
+            json={"selected_candidates": 3, "top_candidates": 3, "random_candidates": 0},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["data"]["selected_candidates"] == 3
+
+    def test_top_candidates_round_trip(self, client):
+        _create_network(client)
+        resp = client.patch(
+            "/v1/training/params",
+            json={"selected_candidates": 4, "top_candidates": 2, "random_candidates": 2},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["data"]["top_candidates"] == 2
+
+    def test_random_candidates_round_trip(self, client):
+        _create_network(client)
+        resp = client.patch(
+            "/v1/training/params",
+            json={"selected_candidates": 4, "top_candidates": 2, "random_candidates": 2},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["data"]["random_candidates"] == 2

--- a/src/tests/unit/api/test_param_validation_helper.py
+++ b/src/tests/unit/api/test_param_validation_helper.py
@@ -1,0 +1,57 @@
+"""Truth-table tests for ``_validate_candidate_pool_triple`` (§1.5 C2.1).
+
+The helper is the single source of truth for the candidate-pool invariant; if
+its logic is wrong, every PATCH path that uses it is wrong. These tests pin
+the invariant table directly so a future refactor can't drift the rules
+without breaking obvious cases first.
+"""
+
+import pytest
+
+from api.lifecycle.manager import _validate_candidate_pool_triple
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "s,t,r,p",
+    [
+        (1, 1, 0, 8),
+        (4, 4, 0, 8),
+        (4, 0, 4, 8),
+        (6, 4, 2, 8),
+        (8, 5, 3, 8),  # S == P (saturation upper edge)
+        (1, 0, 1, 1),  # P == S == 1, R == S
+    ],
+)
+def test_valid_triples_return_none(s, t, r, p):
+    assert _validate_candidate_pool_triple(s, t, r, p) is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "s,t,r,p,fragment",
+    [
+        # S out of range
+        (0, 0, 0, 8, "selected_candidates 0 not in"),
+        (9, 5, 4, 8, "selected_candidates 9 not in"),
+        # Negative components
+        (4, -1, 5, 8, "must be >= 0"),
+        (4, 5, -1, 8, "must be >= 0"),
+        # Component exceeds S
+        (4, 5, 0, 8, "each component must be"),
+        (4, 0, 5, 8, "each component must be"),
+        # Both zero with S > 0
+        (4, 0, 0, 8, "cannot both be 0"),
+        # Degenerate: T==0 but R != S
+        (4, 0, 3, 8, "with top_candidates=0"),
+        # Degenerate: R==0 but T != S
+        (4, 3, 0, 8, "with random_candidates=0"),
+        # Both nonzero but T+R != S
+        (4, 1, 1, 8, "must equal S=4"),
+        (4, 3, 2, 8, "must equal S=4"),
+    ],
+)
+def test_invalid_triples_return_specific_violation(s, t, r, p, fragment):
+    msg = _validate_candidate_pool_triple(s, t, r, p)
+    assert msg is not None, f"expected violation for ({s}, {t}, {r}, p={p})"
+    assert fragment in msg, f"violation message {msg!r} missing fragment {fragment!r}"


### PR DESCRIPTION
## Summary

PR-4a of the [FRONTEND_ISSUES_PLAN_2026-05-09 §1.5](https://github.com/pcalnon/juniper-canopy/blob/main/notes/FRONTEND_ISSUES_PLAN_2026-05-09.md) series — closes the canopy-adapter silent-drop for the five candidate-pool selection knobs by giving cascor a real schema, storage, and post-merge invariant validation for them. PR-5 (canopy adapter map extension) can now ship without 404 storms.

> **Scope is intentionally schema-only.** Spec §1.5 C2 implicitly assumed the candidate-pool selection concepts (multi/top/random) already existed in `cascade_correlation.py` — they don't. Splitting the work as PR-4a (this — schema + validation) and PR-4b (selection-logic rewrite in `_select_best_candidates`/`grow_network`) was confirmed in scoping. The five new fields round-trip through PATCH/GET and persist on the network today, but the live training loop still uses the legacy single-top-correlation path. Defaults preserve current behavior.

## Five new params

| Field | Type | Default | Purpose |
|------|------|---------|---------|
| `multi_candidate` | bool | False | Promote multiple candidates per growth iteration (PR-4b) |
| `candidate_selection` | Literal["top","random","mixed"] | "top" | Selection strategy (PR-4b) |
| `selected_candidates` | int >= 1 | 1 | S — total promoted per iteration |
| `top_candidates` | int >= 0 | 1 | T — top-correlation slice |
| `random_candidates` | int >= 0 | 0 | R — random slice |

## Wire-up

- `src/api/models/training.py`: extends `TrainingParamUpdateRequest` and `TrainingParams` with the five fields, mirroring existing pydantic constraint style.
- `src/cascade_correlation/cascade_correlation.py`: stores the five attributes on `CascadeCorrelationNetwork.__init__` with defaults that preserve current behavior.
- `src/api/lifecycle/manager.py`:
  - new module-level `InvalidCandidatePoolError(ValueError)` — subclasses `ValueError` so existing handlers keep working
  - new pure helper `_validate_candidate_pool_triple(s, t, r, p)` returning `None` or a violation string
  - new `TrainingLifecycleManager._validate_candidate_pool_post_merge(params)` that folds the PATCH delta over the current network values before validating
  - `_apply_params_unlocked` calls the validator before any setattr, so a violating PATCH never partially applies
  - `get_training_params` now surfaces the five fields
- `src/api/routes/training.py`: PATCH `/v1/training/params` translates `InvalidCandidatePoolError` to **HTTP 422** with the violation string in `detail` (distinct from 404 for missing network).

## Atomicity (Resolution log Q2 — required, not optional)

The validator runs against the **post-merge** triple, not the per-key delta. This means a multi-key PATCH that's only valid as a unit is accepted in one shot:

```http
PATCH /v1/training/params
{ "selected_candidates": 6, "top_candidates": 4, "random_candidates": 2 }
```

…starting from `{S=1, T=1, R=0}` succeeds, even though per-key (S=6 with inherited T=1, R=0) would fail `T+R == S`. A test pins this explicitly.

`candidate_pool_size` in the same PATCH validates against the new pool, not the old — also pinned by a test.

## Truth table

Per spec §1.5 C2.1:

1. `1 ≤ S ≤ P`
2. `T ≥ 0` and `R ≥ 0`
3. `T ≤ S` and `R ≤ S`
4. Degenerate: if `R == 0` then `T == S`; if `T == 0` then `R == S`
5. Both nonzero: `T + R == S`
6. `T == 0 and R == 0` is illegal when `S > 0`

## Test plan

- [x] `pytest src/tests/unit/api/test_param_validation_helper.py` — 17/17 (truth table)
- [x] `pytest src/tests/integration/api/test_candidate_pool_invariants.py --integration` — 18/18 (valid + invalid + atomicity + pool-size + per-field round-trip + Literal rejection)
- [x] `pytest src/tests/unit/api/test_lifecycle_*.py --integration` — 209/209 (no lifecycle regression)
- [x] `pytest src/tests/integration/api/ --integration` — 74/74 (no broader regression)

## Follow-ups

- **PR-4b**: rewire `_select_best_candidates` + `grow_network` to actually consume `multi_candidate` / `candidate_selection` / `(S, T, R)`. Adds end-to-end behavior tests showing the promotion logic respects the triple.
- **PR-5** (canopy): extend `_CANOPY_TO_CASCOR_PARAM_MAP` with the five new keys + the C2.2 clientside validator.
- **PR-4 spec §1.6 — additional canopy-side adapter mock-drop test** ships with PR-5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)