### PR TITLE
feat(phase2): P2-1b — DELETE /v1/training/dataset/live cancel + polish (Issue #3)

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -94,6 +94,28 @@ class SwapInProgressError(RuntimeError):
     """
 
 
+class NoSwapInProgressError(RuntimeError):
+    """Raised by ``request_swap_cancel`` when no swap is currently in flight.
+
+    Promotes to HTTP 404 Not Found on ``DELETE /v1/training/dataset/live`` — the
+    resource (an in-flight swap) being cancelled does not exist. Distinct from
+    409 (resource exists, conflicting state) so the canopy "Cancel" affordance
+    can distinguish "nothing to cancel" from "swap already finished racing you".
+    """
+
+
+class SwapCancelledError(RuntimeError):
+    """Raised by ``swap_dataset_live`` when a concurrent cancel was honoured.
+
+    The route translates this to HTTP 200 with ``{"status": "cancelled"}`` —
+    the swap operation completed with cancellation as its terminal state, the
+    pre-swap snapshot has been restored, and training continues on the OLD
+    dataset. From the caller's perspective the request was handled cleanly;
+    distinguishing it from a generic 5xx prevents the canopy "Live Switch
+    failed" toast from firing on a user-initiated cancel.
+    """
+
+
 class _PreSwapSnapshot:  # noqa: D101 - frozen container, not part of the public surface
     __slots__ = ("train_x", "train_y", "val_x", "val_y", "state_dict", "input_size", "output_size", "dataset_config")
 
@@ -1068,6 +1090,15 @@ class TrainingLifecycleManager:
         self._experimental_functions_enabled: bool = os.environ.get("CASCOR_EXPERIMENTAL_FUNCTIONS_ENABLED") == "1"
         self._current_dataset_config: Optional[Dict[str, Any]] = None
         self._swap_in_progress: bool = False
+        # P2-1b: ``_swap_cancel_requested`` is signalled by
+        # ``DELETE /v1/training/dataset/live`` and observed at safe checkpoints
+        # inside ``swap_dataset_live`` (post-fetch, pre-future-resubmit). Using
+        # an ``Event`` rather than a bool gives a memory-barriered read across
+        # the cancel-issuer thread and the swap-driver thread without needing
+        # to re-acquire ``_training_lock`` (which the swap holds for its full
+        # duration). Cleared in the swap's ``finally`` so a future swap doesn't
+        # observe a stale set from a prior aborted swap.
+        self._swap_cancel_requested: threading.Event = threading.Event()
 
         # CAN-015g (g-6): training-loop weight history recorder.
         # Lazily attached on first ``start_training`` call; persists
@@ -2253,8 +2284,49 @@ class TrainingLifecycleManager:
         self._experimental_functions_enabled = bool(enabled)
         return {"experimental_functions_enabled": self._experimental_functions_enabled}
 
+    def request_swap_cancel(self) -> Dict[str, Any]:
+        """Signal an in-flight ``swap_dataset_live`` to abort and roll back.
+
+        Backed by ``_swap_cancel_requested`` (a ``threading.Event``). The flag
+        is observed at the next checkpoint inside ``swap_dataset_live``
+        (post-fetch and pre-future-resubmit), which raises ``SwapCancelledError``
+        to trip the existing §3.8 rollback path.
+
+        Returns a small descriptor dict on success. Raises
+        ``NoSwapInProgressError`` (route → 404) if no swap is currently in
+        flight — important UX signal so the canopy "Cancel" button doesn't
+        falsely succeed against a swap that already finished racing the click.
+
+        The cancel is asynchronous: an in-flight ``_reload_dataset`` HTTP fetch
+        cannot be interrupted mid-syscall, so the swap may take up to one
+        full fetch RTT to observe the flag. The DELETE response means
+        "signal accepted", not "swap aborted by the time you read this".
+        """
+        # Snapshot the flag under the lock — the swap mutates it inside
+        # ``_training_lock`` so reading without the lock could see a stale
+        # False during the brief window between swap-start and the very first
+        # checkpoint. Holding the lock here also prevents a race where a swap
+        # finishes between our check and our set().
+        with self._training_lock:
+            if not self._swap_in_progress:
+                raise NoSwapInProgressError("no_swap_in_progress")
+            self._swap_cancel_requested.set()
+            return {"status": "cancel_requested"}
+
+    def _check_swap_cancel(self) -> None:
+        """Raise ``SwapCancelledError`` if a cancel has been signalled.
+
+        Called at safe checkpoints inside ``swap_dataset_live`` where state
+        is consistent enough that the standard §3.8 rollback path can restore
+        the pre-swap snapshot. The first checkpoint sits immediately after
+        ``_reload_dataset`` returns — the most likely point a user-initiated
+        cancel will land, since the fetch is the long pole of a swap.
+        """
+        if self._swap_cancel_requested.is_set():
+            raise SwapCancelledError("swap_cancelled_by_client")
+
     def swap_dataset_live(self, **cfg: Any) -> Dict[str, Any]:  # noqa: C901
-        """In-flight dataset swap (P2-1a equal-dim-only skeleton).
+        """In-flight dataset swap (P2-1a equal-dim skeleton + P2-1b polish).
 
         Phase 2 step-by-step flow per spec §3.2:
           1. Acquire ``_training_lock`` (entire swap held under the lock —
@@ -2263,30 +2335,40 @@ class TrainingLifecycleManager:
              and ``is_started()`` (raises ValueError → 422).
           3. Set ``_swap_in_progress`` flag (concurrent swap → 409 via the
              ``SwapInProgressError`` sentinel raised here).
-          4. Snapshot pre-swap state for rollback (§3.7 guardrail #1).
+          4. Snapshot pre-swap state for rollback (§3.7 guardrail #1) +
+             capture the in-flight candidate-pool depth so the response can
+             surface it (§3.5 — "Swap discarded N in-flight candidates").
           5/6. Signal stop on the training future; await its clean exit.
              Pre-P2-PRE-1 the training thread ignored ``_stop_requested``;
              the fix at ``f4453fa`` wires the signal into the training-loop
              callbacks via ``_check_for_interrupt`` so this actually works.
           7. ``_reload_dataset`` fetches the new dataset (juniper-data I/O).
+             P2-1b: a ``_check_swap_cancel`` checkpoint fires here — a
+             DELETE arriving during the fetch trips ``SwapCancelledError``
+             and the §3.8 rollback restores the pre-swap snapshot.
           8. P2-1a only — reject any input/output dim change with
              ``ValueError("dim_change_unsupported")`` (→ 422). P2-1c/1d will
              implement the architecture adapter for grow/shrink.
           10. Reset ``_auto_snap_best_metric`` so the stale ratchet from
               the old dataset doesn't suppress new auto-snaps.
           11. Candidate pool is implicitly abandoned by the future stopping
-              in step 6 — workers and in-flight candidates discarded.
+              in step 6 — workers and in-flight candidates discarded. The
+              count was captured pre-stop in step 4 (it is necessarily zero
+              after the future stops, so reading it later is wrong).
           12. Submit a new training future on the new tensors. ``network.fit``
-              naturally starts with output training, so the "output mode
-              first" semantic from §3.5 is implicit.
+              naturally starts with output training, so the §3.5 "output
+              training first" semantic is implicit (resolves §8 Q5).
           14. Force a topology rebroadcast (no-op equal-dim, but plumbs the
               WebSocket path for P2-1c/1d when dims actually change).
-          15-16. Clear the in-progress flag in ``finally``; return structured
-                 response per §3.3.
+          15-16. Clear the in-progress + cancel flags in ``finally``; return
+                 structured response per §3.3. Emit the §3.7 #5 structured
+                 INFO log line.
 
         On ANY failure between step 4 and step 14: restore the pre-swap
         snapshot, resume training on the OLD dataset (best-effort), clear
         the flag, raise the original exception (the route translates it).
+        A ``SwapCancelledError`` is a clean termination — same rollback,
+        but the route maps it to 200 with ``{"status": "cancelled"}``.
         """
         # Step 2: validate gate (before acquiring lock — fast-path 403)
         if not self._experimental_functions_enabled:
@@ -2301,6 +2383,11 @@ class TrainingLifecycleManager:
             if self._swap_in_progress:
                 raise SwapInProgressError("swap_already_in_progress")
             self._swap_in_progress = True
+            # P2-1b: clear any stale cancel signal so we start each swap with
+            # a fresh cancellation slate. A DELETE that arrived during the
+            # window between two consecutive swaps must not pre-cancel the
+            # next one — the flag is per-swap, not sticky.
+            self._swap_cancel_requested.clear()
 
             try:
                 # Step 4: snapshot pre-swap state.
@@ -2314,6 +2401,13 @@ class TrainingLifecycleManager:
                     output_size=getattr(self.network, "output_size", None),
                     dataset_config=dict(self._current_dataset_config) if self._current_dataset_config else None,
                 )
