### PR TITLE
fix(api): ERR-06 — chain HTTPException raises with `from e` (7 sites)

### DIFF
--- a/src/api/routes/network.py
+++ b/src/api/routes/network.py
@@ -28,7 +28,7 @@ async def create_network(request: Request, body: NetworkCreateRequest) -> dict:
         return success_response(info)
     except RuntimeError as e:
         logger.debug("Create network failed: %s", e)
-        raise HTTPException(status_code=409, detail="Network cannot be created in the current state")
+        raise HTTPException(status_code=409, detail="Network cannot be created in the current state") from e
 
 
 @router.get("")
@@ -49,7 +49,7 @@ async def delete_network(request: Request) -> dict:
         return success_response({"deleted": True})
     except RuntimeError as e:
         logger.debug("Delete network failed: %s", e)
-        raise HTTPException(status_code=409, detail="Network cannot be deleted in the current state")
+        raise HTTPException(status_code=409, detail="Network cannot be deleted in the current state") from e
 
 
 @router.get("/topology")

--- a/src/api/routes/training.py
+++ b/src/api/routes/training.py
@@ -75,7 +75,7 @@ async def start_training(request: Request, body: TrainingStartRequest = None) ->
         return success_response(result)
     except (RuntimeError, ValueError) as e:
         logger.debug("Start training failed: %s", e)
-        raise HTTPException(status_code=409, detail="Training cannot be started in the current state")
+        raise HTTPException(status_code=409, detail="Training cannot be started in the current state") from e
 
 
 @router.post("/stop")
@@ -95,7 +95,7 @@ async def pause_training(request: Request) -> dict:
         return success_response(result)
     except RuntimeError as e:
         logger.debug("Pause training failed: %s", e)
-        raise HTTPException(status_code=409, detail="Training cannot be paused in the current state")
+        raise HTTPException(status_code=409, detail="Training cannot be paused in the current state") from e
 
 
 @router.post("/resume")
@@ -107,7 +107,7 @@ async def resume_training(request: Request) -> dict:
         return success_response(result)
     except RuntimeError as e:
         logger.debug("Resume training failed: %s", e)
-        raise HTTPException(status_code=409, detail="Training cannot be resumed in the current state")
+        raise HTTPException(status_code=409, detail="Training cannot be resumed in the current state") from e
 
 
 @router.post("/reset")
@@ -159,9 +159,9 @@ async def update_training_params(request: Request, body: TrainingParamUpdateRequ
         # FRONTEND_ISSUES_PLAN_2026-05-09 §1.5 C2.1 — surface the violation
         # string in the JSON body so the canopy adapter can route it through
         # the same `mismatches`/`skipped` toast machinery from C3.
-        raise HTTPException(status_code=422, detail=str(e))
+        raise HTTPException(status_code=422, detail=str(e)) from e
     except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e))
+        raise HTTPException(status_code=404, detail=str(e)) from e
 
 
 # FRONTEND_ISSUES_PLAN_2026-05-09 §3.5.1 + §3.5.2 P1 — Issue #3 Phase 1 dataset


### PR DESCRIPTION
## Summary

- Add ``from e`` chaining to 7 ``raise HTTPException(...)`` calls in ``src/api/routes/network.py`` and ``src/api/routes/training.py`` that catch a specific exception, log it, then re-raise without chaining. Preserves the original traceback / ``__cause__`` so Sentry, structured-JSON loggers, and uvicorn tracebacks all surface the root cause.
- 2 files, +7 / -7 lines.

The v7 roadmap names 6 sites (network.py:31,52 and training.py:89,109,121,170). A per-file scan caught one additional site (``start_training`` at training.py:78) that matches the exact pattern but wasn't in the citation — included here since the fix is identical.

Roadmap reference: §18 ERR-06 in ``juniper-ml/notes/JUNIPER_OUTSTANDING_DEVELOPMENT_ITEMS_V7_IMPLEMENTATION_ROADMAP.md``.

## What changed

| File | Line | Handler | Exception caught |
|------|------|---------|------------------|
| network.py | 31 | ``create_network`` | ``RuntimeError`` |
| network.py | 52 | ``delete_network`` | ``RuntimeError`` |
| training.py | 78 | ``start_training`` | ``(RuntimeError, ValueError)`` |
| training.py | 98 | ``pause_training`` | ``RuntimeError`` |
| training.py | 110 | ``resume_training`` | ``RuntimeError`` |
| training.py | 162 | ``update_training_params`` | ``InvalidCandidatePoolError`` |
| training.py | 164 | ``update_training_params`` | ``ValueError`` |

## Sites left intentionally unchained

- Guard-clause raises (``if not lifecycle.has_network(): raise HTTPException(...)``) — no exception in scope to chain from.
- Status-based dispatch raises in ``patch_weights`` / ``add_hidden_unit`` (network.py:110-121, :168-176) — same reason; the function inspects a sentinel return rather than catching.
- Pre-existing ``from exc`` sites (training.py:217, 219, 226, 229, 233, 260 + snapshots.py:426, 428).
- The other 6 route files (``admin.py``, ``decision_boundary.py``, ``history.py``, ``metrics.py``, ``workers.py``, ``dataset.py``, ``health.py``, ``snapshots.py``) — verified clean by an ad-hoc detector script.

## Detector script (run against ``src/api/routes/*.py``)

```python
import re, pathlib
routes = pathlib.Path(\"src/api/routes\")
for f in routes.glob(\"*.py\"):
    text = f.read_text()
    pattern = re.compile(r\"^(\\s+)except\\s+[^\\n]*\\s+as\\s+(\\w+)\\s*:\\s*\\n((?:\\1\\s+.*\\n)+)\", re.MULTILINE)
    for m in pattern.finditer(text):
        body, name = m.group(3), m.group(2)
        for line in body.split(\"\\n\"):
            if \"raise HTTPException\" in line and f\"from {name}\" not in line and \" from \" not in line:
                print(f.name, line.strip())
```

Returns 0 hits after this change; returned 7 before.

## Test plan

- [x] ``pytest src/tests/unit/api/ src/tests/integration/api/ -q --timeout=60`` → full pass (only ``--integration``-gated tests skipped, expected)
- [x] ``pre-commit run --files src/api/routes/network.py src/api/routes/training.py`` → all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)