### PR TITLE
fix(cascade_correlation): candidate result collection drops local-pool results -> 0 hidden units

### DIFF
--- a/src/cascade_correlation/cascade_correlation.py
+++ b/src/cascade_correlation/cascade_correlation.py
@@ -191,6 +191,17 @@ class ValidateTrainingResults:
 # Maximum queue size to prevent unbounded memory growth (DoS vector)
 _QUEUE_MAXSIZE = 1024
 
+# DUAL-PATH/TIMEOUT FIX (2026-05-30): default *inactivity* timeout for candidate
+# result collection. ``_collect_training_results`` historically used a fixed 60s
+# TOTAL deadline, which was shorter than multi-minute candidate rounds (a
+# 40-candidate pool can take >2 min), so the collector returned ~0 results while
+# the persistent workers were still training — yielding best_candidate=None and
+# 0 hidden units grown. The value below is the maximum gap BETWEEN consecutive
+# results (the deadline is reset on each result), backstopped by a worker-liveness
+# early-exit, so a slow-but-progressing round is never abandoned while a genuinely
+# stalled or dead pool still bails out promptly.
+_CASCADE_CORRELATION_NETWORK_RESULT_COLLECTION_INACTIVITY_TIMEOUT = 300.0
+
 
 # Server-owned queues (live in Manager server process)--created in the manager server process
 _task_queue = None
@@ -2400,7 +2411,7 @@ class CascadeCorrelationNetwork:
 
         # Collect results, NOTE: results is of type list of data class: [candidate_training_result, ...]
         self.logger.debug("CascadeCorrelationNetwork: _collect_worker_results: Collecting results from workers")
-        results = self._collect_training_results(result_queue, len(tasks), round_id=round_id)
+        results = self._collect_training_results(result_queue, len(tasks), round_id=round_id, workers=workers)
         self.logger.debug(f"CascadeCorrelationNetwork: _collect_worker_results: Collected {len(results)} results")
         # ``sleepytime`` is now only consumed by callers that pass it
         # explicitly. Suppress the unused-arg warning at call sites.
@@ -2591,10 +2602,13 @@ class CascadeCorrelationNetwork:
         self,
         result_queue: Queue,
         num_tasks: int,
-        # TODO: Make these into proper constants
-        queue_timeout: float = 60.0,
+        # DUAL-PATH/TIMEOUT FIX (2026-05-30): ``queue_timeout`` is now the maximum
+        # *inactivity* gap (seconds with no new result), reset on each result —
+        # NOT a fixed total deadline. See the module constant for the rationale.
+        queue_timeout: float = _CASCADE_CORRELATION_NETWORK_RESULT_COLLECTION_INACTIVITY_TIMEOUT,
         request_timeout: float = 1.0,
         round_id: Optional[str] = None,
