### PR TITLE
fix(ci): suppress torch CVE-2025-3000 in pip-audit (advisory DB re-keyed PYSEC→CVE)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -685,7 +685,15 @@ jobs:
           # PYSEC-2025-210  torch.profiler.profile — DoS via missing profiler.stop()
           # PYSEC-2026-139  pt2 Loading Handler — deserialization (local; PR open upstream)
           #
-          # Tracking note: when removing IDs, also delete from
+          # 2026-06-14: pip-audit's advisory DB re-keyed some of these from their PYSEC ids
+          # to their CVE aliases, so the PYSEC-only ignores stopped matching and CI went red
+          # on CVE-2025-3000 (torch.jit.script). The 4 advisories below remain UNFIXED at
+          # every torch release — the only ones reportable against latest torch — so we now
+          # suppress them by BOTH ids (PYSEC + CVE) to stay re-key-proof:
+          #   PYSEC-2025-189 = CVE-2025-2148    PYSEC-2025-190 = CVE-2025-2149
+          #   PYSEC-2025-192 = CVE-2025-2998    PYSEC-2025-194 = CVE-2025-3000
+          #
+          # Tracking note: when adding/removing IDs, also update
           # juniper-cascor-worker's analogous block (kept in sync).
           # ──────────────────────────────────────────────────────────────────────
           pip-audit -r reports/security/pip-freeze.txt --strict --desc on \
@@ -700,6 +708,10 @@ jobs:
             --ignore-vuln PYSEC-2025-197 \
             --ignore-vuln PYSEC-2025-210 \
             --ignore-vuln PYSEC-2026-139 \
+            --ignore-vuln CVE-2025-2148 \
+            --ignore-vuln CVE-2025-2149 \
+            --ignore-vuln CVE-2025-2998 \
+            --ignore-vuln CVE-2025-3000 \
             || (echo "::error::Critical/High vulnerabilities found in dependencies" && exit 1)
 
       - name: Upload Security Reports


### PR DESCRIPTION
## Summary

Fixes the **red `Security Scans` / `Quality Gate`** on `main` (and therefore on every open PR). pip-audit's advisory DB re-keyed several unfixed torch advisories from their **PYSEC** ids to their **CVE** aliases, so the existing PYSEC-only `--ignore-vuln` entries stopped matching and the audit failed on:

```
torch 2.12.0  CVE-2025-3000   (no fix version)  — torch.jit.script memory corruption
```

`main` was green on 2026-06-09 (`0914ca11`) and went red on `c350651` (2026-06-14) with no code cause — this is pure advisory-DB drift under an unpinned `pip install torch`.

## Root cause

The Security Scans job suppresses 11 torch advisories by **PYSEC id**. `PYSEC-2025-194 == CVE-2025-3000 == GHSA-rrmf-rvhw-rf47` (verified via OSV), and pip-audit now reports it under the **CVE** id, which `--ignore-vuln PYSEC-2025-194` does not match.

## Fix

Add CVE-keyed aliases for the **4 torch advisories that remain UNFIXED at every release** — the only ones that can be reported against latest torch, hence the only ones that can flip PYSEC→CVE — suppressing each by **both** ids (re-key-proof):

| PYSEC | CVE | API surface | Fixed upstream? |
|-------|-----|-------------|------------------|
| PYSEC-2025-189 | CVE-2025-2148 | tuple handler | ❌ none |
| PYSEC-2025-190 | CVE-2025-2149 | scale/zero_point | ❌ none |
| PYSEC-2025-192 | CVE-2025-2998 | `pad_packed_sequence` | ❌ none |
| PYSEC-2025-194 | **CVE-2025-3000** | `torch.jit.script` | ❌ none |

All four are local-access-required memory-corruption/DoS advisories with **no upstream fix** (verified OSV + GHSA 2026-06-14); suppression is consistent with the existing handling of the rest of the torch advisory set. The *fixed* advisories already in the list (e.g. `lstm_cell` / CVE-2025-3001, fixed 2.10.0) need no CVE alias — latest torch carries their fix, so pip-audit never reports them.

## Scope / follow-ups

- **`juniper-cascor-worker`** carries the byte-identical ignore block (its `ci.yml`) and the in-file tracking note mandates keeping the two in sync — it will flip red the same way on its next push. **Separate PR to follow** (separate repo).
- The two `security-scan.yml` weeklies run `pip-audit --strict` with **no** ignore block at all — a pre-existing, separate matter, not addressed here.
- Unrelated in-flight: #329 raises the `juniper-cascor-model` published torch floor to `>=2.10.0` (consumer metadata; does not touch this CI audit).

## Validation

- `pre-commit run --files .github/workflows/ci.yml` → YAML syntax + yamllint **Passed**
- CI on this PR re-runs Security Scans (installs torch 2.12.0 + pip-audit) — expected **green**

🤖 Generated with [Claude Code](https://claude.com/claude-code)