### PR TITLE
chore(readme): sync compat matrix post-v0.5.0 cascor/canopy + v0.4.0 worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Verified compatible versions:
 
 | juniper-data | juniper-cascor | juniper-canopy | data-client | cascor-client | cascor-worker |
 |--------------|----------------|----------------|-------------|---------------|---------------|
-| 0.6.x        | 0.4.x          | 0.4.x          | >=0.4.1     | >=0.4.0       | >=0.3.0       |
+| 0.6.x        | 0.5.x          | 0.5.x          | >=0.4.1     | >=0.4.0       | >=0.4.0       |
 
 For full-stack Docker deployment and integration tests, see [`juniper-deploy`](https://github.com/pcalnon/juniper-deploy).
 


### PR DESCRIPTION
## Summary

Bump the README "Verified compatible versions" row to reflect today's ecosystem release wave:
- `juniper-cascor`: 0.4.x → 0.5.x (this repo, #300)
- `juniper-canopy`: 0.4.x → 0.5.x (juniper-canopy#314)
- `juniper-cascor-worker`: `>=0.3.0` → `>=0.4.0` (juniper-cascor-worker#88, CFG-06)

v0.5.0 (#300) deliberately deferred this README sync. This is the catch-up across all 8 ecosystem repos (1 PR per repo for review locality).

## Test plan

- [ ] CI `Documentation Links` job is green (`juniper-check-doc-links` cross-repo validator catches any broken links)
- [ ] No other CI surface touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)