### PR TITLE
ci: swap docs job to juniper-doc-tools PyPI install (Wave 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,12 +120,22 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_TEST_VERSION }}
 
+      # Wave 2 of the doc-link migration plan
+      # (juniper-ml notes/JUNIPER_DOC_TOOLS_PYPI_MIGRATION_PLAN_2026-05-18.md):
+      # the validator is installed from PyPI instead of run from the
+      # inline scripts/check_doc_links.py copy. The inline copy stays in
+      # place through Wave 4 so this swap remains a one-line revert.
+      - name: Install juniper-doc-tools
+        run: |
+          python -m pip install --upgrade "pip>=26.1.1"
+          pip install "juniper-doc-tools>=0.1.0,<0.2.0"
+
       - name: Validate Documentation Links
         run: |
           echo "╔════════════════════════════════════════════════════════════╗"
           echo "║       Juniper Cascor - Documentation Link Validation       ║"
           echo "╚════════════════════════════════════════════════════════════╝"
-          python scripts/check_doc_links.py \
+          juniper-check-doc-links \
             --exclude templates \
             --exclude history \
             --exclude legacy \


### PR DESCRIPTION
## Summary

Wave 2 of the [doc-link validator PyPI migration plan](https://github.com/pcalnon/juniper-ml/blob/main/notes/JUNIPER_DOC_TOOLS_PYPI_MIGRATION_PLAN_2026-05-18.md). Replaces the inline `python scripts/check_doc_links.py …` invocation in this repo's docs CI job with `pip install juniper-doc-tools` + `juniper-check-doc-links …`.

Follows the [pattern proven by juniper-ml#276](https://github.com/pcalnon/juniper-ml/pull/276) — same 11-line diff applied to this repo's `ci.yml`.

## The diff (11 lines)

```diff
+      - name: Install juniper-doc-tools
+        run: |
+          python -m pip install --upgrade "pip>=26.1.1"
+          pip install "juniper-doc-tools>=0.1.0,<0.2.0"
+
       - name: Validate Documentation Links
         run: |
           ...
-          python scripts/check_doc_links.py \
+          juniper-check-doc-links \
             --exclude templates \
             ... (unchanged) ...
             --cross-repo skip
```

## Rollback

Inline `scripts/check_doc_links.py` stays in place through **Wave 4** so this swap is a **one-line revert**: change `juniper-check-doc-links` back to `python scripts/check_doc_links.py` and drop the Install step.

## Test plan

- [x] pre-commit on the touched file: clean
- [ ] CI: `Install juniper-doc-tools` step succeeds
- [ ] CI: `juniper-check-doc-links` is invoked successfully
- [ ] CI: `Documentation Links` job stays the same color as it was on main (green if docs are clean, same-as-main red otherwise — this PR doesn't change docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)