### PR TITLE
feat(dataset): stage/cancel pending dataset + reload on start (Issue #3 Phase 1, PR-6)

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -999,6 +999,14 @@ class TrainingLifecycleManager:
         # Network creation params (for reset)
         self._network_params: Optional[Dict[str, Any]] = None
 
+        # FRONTEND_ISSUES_PLAN_2026-05-09 §3.5.1 / Issue #3 Phase 1 — staged
+        # dataset config. Set by ``stage_dataset_config`` (POST /v1/training/
+        # dataset), consumed + cleared by the next ``start_training`` via
+        # ``_reload_dataset``. ``clear_pending_dataset_config`` (DELETE) and
+        # ``get_pending_dataset_config`` (GET .../pending) round it out so the
+        # canopy banner can show the staged change and offer Cancel.
+        self._pending_dataset_config: Optional[Dict[str, Any]] = None
+
         # CAN-015g (g-6): training-loop weight history recorder.
         # Lazily attached on first ``start_training`` call; persists
         # across re-trains so callbacks register exactly once.
@@ -1862,6 +1870,16 @@ class TrainingLifecycleManager:
                 self._val_x = x_val
                 self._val_y = y_val
 
+            # FRONTEND_ISSUES_PLAN_2026-05-09 §3.5.1 / Issue #3 Phase 1 — if
+            # the user staged a dataset change while training was stopped,
+            # consume it now (before the future is submitted). On reload
+            # failure, leave the staged config in place so the user can fix
+            # the upstream juniper-data issue and Restart-and-retry without
+            # losing their selection.
+            if self._pending_dataset_config:
+                self._reload_dataset(**self._pending_dataset_config)
+                self._pending_dataset_config = None
+
             if self._train_x is None or self._train_y is None:
                 raise ValueError("Training data not provided")
 
@@ -1998,6 +2016,10 @@ class TrainingLifecycleManager:
             "training_state": training_state,
             "network_loaded": self.network is not None,
             "training_active": self.state_machine.is_started(),
+            # FRONTEND_ISSUES_PLAN_2026-05-09 §3.5.1 / Issue #3 Phase 1 — drives
+            # the canopy "Dataset change pending — restart training to apply"
+            # banner without canopy having to poll a separate route.
+            "pending_dataset": self.get_pending_dataset_config(),
         }
 
     def get_metrics(self) -> Dict[str, Any]:
@@ -2034,6 +2056,100 @@ class TrainingLifecycleManager:
     def has_training_data(self) -> bool:
         """Check if training data is loaded."""
         return self._train_x is not None and self._train_y is not None
