### PR TITLE
fix(CFG-03): converge SENTRY_SDK_DSN -> JUNIPER_CASCOR_SENTRY_DSN with deprecation period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+
+- **CFG-03**: `SENTRY_SDK_DSN` is now deprecated in favor of the prefixed `JUNIPER_CASCOR_SENTRY_DSN` env var (which already backs the pydantic `Settings.sentry_dsn` field via `env_prefix='JUNIPER_CASCOR_'` consumed by `configure_sentry()` in `src/api/app.py`). Historically the bootstrap Sentry init at the top of `src/main.py` read a second, unprefixed `SENTRY_SDK_DSN` — two env vars for the same feature is operator-hostile. A new `_resolve_sentry_dsn() -> str | None` helper in `src/main.py` consolidates the lookup with the following precedence: (1) `JUNIPER_CASCOR_SENTRY_DSN` wins when set; (2) `SENTRY_SDK_DSN` is still honored when only the legacy name is set, but emits a `DeprecationWarning` (`warnings.warn(..., DeprecationWarning, stacklevel=2)`); (3) when both are set to **different** values, the prefixed form wins and a `[juniper-cascor] CFG-03 WARNING:` line is emitted on stderr so split-config drift is visible at startup; (4) when both are set to the **same** value, the prefixed form wins silently (no-op for migration-in-progress deployments). `SENTRY_SDK_DSN` will be **removed in a future release** — update deployment manifests, secrets, and `.env` files to the prefixed name. Pinned by 5-case regression suite at `src/tests/unit/test_cfg_03_sentry_dsn_resolution.py` (prefixed-only, legacy-only, both-same, both-different, neither-set). Tracks CFG-03 in the v7 outstanding-development roadmap.
+
 ### Added
 
 - **METRICS-MON R3.7 (soak complete)**: macOS leg of the unit-tests CI matrix flipped from `experimental: true` → `experimental: false`, making the `macos-latest` (Python 3.12) leg **required**. Failures on macOS now block the job. The `continue-on-error: ${{ matrix.experimental == true }}` job-level guard is preserved as a future-proof escape hatch for future experimental matrix entries; with `experimental: false` it evaluates to `false`. Soak window 2026-05-01 → 2026-05-15 confirmed clean (per user direction). Closes the post-soak follow-up of the R3.7 fan-out.

--- a/src/main.py
+++ b/src/main.py
@@ -118,8 +118,60 @@ from spiral_problem.spiral_problem import SpiralProblem
 # from inspect import currentframe, getframeinfo
 
 
