### PR TITLE
fix: make api_keys validator accept None / empty / csv / list

### DIFF
--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -200,10 +200,32 @@ class Settings(BaseSettings):
 
     @field_validator("api_keys", mode="before")
     @classmethod
-    def _empty_string_to_none(cls, v: Any) -> list[str] | None:
-        if isinstance(v, str) and v.strip() == "":
+    def _parse_api_keys(cls, v: Any) -> list[str] | None:
+        """Normalise ``api_keys`` to ``list[str] | None``.
+
+        Accepts (in order of likelihood):
+
+        * ``None`` or empty string → ``None`` (auth disabled).
+        * Plain string ``"key1,key2"`` → ``["key1", "key2"]`` (the format
+          a single-string Docker secret file naturally produces; matches
+          the juniper-data parser).
+        * Already a list (including JSON-deserialised lists from
+          ``pydantic-settings``) → returned as-is.
+
+        Without this validator the bare string read from a Docker secrets
+        file (e.g. ``CHANGE_BEFORE_PRODUCTION_USE`` from
+        ``secrets.example/juniper_cascor_api_keys.txt``) would hit
+        pydantic's ``list[str]`` coercion and fail with
+        ``ValidationError: api_keys ... Input should be a valid list``,
+        putting the ``juniper-cascor`` container into a restart loop on
+        any default ``docker compose up``. Mirrors the
+        ``_parse_api_keys`` validator on ``juniper-data``'s ``Settings``.
+        """
+        if v is None or v == "":
             return None
-        return v
+        if isinstance(v, str):
+            return [k.strip() for k in v.split(",") if k.strip()]
+        return v  # type: ignore[return-value]
 
     rate_limit_enabled: bool = _JUNIPER_CASCOR_API_RATELIMIT_DISABLED
     rate_limit_requests_per_minute: int = _JUNIPER_CASCOR_API_RATELIMIT_DEFAULT

--- a/src/tests/unit/api/test_api_settings.py
+++ b/src/tests/unit/api/test_api_settings.py
@@ -60,3 +60,93 @@ class TestSettings:
         s2 = get_settings()
         assert s1 is s2
         get_settings.cache_clear()
+
+
+@pytest.mark.unit
+class TestApiKeysParser:
+    """``_parse_api_keys`` must normalise every shape the secret-file
+    pipeline can produce to a ``list[str] | None``.
+
+    The historical ``_empty_string_to_none`` validator only handled the
+    empty-string case; a bare string like
+    ``CHANGE_BEFORE_PRODUCTION_USE`` (the placeholder shipped in
+    juniper-deploy's ``secrets.example/juniper_cascor_api_keys.txt``)
+    fell through to pydantic's ``list[str]`` coercion and crashed the
+    container with ``list_type`` ValidationError.
+
+    Mirrors the contract pinned by juniper-data's ``_parse_api_keys``.
+    """
+
+    def test_none_becomes_none(self):
+        from api.settings import Settings
+
+        settings = Settings(api_keys=None)
+        assert settings.api_keys is None
+
+    def test_empty_string_becomes_none(self):
+        """An empty Docker secret file (0-byte) yields ``""`` from
+        ``get_secret``; that must disable auth, not crash."""
+        from api.settings import Settings
+
+        settings = Settings(api_keys="")
+        assert settings.api_keys is None
+
+    def test_bare_string_becomes_single_element_list(self):
+        """A non-empty secret file containing a single token (the typical
+        out-of-the-box deploy placeholder) becomes a one-element list."""
+        from api.settings import Settings
+
+        settings = Settings(api_keys="CHANGE_BEFORE_PRODUCTION_USE")
+        assert settings.api_keys == ["CHANGE_BEFORE_PRODUCTION_USE"]
+
+    def test_comma_separated_string_is_split(self):
+        """CSV input is the documented shape for multi-key secret files —
+        same convention as juniper-data."""
+        from api.settings import Settings
+
+        settings = Settings(api_keys="key1,key2,key3")
+        assert settings.api_keys == ["key1", "key2", "key3"]
+
+    def test_comma_separated_string_strips_whitespace_and_empties(self):
+        """``"key1, key2 , ,"`` → ``["key1", "key2"]`` (trim + drop empties)."""
+        from api.settings import Settings
+
+        settings = Settings(api_keys="key1, key2 , ,")
+        assert settings.api_keys == ["key1", "key2"]
+
+    def test_list_input_passed_through(self):
+        """Direct list input (e.g. from a JSON-deserialised
+        ``pydantic-settings`` env var, or a programmatic constructor)
+        must round-trip without re-parsing."""
+        from api.settings import Settings
+
+        settings = Settings(api_keys=["key1", "key2"])
+        assert settings.api_keys == ["key1", "key2"]
+
+    def test_json_list_string_auto_parsed_by_pydantic(self, monkeypatch):
+        """``["k1","k2"]`` as a string env var should reach the validator
+        as a list (pydantic-settings auto-parses JSON for complex
+        fields). This pins the path the deploy-side JSON-array
+        placeholder fix relies on."""
+        monkeypatch.setenv("JUNIPER_CASCOR_API_KEYS", '["k1","k2"]')
+        from api.settings import Settings
+
+        settings = Settings()
+        assert settings.api_keys == ["k1", "k2"]
+
+    def test_secret_file_with_bare_placeholder_does_not_crash(self, monkeypatch, tmp_path):
+        """End-to-end regression: a Docker secret file containing the
+        bare ``CHANGE_BEFORE_PRODUCTION_USE`` placeholder must NOT
+        raise ``list_type`` ValidationError. This is the exact failure
+        that caused the ``juniper-cascor`` restart loop after the
+        CVE-2026-48710 alertmanager port-conflict recovery."""
+        secret_path = tmp_path / "juniper_cascor_api_keys"
+        secret_path.write_text("CHANGE_BEFORE_PRODUCTION_USE")
+        monkeypatch.setenv("JUNIPER_CASCOR_API_KEYS_FILE", str(secret_path))
+        # Also clear any direct env var that would short-circuit the file
+        # read path inside ``get_secret``.
+        monkeypatch.delenv("JUNIPER_CASCOR_API_KEYS", raising=False)
+        from api.settings import Settings
+
+        settings = Settings()
+        assert settings.api_keys == ["CHANGE_BEFORE_PRODUCTION_USE"]


