### PR TITLE
fix(README): disable MD013/MD033/MD041 for inline-HTML logo + long-prose layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+<!-- markdownlint-disable MD013 MD033 MD041 -->
+<!--
+  MD013 (line-length): README contains prose paragraphs that intentionally
+                       exceed the 512-char ecosystem limit. Disabled file-wide
+                       since wrapping mid-sentence harms PyPI rendering.
+  MD033 (no-inline-html): The right-aligned logo + spacing rely on HTML.
+  MD041 (first-line-heading): The HTML logo is the first line by design.
+-->
 <div align="right" width="150px" height="150px" align="right" valign="top"> <img src="images/Juniper_Logo_150px.png" alt="Juniper" align="right" valign="top" width="150px" /></div>
 <br /> <br /> <br /> <br />
 


### PR DESCRIPTION
## Summary

Pre-commit's `markdownlint` step has been failing on this repo's `main` branch since the recent `docs: normalize ... README to the §4 canonical layout` PR landed. juniper-ml hit the same failure class and fixed it in [pcalnon/juniper-ml#283](https://github.com/pcalnon/juniper-ml/pull/283); this PR ports the exact same fix here.

## The fix

Prepend a `<!-- markdownlint-disable ... -->` directive at the top of `README.md` covering the three rules the canonical layout intentionally violates:

| Rule | Why disabled |
|---|---|
| `MD013` (line-length) | The README has prose paragraphs > 512 chars; wrapping mid-sentence harms the PyPI render. |
| `MD033` (no-inline-html) | The right-aligned logo block + `<br />` spacing rely on inline HTML. |
| `MD041` (first-line-heading) | The HTML logo div is the first line by design (before the H1). |

The directive is rendered invisibly by PyPI / GitHub so the README presentation is unchanged.

## Test plan

- [x] `pre-commit run --files README.md` passes locally (8 hooks pass, no failures)
- [ ] CI: `Pre-commit (Python 3.12/3.13/3.14)` should turn green, unblocking the `Quality Gate`

## Why now

You explicitly flagged "tackle the pre-existing pre-commit failures as a separate session" during the doc-link migration. This is that session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)