### PR TITLE
fix(cascade_correlation): BUG-CC-09 — re-validate max_epochs after output_epochs fall-back

### DIFF
--- a/src/cascade_correlation/cascade_correlation.py
+++ b/src/cascade_correlation/cascade_correlation.py
@@ -1770,6 +1770,14 @@ class CascadeCorrelationNetwork:
         self.logger.trace("CascadeCorrelationNetwork: fit: Starting initial training of the output layer.")
         self.logger.info("CascadeCorrelationNetwork: fit: Initial training of output layer")
         max_epochs = (max_epochs, self.output_epochs)[max_epochs is None]
+        # BUG-CC-09: re-validate after the ``self.output_epochs`` fall-back —
+        # the earlier check only ran when ``max_epochs`` came in non-None,
+        # so a misconfigured ``self.output_epochs`` (0 or negative) would
+        # otherwise reach ``train_output_layer`` and silently no-op the
+        # training loop (``range(0)`` body never executes; weights stay at
+        # whatever the previous iteration left them; the returned
+        # ``final_loss`` reflects the unchanged forward pass).
+        self._validate_positive_integer(max_epochs, "max_epochs (resolved)")
         train_loss = self.train_output_layer(x_train, y_train, max_epochs)
         self.history["train_loss"].append(train_loss)
         if x_val is not None and y_val is not None:

--- a/src/tests/unit/test_cascade_correlation_coverage.py
+++ b/src/tests/unit/test_cascade_correlation_coverage.py
@@ -256,6 +256,39 @@ class TestFitMethod:
         assert hasattr(simple_network, "history")
         assert "train_loss" in simple_network.history or len(simple_network.history) > 0
 
+    # BUG-CC-09: ``fit()`` previously resolved ``max_epochs`` from
+    # ``self.output_epochs`` AFTER the only ``_validate_positive_integer``
+    # call, so a misconfigured ``self.output_epochs`` (0 or negative) would
+    # silently no-op the output-training loop and leave weights unchanged.
+    # The guard added in this PR re-validates the resolved value.
+
+    @pytest.mark.unit
+    @pytest.mark.timeout(10)
+    def test_fit_rejects_zero_output_epochs_misconfig(self, simple_network, simple_2d_data):
+        """BUG-CC-09: ``self.output_epochs=0`` must be rejected at fit-time,
+        not silently no-op the training loop. Without the resolved-value
+        re-validation, ``range(0)`` would skip training and ``final_loss``
+        would reflect the untrained forward pass."""
+        from cascade_correlation.cascade_correlation_exceptions.cascade_correlation_exceptions import ValidationError
+
+        set_deterministic_behavior()
+        x, y = simple_2d_data
+        simple_network.output_epochs = 0
+        with pytest.raises(ValidationError, match="max_epochs"):
+            simple_network.fit(x_train=x, y_train=y)
+
+    @pytest.mark.unit
+    @pytest.mark.timeout(10)
+    def test_fit_rejects_negative_output_epochs_misconfig(self, simple_network, simple_2d_data):
+        """BUG-CC-09: negative output_epochs caught alongside zero."""
+        from cascade_correlation.cascade_correlation_exceptions.cascade_correlation_exceptions import ValidationError
+
+        set_deterministic_behavior()
+        x, y = simple_2d_data
+        simple_network.output_epochs = -1
+        with pytest.raises(ValidationError, match="max_epochs"):
+            simple_network.fit(x_train=x, y_train=y)
+
 
 class TestAccuracyCalculation:
     """Tests for accuracy calculation."""


### PR DESCRIPTION
## Summary

`fit()` resolved a `None` `max_epochs` argument from `self.output_epochs` **after** the only `_validate_positive_integer` call, so a misconfigured `self.output_epochs` (0 or negative) bypassed validation and reached `train_output_layer` with a non-positive value. The training loop is `for epoch in range(epochs):` — `range(0)` / `range(<0)` yield no iterations, so the body never runs, weights never update, and the returned `final_loss` reflects the *unchanged* forward pass. Silent no-op training (v7 roadmap §5.1 BUG-CC-09).

## Fix

Re-validate `max_epochs` after the `(max_epochs, self.output_epochs)[max_epochs is None]` resolution by reusing the existing `_validate_positive_integer` helper. 3-line change.

## Why this approach, not the roadmap's silent-skip

The v7 roadmap suggested `if max_epochs <= 0: train_loss = float("inf")`. That would mask the misconfiguration. Hard-failing via the existing validator surfaces the config error at the call site rather than producing a "trained" network that never saw a gradient update.

## Test plan

- [x] New `test_fit_rejects_zero_output_epochs_misconfig` pins the ValidationError for `self.output_epochs == 0`.
- [x] New `test_fit_rejects_negative_output_epochs_misconfig` covers negative values.
- [x] 5/5 `TestFitMethod` tests pass.
- [x] `pre-commit run` clean.

## Refs

- v7 roadmap §5.1 — BUG-CC-09

🤖 Generated with [Claude Code](https://claude.com/claude-code)