+        workers: Optional[list] = None,
     ) -> list:
         """
         Description:
@@ -2621,10 +2635,30 @@ class CascadeCorrelationNetwork:
         self.logger.debug(f"CascadeCorrelationNetwork: _collect_training_results: Collecting {num_tasks} results (round_id={round_id})")
         self.logger.debug(f"CascadeCorrelationNetwork: _collect_training_results: Timeout set to {queue_timeout} seconds")
         self.logger.debug(f"CascadeCorrelationNetwork: _collect_training_results: Result Queue: Length: {result_queue.qsize()}, Contents: {list(result_queue.queue) if hasattr(result_queue, 'queue') else 'N/A'}")
-        deadline = time.time() + queue_timeout
+        # DUAL-PATH/TIMEOUT FIX (2026-05-30): wait on an *inactivity* deadline that
+        # is reset whenever a result is collected, plus a worker-liveness
+        # early-exit, instead of a fixed total wall-clock deadline. Persistent
+        # workers (RC-4) stay alive for the whole round, so a multi-minute round
+        # streams results in over time; the previous fixed total deadline
+        # (default 60s) abandoned collection mid-round — returning ~0 results and
+        # producing best_candidate=None / 0 hidden units grown. We keep waiting as
+        # long as results keep arriving (or a worker is alive and could still
+        # deliver one), and stop only after ``queue_timeout`` seconds with NO new
+        # result, once every worker has exited with the queue drained, or on error.
+        inactivity_deadline = time.time() + queue_timeout
         get_attempts = 0
         empty_count = 0
-        while collected_results < num_tasks and time.time() < deadline:
+        while collected_results < num_tasks:
+            # Early-exit: no live worker remains to deliver the outstanding
+            # results and the queue is already drained — waiting is pointless.
+            if workers is not None and not any(w.is_alive() for w in workers) and result_queue.empty():
+                self.logger.warning(f"CascadeCorrelationNetwork: _collect_training_results: All workers exited with " f"{collected_results}/{num_tasks} results collected and the result queue drained; stopping.")
+                break
+            # Inactivity guard: give up only after a full ``queue_timeout`` gap
+            # with no new result (a genuinely stalled or hung pool).
+            if time.time() > inactivity_deadline:
+                self.logger.warning(f"CascadeCorrelationNetwork: _collect_training_results: No new result for {queue_timeout:.0f}s " f"(inactivity timeout) with {collected_results}/{num_tasks} collected; stopping.")
+                break
             try:
                 get_attempts += 1
                 result = result_queue.get(timeout=request_timeout)
@@ -2642,11 +2676,13 @@ class CascadeCorrelationNetwork:
                     continue
                 results.append(result)
                 collected_results += 1
+                # Progress — extend the inactivity window past this result.
+                inactivity_deadline = time.time() + queue_timeout
                 _rc4.emit("parent.collect.got", candidate_id=getattr(result, "candidate_id", None), n=collected_results, expected=num_tasks)
                 self.logger.verbose(f"CascadeCorrelationNetwork: _collect_training_results: Collected {collected_results}/{num_tasks}")
             except Empty as empty_e:
                 empty_count += 1
-                _rc4.emit("parent.collect.empty", attempt=get_attempts, empty_count=empty_count, deadline_remaining=max(0.0, deadline - time.time()))
+                _rc4.emit("parent.collect.empty", attempt=get_attempts, empty_count=empty_count, deadline_remaining=max(0.0, inactivity_deadline - time.time()))
                 self.logger.warning(f"CascadeCorrelationNetwork: _collect_training_results: Result queue empty, continuing: {empty_e}")
                 continue
             except Exception as e:
@@ -3450,7 +3486,17 @@ class CascadeCorrelationNetwork:
         """
         # Check if existing pool is valid (right size, all workers alive)
         alive_count = sum(1 for w in self._persistent_workers if w.is_alive()) if self._persistent_workers else 0
-        pool_valid = self._persistent_workers and self._persistent_task_queue is not None and self._persistent_result_queue is not None and alive_count == self._persistent_pool_size and self._persistent_pool_size == num_workers
+        # DUAL-PATH FIX (2026-05-30): reuse a healthy persistent pool whenever it
+        # already has at least as many live workers as requested. A larger pool
+        # serves a smaller request (e.g. a remote-fallback retry batch of 2 tasks)
+        # — surplus workers simply idle on the empty task queue. The previous
+        # exact-size check (``_persistent_pool_size == num_workers``) tore the pool
+        # down to resize it, which SIGKILLed in-flight workers and orphaned their
+        # result queue mid-round — the root cause of "expected N, got 2" /
+        # 0 hidden units grown under dual-path dispatch. Only rebuild when no
+        # healthy pool exists or MORE workers are needed.
+        pool_healthy = bool(self._persistent_workers) and self._persistent_task_queue is not None and self._persistent_result_queue is not None and alive_count == self._persistent_pool_size
+        pool_valid = pool_healthy and num_workers <= self._persistent_pool_size
 
         if pool_valid:
             self.logger.debug(f"CascadeCorrelationNetwork: _ensure_worker_pool: Reusing existing pool of {alive_count} workers")

