### PR TITLE
ci(release): enforce GitHub-Release-per-deploy on publish workflows (Option B)

### DIFF
--- a/.github/workflows/publish-cascor-model.yml
+++ b/.github/workflows/publish-cascor-model.yml
@@ -50,6 +50,27 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
+      # Release-convention gate: a tag-triggered publish only proceeds when a GitHub Release exists
+      # for the tag (publish by cutting a Release, never a bare `git push <tag>`). workflow_dispatch
+      # skips this as the manual escape hatch.
+      - name: Require a GitHub Release for this tag
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          for attempt in 1 2 3 4 5; do
+            if gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json tagName >/dev/null 2>&1; then
+              echo "GitHub Release found for $tag — proceeding."
+              exit 0
+            fi
+            echo "No GitHub Release for $tag yet — retrying in 5s (attempt $attempt/5)"
+            sleep 5
+          done
+          echo "::error::No GitHub Release exists for tag $tag. Per the release convention, publish by cutting a GitHub Release (gh release create $tag ...), not a bare tag push. Use workflow_dispatch to override."
+          exit 1
+
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"

--- a/.github/workflows/publish-protocol.yml
+++ b/.github/workflows/publish-protocol.yml
@@ -47,6 +47,27 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
+      # Release-convention gate: a tag-triggered publish only proceeds when a GitHub Release exists
+      # for the tag (publish by cutting a Release, never a bare `git push <tag>`). workflow_dispatch
+      # skips this as the manual escape hatch.
+      - name: Require a GitHub Release for this tag
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          for attempt in 1 2 3 4 5; do
+            if gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json tagName >/dev/null 2>&1; then
+              echo "GitHub Release found for $tag — proceeding."
+              exit 0
+            fi
+            echo "No GitHub Release for $tag yet — retrying in 5s (attempt $attempt/5)"
+            sleep 5
+          done
+          echo "::error::No GitHub Release exists for tag $tag. Per the release convention, publish by cutting a GitHub Release (gh release create $tag ...), not a bare tag push. Use workflow_dispatch to override."
+          exit 1
+
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,9 @@ permissions:
 jobs:
   testpypi:
     name: Publish to TestPyPI
+    # Release-convention guard: publish juniper-cascor only for the main `v*` release, NOT for a
+    # sub-package `juniper-cascor-<pkg>-v*` release (which also fires this release-triggered workflow).
+    if: startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
     environment: testpypi
     steps:


### PR DESCRIPTION
## Summary

Rolls out the release-convention gate (juniper-ml #458 / `PYPI-PUBLISH-PROCEDURE.md` §11) to juniper-cascor — both the tag-triggered sub-package workflows and the release-triggered main `publish.yml`.

## Changes

- **`publish-cascor-model.yml`** + **`publish-protocol.yml`** (tag-triggered): a **"Require a GitHub Release for this tag"** gate as the first build step — publish proceeds only if `gh release view <tag>` finds a Release (5×5s retry for the tag/Release race). Bare `git push <tag>` → fails fast. `workflow_dispatch` skips it.
- **`publish.yml`** (release-triggered, main `juniper-cascor`): guard the `testpypi` job with `if: startsWith(github.event.release.tag_name, 'v')`. **Fixes a live latent bug:** the unguarded `on: release: published` fires juniper-cascor's publish on a sub-package `juniper-cascor-<pkg>-v*` release (e.g. `juniper-cascor-model-v0.1.0`, 2026-06-14). The guard scopes it to the main `v*` release. (`pypi` job `needs: testpypi`, so it cascades.)

## Why fail-safe

A mis-fire **blocks a release** (recoverable via `workflow_dispatch`), never a **wrong publish**.

## Testing

YAML parse ✓ · `actionlint` (exit 0) ✓ · `yamllint` ✓. (actionlint flagged a *pre-existing* SC2086 in `publish.yml:40`'s verify step — unrelated to this change.) First real release validates the gate end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
