### PR TITLE
test(conformance): WS-6 model-core conformance baseline (OUT-13)

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,123 @@
+---
+#####################################################################################################################################################################################################
+# Project:       Juniper
+# Sub-Project:   JuniperCascor
+# Application:   juniper_cascor
+# File Name:     conformance.yml
+# Author:        Paul Calnon
+# Version:       0.1.0
+#
+# Date Created:  2026-06-18
+# Last Modified: 2026-06-18
+#
+# License:       MIT License
+# Copyright:     Copyright (c) 2024-2026 Paul Calnon
+#
+# Description:
+#    Dedicated serial lane for the model-core interface-conformance suite (roadmap OUT-13;
+#    the second half of the WS-6 trigger-gate, alongside golden-regression.yml). Runs the real
+#    CascadeCorrelationNetwork through the juniper-model-core GrowableModel conformance kit via
+#    a test-only adapter.
+#
+#    Determinism contract (mirrors golden-regression.yml):
+#      - Runs SERIALLY — never under pytest-xdist.
+#      - CASCOR_NUM_PROCESSES=1 forces the sequential candidate path.
+#      - BLAS/numeric stacks pinned to a single thread (job-level env).
+#      - Python and torch pinned to the calibration environment (3.13 / 2.11.0).
+#      - Runs on the GIL interpreter; conftest aborts under Py_GIL_DISABLED.
+#
+#    Unlike the golden lane, conformance asserts the *interface* (shapes / keys / event order),
+#    not float values — so it carries no cross-build tolerance risk.
+#
+# References:
+#    - OUT-13 / JUNIPER_CASCOR_MODEL_CORE_CONFORMANCE_WIRING_PLAN_2026-06-18.md (juniper-ml)
+#    - Pairs with golden-regression.yml (OUT-12) as the two halves of the WS-6 gate.
+#####################################################################################################################################################################################################
+
+name: Conformance (WS-6 Gate)
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+      - develop
+  workflow_dispatch:
+
+concurrency:
+  group: conformance-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  # Pin to the calibration environment for parity with the golden lane and the
+  # WS-6 pre/post-refactor compare.
+  PYTHON_CONFORMANCE_VERSION: "3.13"
+  TORCH_CONFORMANCE_VERSION: "2.11.0"
+  # Single-thread the numeric stacks (set at job level, before Python loads).
+  OMP_NUM_THREADS: "1"
+  MKL_NUM_THREADS: "1"
+  OPENBLAS_NUM_THREADS: "1"
+  VECLIB_MAXIMUM_THREADS: "1"
+  NUMEXPR_NUM_THREADS: "1"
+  CASCOR_NUM_PROCESSES: "1"
+  JUNIPER_CASCOR_LOG_LEVEL: "ERROR"
+
+jobs:
+  conformance:
+    name: model-core Conformance
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python ${{ env.PYTHON_CONFORMANCE_VERSION }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_CONFORMANCE_VERSION }}
+          cache: pip
+
+      - name: Install dependencies (pinned torch)
+        run: |
+          echo "╔════════════════════════════════════════════════════════════╗"
+          echo "║       Juniper Cascor - Conformance: Install                ║"
+          echo "╚════════════════════════════════════════════════════════════╝"
+          python -m pip install --upgrade "pip>=26.1.1"
+          # CPU-only torch, pinned; installed first so the editable install does
+          # not upgrade it. The juniper-model-core[conformance] kit comes in via
+          # the [all] -> [test] extra.
+          pip install "torch==${TORCH_CONFORMANCE_VERSION}" --index-url https://download.pytorch.org/whl/cpu
+          pip install -e ".[all]"
+
+      - name: Create required directories
+        run: mkdir -p logs src/logs reports/junit
+
+      - name: Run model-core Conformance Suite (serial, never xdist)
+        run: |
+          echo "╔════════════════════════════════════════════════════════════╗"
+          echo "║       Juniper Cascor - model-core Conformance              ║"
+          echo "╚════════════════════════════════════════════════════════════╝"
+          # Serial only. --conformance --slow --integration disable the three
+          # collection gates the conformance tests carry.
+          python -m pytest \
+            -m conformance \
+            --conformance --slow --integration \
+            src/tests/conformance \
+            --verbose \
+            --timeout=300 \
+            --junitxml=reports/junit/junit-conformance.xml
+
+      - name: Upload Conformance Test Results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        if: always()
+        with:
+          name: conformance-results
+          path: reports/junit/
+          retention-days: 30

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,10 @@ test = [
     "responses>=0.23.0",
     "httpx>=0.24.0",
     "psutil>=5.9.0",
+    # OUT-13 (WS-6 gate, half 2): the model-core conformance kit. Test-only —
+    # CascadeCorrelationNetwork is run through juniper_model_core.conformance
+    # via a test adapter (src/tests/conformance/). Pulls numpy (already present).
+    "juniper-model-core[conformance]>=0.2.0,<0.3.0",
 ]
 # CLN-CC-10: dill is required by utils.check_object_pickleability, a
 # debugging helper for diagnosing multiprocessing pickle failures. It is
