### PR TITLE
release: prep v0.5.0 — bump pyproject + CHANGELOG + AGENTS.md + conda env

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 **Author**: Paul Calnon
 **License**: MIT License
 **Version**: 0.5.0
-**Last Updated**: 2026-05-22
+**Last Updated**: 2026-05-23
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 **Repository**: pcalnon/juniper-cascor
 **Author**: Paul Calnon
 **License**: MIT License
-**Version**: 0.4.0
+**Version**: 0.5.0
 **Last Updated**: 2026-05-22
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-22
+
+**Note on version history**: `pyproject.toml` was bumped 0.3.17 → 0.4.0 on 2026-03-03 in preparation for a 0.4.0 release that was never cut to PyPI (the `[0.4.0]` section below documents the work that *would have* shipped). This 0.5.0 release rolls up both that work and the subsequent ~2.5 months of changes (469 commits since `v0.3.17`) into a single PyPI release. Subsequent entries in this section list the additional work landed since 2026-03-03.
+
 ### Added
 
-- **`util/test_agents_md_version_drift.py`** -- portable port of juniper-ml's lint test pinning `AGENTS.md`'s `**Version**:` header to `pyproject.toml`'s `[project].version`. Catches the failure class where a `pyproject.toml` bump leaves the agent-facing contract stale. Preventive-only here: cascor's `AGENTS.md` and `pyproject.toml` are already in sync at `0.4.0`. Wired into the CI tests job next to the existing `test_workflow_script_paths.py` lint.
+- **AGENTS.md header schema standardization** (juniper-cascor#299, juniper-ml#316/#319): adopted the canonical 6-field schema (`**Project**` / `**Repository**` / `**Author**` / `**License**` / `**Version**` / `**Last Updated**`, in that relative order). Added `.github/workflows/agents-md-touch-up.yml` (auto-bumps `**Last Updated**` to today's UTC date on every PR push touching `AGENTS.md`; idempotent). Added `juniper-lint-agents-md-header` CI step (via `juniper-ci-tools>=0.4.0` PyPI dependency). `**Repository**: pcalnon/juniper-cascor` added to AGENTS.md header; required-field order corrected to canonical.
+- **`util/test_agents_md_version_drift.py`** -- portable port of juniper-ml's lint test pinning `AGENTS.md`'s `**Version**:` header to `pyproject.toml`'s `[project].version`. Catches the failure class where a `pyproject.toml` bump leaves the agent-facing contract stale. Preventive-only here: cascor's `AGENTS.md` and `pyproject.toml` are already in sync at `0.5.0`. Wired into the CI tests job next to the existing `test_workflow_script_paths.py` lint.
 
 ### Removed
 

--- a/conf/conda_environment_ci.yaml
+++ b/conf/conda_environment_ci.yaml
@@ -4,7 +4,7 @@
 # Purpose:       Cascade Correlation Neural Network Backend
 #
 # Author:        Paul Calnon
-# Version:       0.4.0
+# Version:       0.5.0
 # Config Name:   conda_environment_ci.yaml
 # Config Path:   Juniper/juniper-cascor/conf/
 #
@@ -118,7 +118,7 @@ dependencies:
       - jaraco-functools==4.5.0
       - jeepney==0.9.0
       - jinja2==3.1.6
-      - juniper-cascor==0.4.0
+      - juniper-cascor==0.5.0
       - juniper-cascor-client==0.4.0
       - juniper-cascor-protocol==0.1.0
       - juniper-cascor-worker==0.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ exclude = ["tests*", "backups*"]
 
 [project]
 name = "juniper-cascor"
-version = "0.4.0"
+version = "0.5.0"
 description = "Cascade Correlation Neural Network implementation for the Juniper project"
 readme = "README.md"
 license = { text = "MIT" }

--- a/requirements.lock
+++ b/requirements.lock
@@ -8,13 +8,13 @@ anyio==4.13.0
     # via
     #   starlette
     #   watchfiles
-certifi==2026.4.22
+certifi==2026.5.20
     # via
     #   requests
     #   sentry-sdk
 charset-normalizer==3.4.7
     # via requests
-click==8.4.0
+click==8.4.1
     # via uvicorn
 contourpy==1.3.3
     # via matplotlib
@@ -40,7 +40,7 @@ h5py==3.16.0
     # via juniper-cascor (pyproject.toml)
 httptools==0.7.1
     # via uvicorn
-idna==3.15
+idna==3.16
     # via
     #   anyio
     #   requests
@@ -154,7 +154,7 @@ setuptools==81.0.0
     # via torch
 six==1.17.0
     # via python-dateutil
-starlette==1.0.0
+starlette==1.0.1
     # via
     #   fastapi
     #   juniper-observability

--- a/src/api/models/common.py
+++ b/src/api/models/common.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
-_API_VERSION: str = "0.4.0"
+_API_VERSION: str = "0.5.0"
 
 
 def coerce_native_scalars(value: Any) -> Any:
@@ -57,7 +57,7 @@ class ResponseEnvelope(BaseModel):
     {
         "status": "success" | "error",
         "data": { ... },
-        "meta": { "timestamp": ..., "version": "0.4.0" }
+        "meta": { "timestamp": ..., "version": "0.5.0" }
     }
     """
 

--- a/src/api/routes/health.py
+++ b/src/api/routes/health.py
@@ -32,7 +32,7 @@ from juniper_observability import LIVENESS_STALENESS_SECONDS, LIVENESS_TICK_BUDG
 from api.models.health import DependencyStatus, ReadinessResponse, probe_dependency
 from api.settings import Settings
 
-_API_VERSION: str = "0.4.0"
+_API_VERSION: str = "0.5.0"
 
 router = APIRouter(tags=["health"])
 

--- a/src/tests/unit/api/test_api_app.py
+++ b/src/tests/unit/api/test_api_app.py
@@ -28,7 +28,7 @@ class TestAppFactory:
         """Test app metadata."""
         app = create_app(Settings(auto_start=False))
         assert app.title == "JuniperCascor API"
-        assert app.version == "0.4.0"
+        assert app.version == "0.5.0"
 
     def test_cors_middleware_skipped_with_empty_origins(self):
         """Test that CORS middleware is not applied when origins is empty."""

--- a/src/tests/unit/api/test_api_app_coverage_deep.py
+++ b/src/tests/unit/api/test_api_app_coverage_deep.py
@@ -38,7 +38,7 @@ class TestLifespanMetricsEnabled:
         with patch("api.app.set_build_info") as mock_build_info, patch("api.app.get_prometheus_app", return_value=MagicMock()):
             app = create_app(settings)
             with TestClient(app):
-                mock_build_info.assert_called_once_with("juniper_cascor", "0.4.0")
+                mock_build_info.assert_called_once_with("juniper_cascor", "0.5.0")
 
     def test_metrics_not_called_when_disabled(self):
         """When metrics_enabled=False (default), set_build_info is NOT called."""

--- a/src/tests/unit/api/test_api_health.py
+++ b/src/tests/unit/api/test_api_health.py
@@ -29,7 +29,7 @@ class TestHealthEndpoints:
         assert response.status_code == 200
         body = response.json()
         assert body["status"] == "ok"
-        assert body["version"] == "0.4.0"
+        assert body["version"] == "0.5.0"
 
     def test_health_includes_service_identifier(self, client):
         """API-02: /v1/health includes the ``service`` field naming this service.
@@ -92,7 +92,7 @@ class TestHealthEndpoints:
         assert response.headers.get("X-Juniper-Readiness") == "ready"
         body = response.json()
         assert body["status"] == "ready"
-        assert body["version"] == "0.4.0"
+        assert body["version"] == "0.5.0"
         assert body["service"] == "juniper-cascor"
         assert "timestamp" in body
         assert body["details"]["network_loaded"] is False
@@ -207,7 +207,7 @@ class TestHealthModels:
         dep = DependencyStatus(name="Data", status="healthy", latency_ms=1.0, message="ok")
         resp = ReadinessResponse(
             status="ready",
-            version="0.4.0",
+            version="0.5.0",
             service="juniper-cascor",
             dependencies={"juniper_data": dep},
             details={"network_loaded": True},

--- a/src/tests/unit/test_api_observability.py
+++ b/src/tests/unit/test_api_observability.py
@@ -307,11 +307,11 @@ class TestSetBuildInfo:
         with patch("prometheus_client.Info") as MockInfo:
             mock_info = MagicMock()
             MockInfo.return_value = mock_info
-            set_build_info("juniper_cascor", "0.4.0")
+            set_build_info("juniper_cascor", "0.5.0")
             MockInfo.assert_called_once_with("juniper_cascor_build", "Build information for juniper-cascor service")
             mock_info.info.assert_called_once()
             call_args = mock_info.info.call_args[0][0]
-            assert call_args["version"] == "0.4.0"
+            assert call_args["version"] == "0.5.0"
             assert "python_version" in call_args
 
 
@@ -558,6 +558,6 @@ class TestObservabilityReadinessTimestamp:
 
         from juniper_observability import ReadinessResponse
 
-        rr = ReadinessResponse(status="ready", version="0.4.0", service="juniper-cascor")
+        rr = ReadinessResponse(status="ready", version="0.5.0", service="juniper-cascor")
         # tz-aware UTC unix timestamp must be within 60s of "now".
         assert abs(time.time() - rr.timestamp) < 60.0


### PR DESCRIPTION
## Summary

Release-prep PR for juniper-cascor v0.5.0. Closes the PyPI ↔ git tag lag identified in the 2026-05-22 ecosystem audit: pyproject was at 0.4.0 with no v0.4.0 tag/release ever cut to PyPI (last released v0.3.17, 2.5 months and 469 commits ago).

Rolls up the pending 0.4.0 work + post-2026-03-03 changes into a single 0.5.0 release.

## Changes

- **pyproject.toml**: `0.4.0` → `0.5.0`
- **conf/conda_environment_ci.yaml**: header comment `# Version: 0.4.0` → `0.5.0`; pinned `juniper-cascor==0.4.0` → `0.5.0` in the `[pip]` block
- **AGENTS.md**: `**Version**: 0.4.0` → `0.5.0` (pinned to pyproject by the version-drift lint)
- **CHANGELOG.md**: rename `[Unreleased]` → `[0.5.0] - 2026-05-22` with a "Note on version history" callout explaining that the existing `[0.4.0] - 2026-03-03` section documents work that was never cut to PyPI; this 0.5.0 release supersedes it. Added an entry for the agents-md header schema standardization (juniper-cascor#299) that landed earlier today.

## Release plan

After this PR merges, cut `v0.5.0` via `gh release create` which fires `.github/workflows/publish.yml` (triggered on `release: published`). Workflow publishes to TestPyPI first (install-verify), then to production PyPI via OIDC trusted publishing. PyPI environment may require manual approval (same gate as juniper-ci-tools v0.4.0 earlier today).

## Verification

- `juniper-lint-agents-md-version --repo-root .` → OK (0.5.0 matches)
- `juniper-lint-agents-md-header --repo-root .` → OK (canonical schema conforms)
- All existing CI gates apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)