### PR TITLE
fix(juniper-cascor-model): raise torch security floor to >=2.10.0

### DIFF
--- a/juniper-cascor-model/CHANGELOG.md
+++ b/juniper-cascor-model/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Raised the `torch` floor to `>=2.10.0`** (was `>=2.0`) — the minimal pin that clears
+  every *fixable* torch CVE affecting `>=2.0`, up to and including
+  [CVE-2025-3001](https://github.com/advisories/GHSA-qfhq-4f3w-5fph) (`lstm_cell` memory
+  corruption, fixed in torch 2.10.0). Verified against OSV + GHSA on 2026-06-14. Four torch
+  CVEs remain unfixed upstream at every version (CVE-2025-2148, CVE-2025-2149, CVE-2025-2998,
+  CVE-2025-3000) and cannot be addressed by any version pin. The deployed `JuniperCascor1`
+  runtime already runs torch 2.11.0, which satisfies the new floor.
+
 ## [0.1.0] - 2026-06-04
 
 ### Added

--- a/juniper-cascor-model/pyproject.toml
+++ b/juniper-cascor-model/pyproject.toml
@@ -24,7 +24,10 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.24",
-    "torch>=2.0",
+    # Security floor: minimal pin that clears every *fixable* torch CVE affecting >=2.0,
+    # up to CVE-2025-3001 (lstm_cell memory corruption, fixed in 2.10.0). Verified against
+    # OSV/GHSA 2026-06-14. Do not relax below 2.10.0. See CHANGELOG [Unreleased] / Security.
+    "torch>=2.10.0",
     "PyYAML>=6.0",
 ]
 


### PR DESCRIPTION
## Summary

Raises the `torch` dependency floor for **juniper-cascor-model** from `>=2.0` to `>=2.10.0` — the minimal pin that clears every **fixable** torch CVE affecting `>=2.0`. This is the security fix gating the package's first PyPI release (0.1.0 is not yet published).

## Security analysis (OSV + GHSA, verified 2026-06-14)

| Item | Result |
|------|--------|
| Highest *fixable* CVE affecting torch≥2.0 | **CVE-2025-3001** (`lstm_cell` memory corruption) — fixed in **2.10.0** |
| Minimal floor clearing all *fixable* CVEs | **`>=2.10.0`** |
| Also cleared along the way | CVE-2025-2999 (2.9.1), CVE-2025-32434 `torch.load` RCE (2.6.0), CVE-2025-3730 (2.8.0), CVE-2025-2953 (2.7.1), CVE-2025-55551..60 (2.7.1/2.9.0), CVE-2025-46148..53 (2.7.0) |
| Unfixed at every version (no pin clears) | CVE-2025-2148, CVE-2025-2149, CVE-2025-2998, CVE-2025-3000 |

The deployed `JuniperCascor1` runtime already runs torch **2.11.0**, which satisfies the new floor; CI installs the latest CPU torch (also satisfied).

## Why `>=2.10.0` and not higher

`>=2.10.0` is the *minimal* floor that resolves all fixable advisories — there is no fixable CVE in the 2.10 → 2.11 → 2.12 range, so a higher floor would over-restrict consumers with no security benefit. The floor still admits 2.11.0 / 2.12.0.

## Scope

- **In scope:** `juniper-cascor-model` only — the package being released. Recorded under CHANGELOG `[Unreleased]` → Security; since 0.1.0 is unpublished, it folds into the first release at tag time.
- **Out of scope / recommended follow-up:** the cascor **application** (`pyproject.toml` root, currently `torch>=2.0.0`) and **juniper-cascor-worker** carry the same class of exposure. Each is a separate release artifact, and the app additionally needs a `requirements.lock` regen (constraint-mode freshness gate). Recommend matching `>=2.10.0` in separate PRs rather than bundling here.

## Validation

- `python -m build --sdist --wheel` → **Successfully built**
- `twine check dist/*` → **PASSED** (sdist + wheel)
- Wheel `METADATA` → `Requires-Dist: torch>=2.10.0` ✓
- `pre-commit run --files` (TOML, Markdown, doc-links) → **Passed**
- Metadata-only change — no source or drift-guard (`tests/test_drift.py`) impact

## Test plan

- [ ] `CI — juniper-cascor-model` green (build + twine + src drift-guard under CPU torch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)