--- a/src/tests/unit/test_candidate_result_collection_dualpath_regression.py
+++ b/src/tests/unit/test_candidate_result_collection_dualpath_regression.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python
+"""Regression tests for the dual-path candidate result-collection bug (2026-05-30).
+
+Symptom (observed on the deployed stack): a training run trains all candidate
+units but grows ZERO hidden units and prematurely reports "Completed", with the
+cascor log showing ``_process_training_results: Mismatch in results count:
+expected 40, got 2``.
+
+Two compounding root causes were confirmed and fixed:
+
+* **Defect 1 — collection timeout shorter than candidate training time.**
+  ``_collect_training_results`` used a fixed 60s *total* deadline. A 40-candidate
+  pool can take >2 min, so the collector abandoned the round with ~0 results
+  while the persistent workers were still training. The deadline is now an
+  *inactivity* deadline (reset on each result) plus a worker-liveness early-exit.
+
+* **Defect 2 — dual-path remote-fallback recreated the local pool mid-round.**
+  ``_ensure_worker_pool`` required an exact size match, so a small remote-fallback
+  retry batch (e.g. 2 tasks) tore down the live 15-worker pool — SIGKILLing
+  in-flight workers and orphaning their result queue. A healthy pool with at
+  least as many live workers as requested is now reused.
+
+These tests exercise the real methods (no real worker processes spawned) so a
+regression in either fix is caught.
+"""
+
+import queue
+import threading
+import time
+from unittest import mock
+
+import pytest
+
+from candidate_unit.candidate_unit import CandidateTrainingResult
+from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
+from cascade_correlation.cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
+
+
+def _make_network(**overrides):
+    defaults = {
+        "input_size": 2,
+        "output_size": 2,
+        "random_seed": 42,
+        "candidate_pool_size": 2,
+        "candidate_epochs": 3,
+        "output_epochs": 3,
+        "max_hidden_units": 2,
+        "patience": 1,
+    }
+    defaults.update(overrides)
+    return CascadeCorrelationNetwork(config=CascadeCorrelationConfig(**defaults))
+
+
+class _FakeWorker:
+    """Stand-in for a multiprocessing worker process (no real process spawned)."""
+
+    def __init__(self, alive=True, pid=4242, name="fake-worker"):
+        self._alive = alive
+        self.pid = pid
+        self.name = name
+
+    def is_alive(self):
+        return self._alive
+
+    def start(self):
+        pass
+
+    def join(self, timeout=None):
+        pass
+
+    def terminate(self):
+        self._alive = False
+
+
+# ---------------------------------------------------------------------------
+# Defect 1 — _collect_training_results inactivity deadline + liveness early-exit
+# ---------------------------------------------------------------------------
+class TestCollectionInactivityDeadline:
+    @pytest.mark.unit
+    def test_inactivity_deadline_resets_on_each_result(self):
+        """A round whose TOTAL duration exceeds queue_timeout must still collect
+        every result, as long as no single GAP between results exceeds it.
+
+        Regression guard: the old fixed-total-deadline behaviour would abandon
+        this round partway through (returning < num_tasks)."""
+        net = _make_network()
+        q = queue.Queue()
+        num_tasks = 5
+        gap = 0.15
+        inactivity = 0.6  # >> gap, << num_tasks * gap (=0.75) total
+
+        def _producer():
+            for cid in range(num_tasks):
+                time.sleep(gap)
+                q.put(CandidateTrainingResult(candidate_id=cid, correlation=0.1 * cid))
+
+        t = threading.Thread(target=_producer, daemon=True)
+        t.start()
+        results = net._collect_training_results(q, num_tasks=num_tasks, queue_timeout=inactivity, request_timeout=0.05)
+        t.join(timeout=2.0)
+
+        assert len(results) == num_tasks, "inactivity deadline must not abandon a slow-but-progressing round"
+
+    @pytest.mark.unit
+    def test_liveness_early_exit_when_all_workers_dead(self):
+        """If every worker has exited and the queue is drained, stop immediately
+        instead of waiting out the (now large) inactivity timeout."""
+        net = _make_network()
+        q = queue.Queue()  # empty
+        dead = _FakeWorker(alive=False)
+
+        start = time.monotonic()
+        results = net._collect_training_results(q, num_tasks=3, queue_timeout=10.0, request_timeout=0.1, workers=[dead])
+        elapsed = time.monotonic() - start
+
+        assert results == []
+        assert elapsed < 2.0, "dead-worker + empty queue must early-exit, not wait the full inactivity timeout"
+
+    @pytest.mark.unit
+    def test_alive_worker_does_not_early_exit(self):
+        """A live worker (which could still deliver) must NOT trigger the
+        dead-worker early-exit; collection waits out the inactivity window."""
+        net = _make_network()
+        q = queue.Queue()  # empty
+        alive = _FakeWorker(alive=True)
+
+        start = time.monotonic()
+        results = net._collect_training_results(q, num_tasks=2, queue_timeout=0.4, request_timeout=0.1, workers=[alive])
+        elapsed = time.monotonic() - start
+
+        assert results == []
+        assert elapsed >= 0.3, "a live worker must keep the collector waiting until the inactivity timeout"
+
+
+# ---------------------------------------------------------------------------
+# Defect 2 — _ensure_worker_pool reentrancy (reuse a larger live pool)
+# ---------------------------------------------------------------------------
+class TestEnsureWorkerPoolReentrancy:
+    @pytest.mark.unit
+    def test_smaller_request_reuses_pool_without_teardown(self):
+        """A request for FEWER workers than the live pool must reuse it — never
+        tear it down (that orphaned in-flight results: the root cause)."""
+        net = _make_network()
+        tq, rq = object(), object()
+        net._persistent_workers = [_FakeWorker(), _FakeWorker(), _FakeWorker()]
+        net._persistent_pool_size = 3
+        net._persistent_task_queue = tq
+        net._persistent_result_queue = rq
+
+        with mock.patch.object(net, "_shutdown_worker_pool") as shut:
+            out_tq, out_rq = net._ensure_worker_pool(1)
+
+        assert out_tq is tq and out_rq is rq, "must return the SAME queues (pool reused)"
+        shut.assert_not_called()
+        assert net._persistent_pool_size == 3
+
+    @pytest.mark.unit
+    def test_equal_request_reuses_pool(self):
+        net = _make_network()
+        tq, rq = object(), object()
+        net._persistent_workers = [_FakeWorker(), _FakeWorker()]
+        net._persistent_pool_size = 2
+        net._persistent_task_queue = tq
+        net._persistent_result_queue = rq
+
+        with mock.patch.object(net, "_shutdown_worker_pool") as shut:
+            out_tq, out_rq = net._ensure_worker_pool(2)
+
+        assert out_tq is tq and out_rq is rq
+        shut.assert_not_called()
+
+    @pytest.mark.unit
+    def test_larger_request_recreates_pool(self):
+        """A request for MORE workers than the live pool legitimately recreates."""
+        net = _make_network()
+        net._persistent_workers = [_FakeWorker(), _FakeWorker()]
+        net._persistent_pool_size = 2
+        net._persistent_task_queue = object()
+        net._persistent_result_queue = object()
+
+        with mock.patch.object(net, "_shutdown_worker_pool") as shut, mock.patch.object(net._mp_ctx, "Queue", return_value=mock.MagicMock()), mock.patch.object(net._mp_ctx, "Process", return_value=_FakeWorker()):
+            net._ensure_worker_pool(5)
+
+        shut.assert_called_once()
+
+    @pytest.mark.unit
+    def test_degraded_pool_recreates(self):
+        """If some workers died (alive < pool size), the pool is not healthy and
+        must be recreated even for the same requested size."""
+        net = _make_network()
+        net._persistent_workers = [_FakeWorker(alive=True), _FakeWorker(alive=False), _FakeWorker(alive=True)]
+        net._persistent_pool_size = 3
+        net._persistent_task_queue = object()
+        net._persistent_result_queue = object()
+
+        with mock.patch.object(net, "_shutdown_worker_pool") as shut, mock.patch.object(net._mp_ctx, "Queue", return_value=mock.MagicMock()), mock.patch.object(net._mp_ctx, "Process", return_value=_FakeWorker()):
+            net._ensure_worker_pool(3)
+
+        shut.assert_called_once()