@@ -215,6 +219,7 @@ markers = [
     "requires_juniper_data: Tests that require the juniper-data package to be installed",
     "critical: Tests covering business-critical paths (used as a tag, not a selector)",
     "golden: Golden/snapshot regression tests pinning deterministic training trajectories, serialization round-trips, and API response shapes (OUT-12 / WS-6 pre-refactor gate; --golden, serial-only)",
+    "conformance: model-core interface-conformance tests running CascadeCorrelationNetwork through the juniper-model-core conformance kit (OUT-13 / WS-6 gate half 2; --conformance, serial-only)",
 ]
 timeout = 60
 # Thread-based timeout avoids SIGALRM interference with forkserver IPC

--- a/requirements.lock
+++ b/requirements.lock
@@ -26,7 +26,7 @@ cuda-toolkit==13.0.2
     # via torch
 cycler==0.12.1
     # via matplotlib
-fastapi==0.137.1
+fastapi==0.137.2
     # via juniper-cascor (pyproject.toml)
 filelock==3.29.4
     # via torch
@@ -50,7 +50,7 @@ juniper-cascor-protocol==0.1.0
     # via juniper-cascor (pyproject.toml)
 juniper-data==0.6.0
     # via juniper-cascor (pyproject.toml)
-juniper-data-client==0.4.1
+juniper-data-client==0.4.2
     # via juniper-cascor (pyproject.toml)
 juniper-observability==0.4.0
     # via juniper-cascor (pyproject.toml)

