### PR TITLE
chore(ci): add lockfile auto-regen on pyproject change + presence guard

### DIFF
--- a/.github/workflows/lockfile-update.yml
+++ b/.github/workflows/lockfile-update.yml
@@ -30,6 +30,9 @@ on:
   push:
     branches:
       - dependabot/pip/**
+  pull_request:
+    paths:
+      - pyproject.toml
 
 permissions:
   contents: write
@@ -38,14 +41,26 @@ jobs:
   update-lockfile:
     name: Update requirements.lock
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    # Run for:
+    #   - any push to a dependabot/pip/** branch (the original trigger), AND
+    #   - pull_request events from this repo's own branches (covers
+    #     manual pyproject.toml edits — e.g. min-version bumps that
+    #     leave main red after merge). Skip PRs from forks since they
+    #     cannot push back with our token.
+    # Replicates juniper-canopy PR #250 / juniper-data PR #122 hardening.
+    if: |
+      (github.event_name == 'push' && github.actor == 'dependabot[bot]') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
 
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           token: ${{ secrets.CROSS_REPO_DISPATCH_TOKEN }}
-          ref: ${{ github.ref }}
+          # For pull_request events, check out the PR head branch (not the
+          # merge ref) so the regen commit can be pushed back. ${{ github.ref }}
+          # remains correct for push events on dependabot/pip/**.
+          ref: ${{ github.head_ref || github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -335,6 +335,16 @@ repos:
         language: system
         files: '^\.env(\.secrets)?$'
         types: [file]
+      - id: require-requirements-lock
+        name: Ensure requirements.lock exists
+        # Guards against accidental deletion. Same incident class as
+        # juniper-data 2026-05-19: Dependabot helper replaced the canonical
+        # lockfile with timestamped backups; a subsequent cleanup PR
+        # deleted those backups, leaving no requirements.lock at all.
+        entry: "bash -c '[ -f requirements.lock ] || { echo ERROR requirements.lock is missing. Regenerate via uv pip compile per workflow. ; exit 1 ; }'"
+        language: system
+        pass_filenames: false
+        always_run: true
 
 # CI configuration (for pre-commit.ci service, if used)
 ci:


### PR DESCRIPTION
## Summary

Two lockfile-lifecycle guardrails. Mirrors juniper-data PR #122 (and originally juniper-canopy PR #250).

1. **Auto-regen on `pyproject.toml` change.** The lockfile-update.yml workflow gains a `pull_request: paths: pyproject.toml` trigger (was push-only on `dependabot/pip/**`). The `if:` condition handles both event types; checkout now uses `${{ github.head_ref || github.ref }}` so the auto-regen commit pushes back to the PR head branch.
2. **Pre-commit presence guard.** Local hook `require-requirements-lock` (always-run) fails loudly if `requirements.lock` is missing from the working tree.

## Requirements

- References JR-CAS-CI-* — CI hygiene.

## Motivating incident

juniper-data 2026-05-19: Dependabot helper replaced the canonical `requirements.lock` with timestamped backups; a subsequent cleanup PR deleted those backups; main went red on Docker Build & Smoke Test + Lockfile Freshness. Both guardrails (auto-regen + presence check) shipped together in PR #122 to prevent recurrence — this PR ports them to juniper-cascor.

## What changed

| File | Change |
|------|--------|
| `.github/workflows/lockfile-update.yml` | Add `pull_request: paths: pyproject.toml` trigger; expand `if:` to cover both event types; switch `ref:` to `${{ github.head_ref || github.ref }}` |
| `.pre-commit-config.yaml` | Add local `require-requirements-lock` hook |

## Test plan

- [x] `pre-commit run --all-files` passes locally.
- [x] No code/test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)