### PR TITLE
fix(api): auto-start off by default + specific start-failure reason (startup hardening)

### DIFF
--- a/src/api/routes/training.py
+++ b/src/api/routes/training.py
@@ -74,8 +74,14 @@ async def start_training(request: Request, body: TrainingStartRequest = None) ->
         result = lifecycle.start_training(x=x, y=y, x_val=x_val, y_val=y_val, **kwargs)
         return success_response(result)
     except (RuntimeError, ValueError) as e:
+        # Surface the specific reason (no network created / training already in progress /
+        # no dataset staged ("Training data not provided") / juniper-data fetch failed /
+        # investigating|replaying a snapshot) rather than a generic message, so API and
+        # Canopy callers can tell *why* the start was rejected and act on it. The generic
+        # string previously masked a juniper-data fetch failure as a bogus "state" error.
+        # See notes/CASCOR_STARTUP_SECRET_INDIRECTION_INVESTIGATION_2026-06-14.md (3.4).
         logger.debug("Start training failed: %s", e)
-        raise HTTPException(status_code=409, detail="Training cannot be started in the current state") from e
+        raise HTTPException(status_code=409, detail=f"Training cannot be started: {e}") from e
 
 
 @router.post("/stop")

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -66,7 +66,13 @@ _JUNIPER_CASCOR_API_METRICS_ENABLED_DEFAULT: bool = _JUNIPER_CASCOR_API_METRICS_
 
 _JUNIPER_CASCOR_API_AUTO_START_DISABLED: bool = False
 _JUNIPER_CASCOR_API_AUTO_START_ENABLED: bool = True
-_JUNIPER_CASCOR_API_AUTO_START_DEFAULT: bool = _JUNIPER_CASCOR_API_AUTO_START_ENABLED
+# Default OFF. Auto-start trains on boot onto a default (empty) network, which violates
+# the clean-STOPPED initial-state assumption every API / Canopy / automation caller makes
+# (it left the #319 probe staring at epoch 7576 / 0 hidden units on a fresh stack). It is
+# a demo/dev convenience only; juniper-deploy's demo opts in explicitly via
+# JUNIPER_CASCOR_AUTO_START=true, so flipping the default does NOT change the demo stack.
+# See notes/CASCOR_STARTUP_SECRET_INDIRECTION_INVESTIGATION_2026-06-14.md (3.3).
+_JUNIPER_CASCOR_API_AUTO_START_DEFAULT: bool = _JUNIPER_CASCOR_API_AUTO_START_DISABLED
 
 _JUNIPER_CASCOR_API_AUTO_START_DATA_SERVICE_DEFAULT: bool = False
 _JUNIPER_CASCOR_API_AUTO_START_DATA_SERVICE_COMMAND_DEFAULT: str = "python -m juniper_data"

--- a/src/tests/unit/api/test_api_app_coverage_deep.py
+++ b/src/tests/unit/api/test_api_app_coverage_deep.py
@@ -74,6 +74,15 @@ class TestLifespanAutoStart:
             with TestClient(app):
                 mock_auto.assert_not_called()
 
+    def test_auto_start_default_is_off(self, monkeypatch):
+        """The ``auto_start`` default must be OFF: a fresh cascor must not auto-train on
+        boot. Auto-start trains onto a default (empty) network and violates the
+        clean-STOPPED initial state every API / Canopy / automation caller assumes; the
+        deploy demo opts in explicitly via ``JUNIPER_CASCOR_AUTO_START=true``. See
+        notes/CASCOR_STARTUP_SECRET_INDIRECTION_INVESTIGATION_2026-06-14.md (3.3)."""
+        monkeypatch.delenv("JUNIPER_CASCOR_AUTO_START", raising=False)
+        assert Settings().auto_start is False
+
 
 # ------------------------------------------------------------------
 # Lifespan: Shutdown branches (lines 64-75)

--- a/src/tests/unit/api/test_training_route_coverage.py
+++ b/src/tests/unit/api/test_training_route_coverage.py
@@ -170,6 +170,16 @@ class TestStartTraining:
         assert response.status_code == 409
         assert "cannot be started" in response.json()["error"]["message"].lower()
 
+    def test_start_training_409_surfaces_specific_reason(self, client_with_network):
+        """The 409 detail must name *why* the start was rejected (here: no dataset
+        loaded), not a generic 'current state' string. The generic message previously
+        masked real causes — e.g. a juniper-data fetch failure surfaced as a bogus state
+        error. See notes/CASCOR_STARTUP_SECRET_INDIRECTION_INVESTIGATION_2026-06-14.md (3.4)."""
+        response = client_with_network.post("/v1/training/start")
+        assert response.status_code == 409
+        msg = response.json()["error"]["message"]
+        assert "Training data not provided" in msg, msg
+
     def test_start_training_rejects_unknown_params(self, client_with_network):
         """SEC-07 regression (supersedes CR-023): unknown keys in ``params``
         are now rejected by Pydantic at the request boundary (422) instead


### PR DESCRIPTION
## Summary

Two low-risk cascor startup/lifecycle hardening changes — follow-up #1 to the secret-indirection investigation (#331). Both address the "faulty startup behaviour" surfaced during the #319 dual-path live demo.

### 1. `auto_start` default → `False`

`settings.py` defaulted `auto_start = True`. On boot the lifespan handler trains onto a **default (empty) network**, so every fresh cascor comes up already-`STARTED` on a 0-unit network — violating the clean-`STOPPED` initial-state assumption that API / Canopy / automation callers make. (This is exactly why the #319 probe found `epoch 7576 / hidden_units 0` on a "fresh" stack.) The code itself warns it is *"demo/dev only"* yet defaults it on.

`juniper-deploy/docker-compose.yml` sets `JUNIPER_CASCOR_AUTO_START: "true"` **explicitly**, so flipping the code default does **not** change the demo stack — it only makes a bare cascor boot clean.

### 2. `POST /v1/training/start` 409 names the actual reason

The route flattened *every* start failure — no network, training already active, **no dataset loaded**, **juniper-data fetch failed**, investigating/replaying — into one generic `"Training cannot be started in the current state"`. That masked the secret-indirection 401 (#331) as a bogus *state* error (the "FSM-409-after-stop" from the demo was that fetch failing). Now the 409 detail carries the specific cause, so API + Canopy callers can act on it.

## Changes
- `src/api/settings.py` — `_JUNIPER_CASCOR_API_AUTO_START_DEFAULT` → disabled.
- `src/api/routes/training.py` — `start_training` 409 detail → `f"Training cannot be started: {e}"`.
- tests — `test_auto_start_default_is_off` (fresh `Settings().auto_start is False`); `test_start_training_409_surfaces_specific_reason` (the 409 names "Training data not provided"). 45/45 in the two touched test files pass.

## Validation
- targeted tests: **45 passed**
- pre-commit (black, isort, flake8, **mypy**, bandit) — all pass
- backward-compatible: existing `test_start_training_no_body` (`"cannot be started"`) still passes

## Context
Part of the startup-defect cluster triaged in `notes/CASCOR_STARTUP_SECRET_INDIRECTION_INVESTIGATION_2026-06-14.md` (§3.3, §3.4) — that doc lands in #331. Next in the series: import-resolution CI guard, then cross-repo (juniper-data-client `_FILE`, Canopy error surfacing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)