### PR TITLE
fix(README + ci): disable README markdownlint for canonical layout + fix dep-docs sed bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+<!-- markdownlint-disable MD013 MD033 MD041 -->
+<!--
+  MD013 (line-length): README contains prose paragraphs that intentionally
+                       exceed the 512-char ecosystem limit (canonical
+                       §4 layout). Wrapping harms PyPI rendering.
+  MD033 (no-inline-html): The right-aligned logo + spacing rely on HTML.
+  MD041 (first-line-heading): The HTML logo is the first line by design.
+  Mirrors the per-file disable applied in juniper-ml #283.
+-->
 <div align="right" width="150px" height="150px" align="right" valign="top"> <img src="images/Juniper_Logo_150px.png" alt="Juniper" align="right" valign="top" width="150px" /></div>
 <br /> <br /> <br /> <br />
 

--- a/scripts/generate_dep_docs.sh
+++ b/scripts/generate_dep_docs.sh
@@ -120,8 +120,16 @@ if command -v conda &> /dev/null; then
     # conda env export --no-builds produces valid YAML; extract only the
     # dependency lines (between "dependencies:" and the next top-level key)
     # to merge with our custom header which already contains "dependencies:".
+    #
+    # 2026-05-20 fix: switched from the previous `sed -n '/^dependencies:$/,
+    # /^[a-z]/{...}'` pipeline to awk because the sed range terminator was
+    # being emitted as a trailing top-level key (`prefix:`, `variables:`) in
+    # some setup-miniconda configurations, breaking YAML validation.
+    # The awk form is end-exclusive: when it sees the next top-level key
+    # (`/^[a-zA-Z]/`), it clears the flag BEFORE printing that line, so the
+    # terminator is reliably omitted.
     conda env export --no-builds \
-        | sed -n '/^dependencies:$/,/^[a-z]/{ /^dependencies:$/d; /^[a-z]/d; p; }' \
+        | awk '/^dependencies:$/{flag=1; next} flag && /^[a-zA-Z]/{flag=0} flag' \
         >> "${CONDA_FILE}"
 
     # Validate generated YAML syntax


### PR DESCRIPTION
## Summary

Two fixes addressing main-branch CI failures introduced by recent merges.

### 1. README.md — Pre-commit failing on markdownlint MD013/line-length

PR #275 normalised the README to the §4 canonical layout, which intentionally inlines long prose paragraphs for PyPI rendering. markdownlint catches lines 10/125/192/194 (each > 512 chars), blocking all 3× Pre-commit matrix variants and the Quality Gate aggregator.

**Fix**: prepend a per-file `<!-- markdownlint-disable MD013 MD033 MD041 -->` directive with explanatory comment. Mirrors juniper-ml PR #283.

### 2. scripts/generate_dep_docs.sh — sed → awk

Preventative fix for the same sed-range defect that's failing juniper-cascor-worker on main right now (the conda env export sed pipeline emits the range terminator as a trailing top-level key under some setup-miniconda configs, breaking the immediately-following YAML validation step). cascor would hit this once Pre-commit goes green and Dependency Documentation runs.

**Fix**: replace `sed -n '/^dependencies:$/,/^[a-z]/{...; /^[a-z]/d; p; }'` with `awk '/^dependencies:$/{flag=1; next} flag && /^[a-zA-Z]/{flag=0} flag'`. The awk form is end-exclusive — clears flag BEFORE printing the terminator line, reliably omitting it.

## Requirements

- References JR-CAS-DOC-* / JR-CAS-CI-* — CI hygiene.

## Test plan

- [x] `pre-commit run --files README.md scripts/generate_dep_docs.sh` — passes locally.
- [x] Pre-commit (Python 3.12/3.13/3.14) + downstream Quality Gate should turn green after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)