### PR TITLE
build(docker): add .dockerignore excluding nested egg-info (provenance hardening)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# =============================================================================
+# JuniperCascor — Docker build context exclusions
+# =============================================================================
+# Keep build artifacts and VCS metadata out of the image. The nested ``**/``
+# egg-info / dist-info forms matter specifically because the Dockerfile does
+# ``COPY src/ ./src/`` and runs with ``ENV PYTHONPATH=/app/src`` — a stale
+# build artifact under src/ would otherwise land on the import path ahead of
+# site-packages and shadow the installed package's metadata version. That is
+# the class of bug fixed for juniper-canopy in #362 (see juniper-ml
+# notes/BUILD_PROVENANCE_DESIGN_2026-06-14.md). A root-only ``*.egg-info/`` is
+# insufficient — it does not match a nested ``src/*.egg-info``. cascor is not
+# vulnerable today (its egg-info sits at the repo root, which ``COPY src/`` does
+# not pick up), so this is preventive hardening + general context hygiene.
+
+# Version control
+.git/
+.gitignore
+
+# Python build artifacts
+__pycache__/
+**/__pycache__/
+*.py[cod]
+*.egg-info/
+**/*.egg-info/
+**/*.dist-info/
+build/
+dist/
+
+# Test / type-check caches
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+coverage.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`.dockerignore` added — excludes build artifacts (incl. nested `**/*.egg-info/`) from the image.** cascor had no `.dockerignore`, so the full build context was sent and any build artifact under `src/` could be `COPY src/`'d into the image. Because cascor runs from `/app/src` (`ENV PYTHONPATH=/app/src`), a stale `src/*.egg-info` would land ahead of site-packages and shadow `importlib.metadata.version("juniper-cascor")` — the class of bug fixed for juniper-canopy in [canopy #362](https://github.com/pcalnon/juniper-canopy/pull/362) (surfaced by the build-provenance `make doctor` work). cascor is **not** vulnerable today (its egg-info is at the repo root, which `COPY src/` does not pick up), so this is preventive hardening + general context hygiene (the file also excludes `.git/`, `__pycache__/`, `*.py[cod]`, `build/`, `dist/`, and test/type-check caches). The nested `**/*.egg-info/` + `**/*.dist-info/` forms are required because a root-only `*.egg-info/` does not match `src/*.egg-info`. Regression test: `src/tests/unit/test_dockerignore_egg_info.py`.
+
 - **Build provenance on `/v1/health` + `/v1/health/ready`.** The service now
   reports the source `git_sha` and ISO-8601 `build_date` baked into its image
   at build time. New `GIT_SHA` / `BUILD_DATE` / `APP_VERSION` Dockerfile

--- a/src/tests/unit/test_dockerignore_egg_info.py
+++ b/src/tests/unit/test_dockerignore_egg_info.py
@@ -1,0 +1,33 @@
+"""Regression: ``.dockerignore`` must exclude *nested* egg-info / dist-info dirs.
+
+juniper-cascor runs from ``/app/src`` (``ENV PYTHONPATH=/app/src`` +
+``COPY src/ ./src/``), so a stale build artifact under ``src/`` would land on
+the import path ahead of site-packages and shadow the installed package's
+metadata version — the class of bug fixed for juniper-canopy in #362. A
+root-only ``*.egg-info/`` does not match a nested ``src/*.egg-info``; this pins
+the ``**/``-prefixed forms so the hardening can't silently regress. See
+juniper-ml ``notes/BUILD_PROVENANCE_DESIGN_2026-06-14.md``.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DOCKERIGNORE = REPO_ROOT / ".dockerignore"
+
+
+def _patterns() -> list[str]:
+    """Return the non-comment, non-blank pattern lines from ``.dockerignore``."""
+    text = DOCKERIGNORE.read_text(encoding="utf-8")
+    return [line.strip() for line in text.splitlines() if line.strip() and not line.lstrip().startswith("#")]
+
+
+def test_dockerignore_exists() -> None:
+    assert DOCKERIGNORE.is_file(), f".dockerignore must exist at the repo root ({REPO_ROOT})."
+
+
+def test_dockerignore_excludes_nested_egg_info() -> None:
+    assert "**/*.egg-info/" in _patterns(), "`.dockerignore` must contain `**/*.egg-info/` so a nested src/*.egg-info build artifact cannot be COPYed into the image and shadow the installed package version on PYTHONPATH=/app/src; a root-only `*.egg-info/` is insufficient."
+
+
+def test_dockerignore_excludes_nested_dist_info() -> None:
+    assert "**/*.dist-info/" in _patterns(), "`.dockerignore` must exclude nested `**/*.dist-info/` for the same reason."


### PR DESCRIPTION
## Summary

cascor had **no `.dockerignore`** — so the full build context was sent and any build artifact under `src/` would be `COPY src/`'d into the image. Because cascor runs from `/app/src` (`ENV PYTHONPATH=/app/src`), a stale `src/*.egg-info` would land on the import path ahead of site-packages and shadow `importlib.metadata.version("juniper-cascor")` — the exact class of bug fixed for juniper-canopy in [canopy #362](https://github.com/pcalnon/juniper-canopy/pull/362) (surfaced by the build-provenance `make doctor` work).

**cascor is not vulnerable today** — verified: its egg-info sits at the repo root (which `COPY src/` does not pick up), the running image has no egg-info on `/app/src`, and `/v1/health` reports the correct 0.5.0. So this is **preventive hardening** + general build-context hygiene.

## Change

New `.dockerignore` excluding build artifacts (`**/*.egg-info/`, `**/*.dist-info/`, `__pycache__/`, `*.py[cod]`, `build/`, `dist/`), VCS metadata (`.git/`), and test/type-check caches. The nested `**/`-prefixed egg-info/dist-info forms are the key bit — a root-only `*.egg-info/` (what canopy carried) does **not** match `src/*.egg-info`.

## Verification

- Pattern proven against a synthetic context containing `src/X.egg-info` — excluded at build time, while real source is kept.
- `src/tests/unit/test_dockerignore_egg_info.py` (3 tests) pins the nested-exclusion patterns so the hardening can't silently regress.
- CI's **Docker Build & Smoke Test** lane rebuilds + smoke-tests the image with the new build context.

## Notes

- Intentionally does **not** exclude `src/tests/` — kept minimal/safe (image behavior unchanged beyond artifact removal); a fuller hygiene `.dockerignore` is a separate optional follow-up.
- Build-provenance follow-up; the companion preventive change for juniper-data is a separate PR.