+
+                # P2-1b: capture the candidate-pool depth BEFORE we stop the
+                # future. Reading after the stop always sees zero (the pool
+                # has been drained by ``_stop_requested``). Only the
+                # CANDIDATE phase has an in-flight pool — output training
+                # has none, so reporting zero in those cases is correct.
+                abandoned_candidate_pool_size = self._snapshot_abandoned_candidate_pool_size()
 
                 # Step 5/6: signal stop, wait for training future to exit cleanly.
                 # P2-PRE-1 (f4453fa) makes _stop_requested actually interrupt
@@ -2339,6 +2433,11 @@ class TrainingLifecycleManager:
                 # Step 7: fetch new dataset. Failure here triggers rollback.
                 self._reload_dataset(**cfg)
 
+                # P2-1b: post-fetch cancel checkpoint. Most user-initiated
+                # cancels land here (the fetch is the long pole). The
+                # SwapCancelledError trips the §3.8 rollback below.
+                self._check_swap_cancel()
+
                 # Step 8: P2-1a dim-change guard.
                 new_input = self._train_x.shape[1]
                 new_output = self._train_y.shape[1]
@@ -2348,6 +2447,12 @@ class TrainingLifecycleManager:
                 # Step 10: reset auto-snap ratchet (§3.7 guardrail #6).
                 with self._auto_snap_lock:
                     self._auto_snap_best_metric = None
