### PR TITLE
feat(ws): add CSV / JSON-array parser for ws_control_allowed_origins

### DIFF
--- a/docs/DEVELOPER_CHEATSHEET.md
+++ b/docs/DEVELOPER_CHEATSHEET.md
@@ -108,6 +108,7 @@ Metrics nuance:
 | `JUNIPER_CASCOR_LOG_FORMAT`      | --                      | Set to `json` for JSON logging         |
 | `JUNIPER_CASCOR_SENTRY_DSN`      | --                      | Sentry DSN                             |
 | `JUNIPER_CASCOR_METRICS_ENABLED` | `false`                 | Enable Prometheus metrics              |
+| `JUNIPER_CASCOR_WS_CONTROL_ALLOWED_ORIGINS` | `http://localhost:8050,http://127.0.0.1:8050,https://localhost:8050,https://127.0.0.1:8050` | `/ws/control` Origin allowlist. Accepts JSON-array or comma-CSV. Empty string disables (opt-out). For docker compose, add `http://juniper-canopy:8050` so canopy's `ControlStreamSupervisor` can connect. |
 
 ---
 

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -3,8 +3,10 @@
 from functools import lru_cache
 from typing import Any
 
+from typing import Annotated
+
 from pydantic import AliasChoices, Field, field_validator, model_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 from api.secrets import get_secret
 
@@ -198,6 +200,46 @@ class Settings(BaseSettings):
                 data["api_keys"] = secret_value
         return data
 
+    @field_validator("ws_control_allowed_origins", mode="before")
+    @classmethod
+    def _parse_ws_control_allowed_origins(cls, v: Any) -> list[str]:
+        """Normalise ``ws_control_allowed_origins`` to ``list[str]``.
+
+        Accepts:
+
+        * ``None`` → empty list (caller has explicitly removed all origins).
+          Most operators want to keep the *default* list; the default is
+          materialised via the ``Field(default=...)`` mechanism and never
+          reaches this validator when the env var is unset.
+        * Plain string ``"http://x:1,http://y:2"`` → ``["http://x:1", "http://y:2"]``
+          (CSV form, mirrors ``_parse_api_keys``).
+        * Plain string ``'["http://x:1","http://y:2"]'`` → list (JSON-array
+          form, the default pydantic-settings env-coercion shape).
+        * Already-list input → returned as-is (covers the programmatic
+          ``Settings(ws_control_allowed_origins=[...])`` callsite used by
+          tests + the ``Field(default=...)`` path when the env var is unset).
+        """
+        if v is None:
+            return []
+        if isinstance(v, str):
+            s = v.strip()
+            if not s:
+                return []
+            # Try JSON-array first to preserve compatibility with the
+            # pydantic-settings auto-coercion for ``list[str]`` env vars.
+            if s.startswith("[") and s.endswith("]"):
+                import json as _json
+
+                try:
+                    parsed = _json.loads(s)
+                except (_json.JSONDecodeError, ValueError):
+                    parsed = None
+                if isinstance(parsed, list):
+                    return [str(item).strip() for item in parsed if str(item).strip()]
+            # Fall back to comma-CSV.
+            return [item.strip() for item in s.split(",") if item.strip()]
+        return list(v)
+
     @field_validator("api_keys", mode="before")
     @classmethod
     def _parse_api_keys(cls, v: Any) -> list[str] | None:
@@ -288,12 +330,43 @@ class Settings(BaseSettings):
     worker_metrics_enabled: bool = _JUNIPER_CASCOR_API_WORKER_METRICS_ENABLED_DEFAULT
 
     # Phase B-pre-b: Control-path security (§S8)