### PR DESCRIPTION
## Summary

- Replace `_empty_string_to_none` field-validator on `Settings.api_keys` with `_parse_api_keys`, mirroring the validator on juniper-data's `Settings`.
- The new validator accepts every reasonable input shape: `None`, empty string, csv string, list, and (via pydantic-settings auto-deserialise) JSON-array env var.
- Add 8 new regression tests in `src/tests/unit/api/test_api_settings.py` pinning each shape plus an end-to-end test that reads the bare `CHANGE_BEFORE_PRODUCTION_USE` placeholder from a tmp-path "secret file" exactly the way `get_secret` does in production.

## Root Cause

The pre-fix validator only handled the empty-string case:

```python
@field_validator("api_keys", mode="before")
@classmethod
def _empty_string_to_none(cls, v: Any) -> list[str] | None:
    if isinstance(v, str) and v.strip() == "":
        return None
    return v   # ← non-empty string falls through to pydantic's list[str] coercion
```

When the Docker secret file at `JUNIPER_CASCOR_API_KEYS_FILE` contained the bare deploy-side placeholder `CHANGE_BEFORE_PRODUCTION_USE`, the validator returned it unchanged and pydantic raised:

```
pydantic_core.ValidationError: 1 validation error for Settings
api_keys
  Input should be a valid list [type=list_type, input_value='CHANGE_BEFORE_PRODUCTION_USE', input_type=str]
```

→ `juniper-cascor` restart-loop on any fresh `docker compose --profile full up`.

## Contract Now (mirrors juniper-data)

| Input | Result |
|---|---|
| `None` | `None` (auth disabled) |
| `""` | `None` (empty secret file = auth disabled — documented state) |
| `"key1"` | `["key1"]` |
| `"key1,key2,key3"` | `["key1", "key2", "key3"]` |
| `"key1, key2 , ,"` | `["key1", "key2"]` (trim + drop empties) |
| `["key1", "key2"]` | `["key1", "key2"]` (pass-through; covers JSON env-var auto-parse + programmatic callers) |

## Test plan

- [x] `pytest src/tests/unit/api/test_api_settings.py -v` → **13 passed** (5 existing + 8 new).
- [x] `pytest src/tests/unit/api/` → **1361 passed, 0 failed** (whole api unit suite — no regressions).
- [ ] CI: full unit + integration suite + lint/format on the matrix.

## Related

- Companion juniper-deploy#91 wraps the placeholder in a JSON-array literal so older cascor images (without this validator) also work. After both ship, the placeholder shape no longer matters.
- Discovered after CVE-2026-48710 alertmanager port-conflict recovery (juniper-deploy host snap removed → cascor came up → exposed this contract mismatch). The end-to-end regression test in this PR is the direct fixture for that incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)