--- a/src/tests/unit/test_parallel_training.py
+++ b/src/tests/unit/test_parallel_training.py
@@ -153,7 +153,7 @@ class TestCollectWorkerResults:
         # since the real implementation does validation we don't need here.
         results_out = [FakeResult(candidate_id=0), FakeResult(candidate_id=1)]
 
-        def fake_collect(rq, num_tasks, round_id=None):
+        def fake_collect(rq, num_tasks, round_id=None, workers=None):
             return results_out
 
         net._collect_training_results = fake_collect
@@ -192,7 +192,7 @@ class TestCollectWorkerResults:
 
         results_out = [FakeResult(candidate_id=0), FakeResult(candidate_id=1)]
 
-        def fake_collect(rq, num_tasks, round_id=None):
+        def fake_collect(rq, num_tasks, round_id=None, workers=None):
             return results_out
 
         net._collect_training_results = fake_collect


### PR DESCRIPTION
## Summary

On the deployed stack a training run trained **all** candidate units but grew **zero hidden units** and prematurely reported "Completed", with cascor logging `_process_training_results: Mismatch in results count: expected 40, got 2`. This fixes the two compounding root causes.

## Root cause (two compounding defects)

**Defect 1 — collection timeout shorter than candidate training time (affects local single-path *and* dual-path).** `_collect_training_results` used a fixed **60s total** deadline. A 40-candidate pool can take >2 min, so the collector abandoned the round with ~0 results while the persistent workers were still training → `best_candidate=None` → 0 hidden units. The live round logged `Training duration: 0:02:18`, and the ~60s gap between "Persistent pool created" and "Dispatching to remote" matched the deadline exactly.