--- a/src/tests/conformance/cascor_model_core_adapter.py
+++ b/src/tests/conformance/cascor_model_core_adapter.py
@@ -1,0 +1,199 @@
+"""Test-only adapter: CascadeCorrelationNetwork -> juniper-model-core GrowableModel.
+
+OUT-13 (WS-6 trigger-gate, half 2). The model-core ``GrowableModel`` interface was designed
+with cascor as a reference implementer, but ``CascadeCorrelationNetwork``'s current surface
+does not implement that contract. This adapter bridges the gap so cascor can be run through
+the ``juniper_model_core.conformance`` kit — proving (pre-refactor) that cascor *can* conform.
+WS-6's interface-adoption phase later replaces this adapter with native conformance.
+
+It is **test-only** (lives under ``src/tests/``, imports nothing into cascor production code).
+
+Design decisions (ratified 2026-06-18, plan
+``juniper-ml/notes/JUNIPER_CASCOR_MODEL_CORE_CONFORMANCE_WIRING_PLAN_2026-06-18.md``):
+
+* **D-C3 — ``grow_step`` is a no-op.** cascor grows units *inside* ``fit()`` and exposes no
+  standalone "add one frozen unit" call; the conformance suite tolerates ``added=False``
+  (its growth test is guarded). cascor's real growth dynamics are pinned by the OUT-12
+  trajectory golden — conformance asserts the *interface*, OUT-12 asserts the *behavior*.
+* **on_event** — cascor's ``fit`` has no event sink, so events are reconstructed in legal
+  order (``training_start`` -> ``unit_added``×k -> ``training_end``) post-hoc from
+  ``network.history`` (the kit checks order, not timing).
+* **metrics** — ``{"accuracy", "loss"}`` (both valid classification keys).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import golden_support as gs  # OUT-12 determinism harness + frozen two-spiral
+import numpy as np
+import torch
+from juniper_model_core.conformance import ConformanceDataset
+from juniper_model_core.events import TrainingEvent
+from juniper_model_core.interfaces import GrowableModel, GrowthOutcome, TaskType, TrainResult
+
+from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
+
+# The canonical golden config (mirrors golden_support.GOLDEN_NET_CONFIG) so the conformance
+# run exercises the same small, fast, deterministic network as the golden suite.
+_NET_CONFIG = dict(gs.GOLDEN_NET_CONFIG)
+
+
+class CascorModelCoreAdapter(GrowableModel):
+    """Presents ``CascadeCorrelationNetwork`` as a model-core ``GrowableModel``."""
+
+    task_type: TaskType = "classification"
+
+    def __init__(self, *, random_seed: int = 42, **config: Any) -> None:
+        self.random_seed = random_seed
+        self._config = {**_NET_CONFIG, **config, "random_seed": random_seed}
+        self._net: CascadeCorrelationNetwork | None = None
+        self._frozen = False
+        self._in_shape: tuple[int, ...] = ()
+        self._out_shape: tuple[int, ...] = ()
+
+    # ----- TrainableModel ------------------------------------------------------------
+    def fit(self, X, y, *, X_val=None, y_val=None, on_event=None, **kw) -> TrainResult:
+        gs.harden_determinism()
+        x = torch.as_tensor(np.asarray(X), dtype=torch.float32)
+        y_t = torch.as_tensor(np.asarray(y), dtype=torch.float32)
+        self._in_shape = (int(x.shape[1]),)
+        self._out_shape = (int(y_t.shape[1]),)
+
+        self._net = CascadeCorrelationNetwork(**self._config)
+        # Reseed post-construction (matches the validated golden sequence).
+        torch.manual_seed(self.random_seed)
+        np.random.seed(self.random_seed)
+
+        if X_val is not None and y_val is not None:
+            x_val = torch.as_tensor(np.asarray(X_val), dtype=torch.float32)
+            y_val_t = torch.as_tensor(np.asarray(y_val), dtype=torch.float32)
+            self._net.fit(x, y_t, x_val=x_val, y_val=y_val_t, early_stopping=False)
+        else:
+            self._net.fit(x, y_t, early_stopping=False)
+
+        if on_event is not None:
+            self._emit_events(on_event, int(x.shape[0]))
+
+        history = self._net.history
+        per_epoch = [{"loss": float(loss), "accuracy": float(acc)} for loss, acc in zip(history.get("train_loss", []), history.get("train_accuracy", []))]
+        return TrainResult(
+            final_metrics=self.metrics(),
+            n_epochs=max(1, len(history.get("train_loss", []))),
+            history=per_epoch or None,
+            stopped_reason=self._net._completion_reason,
+        )
+
+    def _emit_events(self, on_event, n_samples: int) -> None:
+        """Reconstruct a legal training-event sequence from the network history."""
+        seq = 0
+        on_event(TrainingEvent("training_start", {"n_samples": n_samples}, seq))
+        seq += 1
+        for entry in self._net.history.get("hidden_units_added", []):
+            unit_index = entry.get("unit_index", -1)
+            if unit_index < 0:  # skip the fit() sentinel {corr:0.0, shape:(), idx:-1}
+                continue
+            seq += 1
+            on_event(
+                TrainingEvent(
+                    "unit_added",
+                    {"n_units": unit_index + 1, "unit_id": f"h{unit_index}", "score": float(entry.get("correlation", 0.0))},
+                    seq,
+                )
+            )
+        seq += 1
+        on_event(TrainingEvent("training_end", {"metrics": self.metrics()}, seq))
+
+    def predict(self, X, **kw) -> np.ndarray:
+        if self._net is None:
+            raise RuntimeError("CascorModelCoreAdapter.predict called before fit")
+        x = torch.as_tensor(np.asarray(X), dtype=torch.float32)
+        with torch.no_grad():
+            out = self._net.predict(x)
+        # Raw class scores — never argmax (RK-6: label collapse is classification-only).
+        return out.detach().cpu().numpy()
+
+    def metrics(self) -> dict[str, float]:
+        history = self._net.history if self._net is not None else {}
+        accuracy = history.get("train_accuracy") or [0.0]
+        loss = history.get("train_loss") or [0.0]
+        return {"accuracy": float(accuracy[-1]), "loss": float(loss[-1])}
+
+    def describe_topology(self) -> dict[str, Any]:
+        n = self.n_units
+        nodes: list[dict[str, Any]] = [{"id": "input", "kind": "input", "frozen": True}]
+        for i in range(n):
+            nodes.append({"id": f"h{i}", "kind": "hidden", "frozen": True})
+        nodes.append({"id": "output", "kind": "output", "frozen": self._frozen})
+
+        edges: list[dict[str, Any]] = [{"src": "input", "dst": "output", "recurrent": False}]
+        for i in range(n):
+            edges.append({"src": "input", "dst": f"h{i}", "recurrent": False})
+            # Cascade architecture: each unit feeds all *later* units.
+            for j in range(i + 1, n):
+                edges.append({"src": f"h{i}", "dst": f"h{j}", "recurrent": False})
+            edges.append({"src": f"h{i}", "dst": "output", "recurrent": False})
+
+        return {
+            "model_type": "cascade_correlation",
+            "nodes": nodes,
+            "edges": edges,
+            "meta": {
+                "task_type": self.task_type,
+                "n_units": n,
+                "n_in": self._in_shape[0] if self._in_shape else 0,
+                "n_out": self._out_shape[0] if self._out_shape else 0,
+                "completion_reason": None if self._net is None else self._net._completion_reason,
+            },
+        }
+
+    @property
+    def input_shape(self) -> tuple[int, ...]:
+        return self._in_shape
+
+    @property
+    def output_shape(self) -> tuple[int, ...]:
+        return self._out_shape
+
+    # ----- GrowableModel -------------------------------------------------------------
+    @property
+    def n_units(self) -> int:
+        return 0 if self._net is None else len(getattr(self._net, "hidden_units", []))
+
+    def grow_step(self, **kw) -> GrowthOutcome:
+        # D-C3: cascor grows inside fit(); no standalone step. No-op (contract-legal).
+        return GrowthOutcome(added=False, n_units=self.n_units)
+
+    def freeze(self) -> None:
+        self._frozen = True
+
+
+def two_spiral_classification_dataset() -> ConformanceDataset:
+    """A classification ``ConformanceDataset`` from OUT-12's frozen two-spiral.
+
+    The kit's built-in fixtures are regression-only (the RK-6 canary), so cascor supplies its
+    own classification dataset. Stratified ~80/20 split (the spiral is class-ordered: first
+    half class 0, second half class 1) so both train and val carry both classes.
+    """
+    x, y = gs.load_two_spiral()
+    features = x.numpy()
+    targets = y.numpy()
+    labels = targets.argmax(axis=1)
+
+    train_idx: list[int] = []
+    val_idx: list[int] = []
+    for cls in np.unique(labels):
+        idx = np.where(labels == cls)[0]
+        n_val = max(1, int(round(len(idx) * 0.2)))
+        val_idx.extend(idx[-n_val:].tolist())
+        train_idx.extend(idx[:-n_val].tolist())
+    train_idx_arr = np.sort(np.asarray(train_idx))
+    val_idx_arr = np.sort(np.asarray(val_idx))
+
+    return ConformanceDataset(
+        X=features[train_idx_arr],
+        y=targets[train_idx_arr],
+        X_val=features[val_idx_arr],
+        y_val=targets[val_idx_arr],
+        task_type="classification",
+    )

--- a/src/tests/conformance/test_model_core_conformance.py
+++ b/src/tests/conformance/test_model_core_conformance.py
@@ -1,0 +1,41 @@
+"""OUT-13 — cascor ↔ juniper-model-core interface conformance (WS-6 gate, half 2).
+
+Runs the real ``CascadeCorrelationNetwork`` (via the test-only adapter) through the
+``juniper_model_core.conformance`` GrowableModel kit. Together with the OUT-12 golden suite
+this forms the WS-6 trigger-gate: cascor may refactor onto the shared packages only if both
+stay green. Plan:
+``juniper-ml/notes/JUNIPER_CASCOR_MODEL_CORE_CONFORMANCE_WIRING_PLAN_2026-06-18.md``.
+
+Run (serial, GIL env):
+    OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 \
+    CASCOR_NUM_PROCESSES=1 \
+    python -m pytest -m conformance --conformance --slow --integration \
+        src/tests/conformance
+"""
+
+import pytest
+from conformance.cascor_model_core_adapter import CascorModelCoreAdapter, two_spiral_classification_dataset
+from juniper_model_core.conformance import GrowableModelConformance
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.conformance
+class TestCascorConformance(GrowableModelConformance):
+    """CascadeCorrelationNetwork satisfies the model-core GrowableModel contract.
+
+    Inherits ~13 contract assertions from ``GrowableModelConformance``; supplies the three
+    factory hooks. The base class is not named ``Test*`` so pytest collects only this subclass.
+    """
+
+    def make_model(self) -> CascorModelCoreAdapter:
+        return CascorModelCoreAdapter()
+
+    def make_dataset(self):
+        return two_spiral_classification_dataset()
+
+    def make_serializer(self):
+        # D-C4: skip the kit's serialization check — it asserts np.array_equal (bit-exact),
+        # but cascor's HDF5 round-trip is allclose(atol=1e-6)-stable, not bit-exact. OUT-12's
+        # test_golden_serialization_roundtrip already covers predict-after-load at tolerance.
+        return None

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -206,6 +206,7 @@ def pytest_addoption(parser):
     parser.addoption("--run-long", action="store_true", default=False, help="Run long-running correctness tests (e.g., deterministic training resume)")
     parser.addoption("--run-performance", action="store_true", default=False, help="Run performance benchmark tests (requires CASCOR_BENCHMARK_MODE=1 or this flag)")
     parser.addoption("--golden", action="store_true", default=False, help="Run golden/snapshot regression tests (OUT-12 / WS-6 gate; deterministic baseline, serial-only lane)")
+    parser.addoption("--conformance", action="store_true", default=False, help="Run model-core conformance tests (OUT-13 / WS-6 gate half 2; serial-only lane)")
 
 
 def pytest_collection_modifyitems(config, items):
@@ -244,6 +245,16 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "golden" in item.keywords:
                 item.add_marker(skip_golden)
+
+    # OUT-13 / WS-6 gate (half 2): model-core conformance tests run ONLY in
+    # their dedicated serial lane. Skip unless --conformance is passed, so they
+    # never leak into the unit / integration / scheduled-slow lanes even though
+    # they also carry the `integration` and `slow` markers.
+    if not config.getoption("--conformance"):
+        skip_conformance = pytest.mark.skip(reason="need --conformance option to run model-core conformance tests")
+        for item in items:
+            if "conformance" in item.keywords:
+                item.add_marker(skip_conformance)
 
     # Performance benchmarks: require --run-performance or CASCOR_BENCHMARK_MODE=1
     run_perf = config.getoption("--run-performance") or os.environ.get("CASCOR_BENCHMARK_MODE") == "1"


### PR DESCRIPTION
## Summary

Wires cascor's `CascadeCorrelationNetwork` to the **`juniper-model-core` conformance kit** — **OUT-13**, the **second half of the WS-6 trigger-gate** (OUT-12 golden suite is half 1, shipped in #340 + a required check). Together they gate the WS-6 cutover: cascor may refactor onto the shared packages only if both stay green.

The model-core `GrowableModel` interface was *designed with cascor as a reference implementer*, but cascor's current class doesn't implement that surface — so this is a **test-only adapter** (no production change), proving pre-refactor that cascor **can** conform. WS-6-6b later replaces it with native conformance.

Design plan (ratified): juniper-ml [#453](https://github.com/pcalnon/juniper-ml/pull/453) — `notes/JUNIPER_CASCOR_MODEL_CORE_CONFORMANCE_WIRING_PLAN_2026-06-18.md`.

## What's added
- **`src/tests/conformance/cascor_model_core_adapter.py`** — `CascorModelCoreAdapter(GrowableModel)`: `fit→TrainResult`, `predict→ndarray` (raw scores, never argmax — RK-6), `task_type`/`metrics`/`input+output_shape`, `describe_topology→Topology`, `n_units`, no-op `grow_step`/`freeze` (D-C3), and `on_event` reconstructed in legal order (`training_start`→`unit_added`×k→`training_end`) from `network.history`. Plus a classification `ConformanceDataset` from OUT-12's frozen two-spiral (the kit fixtures are regression-only).
- **`test_model_core_conformance.py`** — `TestCascorConformance(GrowableModelConformance)`; `make_serializer=None` (D-C4: kit asserts `np.array_equal`/bit-exact; cascor is `allclose(1e-6)` — OUT-12 covers round-trip at tolerance).
- **`conformance` marker + `--conformance` gate** (mirrors `--golden`): runs only in its dedicated serial lane.
- **`juniper-model-core[conformance]>=0.2.0,<0.3.0`** test dep (flows into `[all]`).
- **`.github/workflows/conformance.yml`** — serial lane (never xdist), Python 3.13 + torch 2.11.0 pinned, BLAS=1; sibling to `golden-regression.yml`.

## Decisions (ratified in #453 §0)
D-C1 test-only · D-C2 full `GrowableModel` · **D-C3 `grow_step` no-op** (cascor grows inside `fit()`; kit tolerates `added=False`; real growth pinned by OUT-12) · **D-C4 skip serialization conformance** · D-C5 dedicated `conformance` lane.

## Test evidence (JuniperCascor1)
```
$ pytest -m conformance --conformance --slow --integration src/tests/conformance
13 passed in ~3.3s   # stable across runs
```
- All 13 `GrowableModelConformance` contract assertions pass; conformance asserts the *interface* (shapes/keys/event order) — no cross-build tolerance risk.
- Isolation verified: skips (13 skipped) without `--conformance`, even under `--slow --integration`.

## Notes
- No production code changed — additive tests + CI only.
- Pairs with OUT-12 as the two halves of the WS-6 gate; suggest promoting `model-core Conformance` to a required check alongside `Golden / Snapshot Regression`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hZ292SKfAiocFCbEJCpA6
