### PR TITLE
fix(ci): suppress 11 unpatched torch PYSEC advisories in pip-audit (Security Scans)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -617,7 +617,41 @@ jobs:
           pip install torch numpy h5py pyyaml matplotlib
           pip freeze > reports/security/pip-freeze.txt
           # CRIT-005: Fail on high/critical vulnerabilities instead of just warning.
+          # ──────────────────────────────────────────────────────────────────────
+          # Suppress 11 PyTorch advisories that pip-audit reports against torch
+          # 2.12.0 (and the 2.5–2.10 lineage) with **no fix versions available
+          # upstream**. All are local-access-required DoS / memory corruption
+          # issues in torch internals; none have published fixes as of
+          # 2026-05-20. We re-evaluate this list quarterly or when pip-audit's
+          # advisory DB syncs a new torch release.
+          #
+          # PYSEC-2025-189  torch.ops.profiler — memory corruption (local)
+          # PYSEC-2025-190  nnq_Sigmoid — improper initialization (local, high complexity)
+          # PYSEC-2025-191  mkldnn_max_pool2d — DoS (local, "existence doubted")
+          # PYSEC-2025-192  pad_packed_sequence — memory corruption (local)
+          # PYSEC-2025-193  unpack_sequence — memory corruption (local)
+          # PYSEC-2025-194  torch.jit.script — memory corruption (local)
+          # PYSEC-2025-195  torch.lstm_cell — memory corruption (local)
+          # PYSEC-2025-196  jit_module_from_flatbuffer — memory corruption (local)
+          # PYSEC-2025-197  caching_allocator_delete — memory corruption (local)
+          # PYSEC-2025-210  torch.profiler.profile — DoS via missing profiler.stop()
+          # PYSEC-2026-139  pt2 Loading Handler — deserialization (local; PR open upstream)
+          #
+          # Tracking note: when removing IDs, also delete from
+          # juniper-cascor-worker's analogous block (kept in sync).
+          # ──────────────────────────────────────────────────────────────────────
           pip-audit -r reports/security/pip-freeze.txt --strict --desc on \
+            --ignore-vuln PYSEC-2025-189 \
+            --ignore-vuln PYSEC-2025-190 \
+            --ignore-vuln PYSEC-2025-191 \
+            --ignore-vuln PYSEC-2025-192 \
+            --ignore-vuln PYSEC-2025-193 \
+            --ignore-vuln PYSEC-2025-194 \
+            --ignore-vuln PYSEC-2025-195 \
+            --ignore-vuln PYSEC-2025-196 \
+            --ignore-vuln PYSEC-2025-197 \
+            --ignore-vuln PYSEC-2025-210 \
+            --ignore-vuln PYSEC-2026-139 \
             || (echo "::error::Critical/High vulnerabilities found in dependencies" && exit 1)
 
       - name: Upload Security Reports


### PR DESCRIPTION
## Summary

Same root cause + fix as juniper-cascor-worker — pip-audit reports 11 PYSEC advisories against `torch 2.12.0` with **no fix versions available upstream** as of 2026-05-20. All are local-access-required DoS / memory corruption in torch internals. No remote-exploit primitives.

## Requirements

- References JR-CAS-CI-* — CI hygiene / security gate.

## What changed

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` (pip-audit step) | Add `--ignore-vuln <ID>` for each of the 11 PYSEC IDs, with a documented comment block listing each ID + rationale + sync note pointing at juniper-cascor-worker's matching block |

Same 11 IDs as the worker (PYSEC-2025-189..197, 210, PYSEC-2026-139).

## Re-evaluation

Quarterly, or when pip-audit's advisory DB syncs a new torch release. When upstream ships a fix, remove the corresponding `--ignore-vuln` line.

## Test plan

- [x] `pre-commit run --files .github/workflows/ci.yml` passes.
- [x] Security Scans + downstream Quality Gate should turn green on CI after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)