**Defect 2 — dual-path remote-fallback recreated the local pool mid-round.** `TaskDistributor._execute_remote_with_fallback` retries failed/incomplete remote results via `local_fn` → `_execute_parallel_training(small_batch)` → `_ensure_worker_pool(2)`. The old exact-size check (`_persistent_pool_size == num_workers`) treated 15≠2 as invalid and tore the pool down — SIGKILLing the 15 in-flight workers and nulling their result queue.

## Fix

- **Defect 1:** `_collect_training_results` now waits on an **inactivity** deadline (reset on each result) + a **worker-liveness early-exit**, not a fixed total deadline. New constant `_CASCADE_CORRELATION_NETWORK_RESULT_COLLECTION_INACTIVITY_TIMEOUT = 300.0`; `workers` threaded through from `_collect_worker_results`.
- **Defect 2:** `_ensure_worker_pool` reuses a healthy pool whenever `num_workers <= _persistent_pool_size` (a larger pool serves a smaller request; surplus workers idle). It only rebuilds when no healthy pool exists or **more** workers are needed.

## Tests

- New `tests/unit/test_candidate_result_collection_dualpath_regression.py` — 7 tests pinning both defects (inactivity reset, liveness early-exit, alive-worker-keeps-waiting; pool reuse-smaller / reuse-equal / recreate-larger / recreate-degraded). No real worker processes spawned.
- Updated two `_collect_training_results` monkeypatch fakes for the new `workers=` kwarg.
- Green locally (JuniperCascor1): the new file + `test_parallel_training`, `test_task_distributor`, and `test_cascade_correlation_coverage{,_deep,_final}`.

## Verification status

Unit-level verified. **Live end-to-end rerun (rebuild image + real training round → confirm hidden units grow) still pending.**

## Follow-up (deferred)

Gate dual-path dispatch behind a workload threshold so a single-node + 2-remote-worker shape stays local (dual-path is net-negative there).

## Rollback

Revert this commit; no schema/API changes, no migration.

Root-cause analysis + full plan: juniper-canopy `notes/fixes/FIX_FRONTEND_REGRESSIONS_2026-05-30.md` §5.1 / §8.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
