### PR TITLE
feat(phase2): P2-2 follow-ups A+B — WS broadcast + GET history route (Issue #3)

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -17,7 +17,7 @@ from api.lifecycle.manager import TrainingLifecycleManager
 from api.middleware import RequestBodyLimitMiddleware, SecurityHeadersMiddleware, SecurityMiddleware
 from api.models.common import error_response
 from api.observability import PrometheusMiddleware, RequestIdMiddleware, configure_logging, configure_sentry, get_prometheus_app, set_build_info
-from api.routes import admin, dataset, decision_boundary, health, metrics, network, snapshots, training, workers
+from api.routes import admin, dataset, decision_boundary, health, history, metrics, network, snapshots, training, workers
 from api.secrets import get_secret
 from api.security import APIKeyAuth, RateLimiter
 from api.settings import Settings, get_settings
@@ -467,6 +467,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(snapshots.router, prefix="/v1")
     app.include_router(workers.router, prefix="/v1")
     app.include_router(admin.router, prefix="/v1")  # Phase 2 P2-1a — experimental-functions gate
+    app.include_router(history.router, prefix="/v1")  # Phase 2 P2-2 Follow-up B — dataset_swap event fetch
 
     # WebSocket Routes
     app.websocket("/ws/training")(training_stream_handler)

--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -2324,6 +2324,42 @@ class TrainingLifecycleManager:
         cfg = self._pending_dataset_config
         return dict(cfg) if cfg else None
 
+    # P2-2 Follow-up B (Issue #3): canopy P2-7 timeline UI reads dataset_swap
+    # events via this lifecycle method without pulling a full snapshot.
+    # The method is read-only and returns a fresh list copy so a caller
+    # iterating the result can't mutate persisted history through the
+    # reference. See notes/PHASE_2_P2_2_FOLLOWUPS_2026-05-14.md.
+
+    def get_dataset_swap_events(self, since: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Return the network's ``dataset_swap`` history events.
+
+        Args:
+            since: Optional ISO-8601 timestamp. If supplied, only events whose
+                ``timestamp`` is STRICTLY greater than ``since`` are returned
+                (lexicographic compare on the ISO-8601 string is correct for
+                UTC timestamps in the canonical format the recorder uses).
+                Events with no timestamp (e.g. loaded from a malformed
+                snapshot) are excluded when ``since`` is set, included
+                otherwise.
+
+        Returns:
+            A list of event dicts in chronological order, copied so the
+            caller can iterate or mutate the result without affecting
+            persisted history. Returns ``[]`` when no network is loaded.
+        """
+        if self.network is None or not hasattr(self.network, "history"):
+            return []
+        events = list(self.network.history.get("dataset_swaps", []) or [])
+        # Deep-copy each event so callers iterating the result can mutate
+        # nested dicts (``arch_changes`` and ``appended_nodes``) without
+        # corrupting persisted history. Matches the recorder's own
+        # deep-copy guarantee (``record_dataset_swap_event``). Event
+        # payloads are small dicts, so the cost is negligible relative
+        # to the safety it provides.
+        if since is None:
+            return [copy.deepcopy(e) for e in events]
+        return [copy.deepcopy(e) for e in events if isinstance(e.get("timestamp"), str) and e["timestamp"] > since]
+
     # ------------------------------------------------------------------
     # Phase 2: experimental-functions gate + live dataset swap (P2-1a)
     # See ISSUE_3_PHASE_2_LIVE_DATASET_SWAP_2026-05-09.md §3.1/§3.2/§3.7/§3.8.
@@ -2665,9 +2701,10 @@ class TrainingLifecycleManager:
                 # Failure to record (e.g., missing helper on a non-cascade
                 # network) is logged at warning but does NOT abort the
                 # swap — the swap itself already succeeded.
+                recorded_event: Optional[Dict[str, Any]] = None
                 if hasattr(self.network, "record_dataset_swap_event"):
                     try:
-                        self.network.record_dataset_swap_event(
+                        recorded_event = self.network.record_dataset_swap_event(
                             before_cfg=pre.dataset_config,
                             after_cfg=dict(self._current_dataset_config) if self._current_dataset_config else None,
                             arch_changes=response_arch,
@@ -2676,6 +2713,23 @@ class TrainingLifecycleManager:
                         )
                     except Exception:
                         self.logger.exception("swap_dataset_live: record_dataset_swap_event failed; swap itself was successful")
+
+                # P2-2 Follow-up A (Issue #3): push the event over the
+                # WebSocket so canopy can render a timeline marker in
+                # real time without polling the history fetch route. The
+                # broadcast envelope uses the existing generic
+                # ``create_event_message`` with an ``event="dataset_swap"``
+                # discriminator — no new envelope type required (avoids a
+                # cross-repo bump of juniper_cascor_protocol). No-op when
+                # no WS clients are connected. Failure-tolerant: a
+                # broadcast error never aborts the swap.
+                if recorded_event is not None and self._ws_manager is not None:
+                    try:
+                        from api.websocket.messages import create_event_message as _create_event_message
+
+                        self._ws_manager.broadcast_from_thread(_create_event_message({"event": "dataset_swap", "swap": recorded_event}))
+                    except Exception:
+                        self.logger.exception("swap_dataset_live: dataset_swap WebSocket broadcast failed; swap itself was successful")
                 return {
                     "status": "swapped",
                     "before_cfg": pre.dataset_config,

--- a/src/api/routes/history.py
+++ b/src/api/routes/history.py
@@ -1,0 +1,49 @@
+"""Training history read routes (P2-2 Follow-up B, Issue #3).
+
+Exposes the network's training-history event lists over REST so canopy can
+render timeline markers without fetching a full HDF5 snapshot. Today only
+the ``dataset_swap`` event list is surfaced — other history keys
+(``train_loss``, ``hidden_units_added``, etc.) are still snapshot-only.
+Future history-fetch routes belong in this module.
+"""
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Query, Request
+
+from api.models.common import success_response
+
+logger = logging.getLogger("juniper_cascor.api.routes.history")
+
+router = APIRouter(prefix="/history", tags=["history"])
+
+
+def _get_lifecycle(request: Request):
+    lifecycle = getattr(request.app.state, "lifecycle", None)
+    if lifecycle is None:
+        raise HTTPException(status_code=503, detail="Lifecycle manager not initialized")
+    return lifecycle
+
+
+@router.get("/dataset_swaps")
+async def get_dataset_swap_events(
+    request: Request,
+    since: Optional[str] = Query(
+        default=None,
+        description="Optional ISO-8601 timestamp. When set, only events with timestamp strictly greater than this value are returned. Lexicographic compare is correct for the canonical UTC format the recorder uses.",
+    ),
+) -> dict:
+    """Return the network's ``dataset_swap`` history events.
+
+    Canopy P2-7 uses this to render timeline markers + paired-diff
+    affordances without joining against the full HDF5 snapshot. The
+    ``?since=`` filter lets long-running clients poll only for new
+    events without redownloading the full list each tick.
+
+    Status codes:
+      200 — list (possibly empty) returned in chronological order.
+    """
+    lifecycle = _get_lifecycle(request)
+    events = lifecycle.get_dataset_swap_events(since=since)
+    return success_response({"events": events})

--- a/src/tests/integration/api/test_swap_dataset_live.py
+++ b/src/tests/integration/api/test_swap_dataset_live.py
@@ -1156,3 +1156,161 @@ def test_swap_dataset_live_pre_swap_snapshot_failure_does_not_abort_swap():
     assert swaps[0]["pre_swap_snapshot_id"] is None
     assert swaps[0]["post_swap_snapshot_id"] == "snap_post_ok"
     mgr.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# P2-2 Follow-up A (Issue #3): WebSocket broadcast of dataset_swap events.
+# The broadcast envelope uses the generic ``create_event_message`` with
+# ``event="dataset_swap"`` as the discriminator — no new protocol-package
+# envelope type. See notes/PHASE_2_P2_2_FOLLOWUPS_2026-05-14.md (Follow-up A).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_swap_dataset_live_broadcasts_dataset_swap_event_on_success():
+    """A successful swap pushes one ``dataset_swap`` event over the
+    WebSocket so canopy can render a timeline marker in real time."""
+    mgr = TrainingLifecycleManager()
+    mgr.create_network(input_size=2, output_size=2)
+    mgr.set_experimental_functions(True)
+    mgr._train_x, mgr._train_y = _make_dummy_tensors(2, 2)
+    mgr._current_dataset_config = {"dataset_type": "spirals"}
+    mgr.state_machine.handle_command(Command.START)
+
+    new_x, new_y = _make_dummy_tensors(4, 2)
+
+    def _fake_reload(**cfg):
+        mgr._train_x = new_x
+        mgr._train_y = new_y
+        mgr._current_dataset_config = {"dataset_type": "moons"}
+
+    mgr._executor = MagicMock()
+    mgr._executor.submit.return_value = MagicMock()
+
+    # Plug in a mock WS manager so we can observe the broadcast.
+    ws_manager = MagicMock()
+    mgr._ws_manager = ws_manager
+
+    with patch.object(mgr, "_reload_dataset", side_effect=_fake_reload):
+        mgr.swap_dataset_live(dataset_type="moons")
+
+    # Exactly one dataset_swap broadcast. Other broadcasts (state, etc.)
+    # may have fired separately via _broadcast_training_state; filter by
+    # envelope discriminator to isolate the one we care about.
+    dataset_swap_calls = [c for c in ws_manager.broadcast_from_thread.call_args_list if c.args and isinstance(c.args[0], dict) and c.args[0].get("data", {}).get("event") == "dataset_swap"]
+    assert len(dataset_swap_calls) == 1, f"expected 1 dataset_swap broadcast, got {len(dataset_swap_calls)}"
+    payload = dataset_swap_calls[0].args[0]
+    # Envelope shape: top-level ``data`` dict with ``event`` discriminator
+    # and a ``swap`` sub-dict carrying the full event record. The
+    # full event is what was just recorded into history, so canopy
+    # gets the same view it would read from the GET /history/dataset_swaps
+    # route — just delivered as a push.
+    assert payload["data"]["event"] == "dataset_swap"
+    assert "swap" in payload["data"]
+    assert payload["data"]["swap"]["arch_changes"]["input_delta"] == 2
+    mgr.shutdown()
+
+
+@pytest.mark.integration
+def test_swap_dataset_live_does_NOT_broadcast_on_cancellation():
+    """Cancelled swap → no dataset_swap broadcast. Canopy must not render
+    a timeline marker for a swap that was aborted."""
+    mgr = TrainingLifecycleManager()
+    mgr.create_network(input_size=2, output_size=2)
+    mgr.set_experimental_functions(True)
+    mgr._train_x, mgr._train_y = _make_dummy_tensors(2, 2)
+    mgr._current_dataset_config = {"dataset_type": "spirals"}
+    mgr.state_machine.handle_command(Command.START)
+
+    def _fake_reload_then_cancel(**cfg):
+        mgr._train_x, mgr._train_y = _make_dummy_tensors(2, 2)
+        mgr._swap_cancel_requested.set()
+
+    mgr._executor = MagicMock()
+    mgr._executor.submit.return_value = MagicMock()
+    ws_manager = MagicMock()
+    mgr._ws_manager = ws_manager
+
+    with patch.object(mgr, "_reload_dataset", side_effect=_fake_reload_then_cancel):
+        with pytest.raises(SwapCancelledError):
+            mgr.swap_dataset_live(dataset_type="moons")
+
+    dataset_swap_calls = [c for c in ws_manager.broadcast_from_thread.call_args_list if c.args and isinstance(c.args[0], dict) and c.args[0].get("data", {}).get("event") == "dataset_swap"]
+    assert dataset_swap_calls == []
+    mgr.shutdown()
+
+
+@pytest.mark.integration
+def test_swap_dataset_live_no_op_broadcast_when_ws_manager_is_none():
+    """No WS clients connected → ``_ws_manager`` is None → the broadcast
+    branch no-ops without error. The swap still succeeds and the history
+    event still records (just no real-time push)."""
+    mgr = TrainingLifecycleManager()
+    mgr.create_network(input_size=2, output_size=2)
+    mgr.set_experimental_functions(True)
+    mgr._train_x, mgr._train_y = _make_dummy_tensors(2, 2)
+    mgr._current_dataset_config = {"dataset_type": "spirals"}
+    mgr.state_machine.handle_command(Command.START)
+
+    new_x, new_y = _make_dummy_tensors(2, 2)
+
+    def _fake_reload(**cfg):
+        mgr._train_x = new_x
+        mgr._train_y = new_y
+        mgr._current_dataset_config = {"dataset_type": "moons"}
+
+    mgr._executor = MagicMock()
+    mgr._executor.submit.return_value = MagicMock()
+    assert mgr._ws_manager is None  # default state
+
+    with patch.object(mgr, "_reload_dataset", side_effect=_fake_reload):
+        result = mgr.swap_dataset_live(dataset_type="moons")
+
+    assert result["status"] == "swapped"
+    assert len(mgr.network.history["dataset_swaps"]) == 1
+    mgr.shutdown()
+
+
+@pytest.mark.integration
+def test_swap_dataset_live_broadcast_failure_does_not_abort_swap():
+    """A WS broadcast error is logged but does NOT abort the swap. The
+    swap has already succeeded; observability failures shouldn't roll
+    back the user's data."""
+    mgr = TrainingLifecycleManager()
+    mgr.create_network(input_size=2, output_size=2)
+    mgr.set_experimental_functions(True)
+    mgr._train_x, mgr._train_y = _make_dummy_tensors(2, 2)
+    mgr._current_dataset_config = {"dataset_type": "spirals"}
+    mgr.state_machine.handle_command(Command.START)
+
+    new_x, new_y = _make_dummy_tensors(2, 2)
+
+    def _fake_reload(**cfg):
+        mgr._train_x = new_x
+        mgr._train_y = new_y
+        mgr._current_dataset_config = {"dataset_type": "moons"}
+
+    mgr._executor = MagicMock()
+    mgr._executor.submit.return_value = MagicMock()
+    ws_manager = MagicMock()
+
+    # Scope the failure to the dataset_swap envelope only. Other
+    # broadcasts (state, etc.) called earlier in swap_dataset_live by
+    # ``_broadcast_training_state`` succeed; only OUR push raises. This
+    # mirrors the production failure mode the test is meant to cover —
+    # the dataset_swap broadcast specifically blowing up after the swap
+    # has otherwise succeeded.
+    def _selective_broadcast_fail(payload, *args, **kwargs):
+        if isinstance(payload, dict) and payload.get("data", {}).get("event") == "dataset_swap":
+            raise RuntimeError("WS connection torn down")
+
+    ws_manager.broadcast_from_thread.side_effect = _selective_broadcast_fail
+    mgr._ws_manager = ws_manager
+
+    with patch.object(mgr, "_reload_dataset", side_effect=_fake_reload):
+        result = mgr.swap_dataset_live(dataset_type="moons")
+
+    assert result["status"] == "swapped"
+    # History event still recorded — broadcast failure is post-record.
+    assert len(mgr.network.history["dataset_swaps"]) == 1
+    mgr.shutdown()

--- a/src/tests/unit/api/test_history_dataset_swaps_route.py
+++ b/src/tests/unit/api/test_history_dataset_swaps_route.py
@@ -1,0 +1,162 @@
+"""P2-2 Follow-up B (Issue #3) — ``GET /v1/history/dataset_swaps`` route + lifecycle.
+
+Covers the lifecycle method ``get_dataset_swap_events(since=None)`` and the
+new ``/v1/history/dataset_swaps`` REST surface. Canopy P2-7's timeline UI
+reads dataset_swap events via this route without fetching a full HDF5
+snapshot.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
+
+from api.app import create_app
+from api.lifecycle.manager import TrainingLifecycleManager
+from api.settings import Settings
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle: get_dataset_swap_events
+# ---------------------------------------------------------------------------
+
+
+def _make_event(timestamp: str, input_delta: int = 0) -> dict:
+    return {
+        "timestamp": timestamp,
+        "before_cfg": {"dataset_type": "spirals"},
+        "after_cfg": {"dataset_type": "moons"},
+        "arch_changes": {"input_delta": input_delta, "output_delta": 0},
+        "pre_swap_snapshot_id": f"snap_pre_{input_delta}",
+        "post_swap_snapshot_id": f"snap_post_{input_delta}",
+    }
+
+
+class TestGetDatasetSwapEvents:
+    def test_returns_empty_when_no_network(self):
+        """No network installed → empty list (not None, not raising)."""
+        mgr = TrainingLifecycleManager()
+        assert mgr.network is None
+        assert mgr.get_dataset_swap_events() == []
+        mgr.shutdown()
+
+    def test_returns_empty_when_history_has_no_swaps(self):
+        """Network with empty dataset_swaps list → empty list."""
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        assert mgr.get_dataset_swap_events() == []
+        mgr.shutdown()
+
+    def test_returns_all_events_when_no_since_filter(self):
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        mgr.network.history["dataset_swaps"] = [
+            _make_event("2026-05-14T10:00:00+00:00", input_delta=0),
+            _make_event("2026-05-14T11:00:00+00:00", input_delta=1),
+            _make_event("2026-05-14T12:00:00+00:00", input_delta=2),
+        ]
+        events = mgr.get_dataset_swap_events()
+        assert len(events) == 3
+        assert [e["arch_changes"]["input_delta"] for e in events] == [0, 1, 2]
+        mgr.shutdown()
+
+    def test_returns_only_events_strictly_after_since(self):
+        """``since`` is exclusive — events with timestamp equal to ``since``
+        are NOT returned (lets a poller pass the last-seen timestamp and
+        get only strictly-newer events)."""
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        mgr.network.history["dataset_swaps"] = [
+            _make_event("2026-05-14T10:00:00+00:00", input_delta=0),
+            _make_event("2026-05-14T11:00:00+00:00", input_delta=1),
+            _make_event("2026-05-14T12:00:00+00:00", input_delta=2),
+        ]
+        events = mgr.get_dataset_swap_events(since="2026-05-14T11:00:00+00:00")
+        assert [e["arch_changes"]["input_delta"] for e in events] == [2]
+        mgr.shutdown()
+
+    def test_since_filter_skips_events_without_timestamp(self):
+        """An event with no string timestamp (e.g. loaded from a malformed
+        snapshot) is excluded when ``since`` is set. Including such events
+        could cause a poller to repeatedly re-fetch them."""
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        mgr.network.history["dataset_swaps"] = [
+            {**_make_event("2026-05-14T10:00:00+00:00"), "timestamp": None},
+            _make_event("2026-05-14T11:00:00+00:00", input_delta=5),
+        ]
+        events = mgr.get_dataset_swap_events(since="2026-05-14T09:00:00+00:00")
+        assert len(events) == 1
+        assert events[0]["arch_changes"]["input_delta"] == 5
+        mgr.shutdown()
+
+    def test_returned_list_is_a_copy(self):
+        """Mutating the returned events MUST NOT affect persisted history.
+        Without the copy, a caller iterating the list could accidentally
+        corrupt the canonical record."""
+        mgr = TrainingLifecycleManager()
+        mgr.create_network(input_size=2, output_size=2)
+        mgr.network.history["dataset_swaps"] = [_make_event("2026-05-14T10:00:00+00:00")]
+        events = mgr.get_dataset_swap_events()
+        events[0]["arch_changes"]["input_delta"] = 999
+        # Persisted event unchanged.
+        assert mgr.network.history["dataset_swaps"][0]["arch_changes"]["input_delta"] == 0
+        mgr.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# REST route
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client():
+    settings = Settings(auto_start=False)
+    app = create_app(settings)
+    with TestClient(app) as c:
+        yield c
+
+
+class TestDatasetSwapsRoute:
+    def test_empty_history_returns_empty_list(self, client):
+        resp = client.get("/v1/history/dataset_swaps")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["data"] == {"events": []}
+
+    def test_returns_events_in_chronological_order(self, client):
+        canned = [
+            _make_event("2026-05-14T10:00:00+00:00", input_delta=0),
+            _make_event("2026-05-14T11:00:00+00:00", input_delta=1),
+        ]
+        with patch.object(client.app.state.lifecycle, "get_dataset_swap_events", return_value=canned):
+            resp = client.get("/v1/history/dataset_swaps")
+        assert resp.status_code == 200
+        events = resp.json()["data"]["events"]
+        assert len(events) == 2
+        assert events[0]["timestamp"] == "2026-05-14T10:00:00+00:00"
+
+    def test_since_query_param_passed_to_lifecycle(self, client):
+        """The route is a thin shim — it passes ``since`` through verbatim
+        to the lifecycle method, which owns the filter semantics."""
+        mock_get = MagicMock(return_value=[])
+        with patch.object(client.app.state.lifecycle, "get_dataset_swap_events", mock_get):
+            resp = client.get("/v1/history/dataset_swaps?since=2026-05-14T11:00:00%2B00:00")
+        assert resp.status_code == 200
+        mock_get.assert_called_once_with(since="2026-05-14T11:00:00+00:00")
+
+    def test_lifecycle_missing_returns_503(self, client):
+        """When the lifecycle is somehow None (e.g. startup hasn't finished
+        wiring it), the route returns 503 like other history-adjacent
+        routes rather than crashing with a 500."""
+        with patch.object(client.app.state, "lifecycle", None):
+            resp = client.get("/v1/history/dataset_swaps")
+        assert resp.status_code == 503


### PR DESCRIPTION
## Summary

Lands both P2-2 follow-ups documented in [`notes/PHASE_2_P2_2_FOLLOWUPS_2026-05-14.md`](../tree/phase2/p2-2-followups-broadcast-and-fetch-route/notes/PHASE_2_P2_2_FOLLOWUPS_2026-05-14.md) as one PR — they share the *dataset_swap event observability* theme and the same files, so bundling avoids two stub PRs of ~150 LOC each.

After this lands, canopy P2-7's timeline UI has two ways to consume `dataset_swap` events: poll the new GET route (good for cold loads / catch-up) or subscribe to the existing WebSocket (good for real-time rendering of swaps that fire while the user is watching).

## Follow-up B — `GET /v1/history/dataset_swaps`

### Lifecycle

New `TrainingLifecycleManager.get_dataset_swap_events(since=None)`:

- Reads from `network.history["dataset_swaps"]` (P2-2's persistence surface).
- Optional ISO-8601 `since` filter for polling clients — returns events with timestamp **strictly greater** than `since`, so a poller can pass its last-seen timestamp and get only new events.
- Skips events without a timestamp when `since` is set (defensive against malformed snapshots).
- **Deep-copies** each event so callers iterating the result can mutate nested dicts (`arch_changes`, `appended_nodes`) without corrupting persisted history. Matches the recorder's own deep-copy guarantee.

### Route

New `src/api/routes/history.py` with `GET /v1/history/dataset_swaps`. Thin shim — passes `since` through verbatim. Registered in `app.py` after the admin router.

## Follow-up A — WebSocket broadcast of dataset_swap

`swap_dataset_live` now captures the event dict returned by `record_dataset_swap_event` and broadcasts it via the existing generic `create_event_message({"event": "dataset_swap", "swap": event_dict})`.

This avoids needing a new envelope class in the external `juniper_cascor_protocol` package — the `event`-discriminator pattern is already used by `training_complete` (`manager.py:1342`).

The broadcast is **failure-tolerant**: a WS error logs at exception level but does NOT abort the swap. The swap has already succeeded; observability failures must not roll back user data. No-op when `_ws_manager` is None.

## Test plan

- [x] **5 unit tests** for `get_dataset_swap_events`: empty when no network, empty when history has no swaps, returns all without filter, strictly-after with `since`, skips timestamp-less when `since` set, deep-copy guarantee
- [x] **4 route tests**: empty list, chronological order, `since` query param passed verbatim, 503 when lifecycle missing
- [x] **4 integration tests** for the WS broadcast: success broadcasts exactly one event with the right envelope shape, cancellation does NOT broadcast, no-op when `_ws_manager` is None, broadcast failure does not abort the swap (selective side_effect targeting only the dataset_swap envelope)
- [x] **3586 tests pass**, 15 skipped (+14 net, no regressions)
- [x] `pre-commit run` clean (black, isort, flake8, mypy, bandit, async-audit)

## Wire format

Broadcast envelope (consumed by canopy WS clients):

```json
{
  "type": "event",
  "timestamp": 1747353600.123,
  "data": {
    "event": "dataset_swap",
    "swap": {
      "timestamp": "2026-05-14T19:55:00+00:00",
      "before_cfg": {"dataset_type": "spirals"},
      "after_cfg":  {"dataset_type": "moons"},
      "arch_changes": {...},
      "pre_swap_snapshot_id":  "snapshot_...",
      "post_swap_snapshot_id": "snapshot_..._2"
    }
  }
}
```

Same `swap` shape canopy gets from the GET route — push and pull paths converge on a single event schema.

## Refs

- Follow-up doc: `notes/PHASE_2_P2_2_FOLLOWUPS_2026-05-14.md` (in cascor main)
- Parent spec: `juniper-canopy/notes/ISSUE_3_PHASE_2_LIVE_DATASET_SWAP_2026-05-09.md`
- Issue: pcalnon/juniper-cascor#3
- Series: P2-PRE-1 (#244) → P2-1a (#245) → P2-1b (#250) → P2-1c (#251) → P2-1d (#252) → P2-2 (#253) → P2-3 (#254) → **P2-2 follow-ups A+B (this PR)** → canopy track

🤖 Generated with [Claude Code](https://claude.com/claude-code)