+
+                # P2-1b: second cancel checkpoint — last chance to abort
+                # before the new future starts. After ``submit()`` the new
+                # training run is live; cancelling then is the user's
+                # responsibility (pause/stop on the new run).
+                self._check_swap_cancel()
 
                 # Step 12: submit new training future. monitored_fit handles
                 # the FSM STOPPED → STARTED transition internally on the new
@@ -2369,11 +2474,17 @@ class TrainingLifecycleManager:
                 # is plumbed for P2-1c/1d when dims actually change).
                 self._broadcast_training_state(force=True)
 
-                # Step 16: structured response per §3.3.
+                # Step 16: structured INFO log per §3.7 guardrail #5, then
+                # structured response per §3.3.
+                hidden_preserved = len(self.network.hidden_units) if hasattr(self.network, "hidden_units") else 0
                 self.logger.info(
-                    "swap_dataset_live: equal-dim swap complete. before_cfg=%r after_cfg=%r mode=output_training_first",
-                    pre.dataset_config,
-                    self._current_dataset_config,
+                    "swap: input %d→%d, output %d→%d, hidden %d preserved, candidates %d abandoned, mode→output_training",
+                    pre.input_size if pre.input_size is not None else new_input,
+                    new_input,
+                    pre.output_size if pre.output_size is not None else new_output,
+                    new_output,
+                    hidden_preserved,
+                    abandoned_candidate_pool_size,
                 )
                 return {
                     "status": "swapped",
@@ -2382,18 +2493,21 @@ class TrainingLifecycleManager:
                     "arch_changes": {
                         "input_delta": 0,
                         "output_delta": 0,
-                        "hidden_preserved": len(self.network.hidden_units) if hasattr(self.network, "hidden_units") else 0,
-                        # P2-1a doesn't yet measure the in-flight pool depth —
-                        # it's implicitly drained by the future stopping. P2-1b
-                        # will surface this for the canopy "Swap discarded N
-                        # in-flight candidates" toast.
-                        "abandoned_candidate_pool_size": 0,
+                        "hidden_preserved": hidden_preserved,
+                        "abandoned_candidate_pool_size": abandoned_candidate_pool_size,
                         "appended_nodes": {"input": 0, "output": 0},
                         "prepended_layers": [],
                     },
                     "mode": "output_training_first",
                 }
 
+            except SwapCancelledError:
+                # Clean cancellation — rollback and re-raise. Route maps to
+                # HTTP 200 with cancelled status; this is NOT an error path
+                # from the user's perspective, just an abandoned-by-request
+                # terminal state with pre-swap data restored.
+                self._rollback_pre_swap_state(pre)
+                raise
             except ValueError:
                 # Validation-class failure (dim_change_unsupported etc.) — rollback
                 # and re-raise so the route can return 422. Note: the original
@@ -2407,8 +2521,31 @@ class TrainingLifecycleManager:
                 self._rollback_pre_swap_state(pre)
                 raise
             finally:
-                # Step 15: clear in-progress flag unconditionally (§3.7 #3).
+                # Step 15: clear in-progress flag + cancel signal unconditionally
+                # (§3.7 #3). Clearing the cancel flag here means a DELETE
+                # arriving exactly as we finish does not survive to bias the
+                # NEXT swap — see ``request_swap_cancel`` for the 404 path
+                # that fires when the DELETE arrives post-clear.
                 self._swap_in_progress = False
