### PR TITLE
fix(lifecycle): make pause_training and stop_training actually interrupt training

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -82,6 +82,23 @@ class InvalidCandidatePoolError(ValueError):
     """
 
 
+class TrainingInterrupted(Exception):
+    """Sentinel raised from training-loop callbacks when the user requests stop.
+
+    Pre-2026-05-10 the ``pause_training`` and ``stop_training`` REST endpoints
+    set ``_pause_event`` / ``_stop_requested`` and transitioned the FSM, but the
+    flags were never observed inside ``cascade_correlation.fit()`` — training
+    ran to natural completion regardless. The fix wires signal checks into the
+    ``_output_training_callback`` and ``_grow_iteration_callback`` hook points;
+    when ``_stop_requested`` is set, the callback raises this sentinel which
+    ``monitored_fit`` catches as a clean cancellation (FSM → STOP, status
+    Stopped, cancelled-counter incremented; not a failure).
+
+    See ``ISSUE_3_PHASE_2_LIVE_DATASET_SWAP_2026-05-09.md`` §3.4 audit findings
+    for the original defect documentation; this fix is P2-PRE-1 of that plan.
+    """
+
+
 def _validate_candidate_pool_triple(s: int, t: int, r: int, p: int) -> Optional[str]:
     """Return ``None`` if (S, T, R, P) satisfy the §1.5 C2.1 invariant or a
     human-readable violation string otherwise.
@@ -1339,7 +1356,33 @@ class TrainingLifecycleManager:
     # Monitoring hooks (monkey-patch approach from CascorIntegration)
     # ------------------------------------------------------------------
 
