### PR TITLE
feat(agents-md): adopt juniper-ci-tools v0.4.0 header-schema lint + auto-bump workflow

### DIFF
--- a/.github/workflows/agents-md-touch-up.yml
+++ b/.github/workflows/agents-md-touch-up.yml
@@ -1,0 +1,98 @@
+# ═══════════════════════════════════════════════════════════════════════
+# AGENTS.md Touch-Up
+#
+# Purpose: keep the **Last Updated**: header in AGENTS.md aligned with
+#          the date the file actually changed, without asking
+#          contributors (or Claude) to remember to bump it.
+#
+# Trigger: pull_request types [opened, reopened, synchronize] with
+#          paths filter on AGENTS.md.
+#
+# Behavior:
+#   1. If the PR's cumulative diff touches AGENTS.md, the workflow
+#      reads the current **Last Updated** value.
+#   2. If it already equals today's UTC date, the job exits no-op.
+#   3. Otherwise the job sed-rewrites the line, commits with
+#      `github-actions[bot]` authorship and a `[skip ci]` tag (so
+#      the bump commit does not re-trigger any workflows), rebases
+#      against any concurrent commits on the PR branch, and pushes
+#      back.
+#
+# Scope: only fires for PRs from the same repository, because the
+#        default GITHUB_TOKEN is read-only for fork-triggered runs.
+#        The Juniper project is solo-authored (@pcalnon) and has no
+#        forks, so this is currently a defensive guard only.
+#
+# Companion lint: tests/test_agents_md_header_schema.py asserts
+#        Last Updated is present + in ISO 8601 date format. The
+#        version-equality check (tests/test_agents_md_version_drift.py)
+#        is a separate concern.
+# ═══════════════════════════════════════════════════════════════════════
+
+name: AGENTS.md Touch-Up
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    paths:
+      - "AGENTS.md"
+
+concurrency:
+  group: agents-md-touch-up-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  touch-up:
+    name: Bump AGENTS.md Last Updated
+    runs-on: ubuntu-latest
+    # Skip on PRs from forks: the default GITHUB_TOKEN is read-only
+    # for fork-triggered workflow runs, so the push back would fail.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Check out PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Bump AGENTS.md `**Last Updated**:` to today (UTC)
+        env:
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          today=$(date -u +%Y-%m-%d)
+
+          if ! grep -q '^\*\*Last Updated\*\*:' AGENTS.md; then
+            echo "::warning::AGENTS.md has no '**Last Updated**:' field; skipping auto-bump."
+            exit 0
+          fi
+
+          current=$(grep -E '^\*\*Last Updated\*\*:' AGENTS.md \
+            | head -1 \
+            | sed -E 's/^\*\*Last Updated\*\*:[[:space:]]*//' \
+            | tr -d '[:space:]')
+
+          if [ "$current" = "$today" ]; then
+            echo "Last Updated already $today; nothing to do."
+            exit 0
+          fi
+
+          echo "Bumping AGENTS.md **Last Updated**: $current -> $today"
+          sed -i "s|^\*\*Last Updated\*\*: .*|**Last Updated**: ${today}|" AGENTS.md
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add AGENTS.md
+          git commit -m "chore(agents-md): bump Last Updated to ${today} [skip ci]"
+
+          # Rebase against any commits that landed concurrently on
+          # the PR branch (rare; defensive). If the rebase fails the
+          # whole job fails loudly rather than force-pushing.
+          git pull --rebase origin "$PR_HEAD_REF"
+          git push origin HEAD:"$PR_HEAD_REF"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
       - name: Install juniper-ci-tools (workflow-path + agents-md lints)
         run: |
           python -m pip install --upgrade "pip>=26.1.1"
-          pip install "juniper-ci-tools>=0.2.0,<0.4.0"
+          pip install "juniper-ci-tools>=0.2.0,<0.5.0"
 
       - name: Lint .github/workflows/ script paths
         run: |
@@ -181,6 +181,21 @@ jobs:
           echo "║       AGENTS.md version-drift lint                         ║"
           echo "╚════════════════════════════════════════════════════════════╝"
           juniper-lint-agents-md-version
+
+      # Pins AGENTS.md's header bullet block to the canonical six-field
+      # schema (Project / Repository / Author / License / Version /
+      # Last Updated, in that relative order). Currency of the
+      # `**Last Updated**` field is maintained by the
+      # `.github/workflows/agents-md-touch-up.yml` workflow (auto-bumps
+      # on every PR push). Shipped as the
+      # ``juniper-lint-agents-md-header`` console script in
+      # ``juniper-ci-tools>=0.4.0`` (juniper-ml#319).
+      - name: Lint AGENTS.md header schema
+        run: |
+          echo "╔════════════════════════════════════════════════════════════╗"
+          echo "║       AGENTS.md header-schema lint                         ║"
+          echo "╚════════════════════════════════════════════════════════════╝"
+          juniper-lint-agents-md-header
 
   # ═══════════════════════════════════════════════════════════════════════════════════════════════
   # Async-route audit (Phase 4 — enforced).
@@ -539,7 +554,7 @@ jobs:
         shell: bash -l {0}
         run: |
           python -m pip install --upgrade "pip>=26.1.1"
-          pip install "juniper-ci-tools>=0.2.0,<0.4.0"
+          pip install "juniper-ci-tools>=0.2.0,<0.5.0"
 
       - name: Generate Dependency Documentation
         shell: bash -l {0}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,11 @@
 # AGENTS.md - Juniper Cascor Project Guide
 
 **Project**: Juniper Cascade Correlation Neural Network
-**Version**: 0.4.0
-**License**: MIT License
+**Repository**: pcalnon/juniper-cascor
 **Author**: Paul Calnon
-**Last Updated**: 2026-04-02
+**License**: MIT License
+**Version**: 0.4.0
+**Last Updated**: 2026-05-22
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 4 sibling adoption of the [AGENTS.md header standardization plan](https://github.com/pcalnon/juniper-ml/blob/main/notes/AGENTS_MD_HEADER_STANDARDIZATION_PLAN_2026-05-22.md). Mirrors juniper-data#141.

## Changes

- **`.github/workflows/ci.yml`**: bump `juniper-ci-tools>=0.2.0,<0.4.0` → `<0.5.0`; add `juniper-lint-agents-md-header` step after the version-drift step.
- **`.github/workflows/agents-md-touch-up.yml`** — NEW. Byte-identical copy of juniper-ml's canonical workflow.
- **`AGENTS.md`**: re-order to canonical schema; add `**Repository**: pcalnon/juniper-cascor`; bump `**Last Updated**: 2026-04-02` → `2026-05-22`.

## Verification

```
$ juniper-lint-agents-md-header --repo-root .
OK: AGENTS.md header conforms to the canonical schema (6 required fields, ISO date).
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)