+                self._swap_cancel_requested.clear()
+
+    def _snapshot_abandoned_candidate_pool_size(self) -> int:
+        """Return the in-flight candidate-pool depth at swap time.
+
+        Only the CANDIDATE phase has live candidates; reading the network's
+        ``candidate_pool_size`` at any other phase returns the configured
+        pool capacity, not the count of work actually being abandoned.
+        Output / inference / idle / paused → 0. Resolves the §3.5 "Swap
+        discarded N in-flight candidates" UX requirement without overstating
+        the abandonment cost in non-candidate phases.
+        """
+        try:
+            phase = self.state_machine.phase
+        except Exception:
+            return 0
+        if phase != TrainingPhase.CANDIDATE:
+            return 0
+        return int(getattr(self.network, "candidate_pool_size", 0) or 0)
 
     def _rollback_pre_swap_state(self, pre: "_PreSwapSnapshot") -> None:
         """Restore the network + tensor refs from a pre-swap snapshot.

--- a/src/api/routes/training.py
+++ b/src/api/routes/training.py
@@ -5,7 +5,12 @@ import logging
 import torch
 from fastapi import APIRouter, HTTPException, Request
 
-from api.lifecycle.manager import InvalidCandidatePoolError, SwapInProgressError
+from api.lifecycle.manager import (
+    InvalidCandidatePoolError,
+    NoSwapInProgressError,
+    SwapCancelledError,
+    SwapInProgressError,
+)
 from api.models.common import success_response
 from api.models.training import StageDatasetRequest, SwapDatasetLiveRequest, TrainingParamUpdateRequest, TrainingStartRequest
 
@@ -203,7 +208,7 @@ async def get_pending_dataset(request: Request) -> dict:
 
 @router.post("/dataset/live")
 async def swap_dataset_live(request: Request, body: SwapDatasetLiveRequest) -> dict:
-    """Initiate an in-flight dataset swap (P2-1a skeleton)."""
+    """Initiate an in-flight dataset swap (P2-1a skeleton; P2-1b cancel-aware)."""
     lifecycle = _get_lifecycle(request)
     cfg = body.model_dump(exclude_none=True)
     try:
@@ -212,6 +217,11 @@ async def swap_dataset_live(request: Request, body: SwapDatasetLiveRequest) -> d
         raise HTTPException(status_code=403, detail=str(exc)) from exc
     except SwapInProgressError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except SwapCancelledError:
+        # P2-1b: a DELETE arrived mid-swap, the §3.8 rollback already restored
+        # pre-swap state. Return 200 with cancelled status — the request was
+        # serviced cleanly; not a failure path.
+        return success_response({"status": "cancelled"})
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     except TimeoutError as exc:
@@ -221,6 +231,33 @@ async def swap_dataset_live(request: Request, body: SwapDatasetLiveRequest) -> d
         # juniper-data fetch failure (raised by _reload_dataset) or other
         # operational error. Rollback already happened inside swap_dataset_live.
         raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@router.delete("/dataset/live")
+async def cancel_swap_dataset_live(request: Request) -> dict:
+    """Cancel an in-flight live dataset swap (P2-1b).
+
+    Sets the cancellation signal observed by ``swap_dataset_live`` at its
+    post-fetch checkpoint. The actual swap may take up to one fetch RTT to
+    observe the flag and unwind — this route only confirms the signal was
+    delivered. The originating ``POST`` returns 200 with
+    ``{"status": "cancelled"}`` once the rollback completes.
+
+    Status codes:
+      200 — cancel signal accepted; an in-flight swap will roll back.
+      403 — experimental-functions gate closed (F2.10).
+      404 — no swap currently in progress.
+    """
+    lifecycle = _get_lifecycle(request)
+    # Gate check mirrors the POST: a closed gate hides the existence of the
+    # entire feature surface, including its cancel side. Avoids a probe vector
+    # where a 404 vs 403 leaks "swap is enabled and idle".
+    if not lifecycle.get_experimental_functions():
+        raise HTTPException(status_code=403, detail="experimental_functions_disabled")
+    try:
+        return success_response(lifecycle.request_swap_cancel())
+    except NoSwapInProgressError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 def _generate_spiral_data(params: dict):

--- a/src/tests/integration/api/test_swap_dataset_live.py
+++ b/src/tests/integration/api/test_swap_dataset_live.py
@@ -26,11 +26,13 @@ import pytest
 import torch
 
 from api.lifecycle.manager import (
+    NoSwapInProgressError,
+    SwapCancelledError,
     SwapInProgressError,
     TrainingLifecycleManager,
     _PreSwapSnapshot,
 )
-from api.lifecycle.state_machine import Command
+from api.lifecycle.state_machine import Command, TrainingPhase
 
 
 def _make_dummy_tensors(input_size: int, output_size: int, n_samples: int = 16):
@@ -360,4 +362,259 @@ def test_rollback_restores_tensor_refs():
     assert mgr._train_x is pre_x
     assert mgr._train_y is pre_y
     assert mgr._current_dataset_config == {"dataset_type": "spirals"}
+    mgr.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# P2-1b: cancel mechanism (request_swap_cancel + DELETE route translation)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_request_swap_cancel_raises_when_no_swap_in_progress():
+    """``DELETE /v1/training/dataset/live`` against an idle lifecycle raises
+    ``NoSwapInProgressError`` (route → 404). Tells the canopy "Cancel" button
+    the swap already finished racing the click."""
+    mgr = TrainingLifecycleManager()
+    mgr.set_experimental_functions(True)
+    assert mgr._swap_in_progress is False
+    with pytest.raises(NoSwapInProgressError, match="no_swap_in_progress"):
+        mgr.request_swap_cancel()
+    mgr.shutdown()
+
+
+@pytest.mark.integration
+def test_request_swap_cancel_sets_signal_when_swap_in_progress():
+    """When a swap IS underway, ``request_swap_cancel`` sets the cancel
+    signal and returns a descriptor dict (no exception)."""
+    mgr = TrainingLifecycleManager()
+    mgr.set_experimental_functions(True)
+    mgr._swap_in_progress = True  # simulate in-flight swap on another thread
+    try:
+        result = mgr.request_swap_cancel()
+        assert result == {"status": "cancel_requested"}
+        assert mgr._swap_cancel_requested.is_set()
+    finally:
+        mgr._swap_in_progress = False
+        mgr._swap_cancel_requested.clear()
+        mgr.shutdown()
+
+
+@pytest.mark.integration
+def test_swap_dataset_live_aborts_when_cancel_set_during_fetch():
+    """A DELETE arriving during ``_reload_dataset`` trips the post-fetch
+    cancel checkpoint → ``SwapCancelledError`` → §3.8 rollback restores the
+    pre-swap tensors. The most common race the user can produce."""
+    mgr = TrainingLifecycleManager()
+    mgr.create_network(input_size=2, output_size=2)
+    mgr.set_experimental_functions(True)
+    pre_train_x, pre_train_y = _make_dummy_tensors(2, 2)
+    mgr._train_x = pre_train_x
+    mgr._train_y = pre_train_y
+    mgr._current_dataset_config = {"dataset_type": "spirals"}
+    mgr.state_machine.handle_command(Command.START)
+
+    def _fake_reload_then_cancel(**cfg):
+        # Simulate the user clicking Cancel while the fetch is in flight.
+        # Real fetch would block on juniper-data HTTP; here we just install
+        # new tensors AND set the cancel flag in the same call.
+        mgr._train_x = torch.randn(8, 2)
+        mgr._train_y = torch.zeros(8, 2)
+        mgr._train_y[:, 0] = 1
+        mgr._current_dataset_config = {"dataset_type": "moons"}
+        mgr._swap_cancel_requested.set()
+
+    mgr._executor = MagicMock()
+    mgr._executor.submit.return_value = MagicMock()
+
+    with patch.object(mgr, "_reload_dataset", side_effect=_fake_reload_then_cancel):
+        with pytest.raises(SwapCancelledError, match="swap_cancelled_by_client"):
+            mgr.swap_dataset_live(dataset_type="moons")
+
+    # §3.8 rollback: pre-swap tensors restored, cancel flag cleared in finally.
+    assert mgr._train_x is pre_train_x
+    assert mgr._train_y is pre_train_y
+    assert mgr._current_dataset_config == {"dataset_type": "spirals"}
+    assert mgr._swap_in_progress is False
+    assert not mgr._swap_cancel_requested.is_set(), "cancel flag not cleared in finally"
+    # No new training future was submitted (we aborted before step 12).
+    assert not mgr._executor.submit.called
+    mgr.shutdown()
+
+
+@pytest.mark.integration
+def test_swap_dataset_live_clears_stale_cancel_flag_at_start():
+    """A cancel signal left set from a previous aborted swap MUST NOT
+    pre-cancel the next swap — the flag is per-swap, not sticky. The
+    swap clears it under the lock right after acquiring ``_swap_in_progress``."""
+    mgr = TrainingLifecycleManager()
+    mgr.create_network(input_size=2, output_size=2)
+    mgr.set_experimental_functions(True)
+    mgr._train_x, mgr._train_y = _make_dummy_tensors(2, 2)
+    mgr._current_dataset_config = {"dataset_type": "spirals"}
+    mgr.state_machine.handle_command(Command.START)
+    # Pre-set the cancel flag as if a prior swap's DELETE leaked through.
+    mgr._swap_cancel_requested.set()
+
+    new_x, new_y = _make_dummy_tensors(2, 2)
+
+    def _fake_reload(**cfg):
+        mgr._train_x = new_x
+        mgr._train_y = new_y
+        mgr._current_dataset_config = {"dataset_type": "moons"}
+
+    mgr._executor = MagicMock()
+    mgr._executor.submit.return_value = MagicMock()
+
+    with patch.object(mgr, "_reload_dataset", side_effect=_fake_reload):
+        # Should complete without raising — the stale flag was cleared.
+        result = mgr.swap_dataset_live(dataset_type="moons")
+
+    assert result["status"] == "swapped"
+    assert mgr._train_x is new_x
+    assert not mgr._swap_cancel_requested.is_set()
+    mgr.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# P2-1b: abandoned_candidate_pool_size accounting
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_abandoned_candidate_pool_size_zero_outside_candidate_phase():
+    """Output / Idle / Paused phases have no in-flight candidates — the
+    response reports zero (not the configured pool capacity)."""
+    mgr = TrainingLifecycleManager()
+    mgr.create_network(input_size=2, output_size=2)
+    mgr.set_experimental_functions(True)
+    mgr._train_x, mgr._train_y = _make_dummy_tensors(2, 2)
+    mgr._current_dataset_config = {"dataset_type": "spirals"}
+    mgr.state_machine.handle_command(Command.START)
+    # Started lands in TrainingPhase.OUTPUT — no candidates in flight.
+    assert mgr.state_machine.phase == TrainingPhase.OUTPUT
+
+    def _fake_reload(**cfg):
+        mgr._train_x, mgr._train_y = _make_dummy_tensors(2, 2)
+        mgr._current_dataset_config = {"dataset_type": "moons"}
+
+    mgr._executor = MagicMock()
+    mgr._executor.submit.return_value = MagicMock()
+
+    with patch.object(mgr, "_reload_dataset", side_effect=_fake_reload):
+        result = mgr.swap_dataset_live(dataset_type="moons")
+
+    assert result["arch_changes"]["abandoned_candidate_pool_size"] == 0
+    mgr.shutdown()
+
+
+@pytest.mark.integration
+def test_abandoned_candidate_pool_size_reports_pool_when_in_candidate_phase():
+    """Mid-CANDIDATE swaps report the in-flight pool depth (Option C of §3.5).
+    Drives the canopy "Swap discarded N in-flight candidates" UX."""
+    mgr = TrainingLifecycleManager()
+    mgr.create_network(input_size=2, output_size=2)
+    mgr.set_experimental_functions(True)
+    mgr._train_x, mgr._train_y = _make_dummy_tensors(2, 2)
+    mgr._current_dataset_config = {"dataset_type": "spirals"}
+    mgr.state_machine.handle_command(Command.START)
+    # Force into CANDIDATE phase to simulate "swap fired during candidate
+    # training". Real production sets this via the cascade-growth callback.
+    mgr.state_machine.set_phase(TrainingPhase.CANDIDATE)
+    # Pin a known pool size on the network so the assertion is meaningful.
+    mgr.network.candidate_pool_size = 8
+
+    def _fake_reload(**cfg):
+        mgr._train_x, mgr._train_y = _make_dummy_tensors(2, 2)
+        mgr._current_dataset_config = {"dataset_type": "moons"}
+
+    mgr._executor = MagicMock()
+    mgr._executor.submit.return_value = MagicMock()
+
+    with patch.object(mgr, "_reload_dataset", side_effect=_fake_reload):
+        result = mgr.swap_dataset_live(dataset_type="moons")
+
+    assert result["arch_changes"]["abandoned_candidate_pool_size"] == 8
+    mgr.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# P2-1b: §3.7 #5 structured INFO completion log
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_swap_dataset_live_emits_structured_completion_log():
+    """§3.7 guardrail #5: on completion the swap emits a single INFO line
+    matching the format:
+        "swap: input I_old→I_new, output O_old→O_new, hidden H preserved, candidates C abandoned, mode→output_training"
+
+    Asserts on the format-string + args passed to ``logger.info`` rather than
+    via caplog — the manager's logger has a custom configuration in this
+    project that does not always propagate to the root logger that caplog
+    attaches its handler to. Patching the bound method makes the assertion
+    independent of logging configuration.
+    """
+    mgr = TrainingLifecycleManager()
+    mgr.create_network(input_size=2, output_size=2)
+    mgr.set_experimental_functions(True)
+    mgr._train_x, mgr._train_y = _make_dummy_tensors(2, 2)
+    mgr._current_dataset_config = {"dataset_type": "spirals"}
+    mgr.state_machine.handle_command(Command.START)
+
+    def _fake_reload(**cfg):
+        mgr._train_x, mgr._train_y = _make_dummy_tensors(2, 2)
+        mgr._current_dataset_config = {"dataset_type": "moons"}
+
+    mgr._executor = MagicMock()
+    mgr._executor.submit.return_value = MagicMock()
+
+    with patch.object(mgr.logger, "info") as info_mock:
+        with patch.object(mgr, "_reload_dataset", side_effect=_fake_reload):
+            mgr.swap_dataset_live(dataset_type="moons")
+
+    # Find the structured completion line among all info() calls.
+    matching = [c for c in info_mock.call_args_list if c.args and isinstance(c.args[0], str) and c.args[0].startswith("swap: input ")]
+    assert len(matching) == 1, f"expected 1 completion line, got {info_mock.call_args_list}"
+    fmt, *args = matching[0].args
+    # Equal-dim swap from this test fixture: 2→2 / 2→2, hidden 0 preserved,
+    # 0 candidates abandoned (Output phase).
+    rendered = fmt % tuple(args)
+    assert rendered == "swap: input 2→2, output 2→2, hidden 0 preserved, candidates 0 abandoned, mode→output_training"
+    mgr.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# P2-1b: topology rebroadcast plumbing (§3.7 guardrail #7)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_swap_dataset_live_forces_topology_rebroadcast_on_completion():
+    """Even an equal-dim swap MUST force a topology rebroadcast — the path
+    is plumbed here so P2-1c/1d (grow/shrink) inherit it. Without the
+    rebroadcast canopy's topology view would lag a real dim change."""
+    mgr = TrainingLifecycleManager()
+    mgr.create_network(input_size=2, output_size=2)
+    mgr.set_experimental_functions(True)
+    mgr._train_x, mgr._train_y = _make_dummy_tensors(2, 2)
+    mgr._current_dataset_config = {"dataset_type": "spirals"}
+    mgr.state_machine.handle_command(Command.START)
+
+    def _fake_reload(**cfg):
+        mgr._train_x, mgr._train_y = _make_dummy_tensors(2, 2)
+        mgr._current_dataset_config = {"dataset_type": "moons"}
+
+    mgr._executor = MagicMock()
+    mgr._executor.submit.return_value = MagicMock()
+
+    with patch.object(mgr, "_broadcast_training_state") as broadcast_mock:
+        with patch.object(mgr, "_reload_dataset", side_effect=_fake_reload):
+            mgr.swap_dataset_live(dataset_type="moons")
+
+    # Exactly one forced broadcast on swap completion. ``force=True`` is the
+    # invariant — the throttled-broadcast path would coalesce the topology
+    # event with metric ticks and lose its standalone framing.
+    forced_calls = [c for c in broadcast_mock.call_args_list if c.kwargs.get("force") is True]
+    assert len(forced_calls) >= 1, f"no force=True broadcast observed: {broadcast_mock.call_args_list}"
     mgr.shutdown()

