### PR TITLE
chore(coverage): local coverage reproduction (make coverage + util script) — audit F1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 **Author**: Paul Calnon
 **License**: MIT License
 **Version**: 0.5.0
-**Last Updated**: 2026-05-23
+**Last Updated**: 2026-06-21
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -766,6 +766,17 @@ src/tests/
 - XML Coverage: `src/tests/reports/coverage.xml`
 - JUnit XML: `src/tests/reports/junit.xml`
 
+### Coverage
+
+Reproduce the CI coverage gate locally (full suite):
+
+```bash
+make coverage                 # convenience wrapper
+bash util/run_coverage.bash   # source of truth (mirrors .github/workflows/ci.yml)
+```
+
+Gate: 80% aggregate (override with `COVERAGE_FAIL_UNDER=<n>`). Coverage runs in parallel mode with a custom data_file (see pyproject `[tool.coverage.run]`); the script reproduces the CI sequence exactly. Full suite by design; for a narrower run use plain `pytest`.
+
 ---
 
 ## CI/CD Pipelines

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+# Minimal Makefile — coverage convenience target.
+# The logic lives in util/run_coverage.bash (single source of truth); this is a thin wrapper.
+.PHONY: coverage
+coverage:  ## Reproduce the CI coverage gate locally (full suite)
+	@bash util/run_coverage.bash

--- a/util/run_coverage.bash
+++ b/util/run_coverage.bash
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#####################################################################################################
+# Project:       Juniper
+# Sub-Project:   JuniperCascor
+# Application:   juniper_cascor
+# File Name:     util/run_coverage.bash
+# Author:        Paul Calnon
+# Version:       0.1.0
+#
+# License:       MIT License
+# Copyright:     Copyright (c) 2024-2026 Paul Calnon
+#
+# Description:
+#    Reproduce the CI coverage gate locally (full suite). Mirrors the coverage
+#    invocation enforced in .github/workflows/ci.yml (parallel coverage with a
+#    custom data_file) so a developer can verify the aggregate gate before pushing.
+#    Runs the FULL gated suite by design; use plain pytest for a subset.
+#
+# Usage:
+#    bash util/run_coverage.bash                          # full suite + gate
+#    make coverage                                        # equivalent wrapper
+#    COVERAGE_FAIL_UNDER=90 bash util/run_coverage.bash   # override the gate
+#
+# References:
+#    - https://pytest-cov.readthedocs.io/
+#####################################################################################################
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+COVERAGE_FAIL_UNDER="${COVERAGE_FAIL_UNDER:-80}"
+
+echo "==> Coverage (reproduces CI gate: ${COVERAGE_FAIL_UNDER}% aggregate) — ${REPO_ROOT}"
+
+# ── Reproduce the CI coverage sequence (keep in sync with .github/workflows/ci.yml) ──
+# Step 1 — Create required directories. pyproject.toml's
+# [tool.coverage.run] data_file = "src/tests/reports/.coverage" means pytest-cov
+# silently fails to write its parallel .coverage.* files if the parent dir does
+# not exist (gitignored, so absent on a fresh checkout), which then leaves the
+# coverage-report step with "No data to report".
+mkdir -p logs src/logs reports/junit reports/htmlcov src/tests/reports
+
+# Step 2 — Run the gated unit suite under coverage. Same selection/markers as CI;
+# the xml/html report flags are CI artifacts only and are dropped locally.
+python -m pytest \
+  -m "unit and not slow" \
+  src/tests/unit \
+  --verbose \
+  --timeout=60 \
+  --maxfail=5 \
+  --cov=src \
+  --cov-report=term-missing
+
+# Step 3 — Enforce the aggregate coverage gate (CI does NOT pass --cov-fail-under
+# inline; it runs a standalone coverage report against the parallel data_file).
+python -m coverage report --fail-under="${COVERAGE_FAIL_UNDER}"
+# ─────────────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds a local reproduction of the CI coverage gate for `juniper-cascor`, which
was previously **CI-only / inert locally**. Developers can now verify the 80%
aggregate gate before pushing.

- **`util/run_coverage.bash`** (source of truth) — faithfully mirrors the
  `unit-tests` job coverage sequence in `.github/workflows/ci.yml`.
- **`Makefile`** — a thin `make coverage` wrapper that delegates to the script.
- **`AGENTS.md`** — a `### Coverage` subsection documenting both entry points
  and the gate semantics.

No coverage-mechanics changes: no `addopts`, no `--cov-fail-under` inline, no
pre-push hook. The script reproduces the existing CI behavior exactly.

## Why this faithfully mirrors CI

`juniper-cascor` has a non-trivial coverage setup. From
`pyproject.toml [tool.coverage.run]`:

```toml
source     = ["src"]
branch     = true
data_file  = "src/tests/reports/.coverage"
parallel   = true
```

The CI `unit-tests` job enforces the gate as a **three-step ordered sequence**
(no `coverage combine` / `coverage erase` exists in CI — pytest-cov combines the
parallel data files during its own report generation, and the standalone
`coverage report` then reads the combined `data_file`):

1. **Create required directories** — `mkdir -p logs src/logs reports/junit reports/htmlcov src/tests/reports`
   (load-bearing: the `data_file` parent dir is gitignored, so it is absent on a
   fresh checkout; without it pytest-cov silently writes no parallel data and the
   gate step reports "No data to report").
2. **Run Unit Tests** — `python -m pytest -m "unit and not slow" src/tests/unit --verbose --timeout=60 --maxfail=5 --junitxml=… --cov=src --cov-report=term-missing --cov-report=xml:… --cov-report=html:…`
3. **Enforce Coverage Gate (80%)** — `python -m coverage report --fail-under=${COVERAGE_FAIL_UNDER}` (`COVERAGE_FAIL_UNDER: "80"`).

The script replicates this exact ordered sequence (incl. the `mkdir` pre-step,
the same selection/markers, and the standalone `coverage report --fail-under`).
The xml/html `--cov-report` flags are CI artifacts only and are dropped locally,
per plan; `--cov=src` and `--cov-report=term-missing` are kept. The override
`COVERAGE_FAIL_UNDER=<n>` is honored just like CI.

## Testing

- `bash -n util/run_coverage.bash` — OK
- `shellcheck --severity=warning util/run_coverage.bash` — clean (no warnings)
- `make -n coverage` — dry-runs to `bash util/run_coverage.bash`
- The coverage suite itself was **not** executed in this PR (per task scope).

## Requirements

References the Juniper audit Wave 1 finding **F1** (local coverage gate was
CI-only/inert). Batch 2 of the remediation plan (juniper-ml PR #486).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
