### PR TITLE
feat(cascade): wire candidate-pool selection logic to PR-4a fields (Issue #1, PR-4b)

### DIFF
--- a/src/cascade_correlation/cascade_correlation.py
+++ b/src/cascade_correlation/cascade_correlation.py
@@ -3691,37 +3691,114 @@ class CascadeCorrelationNetwork:
         self.logger.info(f"CascadeCorrelationNetwork: add_unit: Current number of hidden units: {len(self.hidden_units)}")
         self.logger.trace("CascadeCorrelationNetwork: add_unit: Completed adding a new hidden unit.")
 
-    def _select_best_candidates(self, results: list, num_candidates: int = 1) -> list:
+    def _select_best_candidates(
+        self,
+        results: list,
+        num_candidates: int = 1,
+        *,
+        strategy: Optional[str] = None,
+        top_count: Optional[int] = None,
+        random_count: Optional[int] = None,
+    ) -> list:
         """
         Description:
-            Select top N candidates for layer addition.
+            Select N candidates for layer addition. Honors the strategy /
+            counts written by the canopy adapter via the PR-4a PATCH surface
+            (multi_candidate / candidate_selection / selected_candidates /
+            top_candidates / random_candidates).
         Args:
-            results: List of CandidateTrainingResult objects
-            num_candidates: Number of candidates to select
+            results: List of CandidateTrainingResult objects.
+            num_candidates: Total candidates to select (S in the §1.5 C2.1
+                triple). Defaults to 1, preserving the legacy single-best
+                behavior when called without strategy kwargs.
+            strategy: One of "top" / "random" / "mixed". If None, falls
+                back to ``self.candidate_selection`` (default "top").
+            top_count: T in the triple. When ``strategy=="mixed"``, the
+                first T picks are by descending correlation. Defaults to
+                ``self.top_candidates``.
+            random_count: R in the triple. When ``strategy=="mixed"``, the
+                last R picks are random from candidates remaining after the
+                top-T selection. Defaults to ``self.random_candidates``.
         Notes:
-            - Candidates are sorted by absolute correlation.
-            - Top N candidates are selected.
-            - Candidates below a correlation threshold are filtered out.
+            - Threshold filtering (``correlation_threshold``) is applied to
+              the *pool* before selection — random/mixed picks never include
+              below-threshold candidates.
+            - Numerical determinism for ``random``/``mixed`` uses
+              ``random.Random(self.random_seed)`` if a seed exists, else
+              the module ``random`` singleton.
         Returns:
-            List of selected CandidateTrainingResult objects
+            List of selected CandidateTrainingResult objects (length <= S).
         """
-        self.logger.debug(f"CascadeCorrelationNetwork: _select_best_candidates: Selecting top {num_candidates} from {len(results)} candidates")
+        strategy = strategy or getattr(self, "candidate_selection", "top") or "top"
+        if top_count is None:
+            top_count = getattr(self, "top_candidates", num_candidates)
+        if random_count is None:
+            random_count = getattr(self, "random_candidates", 0)
 
-        # Sort by absolute correlation
-        sorted_results = sorted(
-            results,
-            key=lambda r: abs(r.correlation) if r.correlation else 0,
-            reverse=True,
-        )
+        self.logger.debug(f"CascadeCorrelationNetwork: _select_best_candidates: strategy={strategy!r} S={num_candidates} T={top_count} R={random_count} pool={len(results)}")
 
-        # Select top N
-        selected = sorted_results[:num_candidates]
-
-        # Filter by threshold
+        # Threshold filter first — every strategy honors it.
         threshold = getattr(self, "correlation_threshold", 0.0)
-        selected = [r for r in selected if abs(r.correlation) >= threshold]
-        self.logger.info(f"CascadeCorrelationNetwork: _select_best_candidates: Selected {len(selected)} candidates with correlations: {[r.correlation for r in selected]}")
+        eligible = [r for r in results if r.correlation is not None and abs(r.correlation) >= threshold]
+        if not eligible:
+            self.logger.info("CascadeCorrelationNetwork: _select_best_candidates: no candidates above correlation_threshold")
+            return []
+
+        # Sort by absolute correlation (descending) — used as the input order
+        # for top-N and as the "remainder pool" for mixed.
+        sorted_eligible = sorted(eligible, key=lambda r: abs(r.correlation), reverse=True)
+
+        if strategy == "top":
+            selected = sorted_eligible[:num_candidates]
+        elif strategy == "random":
+            # Uniform pick from the eligible pool. ``num_candidates`` is the
+            # upper bound; if the pool has fewer eligible members we just
+            # return all of them.
+            rng = self._candidate_selection_rng()
+            selected = list(rng.sample(sorted_eligible, min(num_candidates, len(sorted_eligible))))
+        elif strategy == "mixed":
+            # T picks by descending correlation, then R uniform random from
+            # the remainder. The §1.5 C2.1 invariant guarantees T+R==S when
+            # both nonzero, but we defensively bound by ``len(sorted_eligible)``.
+            top_slice = sorted_eligible[:top_count]
+            remainder = sorted_eligible[top_count:]
+            rng = self._candidate_selection_rng()
+            random_slice = list(rng.sample(remainder, min(random_count, len(remainder))))
+            selected = top_slice + random_slice
+        else:
+            self.logger.warning(f"CascadeCorrelationNetwork: _select_best_candidates: unknown strategy {strategy!r}, falling back to 'top'")
+            selected = sorted_eligible[:num_candidates]
+
+        self.logger.info(f"CascadeCorrelationNetwork: _select_best_candidates: Selected {len(selected)} via {strategy!r} with correlations: {[round(r.correlation, 4) for r in selected]}")
         return selected
+
+    def _candidate_selection_rng(self) -> random.Random:
+        """Return a deterministic RNG seeded from the network's ``random_seed``
+        if available, else the module ``random`` singleton.
+
+        Local instance so a parallel candidate-training pass on another
+        thread doesn't perturb this selection's draw sequence.
+        """
+        seed = getattr(self, "random_seed", None)
+        return random.Random(seed) if seed is not None else random.Random()
+
+    def _effective_candidate_count(self) -> int:
+        """How many candidates ``grow_network`` should promote per iteration.
+
+        Resolution order (first match wins):
+
+          1. ``self.candidates_per_layer`` if > 1 — legacy attribute that
+             scripted runs may have set; preserved for backward compatibility.
+          2. ``self.selected_candidates`` if ``self.multi_candidate`` is True
+             — the PR-4a PATCH-surface knobs.
+          3. 1 — the single-best-candidate path.
+        """
+        legacy_count = getattr(self, "candidates_per_layer", None)
+        if legacy_count is not None and legacy_count > 1:
+            return int(legacy_count)
+        if getattr(self, "multi_candidate", False):
+            return int(getattr(self, "selected_candidates", 1))
+        return 1
 
     def add_units_as_layer(self, candidates: list, x: torch.Tensor) -> None:
         """
@@ -3883,19 +3960,22 @@ class CascadeCorrelationNetwork:
                     all_correlations=list(_correlations),
                 )
 
-            # Determine number of candidates to add
-            candidates_per_layer = getattr(self, "candidates_per_layer", 1)
+            # FRONTEND_ISSUES_PLAN_2026-05-09 §1.5 C2 / Issue #1 — multi-candidate
+            # promotion plus the (S, T, R) selection-strategy triple, wired
+            # through the PR-4a PATCH surface (multi_candidate /
+            # candidate_selection / selected_candidates / top/random_candidates).
+            effective_count = self._effective_candidate_count()
 
             # Add candidate(s) to the network and retrain the output layer
-            if candidates_per_layer > 1:
+            if effective_count > 1:
                 if selected_candidates := self._select_best_candidates(
                     training_results.candidate_objects,
-                    num_candidates=candidates_per_layer,
+                    num_candidates=effective_count,
                 ):
                     self.add_units_as_layer([c for c in selected_candidates if c.candidate], x_train)
                     train_loss = self.train_output_layer(x_train, y_train, self.output_epochs)
                     train_accuracy = self.get_accuracy(x_train, y_train)
-                    self.logger.info(f"CascadeCorrelationNetwork: grow_network: Added {len(selected_candidates)} candidates as layer")
+                    self.logger.info(f"CascadeCorrelationNetwork: grow_network: Added {len(selected_candidates)} candidates as layer (strategy={getattr(self, 'candidate_selection', 'top')!r})")
                 else:
                     self.logger.warning("CascadeCorrelationNetwork: grow_network: No candidates met selection criteria")
                     break

--- a/src/tests/unit/cascade_correlation/test_select_best_candidates.py
+++ b/src/tests/unit/cascade_correlation/test_select_best_candidates.py
@@ -1,0 +1,240 @@
+"""§1.5 C2 (Issue #1, PR-4b) — _select_best_candidates strategy paths.
+
+Three strategies in scope:
+
+  - "top": pick the N highest-correlation candidates (legacy behavior).
+  - "random": pick N uniformly at random from the eligible pool.
+  - "mixed": pick T highest-correlation + R random from the remainder
+    (the §1.5 C2.1 invariant guarantees T+R==S when both nonzero).
+
+Threshold filtering (``correlation_threshold``) applies to every
+strategy — random/mixed picks never include below-threshold candidates.
+
+PR-4a shipped the schema + invariant validator. PR-4b wires those
+fields into selection here.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
+from candidate_unit.candidate_unit import CandidateTrainingResult
+
+
+def _make_pool(correlations: list[float]) -> list[CandidateTrainingResult]:
+    """Build a list of CandidateTrainingResult fakes with the given correlations."""
+    pool = []
+    for i, corr in enumerate(correlations):
+        result = CandidateTrainingResult(
+            candidate_id=i,
+            correlation=corr,
+            candidate=MagicMock(name=f"candidate-{i}"),
+            success=True,
+        )
+        pool.append(result)
+    return pool
+
+
+def _make_network(**attrs):
+    """Bare CascadeCorrelationNetwork — only the attrs the selector reads."""
+    net = CascadeCorrelationNetwork.__new__(CascadeCorrelationNetwork)
+    import logging
+
+    net.logger = logging.getLogger("test_select")
+    net.correlation_threshold = attrs.pop("correlation_threshold", 0.0)
+    net.candidate_selection = attrs.pop("candidate_selection", "top")
+    net.top_candidates = attrs.pop("top_candidates", 1)
+    net.random_candidates = attrs.pop("random_candidates", 0)
+    # random_seed=42 makes random/mixed picks deterministic across runs.
+    net.random_seed = attrs.pop("random_seed", 42)
+    return net
+
+
+# ---------------------------------------------------------------------------
+# top strategy (legacy behavior)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTopStrategy:
+    def test_top_picks_highest_correlations_in_order(self):
+        net = _make_network()
+        pool = _make_pool([0.1, 0.9, 0.5, 0.7, 0.3])
+        selected = net._select_best_candidates(pool, num_candidates=3, strategy="top")
+        # Sorted descending by abs(correlation): 0.9, 0.7, 0.5
+        assert [r.correlation for r in selected] == [0.9, 0.7, 0.5]
+
+    def test_top_handles_negative_correlations_via_abs(self):
+        net = _make_network()
+        pool = _make_pool([-0.95, 0.1, -0.4, 0.2])
+        selected = net._select_best_candidates(pool, num_candidates=2, strategy="top")
+        # |-0.95| > |0.2|; -0.95 wins; next is |-0.4| > |0.1|
+        assert [r.correlation for r in selected] == [-0.95, -0.4]
+
+    def test_top_strategy_default_when_unspecified(self):
+        net = _make_network(candidate_selection="top")
+        pool = _make_pool([0.1, 0.9, 0.5])
+        # No explicit strategy kwarg — falls back to self.candidate_selection.
+        selected = net._select_best_candidates(pool, num_candidates=2)
+        assert [r.correlation for r in selected] == [0.9, 0.5]
+
+
+# ---------------------------------------------------------------------------
+# Threshold filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestThresholdFilter:
+    def test_threshold_excludes_below_min_correlation(self):
+        net = _make_network(correlation_threshold=0.5)
+        pool = _make_pool([0.1, 0.9, 0.3, 0.6, 0.49])
+        # Only 0.9 and 0.6 are >= 0.5.
+        selected = net._select_best_candidates(pool, num_candidates=5, strategy="top")
+        assert sorted(r.correlation for r in selected) == [0.6, 0.9]
+
+    def test_empty_when_nothing_above_threshold(self):
+        net = _make_network(correlation_threshold=0.99)
+        pool = _make_pool([0.1, 0.5, 0.9])
+        selected = net._select_best_candidates(pool, num_candidates=3, strategy="top")
+        assert selected == []
+
+
+# ---------------------------------------------------------------------------
+# random strategy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRandomStrategy:
+    def test_random_returns_n_from_eligible_pool(self):
+        net = _make_network(random_seed=42)
+        pool = _make_pool([0.1, 0.9, 0.5, 0.7, 0.3, 0.4])
+        selected = net._select_best_candidates(pool, num_candidates=3, strategy="random")
+        assert len(selected) == 3
+        # All picks come from the original pool (no fabricated entries).
+        assert {id(r) for r in selected} <= {id(r) for r in pool}
+
+    def test_random_with_seed_is_deterministic(self):
+        net1 = _make_network(random_seed=7)
+        net2 = _make_network(random_seed=7)
+        pool = _make_pool([0.1, 0.9, 0.5, 0.7, 0.3, 0.4])
+        s1 = net1._select_best_candidates(pool, num_candidates=3, strategy="random")
+        s2 = net2._select_best_candidates(pool, num_candidates=3, strategy="random")
+        assert [r.candidate_id for r in s1] == [r.candidate_id for r in s2]
+
+    def test_random_does_not_always_pick_top_correlations(self):
+        """Distinguishes random from top — the union of picks across many
+        calls should contain at least one non-top candidate."""
+        # Different seed each call to span the sample space.
+        pool = _make_pool([0.1, 0.9, 0.5, 0.7, 0.3, 0.2])
+        all_picks: set[int] = set()
+        for seed in range(20):
+            net = _make_network(random_seed=seed)
+            sel = net._select_best_candidates(pool, num_candidates=2, strategy="random")
+            all_picks.update(r.candidate_id for r in sel)
+        # Across 20 seeds × 2 picks we should see candidates that aren't the top-2.
+        # Top-2 by correlation: id=1 (0.9), id=3 (0.7). Anything else proves randomness.
+        non_top_seen = all_picks - {1, 3}
+        assert non_top_seen, f"random strategy never picked a non-top candidate across 20 seeds: {all_picks}"
+
+    def test_random_honors_threshold(self):
+        net = _make_network(correlation_threshold=0.5, random_seed=1)
+        pool = _make_pool([0.1, 0.9, 0.3, 0.6, 0.49, 0.7])
+        selected = net._select_best_candidates(pool, num_candidates=5, strategy="random")
+        for r in selected:
+            assert abs(r.correlation) >= 0.5, f"random pick {r.correlation} below threshold"
+
+
+# ---------------------------------------------------------------------------
+# mixed strategy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMixedStrategy:
+    def test_mixed_t2_r2_picks_top_two_plus_two_random(self):
+        net = _make_network(random_seed=42)
+        pool = _make_pool([0.1, 0.9, 0.5, 0.7, 0.3, 0.4, 0.2])
+        selected = net._select_best_candidates(pool, num_candidates=4, strategy="mixed", top_count=2, random_count=2)
+        assert len(selected) == 4
+        # First 2 are deterministic (top by correlation): 0.9 and 0.7.
+        assert [r.correlation for r in selected[:2]] == [0.9, 0.7]
+        # Last 2 are random from {0.5, 0.4, 0.3, 0.2, 0.1} (post-top remainder).
+        random_corrs = [r.correlation for r in selected[2:]]
+        assert all(c in {0.5, 0.4, 0.3, 0.2, 0.1} for c in random_corrs), random_corrs
+
+    def test_mixed_uses_self_attrs_when_kwargs_omitted(self):
+        net = _make_network(candidate_selection="mixed", top_candidates=3, random_candidates=1, random_seed=42)
+        pool = _make_pool([0.1, 0.9, 0.5, 0.7, 0.3, 0.4])
+        selected = net._select_best_candidates(pool, num_candidates=4)
+        assert len(selected) == 4
+        # First 3 are top by correlation: 0.9, 0.7, 0.5.
+        assert [r.correlation for r in selected[:3]] == [0.9, 0.7, 0.5]
+
+    def test_mixed_with_t_zero_is_pure_random(self):
+        net = _make_network(random_seed=42)
+        pool = _make_pool([0.1, 0.9, 0.5, 0.7, 0.3])
+        selected = net._select_best_candidates(pool, num_candidates=3, strategy="mixed", top_count=0, random_count=3)
+        assert len(selected) == 3
+
+    def test_mixed_with_r_zero_is_pure_top(self):
+        net = _make_network(random_seed=42)
+        pool = _make_pool([0.1, 0.9, 0.5, 0.7, 0.3])
+        selected = net._select_best_candidates(pool, num_candidates=3, strategy="mixed", top_count=3, random_count=0)
+        assert [r.correlation for r in selected] == [0.9, 0.7, 0.5]
+
+
+# ---------------------------------------------------------------------------
+# Unknown strategy fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_unknown_strategy_falls_back_to_top():
+    net = _make_network()
+    pool = _make_pool([0.1, 0.9, 0.5])
+    selected = net._select_best_candidates(pool, num_candidates=2, strategy="lottery")
+    assert [r.correlation for r in selected] == [0.9, 0.5]
+
+
+# ---------------------------------------------------------------------------
+# _effective_candidate_count — wires the multi_candidate + selected_candidates
+# PATCH-surface knobs into the grow_network branch selector.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestEffectiveCandidateCount:
+    def _net(self, **attrs):
+        net = CascadeCorrelationNetwork.__new__(CascadeCorrelationNetwork)
+        # Defaults match what __init__ would set.
+        net.multi_candidate = attrs.get("multi_candidate", False)
+        net.selected_candidates = attrs.get("selected_candidates", 1)
+        if "candidates_per_layer" in attrs:
+            net.candidates_per_layer = attrs["candidates_per_layer"]
+        return net
+
+    def test_default_is_one_for_legacy_single_candidate_path(self):
+        assert self._net()._effective_candidate_count() == 1
+
+    def test_multi_candidate_off_returns_one_regardless_of_S(self):
+        net = self._net(multi_candidate=False, selected_candidates=4)
+        assert net._effective_candidate_count() == 1
+
+    def test_multi_candidate_on_returns_selected_candidates(self):
+        net = self._net(multi_candidate=True, selected_candidates=4)
+        assert net._effective_candidate_count() == 4
+
+    def test_legacy_candidates_per_layer_wins_when_gt_one(self):
+        net = self._net(multi_candidate=True, selected_candidates=4, candidates_per_layer=8)
+        assert net._effective_candidate_count() == 8
+
+    def test_legacy_candidates_per_layer_one_does_not_force_single(self):
+        """Setting candidates_per_layer=1 explicitly shouldn't force single-
+        candidate when multi_candidate is True with S>1."""
+        net = self._net(multi_candidate=True, selected_candidates=3, candidates_per_layer=1)
+        assert net._effective_candidate_count() == 3


### PR DESCRIPTION
## Summary

Closes the "PR-4a fields are storage-only" caveat from [cascor #241](https://github.com/pcalnon/juniper-cascor/pull/241). The PATCH-surface knobs that PR-4a + canopy PR-5 wired through (`multi_candidate` / `candidate_selection` / `selected_candidates` / `top_candidates` / `random_candidates`) now actually affect candidate promotion in `grow_network`. Issue #1's user-visible round-trip is now fully behavior-bearing.

> **Defaults preserve current behavior exactly:** `multi_candidate=False` + `selected_candidates=1` + `candidate_selection="top"` ⇒ single-best-candidate path, identical to the pre-PR-4b sort-by-correlation pick. The legacy `self.candidates_per_layer` attribute still wins when set so existing scripted runs (cascor end-to-end tests etc.) are unaffected.

## What ships (`cascade_correlation.py`)

### `_select_best_candidates` extended with strategy paths

```python
def _select_best_candidates(
    results, num_candidates=1,
    *, strategy=None, top_count=None, random_count=None,
) -> list: ...
```

| strategy | behavior |
|----------|----------|
| `"top"` | current behavior — top-N by absolute correlation |
| `"random"` | uniform pick from the eligible (above-threshold) pool; determinism via `random.Random(self.random_seed)` |
| `"mixed"` | top T highest-correlation + R uniform random from the remainder; the §1.5 C2.1 invariant guarantees `T+R==S` when both nonzero |
| unknown | falls back to `"top"` with a warning |

Threshold filtering (`correlation_threshold`) is applied to the *pool* before selection — random/mixed picks never include below-threshold candidates.

### New `_effective_candidate_count` helper

Extracts the resolution order so `grow_network`'s branch selector is one line and the logic is unit-testable in isolation:

1. `self.candidates_per_layer` if `> 1` (legacy backward-compat).
2. `self.selected_candidates` if `self.multi_candidate` is `True` (the PR-4a knobs).
3. `1` (single-best-candidate path).

### New `_candidate_selection_rng` helper

Returns a `random.Random` instance seeded from `self.random_seed` if available — local instance so a parallel candidate-training pass on another thread doesn't perturb this selection's draw sequence.

## Tests (19 new, all green)

`src/tests/unit/cascade_correlation/test_select_best_candidates.py`:

| Block | Cases |
|-------|-------|
| `top` strategy | highest-correlation order; negative correlations via abs; default fallback to `self.candidate_selection` |
| `threshold` filter | excludes below-min, returns `[]` when nothing eligible |
| `random` strategy | returns N from eligible pool; deterministic with seed; doesn't always pick top-N (proven across 20 seeds); honors threshold |
| `mixed` strategy | T-then-R pick order; reads `self.*` defaults when kwargs omitted; T=0 ⇒ pure random; R=0 ⇒ pure top |
| unknown strategy | falls back to "top" |
| `_effective_candidate_count` | defaults to 1; multi_candidate=False forces 1 regardless of S; multi_candidate=True returns selected_candidates; legacy candidates_per_layer wins when > 1; candidates_per_layer=1 doesn't suppress the multi_candidate path |

## Test plan

- [x] `pytest src/tests/unit/cascade_correlation/test_select_best_candidates.py` — 19/19
- [x] Lifecycle units (5 files) + integration api (full suite): exit 0, no behavior regressions for default config
- [ ] Manual smoke after merge: PATCH `{multi_candidate: true, selected_candidates: 4, candidate_selection: "mixed", top_candidates: 2, random_candidates: 2, candidate_pool_size: 8}`, train on a small dataset, observe 4 candidates added per growth iteration with the top-2 + random-2 split

## Issue #1 status

| PR | Description | Status |
|----|-------------|--------|
| PR-4a (cascor #241) | candidate-pool schema + invariant validator | ✅ merged |
| PR-2 (canopy) | Apply toast surfaces dropped keys | ✅ merged |
| PR-5 (canopy) | adapter map ext + clientside validator + roundtrip verify | ✅ merged |
| **PR-4b (this PR)** | **selection-logic wiring — storage → behavior** | open |

Issue #1's user-visible round-trip closes when this merges: canopy form → adapter map → cascor PATCH → network attrs → `grow_network` candidate selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)