### PR TITLE
ci(deps): swap scripts/generate_dep_docs.sh -> juniper-ci-tools (Wave 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -508,13 +508,24 @@ jobs:
             pip install "juniper-data-client @ git+https://github.com/pcalnon/juniper-data-client.git@main" || true
           pip install -e ".[all]"
 
+      # Wave 2 of the dep-docs PyPI migration -- replaces the inline
+      # bash scripts/generate_dep_docs.sh with the juniper-ci-tools
+      # console script from PyPI. See juniper-ml plan
+      # notes/JUNIPER_CI_TOOLS_PYPI_MIGRATION_PLAN_2026-05-20.md.
+      # The inline script will be removed in Wave 4.
+      - name: Install juniper-ci-tools
+        shell: bash -l {0}
+        run: |
+          python -m pip install --upgrade "pip>=26.1.1"
+          pip install "juniper-ci-tools>=0.1.0,<0.2.0"
+
       - name: Generate Dependency Documentation
         shell: bash -l {0}
         run: |
           echo "╔════════════════════════════════════════════════════════════╗"
           echo "║       Juniper Cascor - Generate Dependency Docs            ║"
           echo "╚════════════════════════════════════════════════════════════╝"
-          bash scripts/generate_dep_docs.sh
+          juniper-generate-dep-docs
 
       - name: Upload Dependency Documentation
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1


### PR DESCRIPTION
Wave 2 of the juniper-ci-tools PyPI migration. Replaces the inline `bash scripts/generate_dep_docs.sh` invocation in the 'Generate Dependency Documentation' CI step with the PyPI-published `juniper-generate-dep-docs` console script from `juniper-ci-tools 0.1.0`.

Plan doc (in juniper-ml): `notes/JUNIPER_CI_TOOLS_PYPI_MIGRATION_PLAN_2026-05-20.md`. PyPI: https://pypi.org/project/juniper-ci-tools/

The inline `scripts/generate_dep_docs.sh` is **NOT deleted** in this PR (Wave 4 deletes it across all 7 repos after Wave 2 has soaked). This PR is a pure CI-step swap and is reverted by changing one line back if needed.

Mirrors the structure of the proof PR juniper-ml#294 (which already merged and passed real CI against the new console script). All 6 fanout PRs share an identical shape; they have no inter-repo dependencies and can be merged in any order.

References: juniper-ml/notes/JUNIPER_CI_TOOLS_PYPI_MIGRATION_PLAN_2026-05-20.md