### PR TITLE
feat(phase2): P2-3 — pre/post-swap auto-snapshot + ID threading (Issue #3)

### DIFF
--- a/notes/PHASE_2_P2_3_FOLLOWUP_REPLAY_REWORK_2026-05-14.md
+++ b/notes/PHASE_2_P2_3_FOLLOWUP_REPLAY_REWORK_2026-05-14.md
@@ -1,0 +1,105 @@
+# P2-3 follow-up: event-sourced replay rework
+
+**Status**: Captured 2026-05-14 during P2-3 implementation. Not yet scheduled.
+**Parent PR**: P2-3 (`phase2/p2-3-swap-snapshots-replay`).
+
+P2-3's parent spec ([`juniper-canopy/notes/ISSUE_3_PHASE_2_LIVE_DATASET_SWAP_2026-05-09.md`](../../juniper-canopy/notes/ISSUE_3_PHASE_2_LIVE_DATASET_SWAP_2026-05-09.md) §3.9 / §7) calls for a *"Replay reconstruction handler (instantaneous transformation, per §8 Answer 3)"* — implying that when replay encounters a `dataset_swap` event mid-playback, a handler fires and transforms the network's dims instantaneously.
+
+The 2026-05-14 P2-3 implementation investigation revealed that **`_ReplaySession` is a passive time-indexed metric playback engine**, not an event-sourced replay engine. The "mid-playback handler" pattern cannot be implemented on top of the current engine without substantial architectural rework. This document captures (a) why P2-3 shipped without the mid-playback handler, (b) the canopy-orchestrated alternative P2-3 enables, and (c) the rework spec to revisit if the alternative turns out insufficient.
+
+---
+
+## 1. Current replay engine (`_ReplaySession`)
+
+Defined at `src/api/lifecycle/manager.py:766`.
+
+Flow on `start_replay(snapshot_id)`:
+
+1. Load the target HDF5 snapshot via `_load_snapshot_to_network()`. The deserializer reconstructs the entire network state — weights, topology, history arrays — exactly as it was at the moment the snapshot was taken.
+2. The replay session captures `network.history` (metric arrays) and `network.weight_history` (CAN-015g per-sample weights).
+3. A background thread (`_run`) advances a `time_index` integer at the configured playback speed and emits synthetic `epoch_end` events frame-by-frame via `_emit_frame(index)`.
+
+The session **does not process individual history events**. There is no event-dispatch table. The `_run` loop is time-indexed, not event-indexed. Topology is frozen at snapshot-load time — there is no live network being mutated.
+
+This means there is no place to plug in a per-event handler for `dataset_swap` that would mutate the replay's network state at the right moment.
+
+## 2. What P2-3 actually shipped
+
+P2-3 ships only the snapshot infrastructure:
+
+- Pre-swap auto-snap in `swap_dataset_live`, capturing the network state immediately before `_resize_network_for_dataset` mutates anything.
+- Post-swap auto-snap after the new training future is submitted.
+- The captured snapshot IDs are threaded into `record_dataset_swap_event(pre_swap_snapshot_id=…, post_swap_snapshot_id=…)`, so the `dataset_swap` history event (from P2-2) now carries both IDs instead of the `None` placeholders.
+
+The snapshot IDs round-trip through `_save_training_history` / `_load_training_history` (the P2-2 serializer plumbing handles them), so a replay session that loaded any post-swap snapshot can read those IDs out of its own history.
+
+## 3. Canopy-orchestrated transitions (the P2-7 path)
+
+Without an event-replay engine, **canopy orchestrates topology transitions at the snapshot boundary**, not in cascor's replay loop. The intended P2-7 UX:
+
+1. When the user starts replay from a snapshot whose `history["dataset_swaps"]` is non-empty, canopy reads each event's timestamp and renders a **timeline marker** at the corresponding playback frame.
+2. As the playback cursor approaches a marker, the timeline UI offers (or auto-fires) a *"continue past swap"* action.
+3. The action calls `POST /v1/snapshots/{post_swap_snapshot_id}/replay/control` with `action="play"` — effectively restarting replay from the post-swap snapshot.
+4. The user sees the topology "change instantaneously" at the marker — achieved by snapshot reload, not by mid-playback mutation. The visible effect matches the spec's *"instantaneous transformation"* wording even though the mechanism differs.
+
+The §8 Answer 3 *"instantaneous transformation"* requirement is satisfied in user-visible terms. The mechanism is a property of the orchestration layer (canopy), not the playback engine (cascor).
+
+## 4. Trigger conditions for picking up the rework
+
+This follow-up should be revisited if any of the following surface during P2-7 or later canopy work:
+
+* **Snapshot-reload feels jarring.** Latency of `POST /replay/control` + snapshot load + replay restart visibly stutters the playback. If the cumulative delay exceeds ~500 ms on a representative network the user experience suffers; an event-sourced engine that mutates a live replay network in place would be smoother.
+
+* **Multi-swap-in-quick-succession.** A snapshot every swap means a replay run that crosses N swap boundaries does N snapshot reloads. For sustained interactive use (e.g., scrubbing back and forth across the timeline) this could compound.
+
+* **Animated topology transitions.** If P2-7's UX evolves to animate the topology change (e.g., show new input/output nodes fading in over a few frames), the snapshot-reload model can't produce intermediate states. An event-sourced replay engine could call `network._resize_network_for_dataset` and interpolate.
+
+* **Mid-replay editing.** A "what if" UX (replay this run but with a different swap dim) would need event-sourced playback so the user's hypothetical change can be applied mid-stream. Currently out of scope; flagged here because it's a natural extension that the snapshot model can't serve.
+
+* **Replay-only snapshot mode.** If snapshot writes become a noticeable training-loop overhead and the team decides to disable auto-snap on swap, the snapshot-orchestration UX dies entirely — at that point we'd need event-replay or some other reconstruction path.
+
+If none of the above surface, this follow-up may stay deferred indefinitely without harm.
+
+## 5. Rework specification (to be applied when triggered)
+
+### 5.1 Engine changes
+
+Convert `_ReplaySession` from passive metric playback to event-sourced playback:
+
+* Add an `_event_queue: list[dict]` field, populated at session start by merging:
+  * Per-epoch metric samples (synthesised from `network.history["train_loss"]` etc., one event per index — current behaviour).
+  * Cascade-add events from `network.history["hidden_units_added"]`.
+  * Dataset-swap events from `network.history["dataset_swaps"]`.
+  * Any future event-with-payload history keys.
+* Order the queue by event timestamp (or by epoch index where timestamps aren't available — needs a backward-compat strategy for old snapshots without per-event timestamps).
+* Replace the `_run` time-index loop with an event-dispatch loop that pops the next event, sleeps until its scheduled time, then dispatches to a per-type handler.
+
+### 5.2 Per-event handlers
+
+* `epoch_end` — current `_emit_frame` behaviour. Broadcast metric tick.
+* `cascade_add` — already pre-baked into the loaded snapshot's topology; the handler just broadcasts a `cascade_add_message` for canopy to update its render.
+* `dataset_swap` — call `network._resize_network_for_dataset(...)` using the event's `arch_changes` to apply the grow side, then set `network.active_output_dim` from the event payload to apply the shrink-via-pad side. Broadcast a `dataset_swap_message`.
+
+### 5.3 Backward compatibility
+
+Snapshots written before the rework have neither per-event timestamps nor a guarantee that `dataset_swaps` exists. The rework must:
+
+* Treat absent `dataset_swaps` as the empty list (already covered by P2-2's load path).
+* Synthesise event timestamps from epoch indices when missing.
+* Provide a feature flag (env var or settings) to fall back to the passive playback engine for snapshots that don't carry enough event metadata.
+
+### 5.4 Estimated cost
+
+* `_ReplaySession` rewrite: 200–400 LOC.
+* Per-event handlers: 50–150 LOC each.
+* Tests covering each handler + ordering + backward compat: 300–500 LOC.
+* Total: ~1000–1500 LOC, likely 1–2 weeks including review and integration with P2-7.
+
+A standalone design conversation should happen first to lock in the event-queue shape, handler protocol, and backward-compat strategy before code lands.
+
+## 6. Files touched (when triggered)
+
+* `src/api/lifecycle/manager.py` — `_ReplaySession` class (mostly rewrite), `start_replay`, `replay_control`.
+* `src/cascade_correlation/cascade_correlation.py` — possible new methods if `_resize_network_for_dataset` needs a "for replay" variant that skips bookkeeping side effects (broadcast, history recording, etc.).
+* `src/snapshots/snapshot_serializer.py` — possibly extending event metadata if backward-compat timestamp synthesis needs help.
+* New: `src/tests/integration/api/test_replay_event_sourced.py` for the dispatch loop + handler tests.

--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -2488,6 +2488,25 @@ class TrainingLifecycleManager:
                 # has none, so reporting zero in those cases is correct.
                 abandoned_candidate_pool_size = self._snapshot_abandoned_candidate_pool_size()
 
+                # P2-3 (Issue #3): pre-swap auto-snap. Fires AFTER the
+                # in-memory rollback snapshot (step 4) but BEFORE any
+                # network mutation, so the on-disk snapshot captures the
+                # genuine pre-swap state. Kept on disk even when the swap
+                # is later cancelled / rolled back — the pre-swap moment
+                # is a valid checkpoint regardless of swap outcome, and
+                # cleanup would just add race conditions.
+                # Failure-tolerant: if the HDF5 write fails the swap
+                # continues without an ID; canopy P2-7 will render the
+                # event without a "Restore from pre-swap" affordance.
+                pre_swap_snapshot_id: Optional[str] = None
+                try:
+                    pre_dataset_name = (pre.dataset_config or {}).get("dataset_type") or "unknown"
+                    pre_snap = self.save_snapshot(description=f"pre-swap before dataset_swap (from {pre_dataset_name})")
+                    if pre_snap is not None:
+                        pre_swap_snapshot_id = pre_snap.get("id")
+                except Exception:
+                    self.logger.exception("swap_dataset_live: pre-swap snapshot failed; swap continues without pre_swap_snapshot_id")
+
                 # Step 5/6: signal stop, wait for training future to exit cleanly.
                 # P2-PRE-1 (f4453fa) makes _stop_requested actually interrupt
                 # the training-loop callbacks via TrainingInterrupted, caught
@@ -2582,6 +2601,22 @@ class TrainingLifecycleManager:
                 # is plumbed for P2-1c/1d when dims actually change).
                 self._broadcast_training_state(force=True)
 
+                # P2-3 (Issue #3): post-swap auto-snap. Captures the
+                # network state AFTER resize + new training future
+                # submission so canopy P2-7's "Restore from post-swap"
+                # affordance and the snapshot-orchestrated replay
+                # transition (see ``notes/PHASE_2_P2_3_FOLLOWUP_REPLAY_REWORK_2026-05-14.md``)
+                # have a concrete handle. Same failure tolerance as the
+                # pre-swap snap.
+                post_swap_snapshot_id: Optional[str] = None
+                try:
+                    post_dataset_name = (self._current_dataset_config or {}).get("dataset_type") or "unknown"
+                    post_snap = self.save_snapshot(description=f"post-swap after dataset_swap (to {post_dataset_name})")
+                    if post_snap is not None:
+                        post_swap_snapshot_id = post_snap.get("id")
+                except Exception:
+                    self.logger.exception("swap_dataset_live: post-swap snapshot failed; swap continues without post_swap_snapshot_id")
+
                 # Step 16: structured INFO log per §3.7 guardrail #5, then
                 # structured response per §3.3. The §3.3 log/response use
                 # the *dataset's* dims as the right-hand side of the arrow
@@ -2622,17 +2657,22 @@ class TrainingLifecycleManager:
                 # canopy P2-7's timeline UI. Only fires on the success branch
                 # — rollback / cancel raise before reaching this point.
                 # Snapshot ID fields are placeholders that P2-3 will populate
-                # once auto-snap-pre/post-swap is wired (see
-                # ``notes/PHASE_2_P2_2_FOLLOWUPS_2026-05-14.md``). Failure
-                # to record (e.g., missing helper on a non-cascade network)
-                # is logged at warning but does NOT abort the swap — the
-                # swap itself already succeeded.
+                # P2-3 (Issue #3): the snapshot IDs that P2-2 left as
+                # placeholders are now populated from the pre/post-swap
+                # auto-snaps above. Either may be ``None`` if the
+                # corresponding snapshot write failed — the event still
+                # records, just without that affordance for canopy P2-7.
+                # Failure to record (e.g., missing helper on a non-cascade
+                # network) is logged at warning but does NOT abort the
+                # swap — the swap itself already succeeded.
                 if hasattr(self.network, "record_dataset_swap_event"):
                     try:
                         self.network.record_dataset_swap_event(
                             before_cfg=pre.dataset_config,
                             after_cfg=dict(self._current_dataset_config) if self._current_dataset_config else None,
                             arch_changes=response_arch,
+                            pre_swap_snapshot_id=pre_swap_snapshot_id,
+                            post_swap_snapshot_id=post_swap_snapshot_id,
                         )
                     except Exception:
                         self.logger.exception("swap_dataset_live: record_dataset_swap_event failed; swap itself was successful")
@@ -3736,7 +3776,18 @@ class TrainingLifecycleManager:
         return snapshots_dir
 
     def save_snapshot(self, description: str = "") -> Optional[Dict[str, Any]]:
-        """Save current network state to an HDF5 snapshot."""
+        """Save current network state to an HDF5 snapshot.
+
+        P2-3 (Issue #3): the timestamp is second-resolution
+        (``YYYYMMDDTHHMMSSZ``) which used to silently overwrite when two
+        snapshots fired within the same second — exactly what happens on
+        ``swap_dataset_live`` where pre- and post-swap snapshots are taken
+        ≤1 s apart for a small network. We now check for an existing file
+        and append ``_2``, ``_3``, etc. to the ID until we find a free
+        slot. The no-collision path is byte-identical to the prior
+        behaviour, so the ``snapshot_YYYYMMDDTHHMMSSZ`` format remains the
+        common case for canopy / REST consumers that parse it.
+        """
         if self.network is None:
             return None
 
@@ -3744,8 +3795,20 @@ class TrainingLifecycleManager:
 
         serializer = CascadeHDF5Serializer()
         timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
-        snapshot_id = f"snapshot_{timestamp}"
-        filepath = self._get_snapshots_dir() / f"{snapshot_id}.h5"
+        base_snapshot_id = f"snapshot_{timestamp}"
+        snapshots_dir = self._get_snapshots_dir()
+        snapshot_id = base_snapshot_id
+        filepath = snapshots_dir / f"{snapshot_id}.h5"
+        # P2-3 collision suffix. Capped at 1000 so a misbehaving filesystem
+        # (e.g., directory not actually writable, every probe returning
+        # exists()=True) cannot wedge the lifecycle in a tight loop. If a
+        # thousand same-second snapshots really exist on disk, the caller
+        # has bigger problems and a hard failure is the right signal.
+        suffix = 2
+        while filepath.exists() and suffix <= 1000:
+            snapshot_id = f"{base_snapshot_id}_{suffix}"
+            filepath = snapshots_dir / f"{snapshot_id}.h5"
+            suffix += 1
 
         success = serializer.save_network(self.network, filepath, include_training_state=True)
         if not success:

--- a/src/tests/integration/api/test_swap_dataset_live.py
+++ b/src/tests/integration/api/test_swap_dataset_live.py
@@ -865,9 +865,14 @@ def test_swap_dataset_live_records_history_event_on_success():
     assert event["arch_changes"] == result["arch_changes"]
     assert event["before_cfg"] == {"dataset_type": "spirals"}
     assert event["after_cfg"] == {"dataset_type": "synthetic_4_2"}
-    # P2-3 placeholders default to None.
-    assert event["pre_swap_snapshot_id"] is None
-    assert event["post_swap_snapshot_id"] is None
+    # P2-3 snapshot IDs are populated by the pre/post-swap auto-snap.
+    # Both should be strings matching the ``snapshot_<TIMESTAMP>[_<n>]``
+    # format. The dedicated P2-3 tests below assert ordering and contents
+    # in detail; here we just confirm the threading is wired.
+    assert isinstance(event["pre_swap_snapshot_id"], str)
+    assert event["pre_swap_snapshot_id"].startswith("snapshot_")
+    assert isinstance(event["post_swap_snapshot_id"], str)
+    assert event["post_swap_snapshot_id"].startswith("snapshot_")
     mgr.shutdown()
 
 
@@ -951,4 +956,203 @@ def test_swap_dataset_live_records_equal_dim_swap():
     assert swaps[0]["after_cfg"] == {"dataset_type": "moons", "noise": 0.2}
     assert swaps[0]["arch_changes"]["input_delta"] == 0
     assert swaps[0]["arch_changes"]["output_delta"] == 0
+    mgr.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# P2-3 (Issue #3): pre + post-swap auto-snapshot + ID threading into the
+# dataset_swap event. The replay-engine rework is deferred per
+# ``notes/PHASE_2_P2_3_FOLLOWUP_REPLAY_REWORK_2026-05-14.md`` — these tests
+# pin only the snapshot infrastructure that P2-3 actually ships.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_swap_dataset_live_takes_pre_and_post_snapshots():
+    """Successful swap triggers exactly two ``save_snapshot`` calls — one
+    pre-swap (before resize), one post-swap (after the new training
+    future submits). Both IDs are threaded into the history event so
+    canopy P2-7 can drive a snapshot-orchestrated transition."""
+    mgr = TrainingLifecycleManager()
+    mgr.create_network(input_size=2, output_size=2)
+    mgr.set_experimental_functions(True)
+    mgr._train_x, mgr._train_y = _make_dummy_tensors(2, 2)
+    mgr._current_dataset_config = {"dataset_type": "spirals", "n_spirals": 2}
+    mgr.state_machine.handle_command(Command.START)
+
+    new_x, new_y = _make_dummy_tensors(4, 2)
+
+    def _fake_reload(**cfg):
+        mgr._train_x = new_x
+        mgr._train_y = new_y
+        mgr._current_dataset_config = {"dataset_type": "moons", "noise": 0.2}
+
+    mgr._executor = MagicMock()
+    mgr._executor.submit.return_value = MagicMock()
+
+    # Patch save_snapshot to return stable IDs without writing HDF5 to
+    # disk — the file-IO behaviour is covered by the unit tests.
+    saved_descriptions = []
+
+    def _fake_save(description=""):
+        saved_descriptions.append(description)
+        return {
+            "id": f"snapshot_test_{len(saved_descriptions):02d}",
+            "path": f"/tmp/{len(saved_descriptions):02d}.h5",
+            "timestamp": "20260514T000000Z",
+            "description": description,
+        }
+
+    with patch.object(mgr, "save_snapshot", side_effect=_fake_save):
+        with patch.object(mgr, "_reload_dataset", side_effect=_fake_reload):
+            result = mgr.swap_dataset_live(dataset_type="moons", noise=0.2)
+
+    # Two snapshots fired, in order.
+    assert len(saved_descriptions) == 2
+    assert "pre-swap" in saved_descriptions[0]
+    assert "post-swap" in saved_descriptions[1]
+    # Descriptions encode swap metadata (deliverable Q2 of the design).
+    assert "spirals" in saved_descriptions[0], f"pre-swap description should name the before dataset: {saved_descriptions[0]!r}"
+    assert "moons" in saved_descriptions[1], f"post-swap description should name the after dataset: {saved_descriptions[1]!r}"
+    # Event has both IDs threaded.
+    swaps = mgr.network.history["dataset_swaps"]
+    assert len(swaps) == 1
+    assert swaps[0]["pre_swap_snapshot_id"] == "snapshot_test_01"
+    assert swaps[0]["post_swap_snapshot_id"] == "snapshot_test_02"
+    # Swap itself succeeded (not just the snapshots).
+    assert result["status"] == "swapped"
+    mgr.shutdown()
+
+
+@pytest.mark.integration
+def test_swap_dataset_live_pre_swap_snapshot_taken_before_resize():
+    """Ordering invariant: the pre-swap snapshot must capture the network
+    BEFORE ``_resize_network_for_dataset`` mutates it. If the snapshot
+    fired after resize, ``pre_swap_snapshot_id`` would point at a
+    network with the post-swap dims, defeating the whole "Restore from
+    pre-swap" P2-7 affordance."""
+    mgr = TrainingLifecycleManager()
+    mgr.create_network(input_size=2, output_size=2)
+    mgr.set_experimental_functions(True)
+    mgr._train_x, mgr._train_y = _make_dummy_tensors(2, 2)
+    mgr._current_dataset_config = {"dataset_type": "spirals"}
+    mgr.state_machine.handle_command(Command.START)
+
+    new_x, new_y = _make_dummy_tensors(5, 3)
+
+    def _fake_reload(**cfg):
+        mgr._train_x = new_x
+        mgr._train_y = new_y
+        mgr._current_dataset_config = {"dataset_type": "moons"}
+
+    mgr._executor = MagicMock()
+    mgr._executor.submit.return_value = MagicMock()
+
+    observed_dims = []
+
+    def _fake_save(description=""):
+        # Capture the network's dims at the moment of each snapshot call.
+        observed_dims.append((description, mgr.network.input_size, mgr.network.output_size))
+        return {"id": f"snap_{len(observed_dims)}", "path": "/tmp/x", "timestamp": "T", "description": description}
+
+    with patch.object(mgr, "save_snapshot", side_effect=_fake_save):
+        with patch.object(mgr, "_reload_dataset", side_effect=_fake_reload):
+            mgr.swap_dataset_live(dataset_type="moons")
+
+    assert len(observed_dims) == 2
+    pre_desc, pre_in, pre_out = observed_dims[0]
+    post_desc, post_in, post_out = observed_dims[1]
+    assert "pre-swap" in pre_desc
+    # Pre-swap snapshot saw the OLD dims.
+    assert pre_in == 2 and pre_out == 2
+    assert "post-swap" in post_desc
+    # Post-swap snapshot saw the NEW dims (after grow).
+    assert post_in == 5 and post_out == 3
+    mgr.shutdown()
+
+
+@pytest.mark.integration
+def test_swap_dataset_live_pre_swap_snapshot_kept_on_cancel():
+    """Per the P2-3 design Q1 decision: a pre-swap snapshot taken before
+    the user cancels stays on disk as a valid checkpoint of the moment
+    the swap was attempted. The dataset_swap event itself does NOT
+    record (the cancel raises before record), so the snapshot exists
+    without a corresponding history event — that's intentional."""
+    mgr = TrainingLifecycleManager()
+    mgr.create_network(input_size=2, output_size=2)
+    mgr.set_experimental_functions(True)
+    mgr._train_x, mgr._train_y = _make_dummy_tensors(2, 2)
+    mgr._current_dataset_config = {"dataset_type": "spirals"}
+    mgr.state_machine.handle_command(Command.START)
+
+    def _fake_reload_then_cancel(**cfg):
+        mgr._train_x, mgr._train_y = _make_dummy_tensors(2, 2)
+        mgr._current_dataset_config = {"dataset_type": "moons"}
+        mgr._swap_cancel_requested.set()
+
+    mgr._executor = MagicMock()
+    mgr._executor.submit.return_value = MagicMock()
+
+    save_calls = []
+
+    def _fake_save(description=""):
+        save_calls.append(description)
+        return {"id": f"snap_{len(save_calls)}", "path": "/tmp/x", "timestamp": "T", "description": description}
+
+    with patch.object(mgr, "save_snapshot", side_effect=_fake_save):
+        with patch.object(mgr, "_reload_dataset", side_effect=_fake_reload_then_cancel):
+            with pytest.raises(SwapCancelledError):
+                mgr.swap_dataset_live(dataset_type="moons")
+
+    # Pre-swap snap fired; post-swap did NOT (the cancel checkpoint trips
+    # before we reach the post-swap snap call site).
+    assert len(save_calls) == 1
+    assert "pre-swap" in save_calls[0]
+    # Event NOT recorded (already covered by P2-2 tests but pinned here
+    # to make the snapshot-vs-event asymmetry explicit).
+    assert mgr.network.history["dataset_swaps"] == []
+    mgr.shutdown()
+
+
+@pytest.mark.integration
+def test_swap_dataset_live_pre_swap_snapshot_failure_does_not_abort_swap():
+    """Snapshot writes are observability, not core functionality. A
+    failed pre-swap snapshot logs and leaves ``pre_swap_snapshot_id`` as
+    None in the recorded event — the swap itself still succeeds."""
+    mgr = TrainingLifecycleManager()
+    mgr.create_network(input_size=2, output_size=2)
+    mgr.set_experimental_functions(True)
+    mgr._train_x, mgr._train_y = _make_dummy_tensors(2, 2)
+    mgr._current_dataset_config = {"dataset_type": "spirals"}
+    mgr.state_machine.handle_command(Command.START)
+
+    new_x, new_y = _make_dummy_tensors(2, 2)
+
+    def _fake_reload(**cfg):
+        mgr._train_x = new_x
+        mgr._train_y = new_y
+        mgr._current_dataset_config = {"dataset_type": "moons"}
+
+    mgr._executor = MagicMock()
+    mgr._executor.submit.return_value = MagicMock()
+
+    call_count = {"n": 0}
+
+    def _fake_save_pre_fails(description=""):
+        call_count["n"] += 1
+        # First call (pre-swap) raises; second (post-swap) succeeds.
+        if call_count["n"] == 1:
+            raise RuntimeError("disk full simulation")
+        return {"id": "snap_post_ok", "path": "/tmp/x", "timestamp": "T", "description": description}
+
+    with patch.object(mgr, "save_snapshot", side_effect=_fake_save_pre_fails):
+        with patch.object(mgr, "_reload_dataset", side_effect=_fake_reload):
+            result = mgr.swap_dataset_live(dataset_type="moons")
+
+    assert result["status"] == "swapped"
+    swaps = mgr.network.history["dataset_swaps"]
+    assert len(swaps) == 1
+    # Pre-swap failed → None; post-swap succeeded → populated.
+    assert swaps[0]["pre_swap_snapshot_id"] is None
+    assert swaps[0]["post_swap_snapshot_id"] == "snap_post_ok"
     mgr.shutdown()

--- a/src/tests/unit/api/test_save_snapshot_collision.py
+++ b/src/tests/unit/api/test_save_snapshot_collision.py
@@ -1,0 +1,146 @@
+"""P2-3 (Issue #3) — ``save_snapshot`` ID collision handling.
+
+The snapshot ID is built from ``datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")``
+— second resolution. Two ``save_snapshot`` calls within the same wall-clock
+second (the common case for ``swap_dataset_live``'s pre/post-swap pair on a
+small network) used to silently overwrite. P2-3 appends ``_2``, ``_3``, ...
+to the ID until a free filename is found.
+
+These tests pin:
+
+* No-collision path: the returned ID matches the pre-P2-3 format byte-for-byte,
+  so any consumer that parses ``snapshot_YYYYMMDDTHHMMSSZ`` keeps working.
+* Collision path: two successive saves produce distinct IDs (with ``_2``
+  suffix), distinct filenames on disk, and both files are valid HDF5.
+* The cap at 1000 prevents a runaway loop on misbehaving filesystems.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import h5py
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
+
+from api.lifecycle.manager import TrainingLifecycleManager
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def mgr_with_temp_snapshots():
+    """Lifecycle manager with a temp snapshots dir + a tiny network so
+    ``save_snapshot`` can actually write something to disk."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        # Override the snapshots dir so we don't pollute the repo's
+        # default path and don't race against parallel test workers.
+        mgr._get_snapshots_dir = lambda: Path(tmpdir)  # type: ignore[method-assign]
+        try:
+            yield mgr, Path(tmpdir)
+        finally:
+            mgr.shutdown()
+
+
+class TestSaveSnapshotIdFormat:
+    def test_no_collision_keeps_legacy_format(self, mgr_with_temp_snapshots):
+        """When the directory is empty, the returned ID matches the
+        ``snapshot_YYYYMMDDTHHMMSSZ`` format with NO suffix — preserves
+        backward compatibility with parsers that read the timestamp out
+        of the ID string."""
+        mgr, _ = mgr_with_temp_snapshots
+        result = mgr.save_snapshot(description="first")
+        assert result is not None
+        snapshot_id = result["id"]
+        # Format: "snapshot_" + 16 chars (YYYYMMDDTHHMMSSZ)
+        assert snapshot_id.startswith("snapshot_")
+        rest = snapshot_id[len("snapshot_") :]
+        assert len(rest) == 16, f"expected 16-char timestamp suffix, got {rest!r}"
+        assert rest.endswith("Z")
+        assert "_" not in rest, "no-collision path must not append a suffix"
+
+
+class TestSaveSnapshotCollision:
+    def test_same_second_calls_produce_distinct_ids(self, mgr_with_temp_snapshots):
+        """Two ``save_snapshot`` calls forced to share the same timestamp
+        must produce distinct IDs. The first keeps the legacy format; the
+        second gets ``_2`` appended."""
+        mgr, snapshots_dir = mgr_with_temp_snapshots
+        # Freeze the timestamp by patching the manager's clock source.
+        # ``datetime.now(UTC)`` inside ``save_snapshot`` resolves via the
+        # module-level import in manager.py.
+        from api.lifecycle import manager as manager_module
+
+        class FrozenDatetime:
+            @classmethod
+            def now(cls, tz=None):
+                # ISO-8601 UTC: 2026-05-14T12:00:00 +00:00
+                import datetime as _real_dt
+
+                return _real_dt.datetime(2026, 5, 14, 12, 0, 0, tzinfo=tz)
+
+        with patch.object(manager_module, "datetime", FrozenDatetime):
+            first = mgr.save_snapshot(description="first")
+            second = mgr.save_snapshot(description="second")
+        assert first is not None
+        assert second is not None
+        assert first["id"] == "snapshot_20260514T120000Z"
+        assert second["id"] == "snapshot_20260514T120000Z_2"
+        # Distinct files on disk — pre-P2-3 the second call would
+        # overwrite the first.
+        assert Path(first["path"]).exists()
+        assert Path(second["path"]).exists()
+        assert first["path"] != second["path"]
+
+    def test_three_same_second_calls_cascade_through_suffixes(self, mgr_with_temp_snapshots):
+        """The collision path is iterative — three calls in the same
+        second yield ``_2`` and ``_3`` suffixes for the second and third."""
+        mgr, _ = mgr_with_temp_snapshots
+        from api.lifecycle import manager as manager_module
+
+        class FrozenDatetime:
+            @classmethod
+            def now(cls, tz=None):
+                import datetime as _real_dt
+
+                return _real_dt.datetime(2026, 5, 14, 12, 0, 0, tzinfo=tz)
+
+        with patch.object(manager_module, "datetime", FrozenDatetime):
+            r1 = mgr.save_snapshot(description="r1")
+            r2 = mgr.save_snapshot(description="r2")
+            r3 = mgr.save_snapshot(description="r3")
+        assert [r1["id"], r2["id"], r3["id"]] == [
+            "snapshot_20260514T120000Z",
+            "snapshot_20260514T120000Z_2",
+            "snapshot_20260514T120000Z_3",
+        ]
+
+    def test_collision_path_files_are_valid_hdf5(self, mgr_with_temp_snapshots):
+        """Beyond distinct IDs and paths, the collision-path files must
+        themselves be valid HDF5 (the serializer wasn't broken by being
+        handed a suffixed filename)."""
+        mgr, _ = mgr_with_temp_snapshots
+        from api.lifecycle import manager as manager_module
+
+        class FrozenDatetime:
+            @classmethod
+            def now(cls, tz=None):
+                import datetime as _real_dt
+
+                return _real_dt.datetime(2026, 5, 14, 12, 0, 0, tzinfo=tz)
+
+        with patch.object(manager_module, "datetime", FrozenDatetime):
+            first = mgr.save_snapshot(description="first")
+            second = mgr.save_snapshot(description="second")
+        # Open both files with h5py to confirm they're valid HDF5 with
+        # at least the format-validation root attrs the loader expects.
+        for snap in (first, second):
+            with h5py.File(snap["path"], "r") as f:
+                assert "format" in f.attrs


### PR DESCRIPTION
## Summary

Implements **P2-3** of Issue #3 — the snapshot infrastructure half. The replay-engine rework half is **deferred** per a design discovery (`_ReplaySession` is a passive time-indexed metric playback engine, not event-sourced), with a follow-up design doc + trigger conditions captured in `notes/PHASE_2_P2_3_FOLLOWUP_REPLAY_REWORK_2026-05-14.md` so the rework can be picked up if/when canopy-orchestrated transitions prove insufficient.

The §3.9 *"instantaneous transformation"* requirement is satisfied in user-visible terms by canopy P2-7 restarting replay from `post_swap_snapshot_id` when the timeline cursor crosses a swap boundary. The mechanism is orchestration-layer; the user sees the topology change appear instantly at the marker.

## What changes

### `save_snapshot` collision fix

Snapshot IDs were second-resolution (`snapshot_YYYYMMDDTHHMMSSZ`) and **silently overwrote** when two snapshots fired within the same wall-clock second — exactly the pre/post-swap pair P2-3 creates. We now check for an existing file and append `_2`, `_3`, … to the ID until a free slot is found. The no-collision path is byte-identical to the pre-P2-3 behaviour, so canopy's existing snapshot-ID parser keeps working unchanged.

A prior test in `test_can_015h_roundtrip.py` carried a `time.sleep(1.1)` workaround for this exact issue with a "tracked as a separate concern" comment — that workaround is now obsolete (kept in place; out of scope to remove).

### Pre-swap auto-snap in `swap_dataset_live`

Fires after the rollback snapshot capture (step 4) but **before any network mutation**, so the on-disk snapshot captures the genuine pre-swap state. Failure-tolerant: a snapshot write failure logs at exception level but does NOT abort the swap. The pre-swap snapshot is **kept on disk even when the swap is later cancelled / rolled back** — it's a valid state record at the moment the user attempted the swap, and cleanup would just add race conditions.

### Post-swap auto-snap in `swap_dataset_live`

Fires after the topology rebroadcast (step 14), before `record_dataset_swap_event`. Same failure tolerance.

### ID threading into `record_dataset_swap_event`

`pre_swap_snapshot_id` and `post_swap_snapshot_id` (the placeholder fields P2-2 left as `None`) are now populated from the captured snapshot IDs. Either may still be `None` if its snapshot write failed — the event still records, just without that affordance for canopy P2-7.

### Snapshot descriptions encode swap metadata

`"pre-swap before dataset_swap (from spirals)"` / `"post-swap after dataset_swap (to moons)"` so the Snapshots tab is human-browsable without joining against the history event metadata.

### Replay rework follow-up doc

`notes/PHASE_2_P2_3_FOLLOWUP_REPLAY_REWORK_2026-05-14.md` documents:

- Why `_ReplaySession` can't host a mid-playback `dataset_swap` handler today (passive time-indexed playback, no event dispatch).
- What P2-3 actually ships and how canopy P2-7 will use the snapshot IDs to render a "continue past swap" affordance.
- A specification for the event-sourced replay rework (event queue, dispatch table, per-event handlers, backward-compat strategy) with explicit trigger conditions to revisit: snapshot-reload feels jarring, multi-swap latency, animated topology transitions, mid-replay editing, replay-only mode.

## Test plan

- [x] **4 unit tests** for `save_snapshot` collision: no-collision keeps legacy format; same-second pair produces `_2` suffix; three calls cascade through `_2` and `_3`; suffixed files are valid HDF5.
- [x] **4 integration tests** for `swap_dataset_live`: success takes pre AND post snapshots in order with metadata-encoded descriptions; pre-swap captures pre-resize dims (ordering invariant); pre-swap snap kept on cancellation (event not recorded but snapshot persists); pre-swap snap failure does not abort the swap.
- [x] **1 P2-2 assertion update**: `pre_swap_snapshot_id` is no longer `None` — now asserts `startswith("snapshot_")`. Other P2-2 unit/integration tests unchanged.
- [x] **3572 tests pass**, 15 skipped (+10 net new tests, no regressions)
- [x] 52 focused tests on the P2-3 surface + P2-2 regression pass
- [x] `pre-commit run` clean (black, isort, flake8, mypy, bandit, async-audit)

## Out of scope (per design doc)

- Event-sourced replay engine + per-event handlers. Trigger conditions documented in the follow-up doc.
- Animated topology transitions in canopy timeline UI.
- Mid-replay editing / "what-if" UX.

## Refs

- Spec: `juniper-canopy/notes/ISSUE_3_PHASE_2_LIVE_DATASET_SWAP_2026-05-09.md` §3.3 / §3.9 / §7 P2-3 row
- Follow-up design: `notes/PHASE_2_P2_3_FOLLOWUP_REPLAY_REWORK_2026-05-14.md` (in this PR)
- Issue: pcalnon/juniper-cascor#3
- Series: P2-PRE-1 (#244) → P2-1a (#245) → P2-1b (#250) → P2-1c (#251) → P2-1d (#252) → P2-2 (#253) → **P2-3 (this PR)** → P2-7 (canopy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)