### PR TITLE
ci(pre-commit): add juniper-doc-tools hook (Wave 3)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -292,6 +292,43 @@ repos:
         exclude: ^(CHANGELOG\.md|notes/|docs/)
 
   # ═══════════════════════════════════════════════════════════════════════════
+  # Documentation link validation (juniper-doc-tools)
+  # Wave 3 of the doc-link migration plan; mirrors the per-PR docs CI lane
+  # so devs catch broken markdown links locally before push.
+  # See juniper-ml notes/JUNIPER_DOC_TOOLS_PYPI_MIGRATION_PLAN_2026-05-18.md.
+  # ═══════════════════════════════════════════════════════════════════════════
+  - repo: local
+    hooks:
+      - id: juniper-check-doc-links
+        name: Validate documentation links
+        entry: juniper-check-doc-links
+        language: python
+        additional_dependencies: ["juniper-doc-tools>=0.1.1,<0.2.0"]
+        args:
+          - --exclude
+          - templates
+          - --exclude
+          - history
+          - --exclude
+          - legacy
+          - --exclude
+          - pull_requests
+          - --exclude
+          - releases
+          - --exclude
+          - analysis
+          - --exclude
+          - fixes
+          - --exclude
+          - development
+          - --exclude
+          - CHANGELOG.md
+          - --cross-repo
+          - skip
+        pass_filenames: false
+        files: \.md$
+
+  # ═══════════════════════════════════════════════════════════════════════════
   # Shell Script Linting - shellcheck
   # MED-013: Changed severity from error to warning to catch more issues
   # ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Wave 3 of the [doc-link validator PyPI migration plan](https://github.com/pcalnon/juniper-ml/blob/main/notes/JUNIPER_DOC_TOOLS_PYPI_MIGRATION_PLAN_2026-05-18.md) — the optional local pre-commit hook.

Adds a `juniper-check-doc-links` hook to `.pre-commit-config.yaml`. Mirrors the per-PR docs CI lane so broken markdown links surface **locally before push**, not after pushing and waiting for CI to flag them.

## Hook design (per Wave 3 §4 + user-confirmed choices)

```yaml
- repo: local
  hooks:
    - id: juniper-check-doc-links
      name: Validate documentation links
      entry: juniper-check-doc-links
      language: python
      additional_dependencies: ["juniper-doc-tools>=0.1.1,<0.2.0"]
      args:
        - --exclude
        - templates
        - --exclude
        - history
        # … (canonical exclude set, mirrors CI)
        - --cross-repo
        - skip
      pass_filenames: false
      files: \.md$
```

Key choices:

- **`language: python` + `additional_dependencies`** (chosen over the plan's `language: system` example). Pre-commit creates an isolated venv with `juniper-doc-tools` installed on first run. No `pip install juniper-doc-tools` prereq for the dev's working venv — the hook self-bootstraps.
- **`pass_filenames: false`** — the validator scans the whole repo, not just changed files. The `files: \.md$` filter only governs *when* the hook fires.
- **`--cross-repo skip`** matches the CI invocation. Local pre-commit doesn't have sibling Juniper repos checked out, so cross-repo links would otherwise fail unnecessarily.
- The canonical `--exclude` set is identical to CI's, so the hook and CI produce the same result on the same tree.

## Test plan

- [x] YAML valid: `python3 -c "import yaml; yaml.safe_load(open('.pre-commit-config.yaml'))"`
- [x] First run installs the isolated hook venv from PyPI; subsequent runs reuse it
- [x] `pre-commit run juniper-check-doc-links --all-files` → `Validate documentation links……Passed`
- [x] All other pre-commit hooks still pass on the touched config file
- [ ] CI: Pre-commit lane stays green (this PR adds 1 hook; existing hooks untouched)

## Companion PRs

1-of-7 parallel ports; identical config landed in juniper-ml + 6 consumer repos. They can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)