+def _resolve_sentry_dsn() -> str | None:
+    """CFG-03: pick the Sentry DSN env var, preferring the prefixed name.
+
+    Historically the bootstrap Sentry init at module-import time read the
+    standalone ``SENTRY_SDK_DSN`` env var, while ``Settings.sentry_dsn``
+    (used by ``configure_sentry`` in ``src/api/app.py``) reads the
+    prefixed ``JUNIPER_CASCOR_SENTRY_DSN`` (via
+    ``env_prefix='JUNIPER_CASCOR_'`` on the pydantic ``Settings`` class).
+    Two env vars for the same feature is operator-hostile — converge on
+    the prefixed name (the ecosystem convention) and keep
+    ``SENTRY_SDK_DSN`` accepted with a ``DeprecationWarning`` so existing
+    deployments are not broken by this PR. The next major release should
+    drop the legacy name.
+
+    Returns:
+        The DSN string to pass to ``sentry_sdk.init``, or ``None`` if
+        neither env var is set (Sentry stays disabled).
+
+    Precedence:
+        1. ``JUNIPER_CASCOR_SENTRY_DSN`` — preferred; matches the
+           ecosystem env-prefix convention and the pydantic Settings
+           field.
+        2. ``SENTRY_SDK_DSN`` — legacy; accepted with a
+           ``DeprecationWarning``.
+
+    When both are set:
+        - Same value -> no warning, prefixed name wins (no-op).
+        - Different values -> stderr line warning of split-config drift;
+          prefixed name wins.
+    """
+    prefixed = os.getenv("JUNIPER_CASCOR_SENTRY_DSN")
+    legacy = os.getenv("SENTRY_SDK_DSN")
+    if not prefixed and legacy:
+        import warnings as _cfg_03_warnings
+
+        _cfg_03_warnings.warn(
+            "SENTRY_SDK_DSN is deprecated; set JUNIPER_CASCOR_SENTRY_DSN instead. " "SENTRY_SDK_DSN will be removed in a future release. Until then, the " "legacy variable continues to work but the prefixed form takes " "precedence whenever both are set.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return legacy
+    if prefixed and legacy and prefixed != legacy:
+        # Both set with different values — the prefixed one wins. Tell
+        # the operator on stderr so split-config drift is visible at
+        # startup.
+        print(
+            "[juniper-cascor] CFG-03 WARNING: both JUNIPER_CASCOR_SENTRY_DSN and SENTRY_SDK_DSN are set " "to different values; JUNIPER_CASCOR_SENTRY_DSN takes precedence. " "Unset SENTRY_SDK_DSN to silence this message.",
+            file=sys.stderr,
+        )
+    return prefixed
+
+
 load_dotenv()
-_sentry_dsn = os.getenv("SENTRY_SDK_DSN")
+_sentry_dsn = _resolve_sentry_dsn()
 if _sentry_dsn:
     # Match configure_sentry()'s behavior at the application-bootstrap
     # site as well: default PII off (SEC-15) and scrub any residual

--- a/src/tests/unit/test_cfg_03_sentry_dsn_resolution.py
+++ b/src/tests/unit/test_cfg_03_sentry_dsn_resolution.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+"""
+Unit tests for CFG-03: _resolve_sentry_dsn() in src/main.py.
+
+CFG-03 converges two historically-divergent Sentry DSN env vars onto a
+single name that matches the ecosystem convention:
+
+    JUNIPER_CASCOR_SENTRY_DSN   (preferred; matches pydantic
+                                 ``Settings`` env_prefix='JUNIPER_CASCOR_')
+    SENTRY_SDK_DSN              (legacy; accepted with DeprecationWarning,
+                                 slated for removal in a future release)
+
+These tests pin the precedence + warning behavior of the helper so the
+deprecation period does not regress.
+"""
+
+import os
+import sys
+import warnings
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from main import _resolve_sentry_dsn  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _clean_sentry_env(monkeypatch):
+    """Start every test with both Sentry DSN env vars unset.
+
+    The host environment may have either variable exported (e.g. a
+    developer running tests inside an activated Juniper shell). Clearing
+    both up front makes each case deterministic.
+    """
+    monkeypatch.delenv("JUNIPER_CASCOR_SENTRY_DSN", raising=False)
+    monkeypatch.delenv("SENTRY_SDK_DSN", raising=False)
+
+
+class TestResolveSentryDsn:
+    """Pin CFG-03 precedence + deprecation-warning contract."""
+
+    def test_prefixed_only_returns_value_no_warning(self, monkeypatch, capsys):
+        """JUNIPER_CASCOR_SENTRY_DSN set, legacy unset -> returns value, no warning."""
+        monkeypatch.setenv("JUNIPER_CASCOR_SENTRY_DSN", "https://prefixed@sentry.example/1")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            # Would raise if a DeprecationWarning fired.
+            result = _resolve_sentry_dsn()
+        assert result == "https://prefixed@sentry.example/1"
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_legacy_only_returns_value_and_warns(self, monkeypatch, capsys):
+        """SENTRY_SDK_DSN set, prefixed unset -> returns value + DeprecationWarning."""
+        monkeypatch.setenv("SENTRY_SDK_DSN", "https://legacy@sentry.example/2")
+        with pytest.warns(DeprecationWarning, match="SENTRY_SDK_DSN is deprecated"):
+            result = _resolve_sentry_dsn()
+        assert result == "https://legacy@sentry.example/2"
+        # No stderr line should be emitted in the legacy-only path; the
+        # deprecation channel is the warning, not stderr.
+        captured = capsys.readouterr()
+        assert "CFG-03 WARNING" not in captured.err
+
+    def test_both_set_same_value_no_warning_no_stderr(self, monkeypatch, capsys):
+        """Both env vars set to the same value -> no warning, no stderr."""
+        dsn = "https://same@sentry.example/3"
+        monkeypatch.setenv("JUNIPER_CASCOR_SENTRY_DSN", dsn)
+        monkeypatch.setenv("SENTRY_SDK_DSN", dsn)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            result = _resolve_sentry_dsn()
+        assert result == dsn
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_both_set_different_values_prefixed_wins_stderr_emitted(self, monkeypatch, capsys):
+        """Both env vars set, different values -> prefixed wins + stderr line."""
+        monkeypatch.setenv("JUNIPER_CASCOR_SENTRY_DSN", "https://prefixed@sentry.example/4")
+        monkeypatch.setenv("SENTRY_SDK_DSN", "https://legacy@sentry.example/5")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            # Legacy-only path is the only one that warns; with prefixed
+            # set, no DeprecationWarning should fire.
+            result = _resolve_sentry_dsn()
+        assert result == "https://prefixed@sentry.example/4"
+        captured = capsys.readouterr()
+        assert "CFG-03 WARNING" in captured.err
+        assert "JUNIPER_CASCOR_SENTRY_DSN takes precedence" in captured.err
+        assert "SENTRY_SDK_DSN" in captured.err
+
+    def test_neither_set_returns_none(self, capsys):
+        """Neither env var set -> returns None (Sentry stays disabled)."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            result = _resolve_sentry_dsn()
+        assert result is None
+        captured = capsys.readouterr()
+        assert captured.err == ""


### PR DESCRIPTION
## Summary

CFG-03 from the v7 outstanding-development roadmap: converge the two divergent Sentry DSN env vars used by juniper-cascor onto a single name (`JUNIPER_CASCOR_SENTRY_DSN`) that matches the ecosystem convention, while keeping the legacy unprefixed name (`SENTRY_SDK_DSN`) accepted with a `DeprecationWarning` so existing deployments are not broken by this PR.

Historically the bootstrap Sentry init at the top of `src/main.py` read `SENTRY_SDK_DSN`, while `Settings.sentry_dsn` (consumed by `configure_sentry()` in `src/api/app.py`) reads the prefixed `JUNIPER_CASCOR_SENTRY_DSN` via `env_prefix='JUNIPER_CASCOR_'`. Two env vars for the same feature made deployment manifests carry both names "just in case" — split-config drift was invisible at startup.

## Production change diff

```diff
+def _resolve_sentry_dsn() -> str | None:
+    """CFG-03: pick the Sentry DSN env var, preferring the prefixed name."""
+    prefixed = os.getenv("JUNIPER_CASCOR_SENTRY_DSN")
+    legacy = os.getenv("SENTRY_SDK_DSN")
+    if not prefixed and legacy:
+        import warnings as _cfg_03_warnings
+        _cfg_03_warnings.warn(
+            "SENTRY_SDK_DSN is deprecated; set JUNIPER_CASCOR_SENTRY_DSN instead. "
+            "SENTRY_SDK_DSN will be removed in a future release. ...",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return legacy
+    if prefixed and legacy and prefixed != legacy:
+        print(
+            "[juniper-cascor] CFG-03 WARNING: both JUNIPER_CASCOR_SENTRY_DSN and "
+            "SENTRY_SDK_DSN are set to different values; "
+            "JUNIPER_CASCOR_SENTRY_DSN takes precedence. ...",
+            file=sys.stderr,
+        )
+    return prefixed

 load_dotenv()
-_sentry_dsn = os.getenv("SENTRY_SDK_DSN")
+_sentry_dsn = _resolve_sentry_dsn()
 if _sentry_dsn:
     # ... unchanged sentry_sdk.init(...) block with SEC-15 PII-off
     # defaults and header scrubbing ...
```

## Behavior matrix

| `JUNIPER_CASCOR_SENTRY_DSN` | `SENTRY_SDK_DSN` | Returns | `DeprecationWarning` | stderr line |
| --- | --- | --- | --- | --- |
| set (`A`) | unset | `A` | no | no |
| unset | set (`L`) | `L` | **yes** | no |
| set (`A`) | set (`A`) | `A` | no | no |
| set (`A`) | set (`B`) | `A` (prefixed wins) | no | **yes** (`CFG-03 WARNING`) |
| unset | unset | `None` (Sentry disabled, as before) | no | no |

Migration path for operators:

1. Update deployment manifests / secrets / `.env` files to use `JUNIPER_CASCOR_SENTRY_DSN`.
2. Leave `SENTRY_SDK_DSN` in place during the rollout (both set, same value → no warning, no stderr, prefixed wins silently).
3. Once the rollout is fully cut over, remove `SENTRY_SDK_DSN`.
4. A future major release will remove the legacy name entirely.

## Why a helper instead of just deleting the legacy lookup?

Deleting `SENTRY_SDK_DSN` outright would silently disable Sentry on every existing deployment that still sets the legacy name — a regression in observability visible only when something fails to be captured. The deprecation period gives operators one release-cycle of grace plus a clear stderr signal when both names are set to *different* values (the only case where the migration would actually break behavior).

## Test plan checklist

- [x] `pre-commit run --files src/main.py src/tests/unit/test_cfg_03_sentry_dsn_resolution.py CHANGELOG.md` — all hooks pass (Black reformatted on first pass, clean on second)
- [x] `conda run -n JuniperCascor1 python -m pytest src/tests/unit/test_cfg_03_sentry_dsn_resolution.py -q --timeout=60` — **5/5 passed**
- [x] Manual confirmation that the new `_resolve_sentry_dsn()` is wired into the bootstrap site (`_sentry_dsn = _resolve_sentry_dsn()`)
- [x] Existing `configure_sentry()` path in `src/api/app.py` (the pydantic `Settings.sentry_dsn`-based init) is unchanged — only the bootstrap-import-time site is touched.

### Regression coverage

`src/tests/unit/test_cfg_03_sentry_dsn_resolution.py` — 5 cases, autouse fixture clears both env vars at start of every test for a deterministic baseline regardless of host shell state:

| Test | Asserts |
| --- | --- |
| `test_prefixed_only_returns_value_no_warning` | Returns prefixed DSN; **no** `DeprecationWarning`; **no** stderr |
| `test_legacy_only_returns_value_and_warns` | Returns legacy DSN; **fires** `pytest.warns(DeprecationWarning, match="SENTRY_SDK_DSN is deprecated")`; **no** stderr |
| `test_both_set_same_value_no_warning_no_stderr` | Returns value; **no** warning; **no** stderr |
| `test_both_set_different_values_prefixed_wins_stderr_emitted` | Returns prefixed; **no** warning; stderr contains `CFG-03 WARNING` + `JUNIPER_CASCOR_SENTRY_DSN takes precedence` |
| `test_neither_set_returns_none` | Returns `None`; **no** warning; **no** stderr |

## Files changed

- `src/main.py` — new `_resolve_sentry_dsn() -> str | None` helper near line 121; bootstrap `_sentry_dsn = os.getenv("SENTRY_SDK_DSN")` → `_sentry_dsn = _resolve_sentry_dsn()`. Downstream `sentry_sdk.init(...)` block unchanged.
- `src/tests/unit/test_cfg_03_sentry_dsn_resolution.py` — new file, 5-case regression suite pinning the precedence + warning contract.
- `CHANGELOG.md` — new `### Deprecated` block under `[Unreleased]` documenting the migration, precedence rules, and "removed in a future release" timeline.

## Out of scope (deliberately)

- `Settings.sentry_dsn` / `configure_sentry()` — already on the prefixed name, no change needed.
- Removing `SENTRY_SDK_DSN` entirely — that is a follow-up after the deprecation period; tracked implicitly by the `# CFG-03` docstring + the CHANGELOG note.
- Container image env-var docs / Helm chart updates — separate juniper-deploy change; the cascor service speaks both names during the deprecation window so manifest updates can be staged independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
