### PR TITLE
fix(cascade_correlation): BUG-CC-09 follow-on — validator accepts numpy integers

### DIFF
--- a/src/cascade_correlation/cascade_correlation.py
+++ b/src/cascade_correlation/cascade_correlation.py
@@ -1588,6 +1588,12 @@ class CascadeCorrelationNetwork:
     def _validate_positive_integer(self, value, param_name: str, allow_zero: bool = False) -> None:
         """
         Validate positive integer parameters.
+
+        Accepts both Python ``int`` and ``numpy.integer`` subclasses (``int64``,
+        ``int32``, etc.). h5py-restored snapshot attributes deserialize as
+        numpy scalars; rejecting them broke every snapshot-restore →
+        ``fit()`` path (BUG-CC-09 regression, 2026-05-19).
+
         Args:
             value: Value to validate
             param_name: Name of the parameter
@@ -1595,7 +1601,7 @@ class CascadeCorrelationNetwork:
         Raises:
             ValidationError: If value is invalid
         """
-        if not isinstance(value, int):
+        if not isinstance(value, (int, np.integer)) or isinstance(value, bool):
             # raise ValidationError(f"Parameter '{param_name}' must be an integer, got {type(value)}")
             raise ValidationError(f"Parameter {param_name!r} must be an integer, got {type(value)}")
         min_val = 0 if allow_zero else 1

--- a/src/tests/unit/test_cascade_correlation_coverage.py
+++ b/src/tests/unit/test_cascade_correlation_coverage.py
@@ -289,6 +289,35 @@ class TestFitMethod:
         with pytest.raises(ValidationError, match="max_epochs"):
             simple_network.fit(x_train=x, y_train=y)
 
+    # BUG-CC-09 regression-of-the-regression (2026-05-19): PR #270's added
+    # ``_validate_positive_integer(max_epochs, "max_epochs (resolved)")`` call
+    # broke snapshot-restore → fit() because the restored ``self.output_epochs``
+    # is a ``numpy.int64`` (h5py returns numpy scalars), and
+    # ``isinstance(np.int64(2), int)`` is False on the cp314 build. The
+    # validator now accepts ``np.integer`` subclasses.
+    @pytest.mark.unit
+    @pytest.mark.timeout(10)
+    def test_fit_accepts_numpy_int_output_epochs_after_snapshot_restore(self, simple_network, simple_2d_data):
+        """BUG-CC-09 fix: validator must accept numpy integers (snapshot-restored ints)."""
+        set_deterministic_behavior()
+        x, y = simple_2d_data
+        # Simulate what happens after snapshot restore: numpy int rather than python int.
+        simple_network.output_epochs = np.int64(2)
+        # Should NOT raise — the resolved-value validation must accept np.integer.
+        history = simple_network.fit(x_train=x, y_train=y)
+        assert "train_loss" in history, "fit() must complete and record train_loss"
+
+    @pytest.mark.unit
+    @pytest.mark.timeout(10)
+    def test_validate_positive_integer_rejects_bool(self, simple_network):
+        """Python booleans are int subclasses but must NOT count as valid integer params."""
+        from cascade_correlation.cascade_correlation_exceptions.cascade_correlation_exceptions import ValidationError
+
+        with pytest.raises(ValidationError, match="must be an integer"):
+            simple_network._validate_positive_integer(True, "test_param")
+        with pytest.raises(ValidationError, match="must be an integer"):
+            simple_network._validate_positive_integer(False, "test_param", allow_zero=True)
+
 
 class TestAccuracyCalculation:
     """Tests for accuracy calculation."""


### PR DESCRIPTION
## Summary

Restores green Integration Tests on \`main\`. PR #270 added an unconditional
\`_validate_positive_integer(max_epochs, "max_epochs (resolved)")\` call after
the \`self.output_epochs\` fall-back. The validator's existing implementation
uses \`isinstance(value, int)\`, which **rejects \`numpy.int64\`** on the cp314 build.

After snapshot restore, \`self.output_epochs\` is a numpy integer (h5py returns
numpy scalars from \`config_group.attrs[...]\`), so the new check raised
\`ValidationError\` before \`fit()\` could record \`train_loss\`. The integration
test \`test_full_roundtrip_add_remove_patch\` fails because \`post_resume_loss\` is
\`None\`.

## Requirements

- References JR-CAS-TRAIN-* / JR-CAS-API-* — snapshot-restore correctness.

## What changed

| File | Change |
|------|--------|
| \`src/cascade_correlation/cascade_correlation.py\` | \`_validate_positive_integer\`: \`isinstance(value, int)\` → \`isinstance(value, (int, np.integer)) or isinstance(value, bool)\` (numpy already imported at module top; bool explicitly rejected because Python bools are an int subclass) |
| \`src/tests/unit/test_cascade_correlation_coverage.py\` | Added 2 regression tests: \`test_fit_accepts_numpy_int_output_epochs_after_snapshot_restore\` and \`test_validate_positive_integer_rejects_bool\` |

## What this does NOT fix (separate scope)

cascor's other failing checks on main are pre-existing and unrelated to PR #270:

- **Dependency Documentation** — dangling symlink: \`scripts/generate_dep_docs.sh\` is a symlink (mode 120000) to \`../util/generate_dep_docs.bash\`, which my own juniper-cascor PR #268 deleted. Needs a separate cleanup PR (replace the symlink with the real script content).
- **Docker Build & Smoke Test** — upstream juniper-data sidecar issue (\`COPY requirements.lock\` failure). Fixed indirectly by juniper-data #122 (regenerate lockfile, sibling PR opening alongside this one).

Both pre-date PR #270 and remain after this fix.

## Test plan

- [x] \`pytest src/tests/unit/test_cascade_correlation_coverage.py -k "BUG-CC-09 or output_epochs or numpy_int or rejects_bool"\` — 4 passed, 30 deselected, on JuniperCascor1 (Py 3.13.13, pytest 9.0.3).
- [x] Pre-commit: all 16 hooks pass (black, ruff, mypy, bandit, flake8, async-route audit, etc.).
- [x] Quick + Full Integration Tests should turn green on CI after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)