### PR TITLE
feat(api): API-02 (2/3) — add "service": "juniper-cascor" to /v1/health base schema

### DIFF
--- a/src/api/routes/health.py
+++ b/src/api/routes/health.py
@@ -57,8 +57,17 @@ async def health_check() -> dict:
     Always returns 200 while the process can respond. Reserved for legacy
     integrations; new probes should use ``/health/live`` or
     ``/health/ready``.
+
+    Response schema (API-02 shared base):
+
+    - ``status``  — always ``"ok"`` on success.
+    - ``version`` — the package version of this service.
+    - ``service`` — canonical service identifier (``"juniper-cascor"``);
+      matches the cross-service ``{status, version, service}`` base
+      shared by juniper-data and juniper-canopy so monitoring tools can
+      tell health responses apart without inspecting the URL.
     """
-    return {"status": "ok", "version": _API_VERSION}
+    return {"status": "ok", "version": _API_VERSION, "service": "juniper-cascor"}
 
 
 @router.get("/health/live")

--- a/src/tests/unit/api/test_api_health.py
+++ b/src/tests/unit/api/test_api_health.py
@@ -31,6 +31,19 @@ class TestHealthEndpoints:
         assert body["status"] == "ok"
         assert body["version"] == "0.4.0"
 
+    def test_health_includes_service_identifier(self, client):
+        """API-02: /v1/health includes the ``service`` field naming this service.
+
+        Part of the shared ``{status, version, service}`` base schema across
+        juniper-data, juniper-cascor, and juniper-canopy so cross-service
+        monitoring tools can tell health responses apart without parsing
+        the URL.
+        """
+        response = client.get("/v1/health")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["service"] == "juniper-cascor"
+
     def test_liveness_probe(self, client):
         """R1.2: GET /v1/health/live runs in-process tick + returns 200 with tick metadata."""
         response = client.get("/v1/health/live")


### PR DESCRIPTION
## Summary

Second of 3 small per-repo PRs adopting §21 **API-02 Approach A**: standardize a shared `{status, version, service}` base across `juniper-data`, `juniper-cascor`, and `juniper-canopy` health endpoints. Cross-service monitoring tools can then tell health responses apart without parsing the URL.

| PR | Repo | Adds |
|----|------|------|
| juniper-data #132 | juniper-data | `"service": "juniper-data"` |
| **this** | juniper-cascor | `"service": "juniper-cascor"` |
| (next) | juniper-canopy | `"service": "juniper-canopy"` (the 5 canopy-specific extras remain as documented optional fields per Approach A guardrails) |

Roadmap reference: §21 API-02 in `juniper-ml/notes/JUNIPER_OUTSTANDING_DEVELOPMENT_ITEMS_V7_IMPLEMENTATION_ROADMAP.md`. Follow-on to API-01 (canopy #299, just merged) which normalized canopy `"status": "healthy"` → `"ok"` to match what data + cascor already returned.

## Production change (`src/api/routes/health.py`)

```diff
-    return {"status": "ok", "version": _API_VERSION}
+    return {"status": "ok", "version": _API_VERSION, "service": "juniper-cascor"}
```

Plus a docstring note explaining the shared base schema and pointing at the sibling services.

## Backward compatibility

**Pure additive.** No existing test was modified.

I audited every `/v1/health` test site in the repo:

| Site | Assertion style |
|------|-----------------|
| `src/tests/unit/api/test_api_health.py:28,214` | targeted-key (`body["status"]`, `body["version"]`) |
| `src/tests/unit/api/test_api_app_coverage_deep.py:421` | route-path membership |
| `src/tests/unit/api/test_api_middleware.py:21,39,77` | fixture + exemption-path |
| `src/tests/integration/test_juniper_data_e2e.py:122` | asserts juniper-data's health (cross-service e2e), not cascor's own |

The flat-response test at line 214 explicitly asserts `"data" not in body` / `"meta" not in body`; adding `"service"` is fine since it is neither key.

## Test plan

Added 1 new test:

| Test | Asserts |
|------|---------|
| `test_health_includes_service_identifier` | `body["service"] == "juniper-cascor"` |

Validation:

- [x] `pytest src/tests/unit/api/test_api_health.py src/tests/unit/api/test_api_app_coverage_deep.py src/tests/unit/api/test_api_middleware.py -q --timeout=60 -k health` -> **19 passed**.
- [x] `pre-commit run --files src/api/routes/health.py src/tests/unit/api/test_api_health.py` -> all hooks pass.

## Files changed

- `src/api/routes/health.py` (+10 / -1)
- `src/tests/unit/api/test_api_health.py` (+13 / -0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)