--- a/src/tests/unit/api/test_phase2_routes.py
+++ b/src/tests/unit/api/test_phase2_routes.py
@@ -22,7 +22,11 @@ from fastapi.testclient import TestClient
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
 
 from api.app import create_app
-from api.lifecycle.manager import SwapInProgressError
+from api.lifecycle.manager import (
+    NoSwapInProgressError,
+    SwapCancelledError,
+    SwapInProgressError,
+)
 from api.settings import Settings
 
 pytestmark = pytest.mark.unit
@@ -158,3 +162,60 @@ class TestSwapDatasetLiveRoute:
         assert resp.status_code == 200
         body = resp.json()
         assert body["data"] == canned
+
+    def test_200_cancelled_when_swap_cancelled_mid_flight(self, client):
+        """P2-1b: ``SwapCancelledError`` → 200 with ``status="cancelled"`` in the
+        response data. Distinct from a 5xx failure so the canopy "Live Switch
+        failed" toast does NOT fire on a user-initiated cancel."""
+        client.post("/v1/admin/experimental_functions", json={"enabled": True})
+        with patch.object(
+            client.app.state.lifecycle,
+            "swap_dataset_live",
+            side_effect=SwapCancelledError("swap_cancelled_by_client"),
+        ):
+            resp = client.post("/v1/training/dataset/live", json={"dataset_type": "spirals"})
+        assert resp.status_code == 200
+        assert resp.json()["data"] == {"status": "cancelled"}
+
+
+# ---------------------------------------------------------------------------
+# P2-1b: DELETE /v1/training/dataset/live — cancel route
+# ---------------------------------------------------------------------------
+
+
+class TestCancelSwapDatasetLiveRoute:
+    """Pin the DELETE-route contract per §7 P2-1b row of the spec."""
+
+    def test_403_when_gate_closed(self, client):
+        """Closed gate hides the cancel surface too — avoids a probe vector
+        that would distinguish "swap enabled but idle" from "swap disabled"."""
+        resp = client.delete("/v1/training/dataset/live")
+        assert resp.status_code == 403
+        assert "experimental_functions_disabled" in resp.json()["detail"]
+
+    def test_404_when_no_swap_in_progress(self, client):
+        """``NoSwapInProgressError`` → 404. The "swap finished racing the
+        click" signal for the canopy Cancel button."""
+        client.post("/v1/admin/experimental_functions", json={"enabled": True})
+        with patch.object(
+            client.app.state.lifecycle,
+            "request_swap_cancel",
+            side_effect=NoSwapInProgressError("no_swap_in_progress"),
+        ):
+            resp = client.delete("/v1/training/dataset/live")
+        assert resp.status_code == 404
+        assert "no_swap_in_progress" in resp.json()["detail"]
+
+    def test_200_when_swap_in_progress(self, client):
+        """Happy path: returns the lifecycle's descriptor dict (cancel signal
+        accepted) wrapped in the success envelope. The swap rollback itself
+        completes asynchronously — see integration tests."""
+        client.post("/v1/admin/experimental_functions", json={"enabled": True})
+        with patch.object(
+            client.app.state.lifecycle,
+            "request_swap_cancel",
+            return_value={"status": "cancel_requested"},
+        ):
+            resp = client.delete("/v1/training/dataset/live")
+        assert resp.status_code == 200
+        assert resp.json()["data"] == {"status": "cancel_requested"}


