### PR TITLE
chore(observability): drop inline MetricsAuthMiddleware, consume from juniper-observability>=0.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,9 +56,14 @@ dependencies = [
     # (DependencyStatus, ReadinessResponse, probe_dependency,
     # JuniperJsonFormatter, RequestIdMiddleware, PrometheusMiddleware,
     # configure_sentry, get_prometheus_app, set_build_info, and the
-    # R1.1/R1.2/R1.3 contract constants). Pinned at the first stable
-    # release; consumers should never resolve back to the alpha line.
-    "juniper-observability>=0.2.0",
+    # R1.1/R1.2/R1.3 contract constants). 0.3.0 added
+    # ``MetricsAuthMiddleware`` + ``parse_trusted_networks`` +
+    # ``normalize_client_ip`` + ``METRICS_DEFAULT_TRUSTED_IPS`` +
+    # ``TrustedNetwork`` so this module can drop its inline copy.
+    # 0.3.1 added the ``logging.warning`` on unparseable client IP
+    # that cascor had been carrying inline since #313 — pin >=0.3.1
+    # so the warning is preserved post-migration.
+    "juniper-observability>=0.3.1",
     # METRICS-MON R2.2.2 / seed-05: WebSocket frame schemas (envelope
     # Pydantic models for /ws/training and /ws/control + WorkerMessageType
     # StrEnum + BinaryFrame numpy codec for /ws/v1/workers). The cascor

--- a/requirements.lock
+++ b/requirements.lock
@@ -18,9 +18,9 @@ click==8.4.1
     # via uvicorn
 contourpy==1.3.3
     # via matplotlib
-cuda-bindings==13.2.0
+cuda-bindings==13.3.1
     # via torch
-cuda-pathfinder==1.5.4
+cuda-pathfinder==1.5.5
     # via cuda-bindings
 cuda-toolkit==13.0.2
     # via torch
@@ -40,7 +40,7 @@ h5py==3.16.0
     # via juniper-cascor (pyproject.toml)
 httptools==0.8.0
     # via uvicorn
-idna==3.16
+idna==3.17
     # via
     #   anyio
     #   requests
@@ -52,7 +52,7 @@ juniper-data==0.6.0
     # via juniper-cascor (pyproject.toml)
 juniper-data-client==0.4.1
     # via juniper-cascor (pyproject.toml)
-juniper-observability==0.2.0
+juniper-observability==0.3.1
     # via juniper-cascor (pyproject.toml)
 kiwisolver==1.5.0
     # via matplotlib
@@ -148,13 +148,13 @@ pyyaml==6.0.3
     #   uvicorn
 requests==2.34.2
     # via juniper-data-client
-sentry-sdk==2.60.0
+sentry-sdk==2.61.0
     # via juniper-cascor (pyproject.toml)
 setuptools==81.0.0
     # via torch
 six==1.17.0
     # via python-dateutil
-starlette==1.1.0
+starlette==1.2.0
     # via
     #   juniper-cascor (pyproject.toml)
     #   fastapi

--- a/src/api/observability.py
+++ b/src/api/observability.py
@@ -26,19 +26,16 @@ See: notes/code-review/METRICS_MONITORING_R2.1_SHARED_OBSERVABILITY_DESIGN_2026-
 in juniper-ml.
 """
 
-import ipaddress
 import logging
 import os
 import threading
-from collections.abc import Iterable
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
-from typing import Union
 
 # Cross-service primitives — re-exported from juniper-observability.
-from juniper_observability import DEFAULT_LOG_FORMAT_PLAIN, DEFAULT_SENTRY_TRACES_SAMPLE_RATE, LOG_FORMAT_JSON, UNMATCHED_ENDPOINT_LABEL, JuniperJsonFormatter, PrometheusMiddleware, RequestIdMiddleware  # noqa: F401 — re-exported for backwards compat
+from juniper_observability import DEFAULT_LOG_FORMAT_PLAIN, DEFAULT_SENTRY_TRACES_SAMPLE_RATE, LOG_FORMAT_JSON, METRICS_DEFAULT_TRUSTED_IPS, UNMATCHED_ENDPOINT_LABEL, JuniperJsonFormatter, MetricsAuthMiddleware, PrometheusMiddleware, RequestIdMiddleware, TrustedNetwork  # noqa: F401 — re-exported for backwards compat
 from juniper_observability import configure_sentry as _shared_configure_sentry
-from juniper_observability import get_prometheus_app, request_id_var, set_build_info  # noqa: F401 — re-exported for backwards compat
+from juniper_observability import get_prometheus_app, normalize_client_ip, parse_trusted_networks, request_id_var, set_build_info  # noqa: F401 — re-exported for backwards compat
 
 # Re-export the SEC-15 hook so ``main.py``'s direct sentry_sdk.init still
 # resolves it through the historical import path.
@@ -709,99 +706,22 @@ def ws_observe_command_handler(command: str, duration: float) -> None:
 
 
 # ---------------------------------------------------------------------------
-# SEC-16 / POC remediation §3.1: MetricsAuthMiddleware — cascor-side IP
-# allowlist for the ``/metrics`` mount. Mirrors
-# ``juniper_data.api.observability.MetricsAuthMiddleware`` verbatim
-# (validator-A recommendation in POC_REMEDIATION_PLAN_2026-05-27 §3.1 was
-# "promote from juniper-data or duplicate inline"; promotion to
-# ``juniper-observability`` is a roadmap §R5 gating issue, so duplicate-
-# inline keeps the rollout independent).
+# SEC-16 / POC remediation §3.1: ``MetricsAuthMiddleware`` — cascor-side IP
+# allowlist for the ``/metrics`` mount.
 #
-# Why this is needed even with ``/metrics`` exempt from
-# ``SecurityMiddleware`` (POC §3.1 "exempt" half): a misconfigured
+# The implementation was promoted to ``juniper-observability`` 0.3.0 (the
+# §6 promotion in POC_REMEDIATION_PLAN_2026-05-27) and now ships from
+# there. juniper-observability 0.3.1 added the ``logging.warning`` that
+# this module used to carry inline, so the two implementations are now
+# byte-for-byte equivalent in behaviour. We re-export the shared
+# symbols at the top of this module for backwards compatibility with
+# the historical ``from api.observability import MetricsAuthMiddleware``
+# imports in ``api.app``, the cascor test suite, and any operator
+# tooling.
+#
+# Why ``MetricsAuthMiddleware`` is needed even with ``/metrics`` exempt
+# from ``SecurityMiddleware`` (POC §3.1 "exempt" half): a misconfigured
 # deployment (port 8200 published directly, or running outside compose /
 # K8s) would expose ``/metrics`` with zero auth. The IP allowlist closes
 # that exposure surface.
 # ---------------------------------------------------------------------------
-
-METRICS_DEFAULT_TRUSTED_IPS: tuple[str, ...] = ("127.0.0.1", "::1")
-
-_NetworkT = Union[ipaddress.IPv4Network, ipaddress.IPv6Network]
-
-
-def _parse_trusted_networks(raw: Iterable[str]) -> tuple[_NetworkT, ...]:
-    """Compile a list of CIDR strings / bare IPs into ``ip_network`` objects.
-
-    Bare-IP entries are widened to host networks (``/32`` or ``/128``) by
-    ``ip_network(..., strict=False)``. Unparseable entries fail loud at
-    init time — operator typos must not silently 403 every scrape. Mirror
-    of ``juniper_data.api.observability._parse_trusted_networks``.
-    """
-    nets: list[_NetworkT] = []
-    for entry in raw:
-        try:
-            nets.append(ipaddress.ip_network(entry, strict=False))
-        except ValueError as exc:
-            raise ValueError(f"JUNIPER_CASCOR_METRICS_TRUSTED_IPS entry {entry!r} is not a valid IP or CIDR: {exc}") from exc
-    return tuple(nets)
-
-
-def _normalize_client_ip(client_ip: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
-    """Strip IPv6 zone-id and unwrap IPv4-mapped IPv6 to its IPv4 form.
-
-    - ``fe80::1%eth0`` → ``fe80::1`` (zone-id rejected by ``ip_address``).
-    - ``::ffff:172.18.0.5`` → ``172.18.0.5`` (membership in an IPv4 CIDR
-      otherwise returns ``False`` despite the underlying address being IPv4).
-    """
-    if "%" in client_ip:
-        client_ip = client_ip.split("%", 1)[0]
-    addr = ipaddress.ip_address(client_ip)
-    if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped is not None:
-        addr = addr.ipv4_mapped
-    return addr
-
-
-class MetricsAuthMiddleware:
-    """ASGI wrapper that restricts ``/metrics`` to a trusted IP allowlist.
-
-    Accepts bare IP literals, CIDR ranges, and a mix of both. IPv6 zone
-    identifiers are stripped from the client address; IPv4-mapped IPv6
-    addresses are unwrapped before membership check so a Docker container
-    appearing as ``::ffff:172.18.0.5`` matches an IPv4 ``172.18.0.0/16``
-    range. Unparseable allowlist entries raise at init time (fail-loud).
-    """
-
-    def __init__(
-        self,
-        app,
-        trusted_ips: Iterable[str] | None = None,
-    ) -> None:
-        self.app = app
-        raw = trusted_ips if trusted_ips is not None else METRICS_DEFAULT_TRUSTED_IPS
-        self.networks: tuple[_NetworkT, ...] = _parse_trusted_networks(raw)
-
-    async def __call__(self, scope, receive, send):
-        if scope["type"] == "http":
-            allowed = False
-            client = scope.get("client")
-            client_ip = client[0] if client else None
-            if client_ip:
-                try:
-                    addr = _normalize_client_ip(client_ip)
-                    allowed = any(addr in net for net in self.networks)
-                except ValueError:
-                    logging.getLogger(__name__).warning(
-                        "Denying /metrics request due to unparseable client IP: %r",
-                        client_ip,
-                    )
-            if not allowed:
-                await send(
-                    {
-                        "type": "http.response.start",
-                        "status": 403,
-                        "headers": [(b"content-type", b"text/plain; charset=utf-8")],
-                    }
-                )
-                await send({"type": "http.response.body", "body": b"Forbidden"})
-                return
-        await self.app(scope, receive, send)

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -291,12 +291,13 @@ class Settings(BaseSettings):
 
         Without this guard a typo like ``172.18.0.0/164`` would silently
         compile to a working-but-empty allowlist that 403s every scrape.
-        Lazy-imports the parser to avoid a settings → observability →
-        settings cycle.
+        Uses the shared ``parse_trusted_networks`` from
+        ``juniper-observability`` so cascor's fail-loud message stays in
+        lockstep with juniper-data and any future consumer.
         """
-        from api.observability import _parse_trusted_networks
+        from juniper_observability import parse_trusted_networks
 
-        _parse_trusted_networks(v)
+        parse_trusted_networks(v)
         return v
 
     # CFG-04: JuniperData service URL. Canonical cross-service env var


### PR DESCRIPTION
## Summary

- Drops cascor's inline ``MetricsAuthMiddleware`` (74 lines) + the private ``_parse_trusted_networks`` / ``_normalize_client_ip`` / ``_NetworkT`` helpers and re-exports the public symbols from ``juniper-observability``.
- Bumps ``juniper-observability>=0.2.0`` → ``>=0.3.1``; lockfile regen pulls 0.3.1 + 5 incidental floor bumps.
- Cleanup-only; no behaviour change vs the pre-migration cascor implementation.

## Context

POC remediation §6 cleanup follow-up. Migration was deferred until the next juniper-observability minor bump that had reasons to touch cascor; juniper-ml#337 (0.3.1) is that bump.

- juniper-observability 0.3.0 ([juniper-ml#335](https://github.com/pcalnon/juniper-ml/pull/335)) promoted ``MetricsAuthMiddleware`` + helpers from the inline duplicates that shipped in [juniper-data#157](https://github.com/pcalnon/juniper-data/pull/157) and [juniper-cascor#313](https://github.com/pcalnon/juniper-cascor/pull/313).
- juniper-observability 0.3.1 ([juniper-ml#337](https://github.com/pcalnon/juniper-ml/pull/337)) added the ``logging.warning`` on unparseable client IP that **this module had been carrying inline since #313** — so the shared implementation is now byte-for-byte equivalent to what cascor was maintaining locally. Pinning to ``>=0.3.1`` (not ``>=0.3.0``) preserves the logging behaviour.

## Changes

- ``src/api/observability.py`` — delete inline impl; re-export the public 5 symbols from ``juniper-observability``. Drop unused ``ipaddress`` / ``Iterable`` / ``Union`` imports.
- ``src/api/settings.py`` — rewire ``_validate_metrics_trusted_ips`` to ``juniper_observability.parse_trusted_networks`` (was the private underscore version). Fail-loud behaviour unchanged.
- ``pyproject.toml`` — ``juniper-observability>=0.3.1``.
- ``requirements.lock`` — regen pin diff:
  - ``juniper-observability`` 0.2.0 → 0.3.1 (target)
  - ``cuda-bindings`` 13.2.0 → 13.3.1
  - ``cuda-pathfinder`` 1.5.4 → 1.5.5
  - ``idna`` 3.16 → 3.17
  - ``sentry-sdk`` 2.60.0 → 2.61.0
  - ``starlette`` 1.1.0 → 1.2.0

## Squash-merge safety

Single commit so GitHub's default squash-merge can't drop the lockfile half (per the [juniper-deploy#92 / feedback_squash_merge_first_commit_only](../../juniper-deploy/pull/92) lesson — multi-commit cleanup PRs lose follow-up commits on merge).

## Requirements

- References ``JR-cascor-OBSV-METRICS-AUTH-MIGRATION`` (POC remediation §6 cleanup follow-up; tracked in juniper-deploy ``POC_REMEDIATION_PLAN_2026-05-27.md``).

## Test plan

- [x] Local ``pytest src/tests/unit/api/test_metrics_auth_middleware.py`` — 12/12 pass
- [x] Local re-export verification — ``MetricsAuthMiddleware.__module__ == "juniper_observability.middleware.metrics_auth"``
- [ ] CI green
- [ ] Lockfile freshness gate green
- [ ] Post-merge: ``make monitor`` from juniper-deploy continues to scrape ``up`` from cascor/metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)