-    ws_control_allowed_origins: list[str] = [
-        "http://localhost:8050",
-        "http://127.0.0.1:8050",
-        "https://localhost:8050",
-        "https://127.0.0.1:8050",
-    ]
+    #
+    # Env binding: ``JUNIPER_CASCOR_WS_CONTROL_ALLOWED_ORIGINS`` (resolved
+    # automatically via the ``env_prefix="JUNIPER_CASCOR_"`` model config).
+    # Two input shapes are accepted:
+    #
+    # 1. JSON-array string: ``'["http://x:1","http://y:2"]'``
+    #    (the form ``pydantic-settings`` produces by default for
+    #    ``list[str]`` env vars).
+    # 2. Comma-CSV string: ``'http://x:1,http://y:2'``
+    #    (the more operator-friendly form; matches the ``_parse_api_keys``
+    #    convention for ``JUNIPER_CASCOR_API_KEYS``).
+    #
+    # The CSV path closes the regression class where juniper-canopy
+    # (running inside docker compose) connects to ``/ws/control`` from
+    # the container hostname → the Origin is ``http://juniper-canopy:8050``
+    # which is **not** in the default allowlist. juniper-deploy E.2 PR-2-D
+    # sets the env var to ``http://juniper-canopy:8050,http://localhost:8050,…``
+    # in compose; without the CSV parser the operator would have to
+    # JSON-escape the list, which is brittle for env-file authoring.
+    #
+    # See juniper-ml ``notes/STACK_REGRESSION_CORRECTIONS_2026-05-27.md``
+    # §E.2 PR-2-B for the regression + remediation context.
+    # ``Annotated[..., NoDecode]`` tells pydantic-settings to *skip* its
+    # default JSON decoding for this env var (which would raise
+    # ``SettingsError`` on CSV-form input before our ``mode='before'``
+    # validator gets a chance to run).  The validator below then handles
+    # both JSON-array and comma-CSV forms uniformly.
+    ws_control_allowed_origins: Annotated[list[str], NoDecode] = Field(
+        default=[
+            "http://localhost:8050",
+            "http://127.0.0.1:8050",
+            "https://localhost:8050",
+            "https://127.0.0.1:8050",
+        ],
+        description=("WebSocket /ws/control Origin allowlist. " "Env var: JUNIPER_CASCOR_WS_CONTROL_ALLOWED_ORIGINS. " "Accepts JSON-array (default ``pydantic-settings`` form) or comma-CSV. " "Empty string disables the allowlist (use only when explicitly opting out)."),
+        validation_alias=AliasChoices("ws_control_allowed_origins", "JUNIPER_CASCOR_WS_CONTROL_ALLOWED_ORIGINS"),
+    )
     ws_control_rate_limit_per_sec: int = 10  # leaky bucket: 10 tokens, 10/s refill
     ws_control_idle_timeout_sec: int = 120  # bidirectional idle timeout
     ws_control_cooldown_rejections: int = 10  # rejections in cooldown window before IP block

--- a/src/tests/unit/api/test_api_settings.py
+++ b/src/tests/unit/api/test_api_settings.py
@@ -150,3 +150,92 @@ class TestApiKeysParser:
 
         settings = Settings()
         assert settings.api_keys == ["CHANGE_BEFORE_PRODUCTION_USE"]
+
+
+@pytest.mark.unit
+class TestWsControlAllowedOriginsParser:
+    """E.2 PR-2-B regression: ``ws_control_allowed_origins`` accepts the
+    juniper-deploy compose env-var form (comma-CSV) as well as the
+    JSON-array form that pydantic-settings auto-emits for ``list[str]``
+    fields. See juniper-ml notes/STACK_REGRESSION_CORRECTIONS_2026-05-27.md
+    §E.2.
+
+    The default allowlist is preserved (``localhost:8050`` /
+    ``127.0.0.1:8050``); when the operator sets
+    ``JUNIPER_CASCOR_WS_CONTROL_ALLOWED_ORIGINS`` to
+    ``"http://juniper-canopy:8050,http://localhost:8050"``, the parser
+    splits on commas — without this PR, that input raised
+    ``SettingsError: error parsing value for field
+    "ws_control_allowed_origins" from source "EnvSettingsSource"`` and
+    blocked the canopy reconnection unblock.
+    """
+
+    def test_default_allowlist_kept_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv("JUNIPER_CASCOR_WS_CONTROL_ALLOWED_ORIGINS", raising=False)
+        from api.settings import Settings
+
+        settings = Settings()
+        assert settings.ws_control_allowed_origins == [
+            "http://localhost:8050",
+            "http://127.0.0.1:8050",
+            "https://localhost:8050",
+            "https://127.0.0.1:8050",
+        ]
+
+    def test_csv_env_var_parsed_into_list(self, monkeypatch):
+        monkeypatch.setenv(
+            "JUNIPER_CASCOR_WS_CONTROL_ALLOWED_ORIGINS",
+            "http://juniper-canopy:8050,http://localhost:8050,http://127.0.0.1:8050",
+        )
+        from api.settings import Settings
+
+        settings = Settings()
+        assert settings.ws_control_allowed_origins == [
+            "http://juniper-canopy:8050",
+            "http://localhost:8050",
+            "http://127.0.0.1:8050",
+        ]
+
+    def test_json_array_env_var_parsed_into_list(self, monkeypatch):
+        """JSON-array form (the default pydantic-settings shape for
+        ``list[str]`` env vars) must still work after the ``NoDecode``
+        annotation defers parsing to the validator.
+        """
+        monkeypatch.setenv(
+            "JUNIPER_CASCOR_WS_CONTROL_ALLOWED_ORIGINS",
+            '["http://x:1","http://y:2"]',
+        )
+        from api.settings import Settings
+
+        settings = Settings()
+        assert settings.ws_control_allowed_origins == ["http://x:1", "http://y:2"]
+
+    def test_csv_whitespace_trimmed(self, monkeypatch):
+        monkeypatch.setenv(
+            "JUNIPER_CASCOR_WS_CONTROL_ALLOWED_ORIGINS",
+            "  http://a:1 ,   http://b:2 ,  ",
+        )
+        from api.settings import Settings
+
+        settings = Settings()
+        assert settings.ws_control_allowed_origins == ["http://a:1", "http://b:2"]
+
+    def test_empty_env_var_yields_empty_list(self, monkeypatch):
+        """Operator opting out of all origins (``X=`` in env-file).
+        Distinct from "env-var unset" (default applies).
+        """
+        monkeypatch.setenv("JUNIPER_CASCOR_WS_CONTROL_ALLOWED_ORIGINS", "")
+        from api.settings import Settings
+
+        settings = Settings()
+        assert settings.ws_control_allowed_origins == []
+
+    def test_programmatic_list_passthrough(self, monkeypatch):
+        """Tests that construct ``Settings(ws_control_allowed_origins=[…])``
+        directly still receive the list unchanged.
+        """
+        monkeypatch.delenv("JUNIPER_CASCOR_WS_CONTROL_ALLOWED_ORIGINS", raising=False)
+        from api.settings import Settings
+
+        settings = Settings(ws_control_allowed_origins=["http://prog:1", "http://prog:2"])
+        assert settings.ws_control_allowed_origins == ["http://prog:1", "http://prog:2"]