### PR DESCRIPTION
## Summary

Implements the **P2-1b** row of [`ISSUE_3_PHASE_2_LIVE_DATASET_SWAP_2026-05-09.md`](../juniper-canopy/notes/ISSUE_3_PHASE_2_LIVE_DATASET_SWAP_2026-05-09.md) §7: a cancel mechanism for the live dataset swap, plus the structured-log / candidate-count / topology-rebroadcast polish called out by §3.7 guardrails #5 and #7.

Builds on **P2-1a** (#245) which landed the experimental-functions gate and the bare equal-dim `swap_dataset_live` skeleton, and **P2-PRE-1** (#244) which made `pause_training` / `stop_training` actually interrupt the training loop.

### What changes

**Lifecycle (`api/lifecycle/manager.py`)**

- New exceptions:
  - `NoSwapInProgressError` → 404 on `DELETE /v1/training/dataset/live`
  - `SwapCancelledError` → 200 with `{"status": "cancelled"}` on the originating `POST`
- `_swap_cancel_requested` (`threading.Event`) observed at two safe checkpoints inside `swap_dataset_live`:
  1. Post-fetch (most likely landing spot for a user cancel — fetch is the long pole)
  2. Pre-future-resubmit (last chance before the new training future goes live)
- `request_swap_cancel()` sets the flag under `_training_lock`. Stale flags are cleared at swap-start AND in `finally`, so DELETE-vs-swap races stay sane (per-swap, not sticky).
- `abandoned_candidate_pool_size` — captured **before** stopping the training future (reading after the future stops always yields zero). Reports the configured pool size when in `TrainingPhase.CANDIDATE`, zero otherwise (§3.5 Option C).
- §3.7 #5 structured INFO log on completion:
  `swap: input 2→3, output 2→2, hidden 5 preserved, candidates 8 abandoned, mode→output_training`
- §3.7 #7 topology rebroadcast already fired in P2-1a via `_broadcast_training_state(force=True)`; new unit test asserts it.

**Route (`api/routes/training.py`)**

- `DELETE /v1/training/dataset/live`: 403 (gate closed) / 404 (no swap) / 200 (cancel signal accepted)
- `POST /v1/training/dataset/live`: now translates `SwapCancelledError` → 200 with `{"status": "cancelled"}` so canopy's "Live Switch failed" toast does not fire on a user-initiated cancel.

### Out of scope (deferred to P2-1c/1d)

- Architecture adapter (grow/shrink) — equal-dim 422 guard retained.
- Spec §8 Q5 (`output_training_first` mode override) resolves naturally: `network.fit()` already starts in output-training mode, so the §3.5 semantic is implicit. Spec doc follow-up to mark Q5 RESOLVED can land separately if convenient.

## Test plan

- [x] `tests/integration/api/test_swap_dataset_live.py` — 22 passing (8 new P2-1b tests)
  - [x] `request_swap_cancel` raises when idle (404 path)
  - [x] `request_swap_cancel` sets signal when swap underway
  - [x] swap aborts cleanly when cancel arrives during fetch
  - [x] stale cancel flag is cleared at swap-start
  - [x] `abandoned_candidate_pool_size` = 0 in Output phase
  - [x] `abandoned_candidate_pool_size` = pool size in CANDIDATE phase
  - [x] §3.7 #5 log format pinned exactly
  - [x] `_broadcast_training_state(force=True)` called on completion
- [x] `tests/unit/api/test_phase2_routes.py` — 14 passing (4 new P2-1b tests)
  - [x] DELETE 403 when gate closed
  - [x] DELETE 404 when no swap in progress
  - [x] DELETE 200 happy path
  - [x] POST 200 + `status=cancelled` on `SwapCancelledError`
- [x] `tests/integration/api/test_pause_stop_actually_interrupts.py` — 8 passing (P2-PRE-1 unaffected)
- [x] Broader: 1314 unit + integration tests pass with no regressions
- [x] `pre-commit run` clean (black, isort, flake8, mypy, bandit, async-audit, etc.)

## Refs

- Spec: `juniper-canopy/notes/ISSUE_3_PHASE_2_LIVE_DATASET_SWAP_2026-05-09.md` §3.2 / §3.5 / §3.7 / §3.8 / §7
- Issue: pcalnon/juniper-cascor#3
- Series: P2-PRE-1 (#244) → P2-1a (#245) → **P2-1b (this PR)** → P2-1c → P2-1d → P2-2 → P2-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)