-    def _install_monitoring_hooks(self) -> None:
+    def _check_for_interrupt(self) -> None:
+        """Raise ``TrainingInterrupted`` on stop request; block on pause.
+
+        Called from the training-loop callbacks installed by
+        ``_install_monitoring_hooks`` (output-epoch + grow-iteration boundaries).
+        Pre-2026-05-10 the ``pause_training`` and ``stop_training`` REST endpoints
+        were observably no-ops at the training-loop level — they updated the FSM
+        but the loop never observed the events. This method is the missing hook.
+
+        The pause wait uses a 0.5 s timeout so a stop request received WHILE
+        paused is observed promptly (the loop re-checks ``_stop_requested`` on
+        each wakeup). Without the timeout, a stop after pause would block forever
+        since ``_pause_event`` would still be cleared.
+
+        Defined as an instance method (rather than a closure inside
+        ``_install_monitoring_hooks``) so it's reachable from
+        ``_install_grow_network_hook`` (which lives in a separate method scope)
+        and so tests can invoke it directly via ``mgr._check_for_interrupt()``.
+        """
+        if self._stop_requested.is_set():
+            raise TrainingInterrupted("stop_requested")
+        while not self._pause_event.is_set():
+            self._pause_event.wait(timeout=0.5)
+            if self._stop_requested.is_set():
+                raise TrainingInterrupted("stop_requested_during_pause")
+
+    def _install_monitoring_hooks(self) -> None:  # noqa: C901
         """Install monitoring hooks on the network via monkey-patching.
 
         Hooks:
@@ -1359,6 +1402,13 @@ class TrainingLifecycleManager:
         sm = self.state_machine
         manager_ref = self
 
+        # P2-PRE-1 (2026-05-10): _check_for_interrupt is an instance method (see
+        # ``TrainingLifecycleManager._check_for_interrupt`` below). It's called
+        # from both _output_training_callback (this module) and _grow_iteration_callback
+        # (which lives in _install_grow_network_hook, a different method) — making
+        # it an instance method instead of a closure puts it in a single shared
+        # scope and lets tests invoke it directly via ``mgr._check_for_interrupt()``.
+
         # METRICS-MON R5.4-pre: per-fit closure box that holds the
         # ``time.perf_counter()`` of the most recent epoch boundary so
         # ``_output_training_callback`` can compute the train-step
@@ -1371,6 +1421,11 @@ class TrainingLifecycleManager:
         _step_timer: dict[str, float | None] = {"prev": None}
 
         def _output_training_callback(epoch, epochs, loss):
+            # P2-PRE-1 (2026-05-10): check pause/stop signals BEFORE emitting metrics.
+            # Raises TrainingInterrupted on stop; blocks here while paused. Called
+            # every 25 output epochs (or last epoch) per train_output_layer's
+            # callback contract — that's the natural pause boundary.
+            manager_ref._check_for_interrupt()
             monitor.on_epoch_end(
                 epoch=epoch,
                 loss=loss,
@@ -1420,8 +1475,13 @@ class TrainingLifecycleManager:
             state.update_state(status="Started", phase="Output", phase_started_at=datetime.now().isoformat())
             manager_ref._broadcast_training_state(force=True)
 
-            # Inject output training callback (Approach B — attribute fallback)
-            manager_ref.network._output_epoch_callback = _output_training_callback
+            # P2-PRE-1 (2026-05-10): the _output_epoch_callback / _grow_iteration_callback
+            # bindings on the network were moved from here (and from monitored_grow)
+            # down to install-time (after the closure definitions, before the network.fit
+            # replacement). Binding at install time removes a subtle race window where
+            # the callbacks were absent between create_network and the first fit() call,
+            # and lets tests drive _check_for_interrupt via the bound callbacks without
+            # having to first start a real fit.
 
             # OBS-WIRE-01 (A.1): mark the session active. Paired with
             # the ``dec_training_sessions`` call in the ``finally``
@@ -1467,6 +1527,20 @@ class TrainingLifecycleManager:
                     inc_training_session_completed(TRAINING_SESSION_STATUS_SUCCESS)
 
                 return result
+            except TrainingInterrupted:
+                # P2-PRE-1 (2026-05-10): clean cancellation path. Raised by
+                # _check_for_interrupt() in the training-loop callbacks when
+                # _stop_requested is set. Treated as a successful stop, NOT a
+                # failure: same FSM/state transitions and gauge increments as
+                # the post-fit stop_event path above (lines 1500–1506), so a
+                # mid-fit stop and a post-fit stop produce the same observable
+                # state. Don't re-raise — the user requested this; it's not an
+                # error from the API perspective.
+                sm.handle_command(Command.STOP)
+                state.update_state(status="Stopped", phase="Idle")
+                manager_ref._broadcast_training_state(force=True)
+                inc_training_session_completed(TRAINING_SESSION_STATUS_CANCELLED)
+                return None
             except Exception as e:
                 sm.mark_failed(str(e))
                 state.update_state(status="Failed", phase="Idle")
@@ -1486,6 +1560,14 @@ class TrainingLifecycleManager:
                 except Exception:
                     manager_ref.logger.debug("dec_training_sessions emission failed", exc_info=True)
                 monitor.on_training_end()
+
+        # P2-PRE-1 (2026-05-10): bind the output-epoch callback at install time
+        # (was previously bound inside monitored_fit on first invocation, leaving
+        # a window where the attribute was absent between create_network and
+        # the first fit() call). Bind-at-install also lets the new
+        # test_pause_stop_actually_interrupts.py tests drive the callback
+        # directly without first having to start a real fit.
+        self.network._output_epoch_callback = _output_training_callback
 
         self.network.fit = monitored_fit
 
@@ -1575,6 +1657,12 @@ class TrainingLifecycleManager:
         self._original_methods["grow_network"] = original_grow
 
         def _grow_iteration_callback(iteration, max_iterations, best_correlation, candidates_trained, candidates_total, phase_detail, **kwargs):
+            # P2-PRE-1 (2026-05-10): pause/stop check at the cascade-iteration boundary.
+            # Pause inside the multiprocessing candidate-training pool is intentionally
+            # out of scope for this fix — the iteration boundary is the natural pause
+            # point for the cascade-growth loop. (Tighter granularity within candidate
+            # training would require multiprocessing-aware signal threading.)
+            manager_ref._check_for_interrupt()
             state.update_state(
                 grow_iteration=iteration,
                 grow_max=max_iterations,
@@ -1601,8 +1689,8 @@ class TrainingLifecycleManager:
             state.update_state(phase="Candidate", phase_started_at=datetime.now().isoformat())
             manager_ref._broadcast_training_state(force=True)
 
-            # Inject grow iteration callback (Approach B — attribute fallback)
-            manager_ref.network._grow_iteration_callback = _grow_iteration_callback
+            # P2-PRE-1 (2026-05-10): _grow_iteration_callback binding moved to
+            # install time (see corresponding comment in monitored_fit above).
 
             # Start drain thread for candidate progress from worker pool.
             # Always started unconditionally — uses deferred queue discovery
@@ -1660,6 +1748,10 @@ class TrainingLifecycleManager:
             # Catch-all for any remaining metrics
             manager_ref._extract_and_record_metrics()
             return result
+
+        # P2-PRE-1 (2026-05-10): bind the grow-iteration callback at install time
+        # (see corresponding comment in _install_monitoring_hooks above).
+        self.network._grow_iteration_callback = _grow_iteration_callback
 
         self.network.grow_network = monitored_grow
 

--- a/src/tests/integration/api/test_pause_stop_actually_interrupts.py
+++ b/src/tests/integration/api/test_pause_stop_actually_interrupts.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python
+"""Regression tests for P2-PRE-1: pause/stop actually interrupt training.
+
+Pre-fix (HEAD 2069930), ``pause_training`` and ``stop_training`` REST endpoints
+set ``_pause_event`` / ``_stop_requested`` and transitioned the FSM, but the
+flags were never observed inside ``cascade_correlation.fit()`` or any inner
+training loop — there are zero references to ``Event``/``wait``/``pause``/
+``threading`` in ``cascade_correlation.py``. The two callbacks wired into the
+training loop (``_output_training_callback``, ``_grow_iteration_callback``)
+were pure metric-emission sinks. ``_stop_requested.is_set()`` was checked only
+*after* ``original_fit()`` returned naturally — by which point fit had already
+run to completion. **Result**: pause and stop were observably no-ops at the
+training-loop level; training ran to natural completion regardless.
+
+The fix wires ``_check_for_interrupt()`` into both callbacks. It raises
+``TrainingInterrupted`` when ``_stop_requested`` is set, and blocks on
+``_pause_event.wait(timeout=0.5)`` when paused (re-checking ``_stop_requested``
+every 0.5 s so a Stop-during-Pause is observed promptly). ``monitored_fit``
+catches ``TrainingInterrupted`` as a clean cancellation: same FSM/state/gauge
+transitions as the post-fit stop-event path, no exception propagated.
+
+These tests pin the contract by invoking the installed callbacks directly via
+``network._output_epoch_callback`` and ``network._grow_iteration_callback``
+(the attribute-fallback hook points at ``cascade_correlation.py:1668`` and
+``cascade_correlation.py:3942``). Driving the callbacks directly avoids the
+need to start a real fit() while still exercising the exact closure-captured
+signal-checking code path.
+
+See ``ISSUE_3_PHASE_2_LIVE_DATASET_SWAP_2026-05-09.md`` §3.4 for the audit
+record and the full P2-PRE-1 / Phase 2 plan.
+"""
+
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from api.lifecycle.manager import TrainingInterrupted, TrainingLifecycleManager
+from api.lifecycle.state_machine import Command
+
+
+@pytest.fixture
+def mgr_with_hooks():
+    """Manager with a network and monitoring hooks installed.
+
+    ``_install_monitoring_hooks`` builds the ``_check_for_interrupt`` closure
+    and assigns ``_output_training_callback`` / ``_grow_iteration_callback``
+    to the network as attribute-fallback hooks. After this fixture the
+    callbacks can be invoked directly via ``mgr.network._output_epoch_callback``
+    and ``mgr.network._grow_iteration_callback`` without starting fit().
+    """
+    mgr = TrainingLifecycleManager()
+    mgr.create_network(input_size=2, output_size=2)
+    mgr._install_monitoring_hooks()
+    yield mgr
+    mgr.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Output-training callback: stop & pause signal checks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_output_callback_raises_on_stop_signal(mgr_with_hooks):
+    """When _stop_requested is set, the output callback raises TrainingInterrupted."""
+    mgr = mgr_with_hooks
+    mgr._stop_requested.set()
+    with pytest.raises(TrainingInterrupted, match="stop_requested"):
+        mgr.network._output_epoch_callback(epoch=1, epochs=10, loss=0.5)
+
+
+@pytest.mark.integration
+def test_output_callback_returns_normally_when_not_paused_or_stopped(mgr_with_hooks):
+    """Default state (pause set, stop clear) — callback returns without raising."""
+    mgr = mgr_with_hooks
+    # __init__ sets _pause_event and clears _stop_requested; double-check.
+    assert mgr._pause_event.is_set()
+    assert not mgr._stop_requested.is_set()
+    # Should not raise; just emit metrics + return None.
+    result = mgr.network._output_epoch_callback(epoch=1, epochs=10, loss=0.5)
+    assert result is None
+
+
+@pytest.mark.integration
+def test_output_callback_blocks_on_pause_then_resumes(mgr_with_hooks):
+    """Clear pause → callback blocks; setting pause from another thread → callback returns."""
+    mgr = mgr_with_hooks
+    mgr._pause_event.clear()  # paused
+    callback_done = threading.Event()
+
+    def _run_callback():
+        mgr.network._output_epoch_callback(epoch=1, epochs=10, loss=0.5)
+        callback_done.set()
+
+    t = threading.Thread(target=_run_callback, daemon=True)
+    t.start()
+
+    # Should NOT complete while paused.
+    assert not callback_done.wait(timeout=1.0), "callback returned early — pause was not observed"
+
+    # Resume: setting pause_event unblocks the wait loop.
+    mgr._pause_event.set()
+    assert callback_done.wait(timeout=2.0), "callback did not return within 2s of resume"
+    t.join(timeout=1.0)
+
+
+@pytest.mark.integration
+def test_output_callback_raises_on_stop_during_pause(mgr_with_hooks):
+    """Paused; setting _stop_requested wakes the wait loop and raises TrainingInterrupted.
+
+    Critical: pre-fix this scenario was impossible (callbacks ignored signals).
+    Post-fix the wait loop's 0.5s timeout ensures a stop after pause is observed
+    promptly — without the timeout the callback would block forever waiting for
+    a resume that's never coming.
+    """
+    mgr = mgr_with_hooks
+    mgr._pause_event.clear()  # paused
+    raised: list[Exception] = []
+    callback_done = threading.Event()
+
+    def _run_callback():
+        try:
+            mgr.network._output_epoch_callback(epoch=1, epochs=10, loss=0.5)
+        except Exception as e:
+            raised.append(e)
+        finally:
+            callback_done.set()
+
+    t = threading.Thread(target=_run_callback, daemon=True)
+    t.start()
+    time.sleep(0.1)  # let the callback enter the wait loop
+
+    mgr._stop_requested.set()
+    assert callback_done.wait(timeout=2.0), "callback did not exit within 2s of stop"
+    t.join(timeout=1.0)
+    assert len(raised) == 1, f"expected exactly one exception, got {raised!r}"
+    assert isinstance(raised[0], TrainingInterrupted)
+    assert "stop_requested_during_pause" in str(raised[0])
+
+
+# ---------------------------------------------------------------------------
+# Grow-iteration callback: same contract at the cascade-iteration boundary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_grow_callback_raises_on_stop_signal(mgr_with_hooks):
+    """Grow-iteration callback also honours stop. Pause inside multiprocessing
+    candidate training is intentionally out of scope (would require
+    multiprocessing-aware signal threading); the iteration boundary is the
+    natural pause point for the cascade-growth loop."""
+    mgr = mgr_with_hooks
+    mgr._stop_requested.set()
+    with pytest.raises(TrainingInterrupted, match="stop_requested"):
+        mgr.network._grow_iteration_callback(
+            iteration=1,
+            max_iterations=10,
+            best_correlation=0.42,
+            candidates_trained=8,
+            candidates_total=8,
+            phase_detail="growing",
+        )
+
+
+@pytest.mark.integration
+def test_grow_callback_returns_normally_when_not_stopped(mgr_with_hooks):
+    mgr = mgr_with_hooks
+    assert not mgr._stop_requested.is_set()
+    # Returns None; updates state. No exception.
+    mgr.network._grow_iteration_callback(
+        iteration=1,
+        max_iterations=10,
+        best_correlation=0.42,
+        candidates_trained=8,
+        candidates_total=8,
+        phase_detail="growing",
+    )
+
+
+# ---------------------------------------------------------------------------
+# monitored_fit: TrainingInterrupted is a clean cancellation, not a failure
+# ---------------------------------------------------------------------------
+
+
+def _mgr_with_mocked_fit(side_effect):
+    """Build a manager whose network.fit is mocked, with monitoring hooks
+    re-installed so ``monitored_fit``'s closure captures the mock as
+    ``original_fit``.
+
+    Required because:
+      1. ``create_network`` already installs hooks (capturing the REAL fit
+         as ``original_fit``), so the second ``_install_monitoring_hooks``
+         call is a no-op (gated by ``_monitoring_active``).
+      2. After hook install, ``self.network.fit`` IS ``monitored_fit``;
+         simply replacing it with a mock detaches monitored_fit entirely.
+
+    Solution: restore the real fit, replace it with the mock, then force a
+    re-install by clearing ``_monitoring_active``. The re-installed
+    monitored_fit closure captures the mock.
+    """
+    mgr = TrainingLifecycleManager()
+    mgr.create_network(input_size=2, output_size=2)
+    # Restore real fit, mock it, then force re-install so closure rebinds.
+    mgr.network.fit = mgr._original_methods["fit"]
+    mock_fit = MagicMock(side_effect=side_effect)
+    mgr.network.fit = mock_fit
+    mgr._monitoring_active = False
+    mgr._install_monitoring_hooks()
+    # Drive FSM to Started so Command.STOP is a valid transition.
+    mgr._stop_requested.clear()
+    assert mgr.state_machine.handle_command(Command.START)
+    return mgr, mock_fit
+
+
+@pytest.mark.integration
+def test_monitored_fit_treats_interrupt_as_clean_cancellation():
+    """When original_fit raises TrainingInterrupted, monitored_fit must:
+    - transition FSM via Command.STOP (not mark_failed)
+    - update training_state to status=Stopped, phase=Idle
+    - NOT re-raise the exception (user requested stop; not an API error)
+    - return None
+    """
+    mgr, mock_fit = _mgr_with_mocked_fit(TrainingInterrupted("stop_requested"))
+    try:
+        # Must not raise — clean cancellation is swallowed by monitored_fit.
+        result = mgr.network.fit(
+            x=MagicMock(),
+            y=MagicMock(),
+            x_val=None,
+            y_val=None,
+        )
+        assert result is None, "monitored_fit returns None on clean cancellation"
+        assert mock_fit.call_count == 1, "original_fit was invoked once"
+
+        state = mgr.training_state.get_state()
+        assert state["status"] == "Stopped", f"expected Stopped, got {state['status']!r}"
+        assert state["phase"] == "Idle", f"expected Idle, got {state['phase']!r}"
+    finally:
+        mgr.shutdown()
+
+
+@pytest.mark.integration
+def test_monitored_fit_treats_other_exceptions_as_failure():
+    """Sanity: NON-TrainingInterrupted exceptions still flow through the
+    failure path (mark_failed, status=Failed, exception re-raised). This
+    pins the boundary between the two except-clauses so a future refactor
+    doesn't accidentally widen the cancellation catch."""
+    mgr, _ = _mgr_with_mocked_fit(RuntimeError("boom"))
+    try:
+        with pytest.raises(RuntimeError, match="boom"):
+            mgr.network.fit(x=MagicMock(), y=MagicMock(), x_val=None, y_val=None)
+        state = mgr.training_state.get_state()
+        assert state["status"] == "Failed"
+    finally:
+        mgr.shutdown()