+
+    # ------------------------------------------------------------------
+    # Pending dataset config (FRONTEND_ISSUES_PLAN_2026-05-09 §3.5.1 + §3.5.2 P1)
+    # ------------------------------------------------------------------
+
+    def stage_dataset_config(self, **cfg: Any) -> Dict[str, Any]:
+        """Stage a dataset-config change for the next ``start_training`` call.
+
+        The actual fetch + tensor swap happens in ``_reload_dataset`` at the
+        top of ``start_training``; staging just records intent so the canopy
+        banner can announce "Dataset change pending" until the user restarts.
+
+        Empty ``cfg`` is a no-op (clears any prior staging — same shape as
+        ``clear_pending_dataset_config``) so the route can use ``cfg or {}``
+        without separate validation.
+        """
+        with self._training_lock:
+            if not cfg:
+                self._pending_dataset_config = None
+                return {"status": "cleared", "config": None}
+            self._pending_dataset_config = dict(cfg)
+            return {"status": "staged", "config": dict(cfg)}
+
+    def clear_pending_dataset_config(self) -> Dict[str, Any]:
+        """Discard any staged dataset change so the next start uses current data."""
+        with self._training_lock:
+            prior = self._pending_dataset_config
+            self._pending_dataset_config = None
+        return {"status": "cleared", "discarded": dict(prior) if prior else None}
+
+    def get_pending_dataset_config(self) -> Optional[Dict[str, Any]]:
+        """Return the staged dataset config (or None) — drives the canopy banner."""
+        cfg = self._pending_dataset_config
+        return dict(cfg) if cfg else None
+
+    def _reload_dataset(self, **cfg: Any) -> None:
+        """Fetch a fresh dataset from juniper-data and replace the live tensors.
+
+        Mirrors ``api/app.py::_auto_start_training``'s pattern: instantiate a
+        ``JuniperDataClient`` from env vars, ``create_dataset`` with the
+        staged generator + params, ``download_artifact_npz``, convert to
+        ``torch.float32`` tensors, swap ``_train_x/_train_y`` (and val if
+        the artifact carries them).
+
+        Held under ``_training_lock`` by the caller (``start_training``);
+        any I/O failure surfaces as ``RuntimeError`` so the caller can leave
+        ``_pending_dataset_config`` in place for the user to retry.
+        """
+        try:
+            from juniper_data_client import JuniperDataClient
+        except ImportError as exc:  # juniper-data-client is an optional extra
+            raise RuntimeError("juniper-data-client is not installed; cannot reload dataset") from exc
+
+        # Pop the generator name; everything else is forwarded as ``params``.
+        cfg = dict(cfg)
+        dataset_type = cfg.pop("dataset_type", None)
+        if not dataset_type:
+            raise RuntimeError("Pending dataset config missing required 'dataset_type'")
+
+        import os as _os
+
+        from cascor_constants.constants_api import _PROJECT_API_JUNIPER_DATA_URL_DEFAULT
+
+        try:
+            from secrets_util import get_secret  # type: ignore[import-not-found]
+        except ImportError:
+            get_secret = lambda _key: None  # noqa: E731
+
+        data_url = _os.environ.get("JUNIPER_DATA_URL", _PROJECT_API_JUNIPER_DATA_URL_DEFAULT)
+        api_key = get_secret("JUNIPER_DATA_API_KEY")
+        client = JuniperDataClient(base_url=data_url, api_key=api_key)
+
+        try:
+            result = client.create_dataset(generator=dataset_type, params=cfg, persist=True)
+            dataset_id = result["dataset_id"]
+            arrays = client.download_artifact_npz(dataset_id)
+        except Exception as exc:
+            raise RuntimeError(f"juniper-data fetch failed: {exc}") from exc
+
+        try:
+            new_train_x = torch.tensor(arrays["X_train"], dtype=torch.float32)
+            new_train_y = torch.tensor(arrays["y_train"], dtype=torch.float32)
+        except KeyError as exc:
+            raise RuntimeError(f"juniper-data artifact missing required key: {exc}") from exc
+
+        self._train_x = new_train_x
+        self._train_y = new_train_y
+        if "X_test" in arrays and "y_test" in arrays:
+            self._val_x = torch.tensor(arrays["X_test"], dtype=torch.float32)
+            self._val_y = torch.tensor(arrays["y_test"], dtype=torch.float32)
+        else:
+            self._val_x = None
+            self._val_y = None
+        self.logger.info("Reloaded dataset %r (%d train samples)", dataset_type, new_train_x.shape[0])
 
     def get_dataset(self) -> Dict[str, Any]:
         """Return dataset metadata."""

--- a/src/api/models/training.py
+++ b/src/api/models/training.py
@@ -149,6 +149,21 @@ class TrainingStatus(BaseModel):
     training_state: dict
 
 
+class StageDatasetRequest(BaseModel):
+    """FRONTEND_ISSUES_PLAN_2026-05-09 §3.5.1 — staged dataset config body.
+
+    All fields optional so the canopy adapter can build the body from
+    whatever subset of dataset inputs the user touched. Empty body
+    clears any prior staging (idempotent with DELETE for that case).
+    """
+
+    dataset_type: Optional[Literal["spirals", "xor", "mnist", "circles", "moons"]] = Field(None, description="Generator name forwarded to juniper-data")
+    n_samples: Optional[int] = Field(None, ge=1, le=_PROJECT_API_MAX_DATASET_SAMPLES, description="Total dataset size")
+    noise: Optional[float] = Field(None, ge=0.0, le=1.0, description="Generator noise factor (0–1)")
+    rotations: Optional[float] = Field(None, ge=0.0, le=10.0, description="Spiral rotations (spirals generator only)")
+    n_spirals: Optional[int] = Field(None, ge=2, le=10, description="Number of spirals (spirals generator only)")
+
+
 class TrainingParamUpdateRequest(BaseModel):
     """Runtime-modifiable training parameters (PATCH semantics — all fields optional)."""
 

--- a/src/api/routes/training.py
+++ b/src/api/routes/training.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, HTTPException, Request
 
 from api.lifecycle.manager import InvalidCandidatePoolError
 from api.models.common import success_response
-from api.models.training import TrainingParamUpdateRequest, TrainingStartRequest
+from api.models.training import StageDatasetRequest, TrainingParamUpdateRequest, TrainingStartRequest
 
 logger = logging.getLogger("juniper_cascor.api.routes.training")
 
