### PR TITLE
docs(agents): add /tmp script-source prohibition + util/ad-hoc/ convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1041,6 +1041,16 @@ Performance micro-benchmarks in `src/tests/performance/` cover:
 
 ---
 
+## Script Placement
+
+**Permanent utilities** live in `util/`. **Single-use / temporary / unfinished scripts** go in `util/ad-hoc/` (create on first use). See [`util/ad-hoc/README.md`](util/ad-hoc/README.md) for the per-script header / lifecycle conventions.
+
+`/tmp/` is **prohibited** as the home for any script that produces, modifies, or analyzes repository content. `/tmp/` is reaped when sessions / sandboxes / containers end, and scripts placed there are lost (irrecoverable). `/tmp/` remains fine as a scratch *workspace* for intermediate artifacts the script itself creates and reads — the prohibition is on script *source files*.
+
+This is an ecosystem-wide rule restated in the parent `Juniper/AGENTS.md` "Cross-Project Conventions" section. Motivating incident: irrecoverable loss of `phase4_consolidate.py` and `v2_citation_validate.py` from the juniper-ml requirements-snapshot effort.
+
+---
+
 ## Worktree Procedures (Mandatory -- Task Isolation)
 
 Git worktrees allow multiple branches to be checked out simultaneously in separate directories. For the Juniper ecosystem, all worktrees are centralized in **`/home/pcalnon/Development/python/Juniper/worktrees/`** using standardized naming convention: `<repo-name>--<branch-name>--<YYYYMMDD-HHMM>--<short-hash>`

--- a/util/ad-hoc/README.md
+++ b/util/ad-hoc/README.md
@@ -1,0 +1,74 @@
+# `util/ad-hoc/` — Single-use, temporary, and unfinished scripts
+
+This directory is the home for scripts that:
+
+- Will run once (or a handful of times) and then be retired.
+- Are work-in-progress and not yet ready for promotion to `util/` proper.
+- Support a one-off investigation, migration, or analysis tied to a specific PR / incident.
+
+It exists because the alternative — authoring such scripts in `/tmp/` — caused real, irrecoverable loss in the v1–v4 juniper-ml requirements-snapshot effort (`phase4_consolidate.py`, `v2_citation_validate.py`).
+
+The repo-level rule lives in [`../../AGENTS.md`](../../AGENTS.md#script-placement); the ecosystem-level restatement lives in the parent `Juniper/AGENTS.md` "Cross-Project Conventions" section (one directory above this repo, outside the juniper-cascor git tree).
+
+---
+
+## Conventions
+
+### File header (Python)
+
+Every Python script in this directory should declare its scope and lifecycle inline:
+
+```python
+"""
+<one-line purpose>
+
+Project: juniper-cascor
+Sub-Project: ad-hoc tooling
+Author: <name>
+Created: YYYY-MM-DD
+Status: ad-hoc — <intent: one-off | wip | migration | investigation>
+Retire when: <condition that makes this script obsolete>
+Related: <PR #, incident, or notes/ doc>
+"""
+```
+
+### File header (bash)
+
+```bash
+#!/usr/bin/env bash
+# <one-line purpose>
+#
+# Project:    juniper-cascor
+# Sub-Project: ad-hoc tooling
+# Author:     <name>
+# Created:    YYYY-MM-DD
+# Status:     ad-hoc — <one-off | wip | migration | investigation>
+# Retire when: <condition>
+# Related:    <PR #, incident, notes/ doc>
+set -euo pipefail
+```
+
+### Naming
+
+- Date-prefix optional but useful: `YYYY-MM-DD_<short-purpose>.{py,bash}`.
+- Use kebab-case or snake_case consistently — match existing siblings.
+
+---
+
+## Lifecycle
+
+| Stage                                      | Action                                                                                                                                                       |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Created**                                | Place here. Include the header above with `Retire when:` populated.                                                                                          |
+| **Used for its purpose**                   | Commit any non-trivial output / log alongside the script (e.g., in `notes/`) so the artifact survives the script.                                            |
+| **Graduates to permanent utility**         | Move to `util/<name>` (drop `ad-hoc` from the header `Status:`). Update any docs that referenced the old path.                                               |
+| **Retired (purpose complete or obsolete)** | Delete in the same PR that completes the work, OR move to `util/ad-hoc/retired/` with the retirement date in the filename. Don't leave dead scripts behind.  |
+
+---
+
+## What does NOT belong here
+
+- Scripts that are part of a documented build / test / release flow → `util/` proper or `scripts/`.
+- Scripts called by CI workflows → `util/` proper (CI should never invoke `util/ad-hoc/`).
+- Tests → repo-appropriate test directory (e.g., `src/tests/` or `tests/`).
+- Generated artifacts (lockfiles, dep docs, build output) → wherever the build tooling expects.


### PR DESCRIPTION
## Summary

Propagates the ecosystem-wide **script-placement SOP** from the parent `Juniper/AGENTS.md` Cross-Project Conventions section into this repo, and creates a dedicated `util/ad-hoc/README.md` with file-header templates and the graduation lifecycle.

## What changed

- `AGENTS.md` — new `## Script Placement` section just before `## Worktree Procedures` summarising the SOP and pointing at the parent guide + the new `util/ad-hoc/README.md`.
- `util/ad-hoc/README.md` — new file. Documents what does and does not belong in `util/ad-hoc/`, the required Python / bash file headers (one-line purpose, Project, Sub-Project, Author, Created, Status, Retire when, Related), naming convention, and the graduation lifecycle (created → used → graduates to `util/` proper OR retired).

## Why

The rule is already authoritative in the parent ecosystem guide; this PR makes it discoverable when reading this repo's `AGENTS.md` directly, and gives `util/ad-hoc/` an in-tree home so new ad-hoc scripts have a clear target rather than getting reflexively dropped in `/tmp/`.

Motivating incident: irrecoverable loss of `phase4_consolidate.py` and `v2_citation_validate.py` from the v1–v4 juniper-ml requirements-snapshot effort — those were written under `/tmp/` and reaped when the host session ended.

## Companion PRs

- juniper-canopy: shipped in canopy #285.
- data-client / cascor-client / cascor-worker / deploy: in flight from a separate thread.

## Test plan

- [x] `pre-commit run` clean (markdown lint, EOF, trailing whitespace).
- [x] AGENTS.md anchor `#script-placement` resolves (relative link from `util/ad-hoc/README.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)