### PR DESCRIPTION
## Summary

- ``Settings.ws_control_allowed_origins`` now accepts both JSON-array (preserved) and comma-CSV (new) shapes for the ``JUNIPER_CASCOR_WS_CONTROL_ALLOWED_ORIGINS`` env var.
- Default allowlist (``localhost:8050`` / ``127.0.0.1:8050``) unchanged — host-mode dev sessions and existing tests are unaffected.
- Unblocks juniper-deploy E.2 PR-2-D from adding ``http://juniper-canopy:8050`` to the compose env block in operator-friendly CSV form.

## Context

The field has been env-bound since juniper-cascor#129 via the model_config's ``env_prefix="JUNIPER_CASCOR_"``, but only the JSON-array form (``'["http://x:1","http://y:2"]'``) worked. The operator-friendly CSV form raised ``SettingsError: error parsing value for field "ws_control_allowed_origins"`` because pydantic-settings tries JSON-decode for ``list[str]`` env vars *before* the ``mode='before'`` validator can split on commas.

This PR annotates the field with ``Annotated[list[str], NoDecode]`` so pydantic-settings defers parsing to the validator, then adds ``_parse_ws_control_allowed_origins`` (mirrors the existing ``_parse_api_keys`` shape) that handles both forms uniformly.

This is **E.2 PR-2-B** of the four-PR Juniper stack-regression remediation cascade tracked in juniper-ml ``notes/STACK_REGRESSION_CORRECTIONS_2026-05-27.md`` §E.2.  The validator's behaviour matrix:

| Input                                       | Output                          |
|---------------------------------------------|---------------------------------|
| env var unset                               | default allowlist (4 origins)   |
| ``"http://x:1,http://y:2"``                 | ``["http://x:1", "http://y:2"]`` |
| ``'["http://x:1","http://y:2"]'``           | ``["http://x:1", "http://y:2"]`` |
| ``""`` (empty)                              | ``[]`` (operator opt-out)       |
| programmatic ``Settings(...)``              | as-is                           |
| trailing/leading whitespace, empty entries  | trimmed / dropped               |

## What's in the PR

- ``src/api/settings.py`` — ``Annotated[..., NoDecode]`` + ``_parse_ws_control_allowed_origins`` + ``validation_alias`` for explicitness.
- ``docs/DEVELOPER_CHEATSHEET.md`` — env-var documentation row.
- ``src/tests/unit/api/test_api_settings.py::TestWsControlAllowedOriginsParser`` — 6 new pinning tests covering every cell in the matrix above.

## Test plan

- [x] ``pytest src/tests/unit/api/test_api_settings.py src/tests/unit/api/test_control_security.py -v`` → **46 passed**.
- [x] ``pytest src/tests/unit/api/`` → **1367 passed**.
- [ ] Post-merge live-stack verification (covered by E.2 PR-2-D): ``docker compose up -d``; ``docker exec juniper-cascor python -c "from api.settings import Settings; print(Settings().ws_control_allowed_origins)"`` shows the juniper-canopy origin in the list.

## Companion PRs

- **E.2 PR-2-A**: pcalnon/juniper-cascor-client#69 — ``origin=`` on ``CascorControlStream`` (the client side of the same handshake).
- **E.2 PR-2-C** (juniper-canopy): thread ``ws_origin`` through ``CascorServiceAdapter``; pin ``juniper-cascor-client>=0.5.0``.
- **E.2 PR-2-D** (juniper-deploy): set the env vars in ``docker-compose.yml``.

Previously merged in this cascade:
- E.0: pcalnon/juniper-deploy#101 ✅
- E.1: pcalnon/juniper-canopy#327 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)