@@ -157,6 +157,37 @@ async def update_training_params(request: Request, body: TrainingParamUpdateRequ
         raise HTTPException(status_code=422, detail=str(e))
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
+
+
+# FRONTEND_ISSUES_PLAN_2026-05-09 §3.5.1 + §3.5.2 P1 — Issue #3 Phase 1 dataset
+# staging endpoints. Stage a dataset config now, restart training to apply
+# (cold-swap), or DELETE the staged config to cancel before restart.
+
+
+@router.post("/dataset")
+async def stage_dataset(request: Request, body: StageDatasetRequest) -> dict:
+    """Stage a dataset-config change for the next ``start_training``.
+
+    Returns the staged config in ``data``. An empty body clears any prior
+    staging (idempotent with DELETE for that case).
+    """
+    lifecycle = _get_lifecycle(request)
+    cfg = body.model_dump(exclude_none=True)
+    return success_response(lifecycle.stage_dataset_config(**cfg))
+
+
+@router.delete("/dataset")
+async def cancel_dataset_stage(request: Request) -> dict:
+    """Discard any staged dataset change — Phase 1 Cancel button target."""
+    lifecycle = _get_lifecycle(request)
+    return success_response(lifecycle.clear_pending_dataset_config())
+
+
+@router.get("/dataset/pending")
+async def get_pending_dataset(request: Request) -> dict:
+    """Return the staged dataset config (or null) — drives the canopy banner."""
+    lifecycle = _get_lifecycle(request)
+    return success_response({"pending": lifecycle.get_pending_dataset_config()})
 
 
 def _generate_spiral_data(params: dict):

--- a/src/tests/integration/api/test_pending_dataset.py
+++ b/src/tests/integration/api/test_pending_dataset.py
@@ -1,0 +1,210 @@
+"""End-to-end PATCH /v1/training/dataset tests for Issue #3 Phase 1.
+
+Pins the spec from FRONTEND_ISSUES_PLAN_2026-05-09 §3.5.1 + §3.5.2 P1:
+
+  - POST /v1/training/dataset stages a config; GET /pending echoes it.
+  - DELETE /v1/training/dataset clears it; GET /pending returns null.
+  - Status payload (`pending_dataset` field) reflects staging state.
+  - start_training picks up + clears the staged config (verified via a
+    JuniperDataClient mock — no live juniper-data instance needed).
+  - Reload failure leaves the staged config in place so the user can
+    fix the upstream issue and retry.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import types
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+from api.app import create_app
+from api.settings import Settings
+
+
+@pytest.fixture
+def client():
+    settings = Settings()
+    app = create_app(settings)
+    tc = TestClient(app)
+    tc.__enter__()
+    yield tc
+    lifecycle = getattr(app.state, "lifecycle", None)
+    if lifecycle:
+        lifecycle._stop_requested.set()
+        if getattr(lifecycle, "_executor", None):
+            lifecycle._executor.shutdown(wait=False, cancel_futures=True)
+    exit_thread = threading.Thread(target=lambda: tc.__exit__(None, None, None), daemon=True)
+    exit_thread.start()
+    exit_thread.join(timeout=5)
+
+
+def _create_network(client) -> None:
+    resp = client.post(
+        "/v1/network",
+        json={"input_size": 2, "output_size": 2, "epochs_max": 5, "candidate_epochs": 2, "output_epochs": 2, "patience": 1},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Staging round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestStagingRoundTrip:
+    def test_post_then_get_pending_echoes_config(self, client):
+        _create_network(client)
+        cfg = {"dataset_type": "spirals", "n_samples": 200, "noise": 0.05}
+        resp = client.post("/v1/training/dataset", json=cfg)
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["data"]["status"] == "staged"
+        assert resp.json()["data"]["config"] == cfg
+
+        resp = client.get("/v1/training/dataset/pending")
+        assert resp.status_code == 200
+        assert resp.json()["data"]["pending"] == cfg
+
+    def test_delete_clears_pending(self, client):
+        _create_network(client)
+        client.post("/v1/training/dataset", json={"dataset_type": "spirals", "n_samples": 200})
+
+        resp = client.delete("/v1/training/dataset")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()["data"]
+        assert body["status"] == "cleared"
+        assert body["discarded"] == {"dataset_type": "spirals", "n_samples": 200}
+
+        resp = client.get("/v1/training/dataset/pending")
+        assert resp.json()["data"]["pending"] is None
+
+    def test_empty_post_clears_pending(self, client):
+        """Empty body should be idempotent with DELETE for the cleared case."""
+        _create_network(client)
+        client.post("/v1/training/dataset", json={"dataset_type": "spirals", "n_samples": 200})
+        resp = client.post("/v1/training/dataset", json={})
+        assert resp.status_code == 200
+        assert resp.json()["data"]["status"] == "cleared"
+        resp = client.get("/v1/training/dataset/pending")
+        assert resp.json()["data"]["pending"] is None
+
+    def test_unknown_dataset_type_rejected_422(self, client):
+        _create_network(client)
+        resp = client.post("/v1/training/dataset", json={"dataset_type": "lottery"})
+        assert resp.status_code == 422, resp.text  # pydantic Literal rejection
+
+
+# ---------------------------------------------------------------------------
+# Status payload
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestStatusPayload:
+    def test_status_includes_pending_dataset_field(self, client):
+        _create_network(client)
+        resp = client.get("/v1/training/status")
+        assert resp.status_code == 200
+        assert "pending_dataset" in resp.json()["data"]
+        assert resp.json()["data"]["pending_dataset"] is None
+
+    def test_status_reflects_staged_config(self, client):
+        _create_network(client)
+        cfg = {"dataset_type": "xor", "n_samples": 100}
+        client.post("/v1/training/dataset", json=cfg)
+        resp = client.get("/v1/training/status")
+        assert resp.json()["data"]["pending_dataset"] == cfg
+
+
+# ---------------------------------------------------------------------------
+# Reload-on-start (mocked juniper-data-client)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_juniper_data_client(monkeypatch):
+    """Install a fake ``juniper_data_client`` module so ``_reload_dataset``
+    works without a live juniper-data instance.
+
+    Returns the mock ``JuniperDataClient`` class so tests can configure
+    ``create_dataset`` / ``download_artifact_npz`` returns and assert on
+    call args.
+    """
+    module = types.ModuleType("juniper_data_client")
+    mock_client_cls = MagicMock()
+    mock_instance = MagicMock()
+    mock_instance.create_dataset.return_value = {"dataset_id": "fake-id-001"}
+    mock_instance.download_artifact_npz.return_value = {
+        "X_train": np.array([[0.0, 0.0], [1.0, 1.0], [0.5, 0.5], [0.2, 0.8]], dtype=np.float32),
+        "y_train": np.array([[1.0, 0.0], [0.0, 1.0], [1.0, 0.0], [0.0, 1.0]], dtype=np.float32),
+    }
+    mock_client_cls.return_value = mock_instance
+    module.JuniperDataClient = mock_client_cls  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "juniper_data_client", module)
+    return mock_client_cls, mock_instance
+
+
+@pytest.mark.integration
+def test_start_training_consumes_and_clears_staged_config(client, fake_juniper_data_client):
+    _, mock_instance = fake_juniper_data_client
+    _create_network(client)
+    cfg = {"dataset_type": "spirals", "n_samples": 4}
+    client.post("/v1/training/dataset", json=cfg)
+
+    # Provide inline data so start_training has *something* before reload runs.
+    client.post(
+        "/v1/training/start",
+        json={"inline_data": {"train_x": [[0.0, 0.0]], "train_y": [[1.0, 0.0]]}},
+    )
+
+    # Reload must have called the JuniperDataClient with the staged params.
+    mock_instance.create_dataset.assert_called_once()
+    call_kwargs = mock_instance.create_dataset.call_args.kwargs
+    assert call_kwargs["generator"] == "spirals"
+    assert call_kwargs["params"] == {"n_samples": 4}
+
+    # And the pending config must have been cleared.
+    resp = client.get("/v1/training/dataset/pending")
+    assert resp.json()["data"]["pending"] is None
+
+
+@pytest.mark.integration
+def test_reload_failure_keeps_pending_for_retry(client, fake_juniper_data_client):
+    """If juniper-data fails the fetch, the staged config must survive so the
+    user can fix the upstream issue and Restart-and-retry without re-clicking
+    Apply Dataset."""
+    _, mock_instance = fake_juniper_data_client
+    mock_instance.create_dataset.side_effect = RuntimeError("juniper-data down")
+
+    _create_network(client)
+    cfg = {"dataset_type": "spirals", "n_samples": 4}
+    client.post("/v1/training/dataset", json=cfg)
+
+    resp = client.post(
+        "/v1/training/start",
+        json={"inline_data": {"train_x": [[0.0, 0.0]], "train_y": [[1.0, 0.0]]}},
+    )
+    # start_training surfaces the RuntimeError as 4xx/5xx; the exact code
+    # depends on the route's exception handler, just assert it's not 200.
+    assert resp.status_code >= 400, resp.text
+
+    pending = client.get("/v1/training/dataset/pending").json()["data"]["pending"]
+    assert pending == cfg, "staged config should survive a reload failure"
+
+
+@pytest.mark.integration
+def test_start_training_without_pending_does_not_invoke_juniper_data(client, fake_juniper_data_client):
+    mock_cls, mock_instance = fake_juniper_data_client
+    _create_network(client)
+
+    client.post(
+        "/v1/training/start",
+        json={"inline_data": {"train_x": [[0.0, 0.0]], "train_y": [[1.0, 0.0]]}},
+    )
+    mock_cls.assert_not_called()
+    mock_instance.create_dataset.assert_not_called()


### PR DESCRIPTION
## Summary

Server-side half of [FRONTEND_ISSUES_PLAN_2026-05-09 §3.5.1 + §3.5.2 Phase 1](https://github.com/pcalnon/juniper-canopy/blob/main/notes/FRONTEND_ISSUES_PLAN_2026-05-09.md). Closes Issue #3's "Dataset View tab doesn't affect training" by giving the dashboard's Apply Dataset button a real backend.

> **Cross-repo lockstep partner: PR-7 (canopy UI + adapter wiring).** Independently safe to merge first since no canopy code yet calls the new endpoints — they're wired but unused on main until PR-7 lands.

## Surface area

### Three new REST routes (`api/routes/training.py`)

| Method | Path | Purpose |
|--------|------|---------|
| `POST` | `/v1/training/dataset` | Stage a config; returns `{status: "staged", config: {...}}`. Empty body clears (idempotent with DELETE). |
| `DELETE` | `/v1/training/dataset` | Phase 1 Cancel button target; returns `{status: "cleared", discarded: …}` so the canopy toast can show what was reverted. |
| `GET` | `/v1/training/dataset/pending` | Peek for the canopy banner; `{pending: null \| {...}}`. |

`StageDatasetRequest` body is fully optional (`dataset_type` Literal[spirals, xor, mnist, circles, moons], `n_samples`, `noise`, `rotations`, `n_spirals`) so canopy can build the body from whatever subset of dataset inputs the user touched.

### Lifecycle manager (`api/lifecycle/manager.py`)

- New `_pending_dataset_config: Optional[Dict[str, Any]]` initialised to `None`.
- New thread-safe `stage_dataset_config(**cfg)` / `clear_pending_dataset_config()` / `get_pending_dataset_config()` accessors.
- New `_reload_dataset(**cfg)` private method — instantiates a `JuniperDataClient` from env vars (mirrors `api/app.py::_auto_start_training`'s pattern), `create_dataset(generator=cfg['dataset_type'], params=…)`, `download_artifact_npz`, swaps `_train_x/_train_y` (and val tensors if the artifact carries `X_test`/`y_test`).
- `start_training` consumes the staged config before submitting the training future. **On reload failure the staged config survives** so the user can fix the upstream juniper-data issue and Restart-and-retry without losing their selection.
- `get_status` payload gains `pending_dataset` so the canopy banner can react without polling the dedicated GET route.

## Test plan

- [x] New `test_pending_dataset.py` (9 tests):
  - Staging round-trip: POST→GET echoes; DELETE clears; empty POST is idempotent with DELETE; unknown `dataset_type` 422'd by pydantic Literal.
  - Status payload: `pending_dataset` field present, reflects staging.
  - Reload-on-start (mocked `JuniperDataClient`): `start_training` calls `create_dataset` with the staged params + clears pending; reload failure surfaces an error AND keeps pending for retry; no pending → no juniper-data calls.
- [x] Lifecycle units (5 files) + integration api (full suite): exit 0, no regressions.
- [ ] Manual smoke (post-merge once PR-7 lands): Apply Dataset → restart → confirm new dataset is in use.

## Phase 2 reference

The richer "live dataset switch" UX is specified separately in [`notes/ISSUE_3_PHASE_2_LIVE_DATASET_SWAP_2026-05-09.md`](https://github.com/pcalnon/juniper-canopy/blob/main/notes/ISSUE_3_PHASE_2_LIVE_DATASET_SWAP_2026-05-09.md) (P2-1 … P2-7). Phase 2 builds on Phase 1's cold-swap behavior; nothing in this PR forecloses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)