### PR TITLE
fix(remote_client): CLN-CC-13 follow-on — remove sys.path.append hacks

### DIFF
--- a/src/remote_client/remote_client.py
+++ b/src/remote_client/remote_client.py
@@ -18,12 +18,6 @@
 #####################################################################################################################################################################################################
 
 import multiprocessing as mp
-import os
-import sys
-
-# Add parent directories to path for imports
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 from log_config.logger.logger import Logger
 


### PR DESCRIPTION
## Summary

- Remove the two module-level ``sys.path.append`` calls in
  ``src/remote_client/remote_client.py`` (lines 25-26). Same pattern as
  cascade_correlation.py, cleaned up in PR #279 (CLN-CC-13). Once the
  package is installed (``pip install -e \".[all]\"`` — which CI does),
  ``from log_config.logger.logger import Logger`` resolves via setuptools'
  flat ``where = [\".\", \"src\"]`` package discovery, no path manipulation needed.
- Also drop ``import os`` and ``import sys`` — neither is referenced
  anywhere else in the file.

Net change: -6 lines, no behavior change for installed users.

## Test plan

- [x] ``python -c \"from remote_client.remote_client import RemoteWorkerClient\"`` → succeeds
- [x] ``pytest src/tests/unit/test_remote_client_coverage.py -q --timeout=60`` → 20 passed
- [x] ``pytest src/tests/unit/ -q --timeout=120 --ignore=src/tests/unit/test_juniper_data_client.py`` → full pass (the ignored file has pre-existing failures unrelated to this PR — juniper-data-client isn't installed in JuniperCascor1; reproduces identically on main)
- [x] ``pre-commit run --files src/remote_client/remote_client.py`` → all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)