### PR TITLE
fix(distributed): int-coerce remote candidate bounds; backport cascor-core normalization (#319)

### DIFF
--- a/src/candidate_unit/candidate_unit.py
+++ b/src/candidate_unit/candidate_unit.py
@@ -44,6 +44,7 @@ import random
 import sys
 import uuid
 from dataclasses import dataclass, field
+from numbers import Integral, Real
 
 # from typing import Optional
 from typing import Any, Callable, Optional
@@ -141,6 +142,16 @@ from utils.activation import ActivationWithDerivative  # noqa: F401, E402
 
 #####################################################################################################################################################################################################
 class CandidateUnit:
+    @staticmethod
+    def _coerce_int_like(value: Any, field_name: str) -> int:
+        """Normalize JSON-decoded numeric payload fields used by seed/range APIs."""
+        if isinstance(value, bool):
+            raise TypeError(f"{field_name} must be an integer, not bool")
+        if isinstance(value, Integral):
+            return int(value)
+        if isinstance(value, Real) and float(value).is_integer():
+            return int(value)
+        raise ValueError(f"{field_name} must be an integer-valued number, got {value!r}")
 
     #################################################################################################################################################################################################
     # Initialize a candidate unit.
@@ -178,15 +189,19 @@ class CandidateUnit:
         self.logger.info("CandidateUnit: __init__: Initializing Candidate Unit with Logger class.")
 
         # Initialize candidate index for unique seeding
-        self.candidate_index = CandidateUnit__candidate_index
+        candidate_index = CandidateUnit__candidate_index if CandidateUnit__candidate_index is not None else 0
+        self.candidate_index = self._coerce_int_like(candidate_index, "CandidateUnit__candidate_index")
         self.logger.verbose(f"CandidateUnit: __init__: Candidate index: {self.candidate_index}")
 
         # Initialize CandidateUnit class attributes for randomness
-        self.random_seed = CandidateUnit__random_seed
+        random_seed = CandidateUnit__random_seed if CandidateUnit__random_seed is not None else _CANDIDATE_UNIT_RANDOM_SEED
+        self.random_seed = self._coerce_int_like(random_seed, "CandidateUnit__random_seed")
         self.logger.verbose(f"CandidateUnit: __init__: Random seed: {self.random_seed}")
-        self.random_max_value = CandidateUnit__random_max_value
+        random_max_value = CandidateUnit__random_max_value if CandidateUnit__random_max_value is not None else _CANDIDATE_UNIT_RANDOM_MAX_VALUE
+        self.random_max_value = self._coerce_int_like(random_max_value, "CandidateUnit__random_max_value")
         self.logger.verbose(f"CandidateUnit: __init__: Random max value: {self.random_max_value}")
-        self.sequence_max_value = CandidateUnit__sequence_max_value
+        sequence_max_value = CandidateUnit__sequence_max_value if CandidateUnit__sequence_max_value is not None else _CANDIDATE_UNIT_SEQUENCE_MAX_VALUE
+        self.sequence_max_value = self._coerce_int_like(sequence_max_value, "CandidateUnit__sequence_max_value")
         self.logger.verbose(f"CandidateUnit: __init__: Random sequence max value: {self.sequence_max_value}")
         # Use unique seed per candidate to ensure different initializations
         unique_seed = self.random_seed + self.candidate_index if self.random_seed else self.candidate_index
@@ -198,11 +213,11 @@ class CandidateUnit:
         self.logger.verbose(f"CandidateUnit: __init__: Input size: {self.input_size}")
         self.output_size = CandidateUnit__output_size
         self.logger.verbose(f"CandidateUnit: __init__: Output size: {self.output_size}")
-        self.activation_fn_base = CandidateUnit__activation_function
-        self.logger.verbose(f"CandidateUnit: __init__: Base Activation function: {self.activation_fn_base}")
 
         # Cache activation function wrapper to avoid recreating on every forward pass (P2 optimization)
-        self.activation_fn = self._init_activation_with_derivative(self.activation_fn_base)
+        self.activation_fn = self._init_activation_with_derivative(CandidateUnit__activation_function)
+        self.activation_fn_base = self.activation_fn.activation_fn
+        self.logger.verbose(f"CandidateUnit: __init__: Base Activation function: {self.activation_fn_base}")
         self.logger.debug("CandidateUnit: __init__: Cached activation function wrapper")
 
         # Initialize CandidateUnit class attributes for training epochs
@@ -268,11 +283,15 @@ class CandidateUnit:
         state.pop("logger", None)
         state.pop("_candidate_display_progress", None)
         state.pop("_candidate_display_status", None)
+        if "activation_fn" in state:
+            state["activation_fn_base"] = state["activation_fn"]
         return state
 
     def __setstate__(self, state):
         """Restore instance from serialized state."""
         self.__dict__.update(state)
+        if "activation_fn_base" not in state and hasattr(self, "activation_fn"):
+            self.activation_fn_base = self.activation_fn
         # Recreate logger
         self.logger = Logger
         self.logger.set_level(self.log_level_name)
@@ -289,11 +308,11 @@ class CandidateUnit:
             max_value: Optional maximum value for random number generation
         """
         self.logger.trace("CandidateUnit: _initialize_randomness: Initializing randomness for the candidate unit")
-        seed = seed or _CANDIDATE_UNIT_RANDOM_SEED
+        seed = self._coerce_int_like(seed or _CANDIDATE_UNIT_RANDOM_SEED, "seed")
         self.logger.verbose(f"CandidateUnit: _initialize_randomness: Random seed set to: {seed}")
         # max_value = max_value or _CANDIDATE_UNIT_RANDOM_MAX_VALUE
         # max_value = 10000
-        max_value = max_value or _PROJECT_MODEL_CANDIDATE_RANDOM_MAX_VALUE  # Using a small max value to limit the number of random calls needed to roll to the desired sequence
+        max_value = self._coerce_int_like(max_value or _PROJECT_MODEL_CANDIDATE_RANDOM_MAX_VALUE, "max_value")  # Using a small max value to limit the number of random calls needed to roll to the desired sequence
         self.logger.verbose(f"CandidateUnit: _initialize_randomness: Random max value set to: {max_value}")
         self._seed_random_generator(seed=seed, max_value=max_value, seeder=np.random.seed, generator=np.random.randint)
         self.logger.trace("CandidateUnit: _initialize_randomness: Completed initialization of numpy random generator with seed and sequence for the candidate unit")
@@ -1073,7 +1092,9 @@ class CandidateUnit:
         self.logger.trace("CandidateUnit: _validate_correlation_params: Starting validation of correlation parameters")
 
         # Check if output and residual error are not None
-        self.logger.debug(f"CandidateUnit: _validate_correlation_params: Output shape: {output.shape if output is not None else 'None'}, Residual error shape: {residual_error.shape if residual_error is not None else 'None'}")
+        # NOTE: shapes are logged after the type check below (line ~1107); logging
+        # output.shape here would AttributeError on non-tensor input before the
+        # TypeError can be raised. Entry-time type detail is logged after the None check.
         self.logger.trace("CandidateUnit: _validate_correlation_params: Validating output and residual error are not None")
         if output is None or residual_error is None:
             raise ValueError("CandidateUnit: _validate_correlation_params: Output and residual error must not be None.")
@@ -1227,7 +1248,8 @@ class CandidateUnit:
         Args:
             activation_fn_base: Base activation function
         """
-        self.activation_fn_base = activation_fn_base
+        self.activation_fn = self._init_activation_with_derivative(activation_fn_base)
+        self.activation_fn_base = self.activation_fn.activation_fn
 
     def set_bias(self, bias: torch.Tensor) -> None:
         """

--- a/src/cascade_correlation/cascade_correlation.py
+++ b/src/cascade_correlation/cascade_correlation.py
@@ -1217,8 +1217,12 @@ class CascadeCorrelationNetwork:
                         "random_value_scale": float(random_value_scale),
                         "candidate_uuid": candidate_uuid,
                         "candidate_seed": candidate_seed,
-                        "random_max_value": float(random_max_value),
-                        "sequence_max_value": float(sequence_max_value),
+                        # Remote candidate bounds are int-valued and feed random.randint()/
+                        # range() in CandidateUnit (which reject floats). Send them as int so
+                        # the JSON wire preserves integer-ness — float() here made the remote
+                        # worker raise "'float' object cannot be interpreted as an integer".
+                        "random_max_value": int(random_max_value),
+                        "sequence_max_value": int(sequence_max_value),
                     },
                     "training_params": {
                         "epochs": int(self.candidate_epochs),

--- a/src/tests/unit/test_candidate_core_worker_contracts.py
+++ b/src/tests/unit/test_candidate_core_worker_contracts.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+"""Worker-facing contracts for the candidate core (CandidateUnit + activation).
+
+These behaviors exist because ``CandidateUnit`` / ``ActivationWithDerivative`` are
+extracted verbatim into the ``juniper-cascor-core`` PyPI package and consumed by the
+distributed ``juniper-cascor-worker`` over a JSON wire. The worker reconstructs
+candidates from JSON-decoded payloads, where:
+
+* integer-valued bounds (``random_max_value`` / ``sequence_max_value`` /
+  ``random_seed`` / ``candidate_index``) arrive as ``float`` (JSON has no int type),
+  yet they feed ``random.randint()`` / ``range()`` which reject floats; and
+* the worker's activation resolver historically returned a legacy
+  ``(activation, derivative)`` tuple.
+
+cascor's own *local* path never hits these shapes (it passes ints and callables), so
+cascor's other tests only exercise the passthrough direction. This file is the
+source-side guard for the worker-facing normalization that the package depends on —
+mirroring the package's ``tests/test_smoke.py`` contracts so a cascor-side regression
+is caught here, not only after a manual re-extraction. Do not "simplify" the
+normalization away: it is the cross-service contract, not dead defensiveness.
+"""
+
+import pickle
+
+import pytest
+import torch
+
+from candidate_unit.candidate_unit import CandidateUnit
+from utils.activation import ActivationWithDerivative
+
+
+# ---------------------------------------------------------------------------
+# ActivationWithDerivative — accept the worker's legacy (activation, derivative) tuple
+# ---------------------------------------------------------------------------
+class TestActivationWorkerTupleContract:
+    @pytest.mark.unit
+    def test_normalizes_worker_activation_tuple_to_callable(self):
+        awd = ActivationWithDerivative((torch.tanh, lambda x: 1.0 - torch.tanh(x) ** 2))
+        assert awd.activation_fn is torch.tanh, "tuple must normalize to its first (callable) element"
+
+    @pytest.mark.unit
+    def test_passes_through_plain_callable(self):
+        awd = ActivationWithDerivative(torch.tanh)
+        assert awd.activation_fn is torch.tanh
+
+    @pytest.mark.unit
+    def test_rejects_tuple_without_leading_callable(self):
+        with pytest.raises(TypeError):
+            ActivationWithDerivative((0.1, 0.2))
+
+
+# ---------------------------------------------------------------------------
+# CandidateUnit — normalize JSON-decoded integer-valued bounds (float -> int)
+# ---------------------------------------------------------------------------
+class TestCandidateUnitBoundCoercion:
+    @pytest.mark.unit
+    def test_float_valued_integer_bounds_are_coerced(self):
+        """The remote worker's JSON payload decodes these as floats; CandidateUnit
+        must store them as int before they reach random.randint()/range()."""
+        candidate = CandidateUnit(
+            CandidateUnit__input_size=2,
+            CandidateUnit__output_size=1,
+            CandidateUnit__candidate_index=2.0,
+            CandidateUnit__random_seed=1.0,
+            CandidateUnit__random_max_value=1.0,
+            CandidateUnit__sequence_max_value=100.0,
+        )
+        assert candidate.candidate_index == 2 and type(candidate.candidate_index) is int
+        assert candidate.random_seed == 1 and type(candidate.random_seed) is int
+        assert candidate.random_max_value == 1 and type(candidate.random_max_value) is int
+        assert candidate.sequence_max_value == 100 and type(candidate.sequence_max_value) is int
+
+    @pytest.mark.unit
+    def test_bool_bounds_rejected(self):
+        """bool is an int subclass but a programming error here — reject it loudly."""
+        with pytest.raises(TypeError):
+            CandidateUnit(
+                CandidateUnit__input_size=2,
+                CandidateUnit__output_size=1,
+                CandidateUnit__random_max_value=True,
+            )
+
+    @pytest.mark.unit
+    def test_non_integer_float_bounds_rejected(self):
+        with pytest.raises(ValueError):
+            CandidateUnit(
+                CandidateUnit__input_size=2,
+                CandidateUnit__output_size=1,
+                CandidateUnit__sequence_max_value=1.5,
+            )
+
+
+# ---------------------------------------------------------------------------
+# CandidateUnit — end-to-end with a worker activation tuple (forward + pickle)
+# ---------------------------------------------------------------------------
+class TestCandidateUnitWorkerActivation:
+    @pytest.mark.unit
+    def test_accepts_worker_activation_tuple_and_stays_picklable(self):
+        candidate = CandidateUnit(
+            CandidateUnit__input_size=2,
+            CandidateUnit__output_size=1,
+            CandidateUnit__activation_function=(torch.tanh, lambda x: 1.0 - torch.tanh(x) ** 2),
+        )
+        output = candidate.forward(torch.ones(2))
+        pickle.dumps(candidate)  # local pool ships candidates by pickle — must not carry a lambda
+
+        assert output.shape == (1,)
+        assert torch.isfinite(output).all()

--- a/src/tests/unit/test_candidate_result_collection_dualpath_regression.py
+++ b/src/tests/unit/test_candidate_result_collection_dualpath_regression.py
@@ -292,6 +292,14 @@ class TestRemoteDispatchCandidateIdMapping:
         _round_id, sent_specs, _tensors = coord.submit_tasks.call_args.args
         assert sent_specs, "tasks must have been submitted to the coordinator"
         assert all(s["training_params"]["epochs"] == net.candidate_epochs for s in sent_specs), "training params must come from self.candidate_* config, not the training_inputs dict"
+        # ISSUE-319 dispatch coercion: int-valued candidate bounds must stay int on
+        # the JSON wire. _make_tasks feeds them as float (1.0); a prior float() here
+        # made the remote worker raise "'float' object cannot be interpreted as an
+        # integer" inside random.randint()/range(). Guard the int() fix.
+        for s in sent_specs:
+            cd = s["candidate_data"]
+            assert type(cd["random_max_value"]) is int, f"random_max_value must be int on the wire, got {type(cd['random_max_value']).__name__}"
+            assert type(cd["sequence_max_value"]) is int, f"sequence_max_value must be int on the wire, got {type(cd['sequence_max_value']).__name__}"
 
     @pytest.mark.unit
     def test_unknown_candidate_id_is_skipped_not_crash(self):

--- a/src/utils/activation.py
+++ b/src/utils/activation.py
@@ -82,9 +82,18 @@ class ActivationWithDerivative:
 
         Args:
             activation_fn: A PyTorch activation function (e.g., torch.tanh, torch.nn.Tanh())
+                or the legacy (activation, derivative) tuple returned by juniper-cascor-worker.
         """
-        self.activation_fn = activation_fn
+        self.activation_fn = self._normalize_activation_fn(activation_fn)
         self._activation_name = self._get_activation_name(activation_fn)
+
+    def _normalize_activation_fn(self, activation_fn):
+        """Accept the worker's legacy (activation, derivative) tuple without keeping lambdas."""
+        if isinstance(activation_fn, tuple):
+            if not activation_fn or not callable(activation_fn[0]):
+                raise TypeError("activation tuple must start with a callable activation function")
+            return activation_fn[0]
+        return activation_fn
 
     def _get_activation_name(self, activation_fn) -> str:
         """
@@ -96,6 +105,7 @@ class ActivationWithDerivative:
         Returns:
             String name of the activation function
         """
+        activation_fn = self._normalize_activation_fn(activation_fn)
         if hasattr(activation_fn, "__name__"):
             return activation_fn.__name__
         elif hasattr(activation_fn, "__class__"):


### PR DESCRIPTION
## Summary

Completes the **#319 dual-path remote candidate** fix and restores the
**juniper-cascor-core `package == src` drift invariant** — without touching the
(separately, actively-published) `juniper-cascor-core` package.

## Root cause — remote candidate crash

`_dispatch_to_remote_workers` serialized the **int-valued** candidate bounds
`random_max_value` / `sequence_max_value` with `float()`, so the JSON wire carried
`1.0` instead of `1`. The remote worker fed those floats to `random.randint()` /
`range()` → `"'float' object cannot be interpreted as an integer"`, starving the
remote leg into the local-retry fallback (the dual-path stall surfaced during
CW-05 stopgap verification). Fix: send them as `int()`.

## Backport — drift invariant

The worker-payload normalization that `juniper-ml#370-376` added **directly to the
`juniper-cascor-core` package** (`CandidateUnit._coerce_int_like` +
`ActivationWithDerivative._normalize_activation_fn`) is backported **verbatim into
cascor src**, restoring the `package == src` invariant that the drift-guard
(`juniper-ml tests/test_cascor_core_drift.py`) enforces. cascor src is the single
source of truth the package extracts from, so the behavior now lives where it
belongs and is tested at the source. The dispatch `int()` fix makes the model-side
coercion **belt-and-suspenders** rather than load-bearing.

> **Sync point:** `candidate_unit.py` / `activation.py` here are byte-identical to
> the `juniper-cascor-core` package at `juniper-ml@f4d66db` (#384). If the package's
> copies of those two files change again before this merges, re-sync is needed.

## Changes

- `src/cascade_correlation/cascade_correlation.py` — `float()`→`int()` for the two
  remote candidate bounds in the dispatch payload.
- `src/candidate_unit/candidate_unit.py`, `src/utils/activation.py` — backport the
  worker-facing normalization (byte-identical to the package).
- `src/tests/unit/test_candidate_result_collection_dualpath_regression.py` — guard
  that dispatched bounds stay `int` on the wire.
- `src/tests/unit/test_candidate_core_worker_contracts.py` *(new)* — source-side
  contracts for the worker-facing normalization (tuple activation, float-valued int
  bounds, bool/non-int rejection), mirroring the package smoke tests.

## Testing

- Full cascor unit suite: **3689 passed, 0 failed**, 15 skipped (`--slow`).
- Serialization/pickle (`--integration --slow`): **62 passed** — the backport touches
  `__getstate__`/`__setstate__`, and cascor's local pool pickles candidates.
- New contracts + dual-path regression: **18 passed**.
- juniper-ml drift-guard re-run against this branch: **passes** (invariant restored).
- pre-commit (black / isort / flake8 / mypy / bandit): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)