### PR TITLE
fix(cascade_correlation): CLN-CC-13 — remove sys.path.append hacks

### DIFF
--- a/src/cascade_correlation/cascade_correlation.py
+++ b/src/cascade_correlation/cascade_correlation.py
@@ -61,15 +61,6 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 
-# import traceback
-
-
-#####################################################################################################################################################################################################
-# Add current and parent dir to Python path for imports
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-# sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-
-
 from candidate_unit.candidate_unit import CandidateTrainingResult, CandidateUnit
 
 #####################################################################################################################################################################################################
@@ -140,6 +131,8 @@ from log_config.logger.logger import Logger
 from parallelism import rc4_ring_buffer as _rc4
 from parallelism.task_distributor import TaskDistributor
 from utils.utils import display_progress
+
+# import traceback
 
 
 #####################################################################################################################################################################################################
@@ -1253,9 +1246,6 @@ class CascadeCorrelationNetwork:
         # Initialize plotter
         self.plotter = CascadeCorrelationPlotter(logger=self.logger)
         self.logger.debug("CascadeCorrelationNetwork: _init_display_components: Display components initialized")
-
-        # Add current dir to Python path for imports
-        sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
     @classmethod
     def create_simple_network(


### PR DESCRIPTION
## Summary

- Delete the module-level ``sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))`` (formerly line 69) and its commented-out variant. The hack pre-dates the project being packaged; once the package is installed (which is exactly what CI does — ``pip install -e \".[all]\"``), absolute imports like ``from candidate_unit.candidate_unit import …`` resolve via setuptools' ``packages.find`` (``where = [\".\", \"src\"]``).
- Also delete the runtime ``sys.path.append`` inside ``_init_display_components`` (formerly line 1258), which ran on every network creation, pointed at the same directory as ``__file__``, and was effectively dead code — every import that would have benefited was already resolved at module load.
- Retain ``import os`` and ``import sys`` — both are still used elsewhere (``sys.version_info``, ``os.environ``, ``os.path.join``, ``os.cpu_count``, etc.).

Roadmap reference: §6 CLN-CC-13 in ``juniper-ml/notes/JUNIPER_OUTSTANDING_DEVELOPMENT_ITEMS_V7_IMPLEMENTATION_ROADMAP.md``.

## Why the roadmap's recommended fix doesn't apply

The roadmap example uses a relative import:

```python
from ..candidate_unit.candidate_unit import CandidateTrainingResult, CandidateUnit
```

That doesn't work here — ``candidate_unit`` and ``cascade_correlation`` are **sibling top-level packages** under the flat ``where = [\".\", \"src\"]`` setuptools layout, not sub-packages of a common parent. The straight-delete + rely-on-install approach is the correct shape, and that's what this PR ships.

## Test plan

- [x] ``pip install -e \".[all]\"`` in JuniperCascor1 → clean install
- [x] ``python -c\"import sys; sys.path = [p for p in sys.path if 'juniper-cascor/src' not in p and 'worktrees/juniper-cascor' not in p]; from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork; print('OK')\"`` → succeeds after sys.path is scrubbed (proves the editable install is doing the work, not a residual src entry)
- [x] ``pytest src/tests/unit/ -q --timeout=120 -x --ignore=src/tests/unit/test_cascor_fix.py`` → full pass with the usual --slow skips
- [x] ``pytest src/tests/unit/test_cascade_correlation_coverage.py src/tests/unit/test_cascade_correlation_coverage_extended.py src/tests/unit/test_utils_extended.py -q --timeout=120`` → full pass
- [x] ``pre-commit run --files src/cascade_correlation/cascade_correlation.py`` → all hooks pass

## Out of scope (follow-ups)

- ``src/remote_client/remote_client.py:25-26`` has the same ``sys.path.append`` pattern. CLN-CC-13 names cascade_correlation.py specifically; the remote_client occurrences should be a separate small PR once this lands clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)