### PR TITLE
feat(security): exempt /metrics + add MetricsAuthMiddleware parity (POC §3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **SEC-16 / POC remediation §3.1**: cascor now has parity with
+  juniper-data's `MetricsAuthMiddleware` — `/metrics` is exempt from
+  `SecurityMiddleware` (so prometheus doesn't 401 ahead of the IP
+  allowlist) AND gated by a parallel in-process IP allowlist with full
+  CIDR + IPv6 normalization. Mirrors the juniper-data implementation
+  verbatim (validator A's "duplicate inline" recommendation in
+  [`POC_REMEDIATION_PLAN_2026-05-27.md` §3.1](https://github.com/pcalnon/juniper-deploy/blob/main/notes/poc/POC_REMEDIATION_PLAN_2026-05-27.md));
+  promotion to `juniper-observability` is a roadmap §R5 follow-up.
+  Concrete changes: `src/api/middleware.py` adds `/metrics` and
+  `/metrics/` to `EXEMPT_PATHS`; `src/api/observability.py` adds
+  `MetricsAuthMiddleware` plus `_parse_trusted_networks` (CIDR
+  fail-loud parser) and `_normalize_client_ip` (zone-id strip,
+  IPv4-mapped IPv6 unwrap); `src/api/settings.py` adds
+  `Settings.metrics_trusted_ips: list[str] = ["127.0.0.1", "::1"]`
+  with a `_validate_metrics_trusted_ips` field validator that
+  surfaces unparseable entries at `Settings()` construction;
+  `src/api/app.py` replaces the bare
+  `app.mount("/metrics", get_prometheus_app())` with
+  `app.mount("/metrics", MetricsAuthMiddleware(get_prometheus_app(), settings.metrics_trusted_ips))`.
+  Why this is needed even with `/metrics` exempt: a misconfigured
+  deployment (port 8200 published directly, or running outside
+  compose / K8s) would expose `/metrics` with zero auth. Regression
+  coverage: new `src/tests/unit/api/test_metrics_auth_middleware.py`
+  (12 tests) pins the `EXEMPT_PATHS` invariant, CIDR v4 allow + miss,
+  mixed CIDR + literal, CIDR v6 allow, IPv4-mapped IPv6 vs IPv4 CIDR
+  (the docker-bridge regression), IPv6 zone-id strip, default
+  loopback works, malformed / missing client address falls through
+  to 403, invalid CIDR raises at `Settings()`, and middleware-init
+  fail-loud as defense in depth. Tests drive the middleware via raw
+  ASGI scopes (not `TestClient` + `create_app`) because the cascor
+  lifespan does not tear down cleanly in unit-test context — same
+  contract either way.
+
 ### Changed
 
 - **CFG-02** (v7 roadmap §13524): `sentry-sdk>=2.0.0` moved from `[project] dependencies` into the `[project.optional-dependencies] observability` extra. The roadmap's recommended Approach A is "optional features should use optional dependencies": Sentry is only initialized when `JUNIPER_CASCOR_SENTRY_DSN` (or the deprecated `SENTRY_SDK_DSN`, see CFG-03) is set, so users running cascor without Sentry no longer pay the install footprint. Matches the canopy `[observability]` precedent. **BREAKING for Sentry users**: deployments that previously relied on `pip install juniper-cascor` pulling sentry-sdk transitively must now use `pip install juniper-cascor[observability]` (or `pip install juniper-cascor[all]` — the `[all]` aggregator already includes `[observability]`). The shared `juniper-observability[sentry]` extra remains an equally-valid alternative. The bootstrap Sentry init at the top of `src/main.py` (previously `import sentry_sdk` unconditionally at line 52 + `sentry_sdk.init(...)` inside `if _sentry_dsn:`) now lazy-imports `sentry_sdk` inside the `if _sentry_dsn:` block, wrapped in `try/except ImportError` that emits a clear stderr warning when a DSN is set but the SDK is not installed (`[juniper-cascor] CFG-02 WARNING: ... install with pip install juniper-cascor[observability]`). The application-bootstrap Sentry path in `src/api/app.py` is unchanged: it already delegates to `juniper_observability.configure_sentry`, which does its own lazy `import sentry_sdk` inside the function and is a no-op when DSN is empty. Pinned by a new 4-case source-level regression suite at `src/tests/unit/test_cfg_02_sentry_sdk_optional.py` (sentry-sdk absent from core deps, present in `[observability]`, no top-level import in `main.py`, lazy import + `except ImportError` guard present). Aligning the `[observability]` extra to `sentry-sdk[fastapi]>=2.0.0` (to match `juniper-observability[sentry]`) is a deferred follow-up — CFG-02 is scoped strictly to moving the dep. Tracks CFG-02 in the v7 outstanding-development roadmap §20.

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -15,7 +15,7 @@ from fastapi.responses import JSONResponse
 from api.lifecycle.manager import TrainingLifecycleManager
 from api.middleware import RequestBodyLimitMiddleware, SecurityHeadersMiddleware, SecurityMiddleware
 from api.models.common import error_response
-from api.observability import PrometheusMiddleware, RequestIdMiddleware, configure_logging, configure_sentry, get_prometheus_app, set_build_info
+from api.observability import MetricsAuthMiddleware, PrometheusMiddleware, RequestIdMiddleware, configure_logging, configure_sentry, get_prometheus_app, set_build_info
 from api.routes import admin, dataset, decision_boundary, health, history, metrics, network, snapshots, training, workers
 from api.secrets import get_secret
 from api.security import APIKeyAuth, RateLimiter
@@ -485,9 +485,14 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.websocket("/ws/control")(control_stream_handler)
     app.websocket("/ws/v1/workers")(worker_stream_handler)
 
-    # Mount Prometheus metrics endpoint
+    # Mount Prometheus metrics endpoint (SEC-16 / POC §3.1: wrap with
+    # trusted-IP auth because ASGI sub-app mounts bypass SecurityMiddleware
+    # — and ``/metrics`` is now in EXEMPT_PATHS specifically so it can be).
     if settings.metrics_enabled:
-        app.mount("/metrics", get_prometheus_app())
+        app.mount(
+            "/metrics",
+            MetricsAuthMiddleware(get_prometheus_app(), settings.metrics_trusted_ips),
+        )
 
     # Exception handlers
     @app.exception_handler(ValueError)

--- a/src/api/middleware.py
+++ b/src/api/middleware.py
@@ -16,6 +16,13 @@ EXEMPT_PATHS = {
     "/docs",
     "/openapi.json",
     "/redoc",
+    # SEC-16 / POC §3.1: ``/metrics`` is gated by the parallel
+    # ``MetricsAuthMiddleware`` IP allowlist (cascor mirror of
+    # ``juniper-data``'s middleware) instead of SecurityMiddleware's
+    # API-key check. Both literal forms cover the FastAPI auto-redirect
+    # from missing/extra trailing slash.
+    "/metrics",
+    "/metrics/",
 }
 
 # Default Content-Security-Policy for API-only services.

--- a/src/api/observability.py
+++ b/src/api/observability.py
@@ -26,11 +26,14 @@ See: notes/code-review/METRICS_MONITORING_R2.1_SHARED_OBSERVABILITY_DESIGN_2026-
 in juniper-ml.
 """
 
+import ipaddress
 import logging
 import os
 import threading
+from collections.abc import Iterable
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
+from typing import Union
 
 # Cross-service primitives — re-exported from juniper-observability.
 from juniper_observability import DEFAULT_LOG_FORMAT_PLAIN, DEFAULT_SENTRY_TRACES_SAMPLE_RATE, LOG_FORMAT_JSON, UNMATCHED_ENDPOINT_LABEL, JuniperJsonFormatter, PrometheusMiddleware, RequestIdMiddleware  # noqa: F401 — re-exported for backwards compat
@@ -703,3 +706,99 @@ def ws_inc_command_responses(command: str, status: str) -> None:
 def ws_observe_command_handler(command: str, duration: float) -> None:
     """Record command handler execution duration."""
     _ensure_ws_metrics()["command_handler_seconds"].labels(command=command).observe(duration)
+
+
+# ---------------------------------------------------------------------------
+# SEC-16 / POC remediation §3.1: MetricsAuthMiddleware — cascor-side IP
+# allowlist for the ``/metrics`` mount. Mirrors
+# ``juniper_data.api.observability.MetricsAuthMiddleware`` verbatim
+# (validator-A recommendation in POC_REMEDIATION_PLAN_2026-05-27 §3.1 was
+# "promote from juniper-data or duplicate inline"; promotion to
+# ``juniper-observability`` is a roadmap §R5 gating issue, so duplicate-
+# inline keeps the rollout independent).
+#
+# Why this is needed even with ``/metrics`` exempt from
+# ``SecurityMiddleware`` (POC §3.1 "exempt" half): a misconfigured
+# deployment (port 8200 published directly, or running outside compose /
+# K8s) would expose ``/metrics`` with zero auth. The IP allowlist closes
+# that exposure surface.
+# ---------------------------------------------------------------------------
+
+METRICS_DEFAULT_TRUSTED_IPS: tuple[str, ...] = ("127.0.0.1", "::1")
+
+_NetworkT = Union[ipaddress.IPv4Network, ipaddress.IPv6Network]
+
+
+def _parse_trusted_networks(raw: Iterable[str]) -> tuple[_NetworkT, ...]:
+    """Compile a list of CIDR strings / bare IPs into ``ip_network`` objects.
+
+    Bare-IP entries are widened to host networks (``/32`` or ``/128``) by
+    ``ip_network(..., strict=False)``. Unparseable entries fail loud at
+    init time — operator typos must not silently 403 every scrape. Mirror
+    of ``juniper_data.api.observability._parse_trusted_networks``.
+    """
+    nets: list[_NetworkT] = []
+    for entry in raw:
+        try:
+            nets.append(ipaddress.ip_network(entry, strict=False))
+        except ValueError as exc:
+            raise ValueError(f"JUNIPER_CASCOR_METRICS_TRUSTED_IPS entry {entry!r} is not a valid IP or CIDR: {exc}") from exc
+    return tuple(nets)
+
+
+def _normalize_client_ip(client_ip: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
+    """Strip IPv6 zone-id and unwrap IPv4-mapped IPv6 to its IPv4 form.
+
+    - ``fe80::1%eth0`` → ``fe80::1`` (zone-id rejected by ``ip_address``).
+    - ``::ffff:172.18.0.5`` → ``172.18.0.5`` (membership in an IPv4 CIDR
+      otherwise returns ``False`` despite the underlying address being IPv4).
+    """
+    if "%" in client_ip:
+        client_ip = client_ip.split("%", 1)[0]
+    addr = ipaddress.ip_address(client_ip)
+    if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped is not None:
+        addr = addr.ipv4_mapped
+    return addr
+
+
+class MetricsAuthMiddleware:
+    """ASGI wrapper that restricts ``/metrics`` to a trusted IP allowlist.
+
+    Accepts bare IP literals, CIDR ranges, and a mix of both. IPv6 zone
+    identifiers are stripped from the client address; IPv4-mapped IPv6
+    addresses are unwrapped before membership check so a Docker container
+    appearing as ``::ffff:172.18.0.5`` matches an IPv4 ``172.18.0.0/16``
+    range. Unparseable allowlist entries raise at init time (fail-loud).
+    """
+
+    def __init__(
+        self,
+        app,
+        trusted_ips: Iterable[str] | None = None,
+    ) -> None:
+        self.app = app
+        raw = trusted_ips if trusted_ips is not None else METRICS_DEFAULT_TRUSTED_IPS
+        self.networks: tuple[_NetworkT, ...] = _parse_trusted_networks(raw)
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http":
+            allowed = False
+            client = scope.get("client")
+            client_ip = client[0] if client else None
+            if client_ip:
+                try:
+                    addr = _normalize_client_ip(client_ip)
+                    allowed = any(addr in net for net in self.networks)
+                except ValueError:
+                    pass
+            if not allowed:
+                await send(
+                    {
+                        "type": "http.response.start",
+                        "status": 403,
+                        "headers": [(b"content-type", b"text/plain; charset=utf-8")],
+                    }
+                )
+                await send({"type": "http.response.body", "body": b"Forbidden"})
+                return
+        await self.app(scope, receive, send)

--- a/src/api/observability.py
+++ b/src/api/observability.py
@@ -790,7 +790,10 @@ class MetricsAuthMiddleware:
                     addr = _normalize_client_ip(client_ip)
                     allowed = any(addr in net for net in self.networks)
                 except ValueError:
-                    pass
+                    logging.getLogger(__name__).warning(
+                        "Denying /metrics request due to unparseable client IP: %r",
+                        client_ip,
+                    )
             if not allowed:
                 await send(
                     {

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -1,9 +1,7 @@
 """API configuration settings using pydantic-settings."""
 
 from functools import lru_cache
-from typing import Any
-
-from typing import Annotated
+from typing import Annotated, Any
 
 from pydantic import AliasChoices, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
@@ -275,6 +273,31 @@ class Settings(BaseSettings):
     log_format: str = _JUNIPER_CASCOR_API_LOG_FORMAT_DEFAULT
     sentry_dsn: str | None = _JUNIPER_CASCOR_API_SENTRY_DSN_DEFAULT
     metrics_enabled: bool = _JUNIPER_CASCOR_API_METRICS_ENABLED_DEFAULT
+
+    # SEC-16 parity with juniper-data: loopback-only by default. Set
+    # ``JUNIPER_CASCOR_METRICS_TRUSTED_IPS='["10.0.0.5","172.18.0.0/16"]'``
+    # (JSON list) or a comma-separated string. Accepts bare IP literals and
+    # CIDR ranges; the in-process ``MetricsAuthMiddleware`` normalises IPv6
+    # zone-ids and IPv4-mapped IPv6 client addresses before membership check,
+    # so a Docker container appearing as ``::ffff:172.18.0.5`` matches an
+    # IPv4 ``172.18.0.0/16`` allowlist entry. Mirrors
+    # ``juniper-data.api.settings.metrics_trusted_ips`` (SEC-16, POC §3.1).
+    metrics_trusted_ips: list[str] = ["127.0.0.1", "::1"]
+
+    @field_validator("metrics_trusted_ips")
+    @classmethod
+    def _validate_metrics_trusted_ips(cls, v: list[str]) -> list[str]:
+        """Fail loud at startup if any allowlist entry is unparseable.
+
+        Without this guard a typo like ``172.18.0.0/164`` would silently
+        compile to a working-but-empty allowlist that 403s every scrape.
+        Lazy-imports the parser to avoid a settings → observability →
+        settings cycle.
+        """
+        from api.observability import _parse_trusted_networks
+
+        _parse_trusted_networks(v)
+        return v
 
     # CFG-04: JuniperData service URL. Canonical cross-service env var
     # is ``JUNIPER_DATA_URL`` (unprefixed) — shared by juniper-data,

--- a/src/tests/unit/api/test_metrics_auth_middleware.py
+++ b/src/tests/unit/api/test_metrics_auth_middleware.py
@@ -1,0 +1,210 @@
+"""Regression tests for cascor's ``MetricsAuthMiddleware`` (POC §3.1).
+
+Mirrors the juniper-data ``TestMetricsAuthMiddlewareCIDR`` suite so the
+two services share a contract: bare IP literals, CIDR ranges, IPv6 zone
+strip, IPv4-mapped IPv6 unwrap, fail-loud invalid config, and the
+``/metrics in EXEMPT_PATHS`` invariant. Promotion of the helper to
+``juniper-observability`` will collapse both suites into a single
+shared one (roadmap §R5).
+
+Tests exercise ``MetricsAuthMiddleware`` directly via ASGI scopes
+(instead of through ``create_app`` + ``TestClient``) because cascor's
+full app lifespan does not tear down cleanly under ``TestClient`` in
+a unit-test context (worker registry monitor, lifecycle manager, etc).
+The middleware contract is the same either way: 200 from the wrapped
+app when the client IP matches, 403 from the middleware when it
+doesn't, no fallthrough either way.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers — minimal ASGI driver for ``MetricsAuthMiddleware``
+# ---------------------------------------------------------------------------
+
+
+async def _stub_app(scope, receive, send) -> None:
+    """ASGI stub that responds 200 with body ``b"metrics-body"``."""
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [(b"content-type", b"text/plain; charset=utf-8")],
+        }
+    )
+    await send({"type": "http.response.body", "body": b"metrics-body"})
+
+
+class _Captured:
+    """Collect the ASGI ``send`` messages so tests can introspect them."""
+
+    def __init__(self) -> None:
+        self.messages: list[dict[str, Any]] = []
+
+    async def send(self, message: dict[str, Any]) -> None:
+        self.messages.append(message)
+
+
+async def _empty_receive() -> dict[str, Any]:  # pragma: no cover — never called by /metrics
+    return {"type": "http.disconnect"}
+
+
+def _scope(client_ip: str | None = "127.0.0.1") -> dict[str, Any]:
+    """Minimal HTTP scope for the metrics-auth middleware."""
+    return {
+        "type": "http",
+        "method": "GET",
+        "path": "/metrics",
+        "headers": [],
+        "client": (client_ip, 12345) if client_ip is not None else None,
+    }
+
+
+async def _drive(middleware, scope) -> _Captured:
+    """Run a single request through the middleware, return captured messages."""
+    captured = _Captured()
+    await middleware(scope, _empty_receive, captured.send)
+    return captured
+
+
+def _status_of(captured: _Captured) -> int:
+    """Pull the HTTP status out of the captured ``http.response.start``."""
+    start = next(m for m in captured.messages if m["type"] == "http.response.start")
+    return int(start["status"])
+
+
+# ---------------------------------------------------------------------------
+# EXEMPT_PATHS invariant
+# ---------------------------------------------------------------------------
+
+
+def test_metrics_in_exempt_paths() -> None:
+    """``/metrics`` must be in ``EXEMPT_PATHS`` so SecurityMiddleware does
+    not 401 prometheus before ``MetricsAuthMiddleware`` ever sees the
+    request. Without this exempt, the IP allowlist is dead code on any
+    deployment that has ``api_keys`` set."""
+    from api.middleware import EXEMPT_PATHS
+
+    assert "/metrics" in EXEMPT_PATHS
+    assert "/metrics/" in EXEMPT_PATHS
+
+
+# ---------------------------------------------------------------------------
+# CIDR + IPv6 normalization in ``MetricsAuthMiddleware``
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestMetricsAuthMiddlewareCIDR:
+    """``MetricsAuthMiddleware`` accepts CIDR ranges, IPv6 zone-ids, and
+    IPv4-mapped IPv6. Pins the contract documented in
+    ``notes/poc/POC_REMEDIATION_PLAN_2026-05-27.md`` §3.1.
+    """
+
+    async def test_cidr_v4_match_allows_request(self) -> None:
+        from api.observability import MetricsAuthMiddleware
+
+        middleware = MetricsAuthMiddleware(_stub_app, trusted_ips=["172.18.0.0/16"])
+        captured = await _drive(middleware, _scope(client_ip="172.18.0.5"))
+        assert _status_of(captured) == 200
+
+    async def test_cidr_v4_miss_rejects_request(self) -> None:
+        from api.observability import MetricsAuthMiddleware
+
+        middleware = MetricsAuthMiddleware(_stub_app, trusted_ips=["172.18.0.0/16"])
+        captured = await _drive(middleware, _scope(client_ip="10.0.0.5"))
+        assert _status_of(captured) == 403
+
+    async def test_mixed_cidr_and_literal_entries_allowed(self) -> None:
+        from api.observability import MetricsAuthMiddleware
+
+        # Literal address (no CIDR suffix) widens to /32; exact match wins.
+        middleware = MetricsAuthMiddleware(_stub_app, trusted_ips=["172.18.0.0/16", "10.0.0.99"])
+        captured = await _drive(middleware, _scope(client_ip="10.0.0.99"))
+        assert _status_of(captured) == 200
+
+    async def test_cidr_v6_match_allows_request(self) -> None:
+        from api.observability import MetricsAuthMiddleware
+
+        middleware = MetricsAuthMiddleware(_stub_app, trusted_ips=["fd00::/8"])
+        captured = await _drive(middleware, _scope(client_ip="fd12::1"))
+        assert _status_of(captured) == 200
+
+    async def test_ipv4_mapped_ipv6_against_ipv4_cidr(self) -> None:
+        """Regression for the docker-bridge IPv4-mapped IPv6 case:
+        ``::ffff:172.18.0.5`` must be unwrapped to ``172.18.0.5`` before
+        CIDR membership."""
+        from api.observability import MetricsAuthMiddleware
+
+        middleware = MetricsAuthMiddleware(_stub_app, trusted_ips=["172.18.0.0/16"])
+        captured = await _drive(middleware, _scope(client_ip="::ffff:172.18.0.5"))
+        assert _status_of(captured) == 200
+
+    async def test_ipv6_zone_id_is_stripped(self) -> None:
+        """``fe80::1%eth0`` would be rejected by ``ip_address`` without the
+        zone-id strip; with it, the address parses and membership works."""
+        from api.observability import MetricsAuthMiddleware
+
+        middleware = MetricsAuthMiddleware(_stub_app, trusted_ips=["fe80::/10"])
+        captured = await _drive(middleware, _scope(client_ip="fe80::1%eth0"))
+        assert _status_of(captured) == 200
+
+    async def test_default_loopback_allowlist_still_works(self) -> None:
+        """Backward-compat: ``None`` defaults to ``("127.0.0.1", "::1")``
+        and 127.0.0.1 resolves."""
+        from api.observability import MetricsAuthMiddleware
+
+        middleware = MetricsAuthMiddleware(_stub_app, trusted_ips=None)
+        captured = await _drive(middleware, _scope(client_ip="127.0.0.1"))
+        assert _status_of(captured) == 200
+
+    async def test_malformed_client_address_falls_through_to_403(self) -> None:
+        """``"not-an-ip"`` (TestClient's default ``"testclient"``-style host)
+        must never accidentally match a CIDR; the ``except ValueError``
+        path in ``__call__`` keeps ``allowed = False``."""
+        from api.observability import MetricsAuthMiddleware
+
+        middleware = MetricsAuthMiddleware(_stub_app, trusted_ips=["0.0.0.0/0"])
+        captured = await _drive(middleware, _scope(client_ip="not-an-ip"))
+        assert _status_of(captured) == 403
+
+    async def test_missing_client_address_falls_through_to_403(self) -> None:
+        """Scope without a ``client`` entry — defensive coverage."""
+        from api.observability import MetricsAuthMiddleware
+
+        middleware = MetricsAuthMiddleware(_stub_app, trusted_ips=["127.0.0.1"])
+        captured = await _drive(middleware, _scope(client_ip=None))
+        assert _status_of(captured) == 403
+
+
+# ---------------------------------------------------------------------------
+# Settings-side fail-loud validation
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_cidr_raises_at_settings_construction() -> None:
+    """Fail-loud: a typo like ``172.18.0.0/164`` must surface at
+    ``Settings()`` time, not on the first scrape (when it would silently
+    403). Mirrors juniper-data's validator."""
+    import pydantic_core
+
+    from api.settings import Settings
+
+    with pytest.raises((ValueError, pydantic_core.ValidationError)):
+        Settings(
+            metrics_enabled=True,
+            metrics_trusted_ips=["172.18.0.0/164"],
+        )
+
+
+def test_middleware_raises_on_invalid_cidr_at_init() -> None:
+    """If the Settings validator were ever bypassed, the middleware itself
+    fails loud on construction too — defense in depth."""
+    from api.observability import MetricsAuthMiddleware
+
+    with pytest.raises(ValueError):
+        MetricsAuthMiddleware(_stub_app, trusted_ips=["172.18.0.0/164"])


### PR DESCRIPTION
## Summary

Mirrors juniper-data's SEC-16 surface: `/metrics` is now exempt from
`SecurityMiddleware` (so prometheus does not 401 ahead of the IP
allowlist) AND gated by a parallel in-process `MetricsAuthMiddleware`
with full CIDR + IPv6 normalization. Closes POC remediation Wave-2
([`POC_REMEDIATION_PLAN_2026-05-27.md` §3.1](https://github.com/pcalnon/juniper-deploy/blob/main/notes/poc/POC_REMEDIATION_PLAN_2026-05-27.md))
— the validator A finding that shipping cascor's bare exempt without
a parallel IP allowlist would widen the unintentional-exposure surface
on any deployment that publishes port 8200 directly or runs outside
compose / K8s.

## Change shape

- `src/api/middleware.py` — `/metrics` + `/metrics/` added to
  `EXEMPT_PATHS`. Both literal forms cover the FastAPI auto-redirect
  from missing/extra trailing slash.
- `src/api/observability.py` — new `MetricsAuthMiddleware` (ASGI
  wrapper, mirrors juniper-data's class verbatim),
  `_parse_trusted_networks` (CIDR + bare-IP, fail-loud on bad config),
  `_normalize_client_ip` (IPv6 zone-id strip, IPv4-mapped IPv6 unwrap),
  `METRICS_DEFAULT_TRUSTED_IPS`.
- `src/api/settings.py` — new
  `Settings.metrics_trusted_ips: list[str] = ["127.0.0.1", "::1"]`
  with `_validate_metrics_trusted_ips` field validator that surfaces
  unparseable entries at `Settings()` construction.
- `src/api/app.py` — replaces the bare
  `app.mount("/metrics", get_prometheus_app())` with
  `app.mount("/metrics", MetricsAuthMiddleware(get_prometheus_app(), settings.metrics_trusted_ips))`.

## Why bigger than juniper-data #155 + #157

juniper-data already had `MetricsAuthMiddleware` shipped earlier
(SEC-16); #155 added `/metrics` to EXEMPT_PATHS and #157 added CIDR
support to the existing middleware. cascor had neither, so this PR
bundles all three: exempt path + new middleware + CIDR + Settings
validator + tests. Validator A's recommendation (POC §3.1) was
"promote from juniper-data or duplicate inline"; promotion to
`juniper-observability` is a roadmap §R5 follow-up, so this PR
duplicates inline — marginal extra LoC, removes the asymmetry
permanently, keeps the rollout independent.

## Test plan

- [x] New `src/tests/unit/api/test_metrics_auth_middleware.py` (12
      tests): `EXEMPT_PATHS` invariant, CIDR v4 allow + miss, mixed
      CIDR + literal, CIDR v6 allow, IPv4-mapped IPv6 vs IPv4 CIDR (the
      docker-bridge regression), IPv6 zone-id strip, default loopback
      works, malformed / missing client address falls through to 403,
      invalid CIDR raises at `Settings()`, middleware-init fail-loud as
      defense in depth.
- [x] Tests drive the middleware via raw ASGI scopes (not
      `TestClient` + `create_app`) because the cascor app lifespan
      does not tear down cleanly in unit-test context. Same middleware
      contract either way.
- [x] Adjacent suites green: `test_api_middleware.py`,
      `test_api_security.py`, `test_metrics_auth_middleware.py` =
      60/60 pass.
- [x] All pre-commit hooks pass.
- [ ] Post-merge: rebuild cascor image, set
      `JUNIPER_CASCOR_METRICS_TRUSTED_IPS='["172.18.0.0/16","172.19.0.0/16","172.20.0.0/16","172.21.0.0/16","127.0.0.1","::1"]'`
      (or similar CIDR covering Docker bridge subnets) in
      juniper-deploy's `.env.observability` or `.env.local`, restart
      stack, and confirm Prometheus's juniper-cascor target flips
      from `down: 401 Unauthorized` to `up`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)