### PR DESCRIPTION
## Summary

- **Defect fix.** Discovered during the P2-1a pause-boundary audit for the Phase 2 live-dataset-swap work (canopy `notes/ISSUE_3_PHASE_2_LIVE_DATASET_SWAP_2026-05-09.md` §3.4).
- Pre-fix, `pause_training` and `stop_training` updated the FSM and broadcast new state via WebSocket, but **training continued to natural completion regardless** — the events were never observed inside `cascade_correlation.fit()` or any inner training loop.
- Fix wires signal checks into the existing `_output_training_callback` (every 25 output epochs) and `_grow_iteration_callback` (cascade-iteration boundary) via a new `_check_for_interrupt()` instance method that raises `TrainingInterrupted` on stop and blocks on pause. `monitored_fit` catches `TrainingInterrupted` as a clean cancellation (same FSM/state/gauge transitions as the post-fit stop-event path).

## Why this slipped through

Existing tests (`test_lifecycle_event_invariants.py`, `test_lifecycle_manager.py::test_stop_training`) verified the *event states* and the *return dict shape* but never asserted that **training actually stops**. The new test file pins the missing behavior contract directly — see `test_monitored_fit_treats_interrupt_as_clean_cancellation` and the four `test_output_callback_*` tests.

## What's in this PR

