### PR TITLE
chore(yamllint): normalize .yamllint.yaml + drop pre-commit -d relaxed (ecosystem-wide)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -350,7 +350,7 @@ repos:
     hooks:
       - id: yamllint
         name: Lint YAML files
-        args: [--format, parsable, -d, relaxed]
+        args: [--format, parsable]
         types: [yaml]
 
   # ═══════════════════════════════════════════════════════════════════════════

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,15 +1,36 @@
 ---
-extends: default
+# yamllint configuration for the Juniper ecosystem.
+#
+# Canonical version: aligns all 8 ecosystem repos to a single ruleset
+# (juniper-ml, juniper-data, juniper-cascor, juniper-canopy,
+#  juniper-data-client, juniper-cascor-client, juniper-cascor-worker,
+#  juniper-deploy).
+#
+# Pre-commit no longer passes `-d relaxed` — it loads this file directly
+# so the rules a developer sees in their editor match the rules CI
+# enforces.
+#
+# Rules:
+#   - extends: relaxed (sane base: no truthy/comments strictness; the
+#     codebase has many comments-at-end-of-line and CI `on:` keys that
+#     would trip the strict default preset).
+#   - line-length: max 512 (matches AGENTS.md ecosystem convention for
+#     black/isort/flake8/markdownlint), level: warning (informational,
+#     does not fail pre-commit unless `--strict` is also passed).
+#
+# Ignores cover:
+#   - Local virtual environments and caches.
+#   - Helm chart templates (Go templating, not valid YAML).
+#   - Generated conda environment / pip requirements snapshots
+#     (indentation/structure reflects upstream conda env export output
+#     and would generate false-positive warnings).
+
+extends: relaxed
 
 rules:
   line-length:
-    max: 320
+    max: 512
     level: warning
-  document-start: disable
-  comments-indentation: disable
-  truthy:
-    allowed-values: ['true', 'false', 'yes', 'no', 'on', 'off']
-    check-keys: false
 
 ignore: |
   .venv/
@@ -17,6 +38,7 @@ ignore: |
   __pycache__/
   .pytest_cache/
   .mypy_cache/
-  data/
-  logs/
-  reports/
+  k8s/helm/*/templates/
+  /conda_environment_ci*.yaml
+  /conf/conda_environment_ci*.yaml
+  /conf/requirements_ci*.yaml


### PR DESCRIPTION
## Summary

Aligns this repo with the canonical Juniper-ecosystem yamllint ruleset and removes the pre-commit override that was silently ignoring the file. One of 8 sibling PRs opened together (juniper-ml, juniper-data, juniper-cascor, juniper-canopy, juniper-data-client, juniper-cascor-client, juniper-cascor-worker, juniper-deploy); each is self-contained.

## Why

Before this PR, the yamllint pre-commit hook invoked:

```yaml
args: [--format, parsable, -d, relaxed]
```

The `-d relaxed` flag passes an **inline** rules set that overrides any `.yamllint.yaml` file. So pre-commit and CI enforced yamllint's bundled "relaxed" preset (line-length: 80 warning, no truthy/comments rules); manual `yamllint .` runs + editor integrations enforced `.yamllint.yaml`. The ecosystem `.yamllint.yaml` files had drifted to different `line-length` values (120 in data/canopy/data-client/deploy; 320 in cascor; juniper-ml had no file at all) and none of them were the canonical convention.

Result: a developer's editor and CI disagreed on what the rules were. This PR ends the split-brain.

## What this changes

### `.yamllint.yaml` (added or replaced)

Single canonical content shared across all 8 ecosystem repos:

```yaml
extends: relaxed

rules:
  line-length:
    max: 512
    level: warning

ignore: |
  .venv/, venv/, __pycache__/, .pytest_cache/, .mypy_cache/
  k8s/helm/*/templates/
  /conda_environment_ci*.yaml
  /conf/conda_environment_ci*.yaml
  /conf/requirements_ci*.yaml
```

- `extends: relaxed` instead of `default` — codebase has many legitimate trailing comments / `on:` truthy keys / structural patterns that the default preset rejects.
- `line-length: 512 warning` matches AGENTS.md's "all linters" convention (black / isort / flake8 / markdownlint already at 512).
- `ignore:` block covers Helm template Go-templating (juniper-deploy), generated dep-docs snapshots, and standard local caches.

### `.pre-commit-config.yaml`

Drops `-d relaxed` from the yamllint hook so it loads `.yamllint.yaml`. Single source of truth: editors, pre-commit, and CI all enforce the same rules.

(juniper-deploy specifically: kept `--strict` since deploy's posture is strictness-by-default; verified canonical config still produces 0 errors / 0 warnings under `--strict`.)

## Verification

- `~/.local/bin/yamllint --format parsable` against every tracked `*.yml` / `*.yaml` in this repo: **0 errors, 0 warnings**.
- `pre-commit run yamllint --all-files`: passes.
- Cross-repo dry-run: canonical config produces **0 errors / 0 warnings** across all 8 ecosystem repos.

## CI impact

None expected: the rules are calibrated against the current codebase.

## Requirements

References: none directly tracked; CI hygiene / ecosystem convergence after `notes/CI_CLEANUP.md` item 3.