### PR TITLE
chore(ci): port generate_dep_docs.sh conda block to canonical python-yaml form (matches worker PR #74)

### DIFF
--- a/scripts/generate_dep_docs.sh
+++ b/scripts/generate_dep_docs.sh
@@ -117,27 +117,37 @@ if command -v conda &> /dev/null; then
     fi
 
     # Append conda dependencies with proper YAML indentation (two-space prefix).
-    # conda env export --no-builds produces valid YAML; extract only the
-    # dependency lines (between "dependencies:" and the next top-level key)
-    # to merge with our custom header which already contains "dependencies:".
-    #
-    # 2026-05-20 fix: switched from the previous `sed -n '/^dependencies:$/,
-    # /^[a-z]/{...}'` pipeline to awk because the sed range terminator was
-    # being emitted as a trailing top-level key (`prefix:`, `variables:`) in
-    # some setup-miniconda configurations, breaking YAML validation.
-    # The awk form is end-exclusive: when it sees the next top-level key
-    # (`/^[a-zA-Z]/`), it clears the flag BEFORE printing that line, so the
-    # terminator is reliably omitted.
+    # We parse `conda env export --no-builds` output as YAML in Python, extract
+    # the dependencies list, and re-emit it with consistent indentation. This
+    # is the third iteration of this block:
+    #   1. sed range with inner delete — leaked the range-terminator line
+    #      (e.g. `prefix:`) into the output under setup-miniconda's
+    #      auto-activate-base.
+    #   2. awk end-exclusive — fixed the leak case but still proved brittle
+    #      against other miniconda output shapes.
+    #   3. This version: parse with PyYAML, re-emit. Robust to any output
+    #      shape because we're not pattern-matching the raw text.
+    # PyYAML is installed by the workflow (see ci.yml dep-docs job) and is
+    # also declared in pyproject.toml [test] extras so local runs work too.
+    # This block is the canonical pattern shared with juniper-cascor-worker
+    # (PR #74), juniper-data, and juniper-canopy.
     conda env export --no-builds \
-        | awk '/^dependencies:$/{flag=1; next} flag && /^[a-zA-Z]/{flag=0} flag' \
-        >> "${CONDA_FILE}"
+        | python -c "
+import sys, textwrap, yaml
+data = yaml.safe_load(sys.stdin)
+deps = data.get('dependencies', [])
+print(textwrap.indent(yaml.dump(deps, default_flow_style=False), '  ').rstrip())
+" >> "${CONDA_FILE}"
 
-    # Validate generated YAML syntax
+    # Validate generated YAML syntax. We do NOT swallow stderr here: a missing
+    # PyYAML install previously surfaced as a misleading "invalid YAML syntax"
+    # message instead of the underlying ModuleNotFoundError (see worker PR #74
+    # for the multi-PR diagnostic detour that motivated this).
     if command -v python &> /dev/null; then
-        if python -c "import yaml; yaml.safe_load(open('${CONDA_FILE}'))" 2>/dev/null; then
+        if python -c "import yaml; yaml.safe_load(open('${CONDA_FILE}'))"; then
             echo "  Validated: ${CONDA_FILE} YAML syntax OK"
         else
-            echo "  ERROR: Generated ${CONDA_FILE} has invalid YAML syntax"
+            echo "  ERROR: ${CONDA_FILE} validation failed (see python error above)"
             exit 1
         fi
     fi


### PR DESCRIPTION
## Summary

Preventative port of ``scripts/generate_dep_docs.sh``'s conda-dependency extraction from the awk end-exclusive form (introduced by cascor PR #276) to the canonical PyYAML parse-and-reemit form that juniper-cascor-worker landed in [PR #74](https://github.com/pcalnon/juniper-cascor-worker/pull/74) and juniper-canopy / juniper-data already exercise.

Not currently failing — this just converges the script across the ecosystem so the next setup-miniconda quirk doesn't trigger another sed-vs-awk-vs-python-yaml diagnostic walk like the worker repo went through on 2026-05-20.

## Why now

The worker repo went through a four-PR multi-day detour (sed → awk #69 → python yaml #72 → fix swallowed-import-error #74) on 2026-05-20. The root cause of the original failure turned out NOT to be the extraction pipeline — it was ``2>/dev/null`` on the YAML-validation step masking a missing ``PyYAML`` install as misleading ``\"invalid YAML syntax\"``. The canonical pattern that emerged:

1. Use PyYAML to extract dependencies (robust to any ``conda env export`` output shape).
2. Install PyYAML in the CI workflow (already done — ``pip install \"pyyaml>=6.0\"`` in cascor's dep-docs job).
3. Declare PyYAML in ``pyproject.toml`` ``[test]`` extras (already done — ``PyYAML>=6.0``).
4. **Do not swallow stderr** on the validation step (this PR fixes it).

## Changes

| Line | Before | After |
|---|---|---|
| Extraction | ``awk '/^dependencies:$/{flag=1; next} flag && /^[a-zA-Z]/{flag=0} flag'`` | ``python -c \"...yaml.safe_load(sys.stdin)...\"`` |
| Validation | ``python -c \"...\" 2>/dev/null`` | ``python -c \"...\"`` (stderr surfaces) |
| Comments | 2026-05-20 sed→awk rationale | Full 3-iteration history + cross-repo cite |

## CI impact

None in the happy path: cascor's ci.yml already installs PyYAML, ``[test]`` extras already declare it.

## Verification

- ``shellcheck -S warning scripts/generate_dep_docs.sh`` clean.
- Local dry-run of the python-yaml block against an active conda env produces correctly-indented ``  - <pkg>=<ver>`` lines (no trailing ``prefix:`` / ``variables:`` leak).

## Requirements

References: none directly tracked; CI hygiene / ecosystem convergence.