**Production code** (`src/api/lifecycle/manager.py`):
- New `TrainingInterrupted(Exception)` sentinel near `InvalidCandidatePoolError`.
- New `_check_for_interrupt()` instance method (the missing pause/stop hook).
- Two existing callbacks now call `manager_ref._check_for_interrupt()`.
- `monitored_fit` gains a `except TrainingInterrupted` clause that catches cleanly (does NOT re-raise, increments `TRAINING_SESSION_STATUS_CANCELLED`).

**Refactor** (defensible on its own):
- `_output_epoch_callback` and `_grow_iteration_callback` are now bound to the network at install time, not on first fit. Removes a subtle race window.
- `_check_for_interrupt` is an instance method (not a closure) so it's reachable from `_install_grow_network_hook` (separate method scope).

**Tests** (`src/tests/integration/api/test_pause_stop_actually_interrupts.py`, 8 cases):
1. `test_output_callback_raises_on_stop_signal`
2. `test_output_callback_returns_normally_when_not_paused_or_stopped`
3. `test_output_callback_blocks_on_pause_then_resumes`
4. `test_output_callback_raises_on_stop_during_pause` (validates the 0.5s wait timeout — pre-fix this was impossible)
5. `test_grow_callback_raises_on_stop_signal`
6. `test_grow_callback_returns_normally_when_not_stopped`
7. `test_monitored_fit_treats_interrupt_as_clean_cancellation`
8. `test_monitored_fit_treats_other_exceptions_as_failure` (pins the boundary so a future refactor doesn't widen the cancellation catch)

## Scope notes

- **Pause inside multiprocessing candidate-training is intentionally out of scope.** The cascade-iteration boundary is the natural pause point for cascade growth; tighter granularity would require multiprocessing-aware signal threading.
- **No behavior change for completed training runs** — the post-fit stop-event check at `manager.py:1500` is preserved as a fallback (now redundant in the typical case but harmless).
- The full `src/tests/unit/api/ + src/tests/integration/api/` sweep passes after the change.

## Test plan

- [x] `pytest tests/integration/api/test_pause_stop_actually_interrupts.py --integration` — 8/8 pass
- [x] `pytest tests/unit/api/test_lifecycle_manager.py tests/integration/api/test_lifecycle_event_invariants.py tests/unit/test_cascade_correlation_callback_hooks.py --integration` — 130/130 existing tests pass (no regression)
- [x] `pytest tests/unit/api/ tests/integration/api/ --integration` — exit 0
- [x] `pre-commit run --files src/api/lifecycle/manager.py src/tests/integration/api/test_pause_stop_actually_interrupts.py` — all hooks pass (flake8, bandit, mypy, black, isort)
- [ ] Manual smoke test: start training in canopy, click Pause, observe training metrics stop emitting; click Stop, observe training future returns within seconds (not minutes)

## Unblocks

- Phase 2 P2-1a (`swap_dataset_live` skeleton). The spec's pause-boundary semantics (manager.py step 5 of the swap flow) now work as assumed.
- Also fixes a UX bug affecting every canopy user, not just Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)