### PR TITLE
feat(phase2): P2-2 — dataset_swap history event + serializer round-trip (Issue #3)

### DIFF
--- a/notes/PHASE_2_P2_2_FOLLOWUPS_2026-05-14.md
+++ b/notes/PHASE_2_P2_2_FOLLOWUPS_2026-05-14.md
@@ -1,0 +1,83 @@
+# P2-2 Follow-ups: real-time broadcast + history fetch route
+
+**Status**: Captured 2026-05-14 during the P2-2 design check-in. Not yet implemented.
+**Parent PR**: P2-2 (`phase2/p2-2-dataset-swap-history`) — landed only the history persistence + serializer round-trip.
+
+This doc records two ideas surfaced during the P2-2 scoping discussion that were intentionally deferred to keep the P2-2 PR focused on persistence. Each is a small, independent follow-up that can land any time after P2-2 merges.
+
+---
+
+## Follow-up A: real-time WebSocket broadcast of `dataset_swap` events
+
+### What
+
+Push the `dataset_swap` event over the existing cascor WebSocket immediately on swap completion, so canopy can render a timeline marker without polling or fetching a snapshot.
+
+### Why deferred from P2-2
+
+History events are currently HDF5-only — no other history surface broadcasts in real time today (the agent investigation 2026-05-14 confirmed `train_loss` / `value_loss` / `train_accuracy` / `value_accuracy` / `hidden_units_added` all persist to HDF5 but do not broadcast). Adding broadcast for `dataset_swap` alone would create asymmetry — the right design conversation is "should all history events broadcast?", which is bigger than P2-2.
+
+Until this follows up, canopy P2-7 will pick up swap events via the snapshot/history GET path.
+
+### Sketch
+
+- In `swap_dataset_live` step 16 (after `record_dataset_swap_event` returns the event dict, in cascor `manager.py`), call `self._ws_manager.broadcast(create_dataset_swap_message(event))`.
+- New helper `create_dataset_swap_message(event)` in the same module as `create_event_message` / `create_cascade_add_message` (cascade_correlation.py around line 1281 per the agent's investigation — confirm before implementing).
+- Wire-format: `{"type": "dataset_swap", "data": {...event payload...}}` mirroring `create_cascade_add_message`'s envelope.
+
+### Tests
+
+- Lifecycle: mock `_ws_manager.broadcast`, run a successful swap, assert the call fires exactly once with the dataset_swap envelope.
+- No broadcast on cancel/rollback (mirror the persistence test).
+- Backpressure: if `_ws_manager` is `None` (no canopy connected), the call no-ops cleanly.
+
+### Effort
+
+~50–100 LOC. Small follow-up PR.
+
+---
+
+## Follow-up B: `GET /v1/history/dataset_swaps` route
+
+### What
+
+REST route that returns the current network's `history["dataset_swaps"]` list as JSON, without requiring callers to fetch a full snapshot.
+
+### Why deferred from P2-2
+
+P2-2 records the events into history; the snapshot serializer makes them durable. The route is purely for convenience — canopy P2-7's "Replay UI swap markers" feature wants this kind of access pattern. But until P2-7 is being implemented, we don't know whether a dedicated GET route is the right shape or whether the events would be better exposed via an existing history-fetch endpoint or via the WebSocket stream (Follow-up A above).
+
+The PR series document at `juniper-canopy/notes/ISSUE_3_PHASE_2_LIVE_DATASET_SWAP_2026-05-09.md` §7 places P2-7 last in the chain. By the time canopy P2-7 is being written, this follow-up's shape will be clear.
+
+### Sketch
+
+- New route in `src/api/routes/history.py` (or wherever history GETs live today — verify before implementing):
+  ```text
+  GET /v1/history/dataset_swaps        — returns the full list
+  GET /v1/history/dataset_swaps?since=ISO8601  — events strictly after a timestamp (optional)
+  ```
+- Response shape: `{"status": "success", "data": {"events": [...]}}` using the existing `success_response` envelope.
+- No write surface — events are append-only via the swap-completion path.
+
+### Tests
+
+- Empty history → empty list.
+- Single swap completed → one event in response.
+- Multiple swaps → events in chronological order.
+- `?since=` filter works (later events only).
+- Route honours the same auth scope as other history endpoints (verify the existing convention).
+
+### Effort
+
+~100–150 LOC. Small follow-up PR.
+
+---
+
+## Pickup order
+
+Either follow-up can land independently of the other. Suggested order if both are needed:
+
+1. **Follow-up B (GET route)** first — gives canopy a fetch path immediately.
+2. **Follow-up A (broadcast)** second — adds the push path. By the time we add broadcast, the consumer shape will be clearer from B.
+
+If only one is needed (e.g. P2-7 ends up only needing the fetch path), Follow-up A can stay deferred indefinitely without blocking anything.

--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -2617,6 +2617,25 @@ class TrainingLifecycleManager:
                     "abandoned_candidate_pool_size": abandoned_candidate_pool_size,
                     "active_output_dim": active_output_dim,
                 }
+                # P2-2 (Issue #3): persist the swap into network history so it
+                # round-trips through snapshot save/load and is available to
+                # canopy P2-7's timeline UI. Only fires on the success branch
+                # — rollback / cancel raise before reaching this point.
+                # Snapshot ID fields are placeholders that P2-3 will populate
+                # once auto-snap-pre/post-swap is wired (see
+                # ``notes/PHASE_2_P2_2_FOLLOWUPS_2026-05-14.md``). Failure
+                # to record (e.g., missing helper on a non-cascade network)
+                # is logged at warning but does NOT abort the swap — the
+                # swap itself already succeeded.
+                if hasattr(self.network, "record_dataset_swap_event"):
+                    try:
+                        self.network.record_dataset_swap_event(
+                            before_cfg=pre.dataset_config,
+                            after_cfg=dict(self._current_dataset_config) if self._current_dataset_config else None,
+                            arch_changes=response_arch,
+                        )
+                    except Exception:
+                        self.logger.exception("swap_dataset_live: record_dataset_swap_event failed; swap itself was successful")
                 return {
                     "status": "swapped",
                     "before_cfg": pre.dataset_config,

--- a/src/cascade_correlation/cascade_correlation.py
+++ b/src/cascade_correlation/cascade_correlation.py
@@ -34,6 +34,7 @@
 #
 #####################################################################################################################################################################################################
 import atexit
+import copy
 import datetime
 import io
 
@@ -729,6 +730,11 @@ class CascadeCorrelationNetwork:
             "train_accuracy": [],
             "value_accuracy": [],
             "hidden_units_added": [],
+            # P2-2 (Issue #3): structured record of every successful
+            # ``swap_dataset_live`` event. One dict appended per swap; see
+            # ``record_dataset_swap_event`` for the payload schema. Sibling
+            # of ``hidden_units_added`` in the event-with-payload pattern.
+            "dataset_swaps": [],
         }
 
         # Snapshot directory
@@ -884,6 +890,67 @@ class CascadeCorrelationNetwork:
             # Stays detached — matches the cascade-correlation convention at
             # ``_install_hidden_unit_helper`` (line ~3568: weights.clone().detach()).
             unit["weights"] = w
+
+    # ------------------------------------------------------------------
+    # P2-2 (Issue #3): live dataset swap history persistence.
+    #
+    # ``record_dataset_swap_event`` is the sole writer for
+    # ``self.history["dataset_swaps"]``. Called from
+    # ``swap_dataset_live`` in the lifecycle layer at the end of the
+    # success path (post-broadcast, pre-return), so cancelled swaps and
+    # rolled-back failures never produce a stale event.
+    #
+    # The payload schema mirrors the §3.3 swap response shape so canopy's
+    # P2-7 timeline UI can render markers without joining against any
+    # other state. Snapshot ID fields are placeholders that P2-3 will
+    # populate once pre/post-swap auto-snapshots are wired.
+    # ------------------------------------------------------------------
+
+    def record_dataset_swap_event(
+        self,
+        *,
+        before_cfg: Optional[Dict[str, Any]],
+        after_cfg: Optional[Dict[str, Any]],
+        arch_changes: Dict[str, Any],
+        pre_swap_snapshot_id: Optional[str] = None,
+        post_swap_snapshot_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Append a structured ``dataset_swap`` event to ``self.history``.
+
+        Returns the event dict that was appended so the caller can use it
+        for logging or for forwarding to a future broadcast layer (see
+        ``notes/PHASE_2_P2_2_FOLLOWUPS_2026-05-14.md`` Follow-up A).
+
+        Each event has the schema:
+
+        ```
+        {
+            "timestamp":              ISO-8601 UTC string,
+            "before_cfg":             dict | None,
+            "after_cfg":              dict | None,
+            "arch_changes":           dict (the §3.3 response shape),
+            "pre_swap_snapshot_id":   str | None  (P2-3 backfills),
+            "post_swap_snapshot_id":  str | None  (P2-3 backfills),
+        }
+        ```
+
+        ``before_cfg`` / ``after_cfg`` are shallow-copied so a later mutation
+        of the caller's dataset_config dict can't ripple back into the
+        history. ``arch_changes`` is deep-copied for the same reason
+        (the nested ``appended_nodes`` / ``prepended_layers`` containers
+        would otherwise alias).
+        """
+        event = {
+            "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "before_cfg": dict(before_cfg) if before_cfg is not None else None,
+            "after_cfg": dict(after_cfg) if after_cfg is not None else None,
+            "arch_changes": copy.deepcopy(arch_changes),
+            "pre_swap_snapshot_id": pre_swap_snapshot_id,
+            "post_swap_snapshot_id": post_swap_snapshot_id,
+        }
+        self.history.setdefault("dataset_swaps", []).append(event)
+        self.logger.debug(f"CascadeCorrelationNetwork: record_dataset_swap_event: recorded event #{len(self.history['dataset_swaps'])} timestamp={event['timestamp']}")
+        return event
 
     def _init_activation_function(self):
         """Initialize activation function components."""

--- a/src/snapshots/snapshot_serializer.py
+++ b/src/snapshots/snapshot_serializer.py
@@ -613,7 +613,7 @@ class CascadeHDF5Serializer:
         # Save policy flags
         mp_group.attrs["autostart"] = True  # Default to autostart on restore
 
-    def _save_training_history(self, hdf5_file: h5py.File, network, compression: str, compression_opts: int) -> None:
+    def _save_training_history(self, hdf5_file: h5py.File, network, compression: str, compression_opts: int) -> None:  # noqa: C901
         """Save training history."""
         if not hasattr(network, "history") or not network.history:
             return
@@ -664,6 +664,35 @@ class CascadeHDF5Serializer:
                             compression,
                             compression_opts,
                         )
+
+        # P2-2 (Issue #3): persist live-dataset-swap events. Each event is
+        # a subgroup under ``history/dataset_swaps/`` named ``event_{i}``
+        # with the schema:
+        #   * ``timestamp``                (str attr, ISO-8601 UTC)
+        #   * ``before_cfg``               (JSON-encoded str attr; ``"null"`` for None)
+        #   * ``after_cfg``                (JSON-encoded str attr; ``"null"`` for None)
+        #   * ``arch_changes``             (JSON-encoded str attr)
+        #   * ``pre_swap_snapshot_id``     (str attr, optional — P2-3 backfill)
+        #   * ``post_swap_snapshot_id``    (str attr, optional — P2-3 backfill)
+        # Nested dicts go through JSON because HDF5 attrs are flat and the
+        # ``arch_changes`` block has variable shape (``appended_nodes`` is
+        # itself a dict). Missing snapshot-ID attrs decode back to None on
+        # load so the §3.9 schema is faithfully reproduced.
+        if "dataset_swaps" in network.history and network.history["dataset_swaps"]:
+            swaps_group = history_group.create_group("dataset_swaps")
+            for i, swap_event in enumerate(network.history["dataset_swaps"]):
+                if not isinstance(swap_event, dict):
+                    continue
+                ev_group = swaps_group.create_group(f"event_{i}")
+                if "timestamp" in swap_event and swap_event["timestamp"] is not None:
+                    ev_group.attrs["timestamp"] = str(swap_event["timestamp"])
+                ev_group.attrs["before_cfg"] = json.dumps(swap_event.get("before_cfg"))
+                ev_group.attrs["after_cfg"] = json.dumps(swap_event.get("after_cfg"))
+                ev_group.attrs["arch_changes"] = json.dumps(swap_event.get("arch_changes", {}))
+                if swap_event.get("pre_swap_snapshot_id") is not None:
+                    ev_group.attrs["pre_swap_snapshot_id"] = str(swap_event["pre_swap_snapshot_id"])
+                if swap_event.get("post_swap_snapshot_id") is not None:
+                    ev_group.attrs["post_swap_snapshot_id"] = str(swap_event["post_swap_snapshot_id"])
 
         # CAN-015g (Phase 6E follow-on, g-1): per-sample weight history
         # for Replay V2. Persisted only when the network exposes a
@@ -1118,20 +1147,24 @@ class CascadeHDF5Serializer:
         np.random.set_state(np_state)
         self.logger.debug("CascadeHDF5Serializer: Restored NumPy random state")
 
-    def _load_training_history(self, hdf5_file: h5py.File, network) -> None:
+    def _load_training_history(self, hdf5_file: h5py.File, network) -> None:  # noqa: C901
         """Load training history."""
         if "history" not in hdf5_file:
             return
 
         history_group = hdf5_file["history"]
 
-        # Initialize history with network's actual keys
+        # Initialize history with network's actual keys. ``dataset_swaps``
+        # is P2-2 (Issue #3) — empty list when loading a pre-P2-2 snapshot,
+        # so the network attribute stays consistent with construction-time
+        # defaults regardless of snapshot vintage.
         network.history = {
             "train_loss": [],
             "value_loss": [],  # Use value_* to match network.history
             "train_accuracy": [],
             "value_accuracy": [],  # Use value_* to match network.history
             "hidden_units_added": [],
+            "dataset_swaps": [],
         }
 
         # Load numeric arrays - handle both old (val_*) and new (value_*) key formats
@@ -1172,6 +1205,50 @@ class CascadeHDF5Serializer:
                     unit_data["bias"] = load_numpy_array(unit_group["bias"])
 
                 network.history["hidden_units_added"].append(unit_data)
+
+        # P2-2 (Issue #3): live dataset swap event history. Each
+        # ``event_{i}`` subgroup carries the same schema written by
+        # ``_save_training_history`` above. Sorted-by-name iteration yields
+        # chronological order because the writer uses zero-padded indices —
+        # but to be defensive we also sort on numeric index where possible.
+        if "dataset_swaps" in history_group:
+            swaps_group = history_group["dataset_swaps"]
+
+            def _event_sort_key(name: str) -> int:
+                # ``event_<N>`` — sort by N; fall back to name for safety.
+                try:
+                    return int(name.split("_", 1)[1])
+                except (IndexError, ValueError):
+                    return -1
+
+            for event_name in sorted(swaps_group.keys(), key=_event_sort_key):
+                ev_group = swaps_group[event_name]
+                event: Dict[str, Any] = {
+                    "timestamp": None,
+                    "before_cfg": None,
+                    "after_cfg": None,
+                    "arch_changes": {},
+                    "pre_swap_snapshot_id": None,
+                    "post_swap_snapshot_id": None,
+                }
+                if "timestamp" in ev_group.attrs:
+                    event["timestamp"] = read_str_attr(ev_group, "timestamp", None)
+                # JSON-encoded nested dicts. Catch decode errors so a
+                # malformed event in one snapshot doesn't kill the whole
+                # history load — log and substitute the schema default.
+                for json_key, default in (("before_cfg", None), ("after_cfg", None), ("arch_changes", {})):
+                    if json_key in ev_group.attrs:
+                        try:
+                            event[json_key] = json.loads(read_str_attr(ev_group, json_key, "null"))
+                        except (json.JSONDecodeError, ValueError) as exc:
+                            self.logger.warning(f"CascadeHDF5Serializer: failed to decode {json_key!r} for {event_name!r}: {exc}; using default {default!r}")
+                            event[json_key] = default
+                if "pre_swap_snapshot_id" in ev_group.attrs:
+                    event["pre_swap_snapshot_id"] = read_str_attr(ev_group, "pre_swap_snapshot_id", None)
+                if "post_swap_snapshot_id" in ev_group.attrs:
+                    event["post_swap_snapshot_id"] = read_str_attr(ev_group, "post_swap_snapshot_id", None)
+                network.history["dataset_swaps"].append(event)
+            self.logger.debug(f"CascadeHDF5Serializer: Loaded {len(network.history['dataset_swaps'])} dataset_swap event(s)")
 
         # CAN-015g (g-1): per-sample weight history. Loaded into a sibling
         # ``weight_history`` attribute on the network so g-2's

--- a/src/tests/integration/api/test_swap_dataset_live.py
+++ b/src/tests/integration/api/test_swap_dataset_live.py
@@ -819,3 +819,136 @@ def test_swap_dataset_live_grow_input_log_line_reports_actual_deltas():
     rendered = fmt % tuple(args)
     assert rendered == "swap: input 2→5, output 2→3, hidden 0 preserved, candidates 0 abandoned, mode→output_training"
     mgr.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# P2-2 (Issue #3): dataset_swap history-event recording from the lifecycle.
+# Pins the success-only contract — cancelled / failed swaps must NOT append
+# an event, so the history reflects only what canopy should render.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_swap_dataset_live_records_history_event_on_success():
+    """Happy path: a successful swap appends exactly one event to
+    ``network.history["dataset_swaps"]`` whose payload mirrors the §3.3
+    response shape. This is the canopy P2-7 timeline-marker entrypoint."""
+    mgr = TrainingLifecycleManager()
+    mgr.create_network(input_size=2, output_size=2)
+    mgr.set_experimental_functions(True)
+    mgr._train_x, mgr._train_y = _make_dummy_tensors(2, 2)
+    mgr._current_dataset_config = {"dataset_type": "spirals"}
+    mgr.state_machine.handle_command(Command.START)
+
+    new_x, new_y = _make_dummy_tensors(4, 2)
+
+    def _fake_reload(**cfg):
+        mgr._train_x = new_x
+        mgr._train_y = new_y
+        mgr._current_dataset_config = {"dataset_type": "synthetic_4_2"}
+
+    mgr._executor = MagicMock()
+    mgr._executor.submit.return_value = MagicMock()
+
+    pre_count = len(mgr.network.history["dataset_swaps"])
+    with patch.object(mgr, "_reload_dataset", side_effect=_fake_reload):
+        result = mgr.swap_dataset_live(dataset_type="synthetic_4_2")
+
+    swaps = mgr.network.history["dataset_swaps"]
+    assert len(swaps) == pre_count + 1, "exactly one history event appended per successful swap"
+    event = swaps[-1]
+    # Schema present.
+    for key in ("timestamp", "before_cfg", "after_cfg", "arch_changes", "pre_swap_snapshot_id", "post_swap_snapshot_id"):
+        assert key in event, f"missing schema field {key!r}"
+    # Payload aligns with the §3.3 response (P2-2 records the SAME
+    # arch_changes dict that the route returns to canopy).
+    assert event["arch_changes"] == result["arch_changes"]
+    assert event["before_cfg"] == {"dataset_type": "spirals"}
+    assert event["after_cfg"] == {"dataset_type": "synthetic_4_2"}
+    # P2-3 placeholders default to None.
+    assert event["pre_swap_snapshot_id"] is None
+    assert event["post_swap_snapshot_id"] is None
+    mgr.shutdown()
+
+
+@pytest.mark.integration
+def test_swap_dataset_live_does_NOT_record_on_cancellation():
+    """A cancelled swap rolls back state and must NOT leave a stale
+    history event — canopy would render a swap that didn't happen."""
+    mgr = TrainingLifecycleManager()
+    mgr.create_network(input_size=2, output_size=2)
+    mgr.set_experimental_functions(True)
+    mgr._train_x, mgr._train_y = _make_dummy_tensors(2, 2)
+    mgr._current_dataset_config = {"dataset_type": "spirals"}
+    mgr.state_machine.handle_command(Command.START)
+
+    def _fake_reload_then_cancel(**cfg):
+        mgr._train_x, mgr._train_y = _make_dummy_tensors(2, 2)
+        mgr._current_dataset_config = {"dataset_type": "moons"}
+        mgr._swap_cancel_requested.set()
+
+    mgr._executor = MagicMock()
+    mgr._executor.submit.return_value = MagicMock()
+
+    pre_count = len(mgr.network.history["dataset_swaps"])
+    with patch.object(mgr, "_reload_dataset", side_effect=_fake_reload_then_cancel):
+        with pytest.raises(SwapCancelledError):
+            mgr.swap_dataset_live(dataset_type="moons")
+
+    assert len(mgr.network.history["dataset_swaps"]) == pre_count, "cancelled swap must not append an event"
+    mgr.shutdown()
+
+
+@pytest.mark.integration
+def test_swap_dataset_live_does_NOT_record_on_fetch_failure():
+    """``_reload_dataset`` raising before the network mutation → no event.
+    The rollback path returns the lifecycle to pre-swap state; the
+    history must reflect that nothing was committed."""
+    mgr = TrainingLifecycleManager()
+    mgr.create_network(input_size=2, output_size=2)
+    mgr.set_experimental_functions(True)
+    mgr._train_x, mgr._train_y = _make_dummy_tensors(2, 2)
+    mgr._current_dataset_config = {"dataset_type": "spirals"}
+    mgr.state_machine.handle_command(Command.START)
+
+    pre_count = len(mgr.network.history["dataset_swaps"])
+    with patch.object(mgr, "_reload_dataset", side_effect=RuntimeError("juniper-data unreachable")):
+        with pytest.raises(RuntimeError, match="juniper-data unreachable"):
+            mgr.swap_dataset_live(dataset_type="spirals")
+
+    assert len(mgr.network.history["dataset_swaps"]) == pre_count
+    mgr.shutdown()
+
+
+@pytest.mark.integration
+def test_swap_dataset_live_records_equal_dim_swap():
+    """Equal-dim swaps are still real user-initiated events (dataset
+    metadata changed; candidates may have been abandoned). The history
+    records them so canopy's timeline doesn't silently drop them."""
+    mgr = TrainingLifecycleManager()
+    mgr.create_network(input_size=2, output_size=2)
+    mgr.set_experimental_functions(True)
+    mgr._train_x, mgr._train_y = _make_dummy_tensors(2, 2)
+    mgr._current_dataset_config = {"dataset_type": "spirals", "n_spirals": 2}
+    mgr.state_machine.handle_command(Command.START)
+
+    new_x, new_y = _make_dummy_tensors(2, 2)
+
+    def _fake_reload(**cfg):
+        mgr._train_x = new_x
+        mgr._train_y = new_y
+        mgr._current_dataset_config = {"dataset_type": "moons", "noise": 0.2}
+
+    mgr._executor = MagicMock()
+    mgr._executor.submit.return_value = MagicMock()
+
+    with patch.object(mgr, "_reload_dataset", side_effect=_fake_reload):
+        mgr.swap_dataset_live(dataset_type="moons", noise=0.2)
+
+    swaps = mgr.network.history["dataset_swaps"]
+    assert len(swaps) == 1
+    assert swaps[0]["before_cfg"] == {"dataset_type": "spirals", "n_spirals": 2}
+    assert swaps[0]["after_cfg"] == {"dataset_type": "moons", "noise": 0.2}
+    assert swaps[0]["arch_changes"]["input_delta"] == 0
+    assert swaps[0]["arch_changes"]["output_delta"] == 0
+    mgr.shutdown()

--- a/src/tests/unit/cascade_correlation/test_record_dataset_swap_event.py
+++ b/src/tests/unit/cascade_correlation/test_record_dataset_swap_event.py
@@ -1,0 +1,141 @@
+"""P2-2 (Issue #3) — ``CascadeCorrelationNetwork.record_dataset_swap_event``.
+
+Covers the network-level history-recording surface defined in
+``notes/PHASE_2_P2_1D_DESIGN_2026-05-13.md`` and pinned by the §3.9 parent-
+spec contract. The recording is fire-and-forget from the lifecycle's
+perspective — these tests verify the payload schema, the snapshot-ID
+placeholder semantics, and that mutating the caller's input after
+recording does not affect the persisted event (deep-copy guarantee).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
+from cascade_correlation.cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
+
+pytestmark = pytest.mark.unit
+
+
+def _make_network() -> CascadeCorrelationNetwork:
+    cfg = CascadeCorrelationConfig(input_size=2, output_size=2, random_seed=42)
+    return CascadeCorrelationNetwork(cfg)
+
+
+def _sample_arch_changes() -> dict:
+    """Reference §3.3 arch_changes payload as written by P2-1d's
+    ``swap_dataset_live`` step 16. Mirroring the live shape here keeps the
+    network method's contract pinned against the lifecycle's expectations."""
+    return {
+        "input_delta": 2,
+        "output_delta": 0,
+        "hidden_preserved": 3,
+        "appended_nodes": {"input": 2, "output": 0},
+        "prepended_layers": [],
+        "abandoned_candidate_pool_size": 5,
+        "active_output_dim": 2,
+    }
+
+
+class TestRecordDatasetSwapEvent:
+    def test_initial_history_has_empty_dataset_swaps_list(self):
+        """Sibling of ``hidden_units_added``: present at construction
+        with empty list. Without this, downstream code would have to
+        defensively ``setdefault`` everywhere."""
+        net = _make_network()
+        assert "dataset_swaps" in net.history
+        assert net.history["dataset_swaps"] == []
+
+    def test_records_event_with_schema_fields(self):
+        net = _make_network()
+        before = {"dataset_type": "spirals", "n_spirals": 2}
+        after = {"dataset_type": "moons", "noise": 0.2}
+        result = net.record_dataset_swap_event(
+            before_cfg=before,
+            after_cfg=after,
+            arch_changes=_sample_arch_changes(),
+        )
+        assert isinstance(result, dict)
+        # Schema: all six required keys present.
+        assert set(result.keys()) == {
+            "timestamp",
+            "before_cfg",
+            "after_cfg",
+            "arch_changes",
+            "pre_swap_snapshot_id",
+            "post_swap_snapshot_id",
+        }
+        # Timestamp is ISO-8601 UTC (ends in +00:00).
+        assert isinstance(result["timestamp"], str)
+        assert "T" in result["timestamp"]  # date/time separator
+        # before_cfg / after_cfg copy the input (equal but distinct object).
+        assert result["before_cfg"] == before
+        assert result["after_cfg"] == after
+        # arch_changes deep-copied (top-level + nested ``appended_nodes``).
+        assert result["arch_changes"] == _sample_arch_changes()
+        # Snapshot IDs default to None (P2-3 backfill).
+        assert result["pre_swap_snapshot_id"] is None
+        assert result["post_swap_snapshot_id"] is None
+        # Appended to history.
+        assert len(net.history["dataset_swaps"]) == 1
+        assert net.history["dataset_swaps"][0] is result
+
+    def test_records_multiple_events_in_order(self):
+        """Each call appends; chronological order preserved."""
+        net = _make_network()
+        for i in range(3):
+            net.record_dataset_swap_event(
+                before_cfg={"step": i},
+                after_cfg={"step": i + 1},
+                arch_changes=_sample_arch_changes(),
+            )
+        assert len(net.history["dataset_swaps"]) == 3
+        assert [e["before_cfg"]["step"] for e in net.history["dataset_swaps"]] == [0, 1, 2]
+
+    def test_caller_mutation_after_record_does_not_affect_event(self):
+        """The deep-copy guarantee: mutating the caller's dicts after the
+        record call must NOT ripple into the persisted event. Without this,
+        a callsite that reuses a dict across swaps would silently corrupt
+        the history list."""
+        net = _make_network()
+        before = {"dataset_type": "spirals", "n_spirals": 2}
+        arch = _sample_arch_changes()
+        net.record_dataset_swap_event(before_cfg=before, after_cfg=None, arch_changes=arch)
+        # Mutate the caller's dicts post-record.
+        before["dataset_type"] = "MUTATED"
+        arch["input_delta"] = 999
+        arch["appended_nodes"]["input"] = 999  # nested mutation
+        # Persisted event unchanged.
+        ev = net.history["dataset_swaps"][0]
+        assert ev["before_cfg"]["dataset_type"] == "spirals"
+        assert ev["arch_changes"]["input_delta"] == 2
+        assert ev["arch_changes"]["appended_nodes"]["input"] == 2
+
+    def test_records_none_dataset_configs(self):
+        """``before_cfg`` / ``after_cfg`` can be None (the lifecycle passes
+        None when ``_current_dataset_config`` is unset, e.g. on first swap
+        before any dataset metadata is tracked)."""
+        net = _make_network()
+        ev = net.record_dataset_swap_event(
+            before_cfg=None,
+            after_cfg=None,
+            arch_changes=_sample_arch_changes(),
+        )
+        assert ev["before_cfg"] is None
+        assert ev["after_cfg"] is None
+
+    def test_records_with_explicit_snapshot_ids(self):
+        """Snapshot ID fields can be populated by callers (P2-3 will do this
+        when auto-snap-pre/post-swap is wired). Tests the path that P2-2
+        leaves dormant but doesn't disable."""
+        net = _make_network()
+        ev = net.record_dataset_swap_event(
+            before_cfg=None,
+            after_cfg=None,
+            arch_changes=_sample_arch_changes(),
+            pre_swap_snapshot_id="snap-pre-123",
+            post_swap_snapshot_id="snap-post-456",
+        )
+        assert ev["pre_swap_snapshot_id"] == "snap-pre-123"
+        assert ev["post_swap_snapshot_id"] == "snap-post-456"

--- a/src/tests/unit/test_snapshot_dataset_swaps.py
+++ b/src/tests/unit/test_snapshot_dataset_swaps.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python
+"""P2-2 (Issue #3): HDF5 round-trip for ``dataset_swap`` history events.
+
+Covers:
+
+* Round-trip of a synthetic ``network.history["dataset_swaps"]`` payload
+  through ``CascadeHDF5Serializer.save_network`` + ``load_network``.
+* Empty-list case: a network with no swaps still produces a valid snapshot
+  that loads with an empty ``dataset_swaps`` list (the construction-time
+  default).
+* Backward compat: snapshots written before P2-2 (no ``dataset_swaps``
+  HDF5 group) load successfully and initialise the list as empty.
+* Chronological order preserved across save/load.
+* Malformed JSON in one event does NOT kill the whole history load —
+  the bad event degrades to schema defaults with a warning, other
+  events restore cleanly.
+* Mixed populated + None ``before_cfg`` / ``after_cfg`` / snapshot ID
+  fields round-trip with the schema-faithful None on the missing sides.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+
+import h5py
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
+from cascade_correlation.cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
+from snapshots.snapshot_serializer import CascadeHDF5Serializer
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def temp_file():
+    with tempfile.NamedTemporaryFile(suffix=".h5", delete=False) as f:
+        path = f.name
+    yield path
+    if os.path.exists(path):
+        os.unlink(path)
+
+
+@pytest.fixture
+def serializer():
+    return CascadeHDF5Serializer()
+
+
+@pytest.fixture
+def simple_network():
+    config = CascadeCorrelationConfig.create_simple_config(input_size=2, output_size=2, learning_rate=0.1, max_hidden_units=3, random_seed=42)
+    return CascadeCorrelationNetwork(config=config)
+
+
+def _sample_event(i: int = 0) -> dict:
+    """Reference §3.3-shaped event; ``i`` lets a test build a small ordered
+    sequence to verify chronology survives the round-trip."""
+    return {
+        "timestamp": f"2026-05-14T00:0{i}:00+00:00",
+        "before_cfg": {"dataset_type": "spirals", "n_spirals": 2 + i},
+        "after_cfg": {"dataset_type": "moons", "noise": 0.1 * i},
+        "arch_changes": {
+            "input_delta": i,
+            "output_delta": 0,
+            "hidden_preserved": 3,
+            "appended_nodes": {"input": i, "output": 0},
+            "prepended_layers": [],
+            "abandoned_candidate_pool_size": 5,
+            "active_output_dim": 2,
+        },
+        "pre_swap_snapshot_id": None,
+        "post_swap_snapshot_id": None,
+    }
+
+
+class TestDatasetSwapsRoundTrip:
+    def test_empty_dataset_swaps_round_trips_as_empty_list(self, serializer, simple_network, temp_file):
+        """Default construction has an empty list; snapshot-then-load must
+        not invent events or drop the key."""
+        assert simple_network.history["dataset_swaps"] == []
+        assert serializer.save_network(simple_network, temp_file, include_training_state=True) is True
+        loaded = serializer.load_network(temp_file)
+        assert loaded is not None
+        assert loaded.history["dataset_swaps"] == []
+
+    def test_single_event_round_trips(self, serializer, simple_network, temp_file):
+        simple_network.history["dataset_swaps"] = [_sample_event(0)]
+        assert serializer.save_network(simple_network, temp_file, include_training_state=True) is True
+        loaded = serializer.load_network(temp_file)
+        assert loaded is not None
+        assert len(loaded.history["dataset_swaps"]) == 1
+        # Compare via JSON (handles nested dict equality + key ordering).
+        assert json.dumps(loaded.history["dataset_swaps"][0], sort_keys=True) == json.dumps(_sample_event(0), sort_keys=True)
+
+    def test_multiple_events_preserve_chronological_order(self, serializer, simple_network, temp_file):
+        """The save writes ``event_{i}`` subgroups; the load sorts by the
+        numeric suffix so the on-disk dict iteration order can't scramble
+        chronology. Pinned here because HDF5 group iteration order is
+        not guaranteed otherwise."""
+        events = [_sample_event(i) for i in range(5)]
+        simple_network.history["dataset_swaps"] = events
+        serializer.save_network(simple_network, temp_file, include_training_state=True)
+        loaded = serializer.load_network(temp_file)
+        assert loaded is not None
+        assert [ev["arch_changes"]["input_delta"] for ev in loaded.history["dataset_swaps"]] == [0, 1, 2, 3, 4]
+
+    def test_none_dataset_configs_round_trip(self, serializer, simple_network, temp_file):
+        """``before_cfg`` / ``after_cfg`` are encoded via ``json.dumps`` so
+        ``None`` becomes the literal string ``"null"`` on disk; the load
+        path must decode that back to Python ``None`` (not the string
+        ``"null"``)."""
+        ev = _sample_event(0)
+        ev["before_cfg"] = None
+        ev["after_cfg"] = None
+        simple_network.history["dataset_swaps"] = [ev]
+        serializer.save_network(simple_network, temp_file, include_training_state=True)
+        loaded = serializer.load_network(temp_file)
+        assert loaded is not None
+        assert loaded.history["dataset_swaps"][0]["before_cfg"] is None
+        assert loaded.history["dataset_swaps"][0]["after_cfg"] is None
+
+    def test_populated_snapshot_ids_round_trip(self, serializer, simple_network, temp_file):
+        """P2-3 will populate snapshot IDs; P2-2 leaves the path live but
+        defaulted to None. This test exercises the populated branch so the
+        attr is written-and-read symmetrically."""
+        ev = _sample_event(0)
+        ev["pre_swap_snapshot_id"] = "snap-pre-abc"
+        ev["post_swap_snapshot_id"] = "snap-post-def"
+        simple_network.history["dataset_swaps"] = [ev]
+        serializer.save_network(simple_network, temp_file, include_training_state=True)
+        loaded = serializer.load_network(temp_file)
+        assert loaded is not None
+        assert loaded.history["dataset_swaps"][0]["pre_swap_snapshot_id"] == "snap-pre-abc"
+        assert loaded.history["dataset_swaps"][0]["post_swap_snapshot_id"] == "snap-post-def"
+
+
+class TestDatasetSwapsBackwardCompat:
+    def test_pre_p2_2_snapshot_loads_with_empty_list(self, serializer, simple_network, temp_file):
+        """Simulate a snapshot from before P2-2 by saving normally, then
+        deleting the ``dataset_swaps`` HDF5 group. The loader must yield
+        an empty list, not raise or skip the ``dataset_swaps`` key."""
+        # Save once with a default empty list.
+        serializer.save_network(simple_network, temp_file, include_training_state=True)
+        # Remove the dataset_swaps group (simulating a snapshot vintage
+        # before P2-2 was written). Note: an EMPTY ``dataset_swaps`` list
+        # produces NO group on disk (the save path skips empties), so this
+        # is also the case for the "saved with P2-2 code but no swaps".
+        with h5py.File(temp_file, "a") as f:
+            if "history/dataset_swaps" in f:
+                del f["history/dataset_swaps"]
+        loaded = serializer.load_network(temp_file)
+        assert loaded is not None
+        # Schema invariant: the key exists with an empty list, not absent.
+        assert loaded.history["dataset_swaps"] == []
+
+
+class TestDatasetSwapsCorruptionTolerance:
+    def test_malformed_arch_changes_json_degrades_to_default(self, serializer, simple_network, temp_file):
+        """A single corrupt event must not break the whole history load.
+        Pin the graceful-degrade contract from the load path's
+        try/except around the JSON decode."""
+        simple_network.history["dataset_swaps"] = [_sample_event(0), _sample_event(1)]
+        serializer.save_network(simple_network, temp_file, include_training_state=True)
+        # Corrupt the ``arch_changes`` JSON for the first event.
+        with h5py.File(temp_file, "a") as f:
+            ev_group = f["history/dataset_swaps/event_0"]
+            ev_group.attrs["arch_changes"] = "{not valid json"
+        loaded = serializer.load_network(temp_file)
+        assert loaded is not None
+        # Both events present; corrupt one has default-empty arch_changes;
+        # other event intact.
+        assert len(loaded.history["dataset_swaps"]) == 2
+        assert loaded.history["dataset_swaps"][0]["arch_changes"] == {}
+        assert loaded.history["dataset_swaps"][1]["arch_changes"]["input_delta"] == 1


### PR DESCRIPTION
## Summary

Implements **P2-2** of Issue #3 (cascor) — the `dataset_swap` history event called for by spec §3.9. Every successful `swap_dataset_live` now appends a structured event to `network.history["dataset_swaps"]`, and the HDF5 snapshot serializer round-trips the event list cleanly. Canopy's P2-7 timeline UI will consume these events to render swap markers without needing to derive them from logs or live state.

Post-P2-1d redesign, the topology is structurally unchanged across swaps, so the event payload reduces to the same `arch_changes` dict the §3.3 swap response already carries (plus a timestamp and snapshot-ID placeholders for P2-3 to backfill).

## What changes

### Network class (`cascade_correlation.py`)

- Added `"dataset_swaps": []` as a sibling of `"hidden_units_added"` in the `self.history` dict.
- New `record_dataset_swap_event(*, before_cfg, after_cfg, arch_changes, pre_swap_snapshot_id=None, post_swap_snapshot_id=None) -> dict` method. Deep-copies the caller's nested dicts so post-call mutation can't ripple back into history.

Event payload (per spec §3.9):

```python
{
    "timestamp":              "2026-05-14T15:42:01.234Z",   # ISO-8601 UTC
    "before_cfg":             {...},                         # dataset cfg or None
    "after_cfg":              {...},                         # dataset cfg or None
    "arch_changes":           {...},                         # the §3.3 response dict
    "pre_swap_snapshot_id":   None,                          # P2-3 backfills
    "post_swap_snapshot_id":  None,                          # P2-3 backfills
}
```

### Lifecycle (`api/lifecycle/manager.py`)

- `swap_dataset_live` calls `record_dataset_swap_event` in the success branch, immediately after the topology rebroadcast and before the structured-log/return. Cancellation and rollback raise before this point, so failed swaps never record an event.
- The same `arch_changes` dict that flows into the route response also flows into the recorder — persisted events and live responses cannot drift.
- A recorder failure is caught + logged at `exception` level but does NOT abort the swap (the swap itself already succeeded; observability shouldn't break user-facing operations).

### Serializer (`snapshots/snapshot_serializer.py`)

- **Save**: each event becomes an HDF5 subgroup at `history/dataset_swaps/event_{i}` with scalar attrs + JSON-encoded string attrs for nested dicts. Empty list → no group on disk.
- **Load**: initialises `history["dataset_swaps"] = []` (backward compat for pre-P2-2 snapshots), then reads each `event_{i}` sorted by numeric suffix (HDF5 group iteration order isn't guaranteed otherwise). Malformed JSON in one event degrades that event to schema defaults with a warning, leaving other events intact.

## Test coverage

- **6 unit tests** for `record_dataset_swap_event`: schema, chronological order, deep-copy guarantee, None cfgs, explicit snapshot IDs, empty initial state.
- **7 unit tests** for serializer round-trip: empty list, single event, multi-event ordering, None cfgs encoded as JSON `"null"` and decoded back to Python `None`, populated snapshot IDs, pre-P2-2 backward compat (missing HDF5 group → empty list), corrupt arch_changes JSON degrades to default.
- **4 integration tests** on `swap_dataset_live`: success records exactly one event matching the §3.3 response, cancelled swap records 0, fetch-failure records 0, equal-dim swap still records (dataset metadata changed even if dims didn't).

## Follow-ups (deferred, captured in `notes/PHASE_2_P2_2_FOLLOWUPS_2026-05-14.md`)

- **Follow-up A**: real-time WebSocket broadcast of `dataset_swap` events. Asymmetric to add for just this event type — the right design conversation is "should all history events broadcast?", bigger than P2-2.
- **Follow-up B**: `GET /v1/history/dataset_swaps` route for canopy P2-7 to fetch the event list without pulling a full snapshot. Shape can wait until P2-7 is being written.

Both are small (~50–150 LOC each), independent, and can land any time post-P2-2.

## Verification

- [x] 3562 tests pass, 15 skipped (+17 net new tests, no regressions)
- [x] 44 focused tests on the P2-2 surface pass (unit + serializer + integration)
- [x] Pause/stop interrupt regression tests pass (P2-PRE-1 healthy)
- [x] `pre-commit run` clean (black, isort, flake8, mypy, bandit, async-audit)

## Refs

- Spec: `juniper-canopy/notes/ISSUE_3_PHASE_2_LIVE_DATASET_SWAP_2026-05-09.md` §3.3 / §3.9 / §7 P2-2 row
- Follow-up design notes: `notes/PHASE_2_P2_2_FOLLOWUPS_2026-05-14.md` (in this PR)
- Issue: pcalnon/juniper-cascor#3
- Series: P2-PRE-1 (#244) → P2-1a (#245) → P2-1b (#250) → P2-1c (#251) → P2-1d (#252) → **P2-2 (this PR)** → P2-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)