### PR TITLE
refactor(api): WS-6 PR-B2a — converge manager attrs to ServiceLifecycleManager seam names

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -184,11 +184,11 @@ class TrainingInterrupted(Exception):
     """Sentinel raised from training-loop callbacks when the user requests stop.
 
     Pre-2026-05-10 the ``pause_training`` and ``stop_training`` REST endpoints
-    set ``_pause_event`` / ``_stop_requested`` and transitioned the FSM, but the
+    set ``_pause_event`` / ``_stop_event`` and transitioned the FSM, but the
     flags were never observed inside ``cascade_correlation.fit()`` — training
     ran to natural completion regardless. The fix wires signal checks into the
     ``_output_training_callback`` and ``_grow_iteration_callback`` hook points;
-    when ``_stop_requested`` is set, the callback raises this sentinel which
+    when ``_stop_event`` is set, the callback raises this sentinel which
     ``monitored_fit`` catches as a clean cancellation (FSM → STOP, status
     Stopped, cancelled-counter incremented; not a failure).
 
@@ -237,12 +237,12 @@ class _WeightHistoryRecorder:
 
     Three trigger points:
       1. **Every Nth epoch** — registered as a callback on
-         ``training_monitor.on_epoch_end``. ``N`` = network's
+         ``monitor.on_epoch_end``. ``N`` = network's
          ``config.weight_history_sampling_interval`` (default 50;
          set to 1 for every-epoch capture; set to 0 to disable the
          periodic trigger and rely on cascade-add only).
       2. **Cascade-grow events** — registered as a callback on
-         ``training_monitor.on_cascade_add``. Always captures
+         ``monitor.on_cascade_add``. Always captures
          regardless of the periodic interval since these are the
          narrative anchors per the parent design.
       3. **Terminal capture** — call ``capture_terminal()`` from the
@@ -1085,10 +1085,10 @@ class TrainingLifecycleManager:
         self.model: Optional[CascorModel] = None
         self.state_machine = TrainingStateMachine()
         self.training_state = TrainingState()
-        self.training_monitor = TrainingMonitor()
+        self.monitor = TrainingMonitor()
 
         # Threading
-        self._training_lock = threading.Lock()
+        self._lock = threading.Lock()
         self._metrics_lock = threading.Lock()
         self._topology_lock = threading.Lock()
         # CONC-02 / BUG-CC-16 (Phase 3B): guard the broadcast throttle so two
@@ -1100,7 +1100,7 @@ class TrainingLifecycleManager:
         self._last_state_broadcast_time: float = 0.0
         self._executor: Optional[ThreadPoolExecutor] = None
         self._training_future: Optional[Future] = None
-        self._stop_requested = threading.Event()
+        self._stop_event = threading.Event()
         self._pause_event = threading.Event()
         self._pause_event.set()  # Not paused initially
         self._last_emitted_history_len = 0
@@ -1116,7 +1116,7 @@ class TrainingLifecycleManager:
         self._val_y: Optional[torch.Tensor] = None
 
         # Network creation params (for reset)
-        self._network_params: Optional[Dict[str, Any]] = None
+        self._params: Optional[Dict[str, Any]] = None
 
         # FRONTEND_ISSUES_PLAN_2026-05-09 §3.5.1 / Issue #3 Phase 1 — staged
         # dataset config. Set by ``stage_dataset_config`` (POST /v1/training/
@@ -1143,7 +1143,7 @@ class TrainingLifecycleManager:
         # inside ``swap_dataset_live`` (post-fetch, pre-future-resubmit). Using
         # an ``Event`` rather than a bool gives a memory-barriered read across
         # the cancel-issuer thread and the swap-driver thread without needing
-        # to re-acquire ``_training_lock`` (which the swap holds for its full
+        # to re-acquire ``_lock`` (which the swap holds for its full
         # duration). Cleared in the swap's ``finally`` so a future swap doesn't
         # observe a stale set from a prior aborted swap.
         self._swap_cancel_requested: threading.Event = threading.Event()
@@ -1174,7 +1174,7 @@ class TrainingLifecycleManager:
         self._register_liveness_monitor_callbacks()
 
         # CAS-006 (Phase 6E Sprint A-4): auto-snap-best.
-        # Hooks ``training_monitor.epoch_end`` and saves a snapshot every
+        # Hooks ``monitor.epoch_end`` and saves a snapshot every
         # time (validation) accuracy beats the best-seen-so-far for the
         # current run. Defaults: feature off, 50-epoch warmup. Both are
         # exposed via TrainingParams + TrainingParamUpdateRequest and
@@ -1200,7 +1200,7 @@ class TrainingLifecycleManager:
         # (so a subsequent run from the same snapshot doesn't mistakenly
         # carry over the marker).
         self._resume_point_epoch: Optional[int] = None
-        self.training_monitor.register_callback("epoch_end", self._maybe_auto_snap_callback)
+        self.monitor.register_callback("epoch_end", self._maybe_auto_snap_callback)
 
         self.logger.info("TrainingLifecycleManager initialized")
 
@@ -1248,7 +1248,7 @@ class TrainingLifecycleManager:
         """
         bump = lambda **_kw: self.bump_liveness()  # noqa: E731 — concise wrapper
         for event in ("epoch_start", "epoch_end", "cascade_add", "training_start", "training_end", "topology_change", "candidate_progress", "phase_change"):
-            self.training_monitor.register_callback(event, bump)
+            self.monitor.register_callback(event, bump)
 
     def bump_liveness(self) -> None:
         """Record that the lifecycle is making forward progress.
@@ -1330,23 +1330,23 @@ class TrainingLifecycleManager:
 
         ws = self._ws_manager
 
-        self.training_monitor.register_callback(
+        self.monitor.register_callback(
             "epoch_end",
             lambda metrics, **kw: ws.broadcast_from_thread(create_metrics_message(metrics)),
         )
-        self.training_monitor.register_callback(
+        self.monitor.register_callback(
             "cascade_add",
             lambda event, **kw: ws.broadcast_from_thread(create_cascade_add_message(event)),
         )
-        self.training_monitor.register_callback(
+        self.monitor.register_callback(
             "training_start",
             lambda **kw: self._broadcast_training_state(force=True),
         )
-        self.training_monitor.register_callback(
+        self.monitor.register_callback(
             "training_end",
             lambda **kw: ws.broadcast_from_thread(create_event_message({"event": "training_complete"})),
         )
-        self.training_monitor.register_callback(
+        self.monitor.register_callback(
             "candidate_progress",
             lambda progress, **kw: ws.broadcast_from_thread(create_candidate_progress_message(progress)),
         )
@@ -1421,11 +1421,11 @@ class TrainingLifecycleManager:
         from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
         from cascade_correlation.cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
 
-        with self._training_lock:
+        with self._lock:
             if self.state_machine.is_started():
                 raise RuntimeError("Cannot create network while training is active")
 
-            self._network_params = kwargs.copy()
+            self._params = kwargs.copy()
             config = CascadeCorrelationConfig.create_simple_config(**kwargs)
             # WS-6 B-phase: wrap the freshly built CCN in the model-core CascorModel.
             self.model = CascorModel(network=CascadeCorrelationNetwork(config=config))
@@ -1451,18 +1451,23 @@ class TrainingLifecycleManager:
 
     def delete_network(self) -> None:
         """Delete the current network."""
-        with self._training_lock:
+        with self._lock:
             if self.state_machine.is_started():
                 raise RuntimeError("Cannot delete network while training is active")
             self._restore_original_methods()
             self.model = None
-            self._network_params = None
+            self._params = None
             self.state_machine.handle_command(Command.RESET)
             self.training_state.update_state(status="Stopped", phase="Idle")
             self.logger.info("Network deleted")
 
+    def has_model(self) -> bool:
+        return self.model is not None
+
     def has_network(self) -> bool:
-        return self.network is not None
+        """Deprecated alias for :meth:`has_model` (WS-6 B2a seam name-align). Kept
+        for any external caller; all in-repo call sites use ``has_model``."""
+        return self.has_model()
 
     @property
     def network(self):
@@ -1516,7 +1521,7 @@ class TrainingLifecycleManager:
         but the loop never observed the events. This method is the missing hook.
 
         The pause wait uses a 0.5 s timeout so a stop request received WHILE
-        paused is observed promptly (the loop re-checks ``_stop_requested`` on
+        paused is observed promptly (the loop re-checks ``_stop_event`` on
         each wakeup). Without the timeout, a stop after pause would block forever
         since ``_pause_event`` would still be cleared.
 
@@ -1525,11 +1530,11 @@ class TrainingLifecycleManager:
         ``_install_grow_network_hook`` (which lives in a separate method scope)
         and so tests can invoke it directly via ``mgr._check_for_interrupt()``.
         """
-        if self._stop_requested.is_set():
+        if self._stop_event.is_set():
             raise TrainingInterrupted("stop_requested")
         while not self._pause_event.is_set():
             self._pause_event.wait(timeout=0.5)
-            if self._stop_requested.is_set():
+            if self._stop_event.is_set():
                 raise TrainingInterrupted("stop_requested_during_pause")
 
     def _install_monitoring_hooks(self) -> None:  # noqa: C901
@@ -1546,9 +1551,9 @@ class TrainingLifecycleManager:
         original_fit = self.network.fit
         self._original_methods["fit"] = original_fit
 
-        monitor = self.training_monitor
+        monitor = self.monitor
         state = self.training_state
-        stop_event = self._stop_requested
+        stop_event = self._stop_event
         sm = self.state_machine
         manager_ref = self
 
@@ -1680,7 +1685,7 @@ class TrainingLifecycleManager:
             except TrainingInterrupted:
                 # P2-PRE-1 (2026-05-10): clean cancellation path. Raised by
                 # _check_for_interrupt() in the training-loop callbacks when
-                # _stop_requested is set. Treated as a successful stop, NOT a
+                # _stop_event is set. Treated as a successful stop, NOT a
                 # failure: same FSM/state transitions and gauge increments as
                 # the post-fit stop_event path above (lines 1500–1506), so a
                 # mid-fit stop and a post-fit stop produce the same observable
@@ -1960,7 +1965,7 @@ class TrainingLifecycleManager:
             # Emit all new entries
             for i in range(last_emitted, current_len):
                 epoch = i + 1
-                self.training_monitor.on_epoch_end(
+                self.monitor.on_epoch_end(
                     epoch=epoch,
                     loss=train_loss_list[i],
                     accuracy=train_accuracy_list[i] if i < len(train_accuracy_list) else None,
@@ -2047,11 +2052,11 @@ class TrainingLifecycleManager:
         affects subsequent samples (changes mid-run land at the next
         ``register`` call when re-attached).
         """
-        if self.network is None or self.training_monitor is None:
+        if self.network is None or self.monitor is None:
             return
         existing = self._weight_history_recorder
         if existing is None or existing.network is not self.network:
-            self._weight_history_recorder = _WeightHistoryRecorder(self.network, self.training_monitor)
+            self._weight_history_recorder = _WeightHistoryRecorder(self.network, self.monitor)
         else:
             # Re-init in case config tunables changed since last training run.
             existing.sampling_interval = int(getattr(self.network.config, "weight_history_sampling_interval", existing.sampling_interval))
@@ -2088,7 +2093,7 @@ class TrainingLifecycleManager:
         if self.network is None:
             raise RuntimeError("No network created")
 
-        with self._training_lock:
+        with self._lock:
             if self.state_machine.is_started():
                 raise RuntimeError("Training already in progress")
             # CAN-015d (B-4): Investigating is the inspection / modification
@@ -2147,7 +2152,7 @@ class TrainingLifecycleManager:
                 if hasattr(self.network, "active_output_dim"):
                     self.network.active_output_dim = active_output_dim
 
-            self._stop_requested.clear()
+            self._stop_event.clear()
             self._pause_event.set()
 
             # CAS-006 (A-4) + CAN-015b (B-2): each training run normally
@@ -2175,7 +2180,7 @@ class TrainingLifecycleManager:
             # training future so the next fit pass observes the new values.
             # ``_apply_params_unlocked`` shares the same whitelist + atomic-
             # rollback path as ``update_params``; calling it here while we
-            # hold ``_training_lock`` avoids re-entering the non-reentrant
+            # hold ``_lock`` avoids re-entering the non-reentrant
             # lock and avoids the race where the background thread could
             # start fit() before update_params lands.
             if network_kwargs:
@@ -2204,7 +2209,7 @@ class TrainingLifecycleManager:
 
     def stop_training(self) -> Dict[str, Any]:
         """Request training stop."""
-        self._stop_requested.set()
+        self._stop_event.set()
         self.state_machine.handle_command(Command.STOP)
         self.training_state.update_state(status="Stopped", phase="Idle")
         self._broadcast_training_state(force=True)
@@ -2240,7 +2245,7 @@ class TrainingLifecycleManager:
         self._reset_event_state()
         self._last_emitted_history_len = 0
         self.state_machine.handle_command(Command.RESET)
-        self.training_monitor.clear_metrics()
+        self.monitor.clear_metrics()
         self.training_state.update_state(
             status="Stopped",
             phase="Idle",
@@ -2253,11 +2258,11 @@ class TrainingLifecycleManager:
     def _reset_event_state(self) -> None:
         """Single source of truth for control-event normalisation.
 
-        Post-condition: ``_stop_requested`` is set (signals any in-flight
+        Post-condition: ``_stop_event`` is set (signals any in-flight
         training thread to stop) and ``_pause_event`` is set (no synthetic
         pause inherited by the next ``start_training`` call).
         """
-        self._stop_requested.set()
+        self._stop_event.set()
         self._pause_event.set()
 
     # ------------------------------------------------------------------
@@ -2267,7 +2272,7 @@ class TrainingLifecycleManager:
     def get_status(self) -> Dict[str, Any]:
         """Get current training status."""
         state_summary = self.state_machine.get_state_summary()
-        monitor_state = self.training_monitor.get_current_state()
+        monitor_state = self.monitor.get_current_state()
         training_state = self.training_state.get_state()
 
         if self.network is not None:
@@ -2320,8 +2325,8 @@ class TrainingLifecycleManager:
     def get_metrics_history(self, count: Optional[int] = None) -> list:
         """Get metrics history."""
         if count:
-            return self.training_monitor.get_recent_metrics(count)
-        return self.training_monitor.get_all_metrics()
+            return self.monitor.get_recent_metrics(count)
+        return self.monitor.get_all_metrics()
 
     def has_training_data(self) -> bool:
         """Check if training data is loaded."""
@@ -2342,7 +2347,7 @@ class TrainingLifecycleManager:
         ``clear_pending_dataset_config``) so the route can use ``cfg or {}``
         without separate validation.
         """
-        with self._training_lock:
+        with self._lock:
             if not cfg:
                 self._pending_dataset_config = None
                 return {"status": "cleared", "config": None}
@@ -2351,7 +2356,7 @@ class TrainingLifecycleManager:
 
     def clear_pending_dataset_config(self) -> Dict[str, Any]:
         """Discard any staged dataset change so the next start uses current data."""
-        with self._training_lock:
+        with self._lock:
             prior = self._pending_dataset_config
             self._pending_dataset_config = None
         return {"status": "cleared", "discarded": dict(prior) if prior else None}
@@ -2441,11 +2446,11 @@ class TrainingLifecycleManager:
         "signal accepted", not "swap aborted by the time you read this".
         """
         # Snapshot the flag under the lock — the swap mutates it inside
-        # ``_training_lock`` so reading without the lock could see a stale
+        # ``_lock`` so reading without the lock could see a stale
         # False during the brief window between swap-start and the very first
         # checkpoint. Holding the lock here also prevents a race where a swap
         # finishes between our check and our set().
-        with self._training_lock:
+        with self._lock:
             if not self._swap_in_progress:
                 raise NoSwapInProgressError("no_swap_in_progress")
             self._swap_cancel_requested.set()
@@ -2467,7 +2472,7 @@ class TrainingLifecycleManager:
         """In-flight dataset swap (P2-1a equal-dim skeleton + P2-1b polish).
 
         Phase 2 step-by-step flow per spec §3.2:
-          1. Acquire ``_training_lock`` (entire swap held under the lock —
+          1. Acquire ``_lock`` (entire swap held under the lock —
              Audit #2 in §3.4 confirmed read-side routes don't contend).
           2. Validate experimental-functions gate (raises PermissionError → 403)
              and ``is_started()`` (raises ValueError → 422).
@@ -2477,7 +2482,7 @@ class TrainingLifecycleManager:
              capture the in-flight candidate-pool depth so the response can
              surface it (§3.5 — "Swap discarded N in-flight candidates").
           5/6. Signal stop on the training future; await its clean exit.
-             Pre-P2-PRE-1 the training thread ignored ``_stop_requested``;
+             Pre-P2-PRE-1 the training thread ignored ``_stop_event``;
              the fix at ``f4453fa`` wires the signal into the training-loop
              callbacks via ``_check_for_interrupt`` so this actually works.
           7. ``_reload_dataset`` fetches the new dataset (juniper-data I/O).
@@ -2516,7 +2521,7 @@ class TrainingLifecycleManager:
         if not self._experimental_functions_enabled:
             raise PermissionError("experimental_functions_disabled")
 
-        with self._training_lock:
+        with self._lock:
             # Step 2 cont: validate training is running.
             if not self.state_machine.is_started():
                 raise ValueError("training_not_running — use POST /v1/training/dataset (cold swap) instead")
@@ -2556,7 +2561,7 @@ class TrainingLifecycleManager:
 
                 # P2-1b: capture the candidate-pool depth BEFORE we stop the
                 # future. Reading after the stop always sees zero (the pool
-                # has been drained by ``_stop_requested``). Only the
+                # has been drained by ``_stop_event``). Only the
                 # CANDIDATE phase has an in-flight pool — output training
                 # has none, so reporting zero in those cases is correct.
                 abandoned_candidate_pool_size = self._snapshot_abandoned_candidate_pool_size()
@@ -2581,11 +2586,11 @@ class TrainingLifecycleManager:
                     self.logger.exception("swap_dataset_live: pre-swap snapshot failed; swap continues without pre_swap_snapshot_id")
 
                 # Step 5/6: signal stop, wait for training future to exit cleanly.
-                # P2-PRE-1 (f4453fa) makes _stop_requested actually interrupt
+                # P2-PRE-1 (f4453fa) makes _stop_event actually interrupt
                 # the training-loop callbacks via TrainingInterrupted, caught
                 # by monitored_fit as clean cancellation. Pre-fix this would
                 # have blocked until natural fit completion (minutes).
-                self._stop_requested.set()
+                self._stop_event.set()
                 self._pause_event.set()  # ensure pause wait loop wakes to observe stop
                 future = self._training_future
                 if future is not None:
@@ -2658,7 +2663,7 @@ class TrainingLifecycleManager:
                 # the FSM STOPPED → STARTED transition internally on the new
                 # invocation; we just need the underlying tensors to be the
                 # new ones (which they are, post-_reload_dataset).
-                self._stop_requested.clear()
+                self._stop_event.clear()
                 self._pause_event.set()
                 if self._executor is None:
                     self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="cascor-train")
@@ -2953,7 +2958,7 @@ class TrainingLifecycleManager:
         ``torch.float32`` tensors, swap ``_train_x/_train_y`` (and val if
         the artifact carries them).
 
-        Held under ``_training_lock`` by the caller (``start_training``);
+        Held under ``_lock`` by the caller (``start_training``);
         any I/O failure surfaces as ``RuntimeError`` so the caller can leave
         ``_pending_dataset_config`` in place for the user to retry.
         """
@@ -3124,7 +3129,7 @@ class TrainingLifecycleManager:
         GAP-WS-28: applies all updates atomically. If any setattr raises,
         every previously-applied key is reverted to its pre-call value
         before re-raising, so the network is never left in a half-updated
-        state. The ``_training_lock`` already prevents the race itself; this
+        state. The ``_lock`` already prevents the race itself; this
         adds the all-or-nothing semantics for the case where a property
         setter rejects a value (currently no setters do, but adding a
         defensive guard now means future validation can be wired in
@@ -3141,7 +3146,7 @@ class TrainingLifecycleManager:
             Exception: Re-raises whatever setattr raised, after rolling back
                 any partially-applied updates.
         """
-        with self._training_lock:
+        with self._lock:
 
             ########################################################################################
             # Do NOT remove this commented out code block until explicit approval has been granted
@@ -3220,12 +3225,12 @@ class TrainingLifecycleManager:
             return self._apply_params_unlocked(params)
 
     def _apply_params_unlocked(self, params: Dict[str, Any]) -> Dict[str, Any]:  # noqa: C901
-        """Apply runtime params assuming the caller already holds ``_training_lock``.
+        """Apply runtime params assuming the caller already holds ``_lock``.
 
         Internal helper extracted from ``update_params`` so that
         ``start_training`` can route TrainingParams body fields through the
         same whitelist + atomic-rollback path without re-entering the
-        non-reentrant ``_training_lock`` (see CASCOR_FIT_KWARGS_LATENT_BUG.md
+        non-reentrant ``_lock`` (see CASCOR_FIT_KWARGS_LATENT_BUG.md
         for the full rationale of the split).
 
         Three storage flavors are supported:
@@ -4038,7 +4043,7 @@ class TrainingLifecycleManager:
           we do it here too so a ``GET /v1/training/params`` between
           retrain and start_training already shows the cleared value)
         - FSM — Stopped / Idle (via ``Command.RESET``)
-        - ``training_monitor.metrics_buffer`` — cleared
+        - ``monitor.metrics_buffer`` — cleared
         - ``_last_emitted_history_len`` — 0
 
         CAN-015c (B-3): rejected when a replay session is active (would
@@ -4069,12 +4074,12 @@ class TrainingLifecycleManager:
                         history[key] = []
 
         # Reset lifecycle-level training state. Mirrors ``reset()`` (line ~840)
-        # but without the ``_stop_requested.set()`` since no training is
+        # but without the ``_stop_event.set()`` since no training is
         # currently running — Retrain is invoked from a stopped state and
         # ``start_training`` will clear the event itself.
         self._last_emitted_history_len = 0
         self.state_machine.handle_command(Command.RESET)
-        self.training_monitor.clear_metrics()
+        self.monitor.clear_metrics()
         self.training_state.update_state(
             status="Stopped",
             phase="Idle",
@@ -4207,7 +4212,7 @@ class TrainingLifecycleManager:
         # no such attribute (or it's None) — the cache then advertises
         # weights_available=false to canopy via state_summary.
         weight_history = getattr(self.network, "weight_history", None)
-        session = _ReplaySession(snapshot_id, history_dict, self.training_monitor, weight_history=weight_history)
+        session = _ReplaySession(snapshot_id, history_dict, self.monitor, weight_history=weight_history)
         self._replay_session = session
         # Marker fields used by Resume / Restore are not relevant here.
         self._resume_point_epoch = None
@@ -4355,7 +4360,7 @@ class TrainingLifecycleManager:
 
     def shutdown(self) -> None:
         """Clean up resources."""
-        self._stop_requested.set()
+        self._stop_event.set()
         self.stop_liveness_heartbeat()
         self._restore_original_methods()
         # CAN-015c (B-3): drain any active replay session so the

--- a/src/api/routes/decision_boundary.py
+++ b/src/api/routes/decision_boundary.py
@@ -29,7 +29,7 @@ async def get_decision_boundary(
     Computation is offloaded to a thread to avoid blocking the event loop.
     """
     lifecycle = _get_lifecycle(request)
-    if not lifecycle.has_network():
+    if not lifecycle.has_model():
         raise HTTPException(status_code=_PROJECT_API_HTTP_404_NOT_FOUND, detail="No network created")
     if not lifecycle.has_training_data():
         raise HTTPException(status_code=_PROJECT_API_HTTP_404_NOT_FOUND, detail="No training data loaded")

--- a/src/api/routes/health.py
+++ b/src/api/routes/health.py
@@ -144,7 +144,7 @@ async def readiness_probe(request: Request, response: Response) -> ReadinessResp
     Sets ``X-Juniper-Readiness`` header to mirror body status.
     """
     lifecycle = getattr(request.app.state, "lifecycle", None)
-    network_loaded = lifecycle.has_network() if lifecycle else False
+    network_loaded = lifecycle.has_model() if lifecycle else False
 
     training_state = "unknown"
     if lifecycle is not None:

--- a/src/api/routes/metrics.py
+++ b/src/api/routes/metrics.py
@@ -18,7 +18,7 @@ def _get_lifecycle(request: Request):
 async def get_metrics(request: Request) -> dict:
     """Get current training metrics snapshot."""
     lifecycle = _get_lifecycle(request)
-    if not lifecycle.has_network():
+    if not lifecycle.has_model():
         raise HTTPException(status_code=404, detail="No network created")
     return success_response(lifecycle.get_metrics())
 

--- a/src/api/routes/network.py
+++ b/src/api/routes/network.py
@@ -35,7 +35,7 @@ async def create_network(request: Request, body: NetworkCreateRequest) -> dict:
 async def get_network(request: Request) -> dict:
     """Get current network info."""
     lifecycle = _get_lifecycle(request)
-    if not lifecycle.has_network():
+    if not lifecycle.has_model():
         raise HTTPException(status_code=404, detail="No network created")
     return success_response(lifecycle.get_network_info())
 
@@ -56,7 +56,7 @@ async def delete_network(request: Request) -> dict:
 async def get_topology(request: Request) -> dict:
     """Get network topology for visualization."""
     lifecycle = _get_lifecycle(request)
-    if not lifecycle.has_network():
+    if not lifecycle.has_model():
         raise HTTPException(status_code=404, detail="No network created")
     topology = lifecycle.get_topology()
     if topology is None:
@@ -68,7 +68,7 @@ async def get_topology(request: Request) -> dict:
 async def get_stats(request: Request) -> dict:
     """Get network weight statistics."""
     lifecycle = _get_lifecycle(request)
-    if not lifecycle.has_network():
+    if not lifecycle.has_model():
         raise HTTPException(status_code=404, detail="No network created")
     return success_response(lifecycle.get_statistics())
 

--- a/src/api/routes/snapshots.py
+++ b/src/api/routes/snapshots.py
@@ -130,7 +130,7 @@ def _build_unified_payload(
 async def save_snapshot(request: Request, body: SnapshotCreateRequest = None) -> dict:
     """Save a snapshot of the current network state."""
     lifecycle = _get_lifecycle(request)
-    if not lifecycle.has_network():
+    if not lifecycle.has_model():
         raise HTTPException(status_code=404, detail="No network created")
     description = body.description if body else ""
     # PERF-CC-01: serializer.save_network is synchronous HDF5 I/O. Run it

--- a/src/api/routes/training.py
+++ b/src/api/routes/training.py
@@ -143,7 +143,7 @@ async def get_status(request: Request) -> dict:
 async def get_params(request: Request) -> dict:
     """Get current training parameters."""
     lifecycle = _get_lifecycle(request)
-    if not lifecycle.has_network():
+    if not lifecycle.has_model():
         raise HTTPException(status_code=404, detail="No network created")
     return success_response(lifecycle.get_training_params())
 
@@ -156,7 +156,7 @@ async def update_training_params(request: Request, body: TrainingParamUpdateRequ
     All fields are optional — only provided fields are updated (PATCH semantics).
     """
     lifecycle = _get_lifecycle(request)
-    if not lifecycle.has_network():
+    if not lifecycle.has_model():
         raise HTTPException(status_code=404, detail="No network created")
     try:
         updated = lifecycle.update_params(body.model_dump(exclude_none=True))

--- a/src/tests/integration/api/test_api_full_lifecycle.py
+++ b/src/tests/integration/api/test_api_full_lifecycle.py
@@ -60,7 +60,7 @@ def client():
     # Signal all background components to stop
     lifecycle = getattr(app.state, "lifecycle", None)
     if lifecycle:
-        lifecycle._stop_requested.set()
+        lifecycle._stop_event.set()
         if getattr(lifecycle, "_executor", None):
             lifecycle._executor.shutdown(wait=False, cancel_futures=True)
 

--- a/src/tests/integration/api/test_can_015h_roundtrip.py
+++ b/src/tests/integration/api/test_can_015h_roundtrip.py
@@ -76,7 +76,7 @@ def client():
 
     lifecycle = getattr(app.state, "lifecycle", None)
     if lifecycle:
-        lifecycle._stop_requested.set()
+        lifecycle._stop_event.set()
         if getattr(lifecycle, "_executor", None):
             lifecycle._executor.shutdown(wait=False, cancel_futures=True)
 

--- a/src/tests/integration/api/test_candidate_pool_invariants.py
+++ b/src/tests/integration/api/test_candidate_pool_invariants.py
@@ -29,7 +29,7 @@ def client():
     yield tc
     lifecycle = getattr(app.state, "lifecycle", None)
     if lifecycle:
-        lifecycle._stop_requested.set()
+        lifecycle._stop_event.set()
         if getattr(lifecycle, "_executor", None):
             lifecycle._executor.shutdown(wait=False, cancel_futures=True)
     exit_thread = threading.Thread(target=lambda: tc.__exit__(None, None, None), daemon=True)

--- a/src/tests/integration/api/test_golden_api_snapshots.py
+++ b/src/tests/integration/api/test_golden_api_snapshots.py
@@ -46,7 +46,7 @@ def _shutdown_client(app, tc):
     """Tear down the TestClient without hanging on the anyio portal join."""
     lifecycle = getattr(app.state, "lifecycle", None)
     if lifecycle:
-        stop = getattr(lifecycle, "_stop_requested", None)
+        stop = getattr(lifecycle, "_stop_event", None)
         if stop is not None:
             stop.set()
         executor = getattr(lifecycle, "_executor", None)

--- a/src/tests/integration/api/test_lifecycle_event_invariants.py
+++ b/src/tests/integration/api/test_lifecycle_event_invariants.py
@@ -1,6 +1,6 @@
 """Regression tests for BUG-CC-#5: control-event normalisation in reset().
 
-Before the fix, ``reset()`` set ``_stop_requested`` but did not re-set
+Before the fix, ``reset()`` set ``_stop_event`` but did not re-set
 ``_pause_event``.  If the user paused before stopping, the next
 ``start_training()`` call would inherit a stale ``_pause_event.clear()``
 and the training loop would synthetically pause after a single iteration.
@@ -23,7 +23,7 @@ def mgr():
     """Fresh lifecycle manager (no network, no executor, no training thread).
 
     Sufficient for testing the event-state contract because ``reset()`` and
-    ``_reset_event_state()`` touch only ``_pause_event``, ``_stop_requested``,
+    ``_reset_event_state()`` touch only ``_pause_event``, ``_stop_event``,
     the FSM, the training-state object, and the broadcast hook — all of which
     are live after ``__init__``.
     """
@@ -44,14 +44,14 @@ def test_reset_event_state_normalises_from_any_prior_state(mgr, pause_set, stop_
     else:
         mgr._pause_event.clear()
     if stop_set:
-        mgr._stop_requested.set()
+        mgr._stop_event.set()
     else:
-        mgr._stop_requested.clear()
+        mgr._stop_event.clear()
 
     mgr._reset_event_state()
 
     assert mgr._pause_event.is_set(), "post: _pause_event must be set"
-    assert mgr._stop_requested.is_set(), "post: _stop_requested must be set"
+    assert mgr._stop_event.is_set(), "post: _stop_event must be set"
 
 
 # ---------------------------------------------------------------------------
@@ -67,7 +67,7 @@ def test_reset_after_pause_leaves_pause_event_set(mgr):
     needing a real training thread / network for the test to be meaningful.
     """
     # Mirror the start path's event manipulations + advance FSM.
-    mgr._stop_requested.clear()
+    mgr._stop_event.clear()
     mgr._pause_event.set()
     assert mgr.state_machine.handle_command(Command.START)
 
@@ -75,7 +75,7 @@ def test_reset_after_pause_leaves_pause_event_set(mgr):
     mgr.pause_training()
     assert not mgr._pause_event.is_set(), "guard: pause must clear _pause_event"
 
-    # User stops — stop_training() sets _stop_requested but does not touch pause.
+    # User stops — stop_training() sets _stop_event but does not touch pause.
     mgr.stop_training()
     assert not mgr._pause_event.is_set(), "guard: stop must not re-set _pause_event"
 
@@ -83,7 +83,7 @@ def test_reset_after_pause_leaves_pause_event_set(mgr):
     mgr.reset()
 
     assert mgr._pause_event.is_set(), "BUG-CC-#5 regression: reset() must normalise _pause_event so the next " "start_training() does not inherit a stale clear()"
-    assert mgr._stop_requested.is_set()
+    assert mgr._stop_event.is_set()
 
 
 # ---------------------------------------------------------------------------
@@ -120,7 +120,7 @@ def test_after_reset_pause_event_is_set(mgr, seq):
     Pre-stages the FSM into STARTED so pause/resume are not all rejected at the
     front door; mirrors what start_training() does to the event pair.
     """
-    mgr._stop_requested.clear()
+    mgr._stop_event.clear()
     mgr._pause_event.set()
     assert mgr.state_machine.handle_command(Command.START)
 
@@ -128,4 +128,4 @@ def test_after_reset_pause_event_is_set(mgr, seq):
         _apply(mgr, cmd)
 
     assert mgr._pause_event.is_set(), f"_pause_event left cleared after sequence {seq}"
-    assert mgr._stop_requested.is_set(), f"_stop_requested left cleared after sequence {seq}"
+    assert mgr._stop_event.is_set(), f"_stop_event left cleared after sequence {seq}"

--- a/src/tests/integration/api/test_pause_stop_actually_interrupts.py
+++ b/src/tests/integration/api/test_pause_stop_actually_interrupts.py
@@ -2,19 +2,19 @@
 """Regression tests for P2-PRE-1: pause/stop actually interrupt training.
 
 Pre-fix (HEAD 2069930), ``pause_training`` and ``stop_training`` REST endpoints
-set ``_pause_event`` / ``_stop_requested`` and transitioned the FSM, but the
+set ``_pause_event`` / ``_stop_event`` and transitioned the FSM, but the
 flags were never observed inside ``cascade_correlation.fit()`` or any inner
 training loop — there are zero references to ``Event``/``wait``/``pause``/
 ``threading`` in ``cascade_correlation.py``. The two callbacks wired into the
 training loop (``_output_training_callback``, ``_grow_iteration_callback``)
-were pure metric-emission sinks. ``_stop_requested.is_set()`` was checked only
+were pure metric-emission sinks. ``_stop_event.is_set()`` was checked only
 *after* ``original_fit()`` returned naturally — by which point fit had already
 run to completion. **Result**: pause and stop were observably no-ops at the
 training-loop level; training ran to natural completion regardless.
 
 The fix wires ``_check_for_interrupt()`` into both callbacks. It raises
-``TrainingInterrupted`` when ``_stop_requested`` is set, and blocks on
-``_pause_event.wait(timeout=0.5)`` when paused (re-checking ``_stop_requested``
+``TrainingInterrupted`` when ``_stop_event`` is set, and blocks on
+``_pause_event.wait(timeout=0.5)`` when paused (re-checking ``_stop_event``
 every 0.5 s so a Stop-during-Pause is observed promptly). ``monitored_fit``
 catches ``TrainingInterrupted`` as a clean cancellation: same FSM/state/gauge
 transitions as the post-fit stop-event path, no exception propagated.
@@ -64,9 +64,9 @@ def mgr_with_hooks():
 
 @pytest.mark.integration
 def test_output_callback_raises_on_stop_signal(mgr_with_hooks):
-    """When _stop_requested is set, the output callback raises TrainingInterrupted."""
+    """When _stop_event is set, the output callback raises TrainingInterrupted."""
     mgr = mgr_with_hooks
-    mgr._stop_requested.set()
+    mgr._stop_event.set()
     with pytest.raises(TrainingInterrupted, match="stop_requested"):
         mgr.network._output_epoch_callback(epoch=1, epochs=10, loss=0.5)
 
@@ -75,9 +75,9 @@ def test_output_callback_raises_on_stop_signal(mgr_with_hooks):
 def test_output_callback_returns_normally_when_not_paused_or_stopped(mgr_with_hooks):
     """Default state (pause set, stop clear) — callback returns without raising."""
     mgr = mgr_with_hooks
-    # __init__ sets _pause_event and clears _stop_requested; double-check.
+    # __init__ sets _pause_event and clears _stop_event; double-check.
     assert mgr._pause_event.is_set()
-    assert not mgr._stop_requested.is_set()
+    assert not mgr._stop_event.is_set()
     # Should not raise; just emit metrics + return None.
     result = mgr.network._output_epoch_callback(epoch=1, epochs=10, loss=0.5)
     assert result is None
@@ -108,7 +108,7 @@ def test_output_callback_blocks_on_pause_then_resumes(mgr_with_hooks):
 
 @pytest.mark.integration
 def test_output_callback_raises_on_stop_during_pause(mgr_with_hooks):
-    """Paused; setting _stop_requested wakes the wait loop and raises TrainingInterrupted.
+    """Paused; setting _stop_event wakes the wait loop and raises TrainingInterrupted.
 
     Critical: pre-fix this scenario was impossible (callbacks ignored signals).
     Post-fix the wait loop's 0.5s timeout ensures a stop after pause is observed
@@ -132,7 +132,7 @@ def test_output_callback_raises_on_stop_during_pause(mgr_with_hooks):
     t.start()
     time.sleep(0.1)  # let the callback enter the wait loop
 
-    mgr._stop_requested.set()
+    mgr._stop_event.set()
     assert callback_done.wait(timeout=2.0), "callback did not exit within 2s of stop"
     t.join(timeout=1.0)
     assert len(raised) == 1, f"expected exactly one exception, got {raised!r}"
@@ -152,7 +152,7 @@ def test_grow_callback_raises_on_stop_signal(mgr_with_hooks):
     multiprocessing-aware signal threading); the iteration boundary is the
     natural pause point for the cascade-growth loop."""
     mgr = mgr_with_hooks
-    mgr._stop_requested.set()
+    mgr._stop_event.set()
     with pytest.raises(TrainingInterrupted, match="stop_requested"):
         mgr.network._grow_iteration_callback(
             iteration=1,
@@ -167,7 +167,7 @@ def test_grow_callback_raises_on_stop_signal(mgr_with_hooks):
 @pytest.mark.integration
 def test_grow_callback_returns_normally_when_not_stopped(mgr_with_hooks):
     mgr = mgr_with_hooks
-    assert not mgr._stop_requested.is_set()
+    assert not mgr._stop_event.is_set()
     # Returns None; updates state. No exception.
     mgr.network._grow_iteration_callback(
         iteration=1,
@@ -209,7 +209,7 @@ def _mgr_with_mocked_fit(side_effect):
     mgr._monitoring_active = False
     mgr._install_monitoring_hooks()
     # Drive FSM to Started so Command.STOP is a valid transition.
-    mgr._stop_requested.clear()
+    mgr._stop_event.clear()
     assert mgr.state_machine.handle_command(Command.START)
     return mgr, mock_fit
 

--- a/src/tests/integration/api/test_pending_dataset.py
+++ b/src/tests/integration/api/test_pending_dataset.py
@@ -35,7 +35,7 @@ def client():
     yield tc
     lifecycle = getattr(app.state, "lifecycle", None)
     if lifecycle:
-        lifecycle._stop_requested.set()
+        lifecycle._stop_event.set()
         if getattr(lifecycle, "_executor", None):
             lifecycle._executor.shutdown(wait=False, cancel_futures=True)
     exit_thread = threading.Thread(target=lambda: tc.__exit__(None, None, None), daemon=True)

--- a/src/tests/integration/api/test_websocket_streaming.py
+++ b/src/tests/integration/api/test_websocket_streaming.py
@@ -29,7 +29,7 @@ def client():
     # Signal all background components to stop
     lifecycle = getattr(app.state, "lifecycle", None)
     if lifecycle:
-        lifecycle._stop_requested.set()
+        lifecycle._stop_event.set()
         if getattr(lifecycle, "_executor", None):
             lifecycle._executor.shutdown(wait=False, cancel_futures=True)
 

--- a/src/tests/unit/api/test_api_health.py
+++ b/src/tests/unit/api/test_api_health.py
@@ -117,7 +117,7 @@ class TestHealthEndpoints:
         """Test GET /v1/health/ready details surface mock lifecycle state."""
 
         class MockLifecycle:
-            def has_network(self):
+            def has_model(self):
                 return True
 
             def get_status(self):

--- a/src/tests/unit/api/test_api_runtime_params.py
+++ b/src/tests/unit/api/test_api_runtime_params.py
@@ -367,7 +367,7 @@ class TestAutoSnapBestCallback:
 
     The route-level tests above cover the wiring (PATCH lands the flag,
     GET surfaces it, validation rejects bad values). These tests cover
-    the actual behavior: when ``training_monitor.on_epoch_end`` fires,
+    the actual behavior: when ``monitor.on_epoch_end`` fires,
     does the lifecycle save a snapshot at the right moments and skip
     the wrong ones?
     """
@@ -481,7 +481,7 @@ class TestAutoSnapBestCallback:
         mgr.shutdown()
 
     def test_callback_subscribed_to_epoch_end_event(self):
-        """The callback is registered on ``training_monitor.epoch_end`` at __init__."""
+        """The callback is registered on ``monitor.epoch_end`` at __init__."""
         from unittest.mock import MagicMock
 
         from api.lifecycle.manager import TrainingLifecycleManager
@@ -495,6 +495,6 @@ class TestAutoSnapBestCallback:
             mgr._auto_snap_min_epochs = 0
         # Trigger the public monitor event — the lifecycle's callback
         # registration must wire through.
-        mgr.training_monitor.on_epoch_end(epoch=10, loss=0.2, accuracy=0.8, learning_rate=0.01, validation_accuracy=0.85)
+        mgr.monitor.on_epoch_end(epoch=10, loss=0.2, accuracy=0.8, learning_rate=0.01, validation_accuracy=0.85)
         assert mgr.save_snapshot.call_count == 1
         mgr.shutdown()

--- a/src/tests/unit/api/test_lifecycle_concurrency.py
+++ b/src/tests/unit/api/test_lifecycle_concurrency.py
@@ -127,7 +127,7 @@ class TestExtractAndRecordMetricsRace:
             with emit_lock:
                 emit_calls.append(epoch)
 
-        monkeypatch.setattr(mgr.training_monitor, "on_epoch_end", slow_on_epoch_end)
+        monkeypatch.setattr(mgr.monitor, "on_epoch_end", slow_on_epoch_end)
         mgr.training_state = MagicMock()
 
         n_threads = 8
@@ -161,7 +161,7 @@ class TestExtractAndRecordMetricsRace:
         mgr.network = fake_network
 
         calls: list = []
-        monkeypatch.setattr(mgr.training_monitor, "on_epoch_end", lambda epoch, **kw: calls.append(epoch))
+        monkeypatch.setattr(mgr.monitor, "on_epoch_end", lambda epoch, **kw: calls.append(epoch))
         mgr.training_state = MagicMock()
 
         mgr._extract_and_record_metrics()

--- a/src/tests/unit/api/test_lifecycle_manager.py
+++ b/src/tests/unit/api/test_lifecycle_manager.py
@@ -16,14 +16,14 @@ class TestLifecycleManagerNetwork:
     def test_initial_state(self):
         """Manager starts with no network."""
         mgr = TrainingLifecycleManager()
-        assert not mgr.has_network()
+        assert not mgr.has_model()
         assert mgr.get_network_info() == {}
 
     def test_create_network(self):
         """Create network returns info dict."""
         mgr = TrainingLifecycleManager()
         info = mgr.create_network(input_size=2, output_size=2)
-        assert mgr.has_network()
+        assert mgr.has_model()
         assert info["input_size"] == 2
         assert info["output_size"] == 2
         assert info["hidden_units"] == 0
@@ -34,7 +34,7 @@ class TestLifecycleManagerNetwork:
         mgr = TrainingLifecycleManager()
         mgr.create_network(input_size=2, output_size=2)
         mgr.delete_network()
-        assert not mgr.has_network()
+        assert not mgr.has_model()
 
     def test_get_network_info(self):
         """Get network info returns expected fields."""
@@ -181,7 +181,7 @@ class TestLifecycleHeartbeat:
         try:
             mgr.stop_liveness_heartbeat()
             before = mgr._liveness_counter
-            mgr.training_monitor.on_phase_change("output")
+            mgr.monitor.on_phase_change("output")
             assert mgr._liveness_counter > before
         finally:
             mgr.stop_liveness_heartbeat()
@@ -397,14 +397,14 @@ class TestLifecycleManagerStatus:
         """Metrics history respects count param."""
         mgr = TrainingLifecycleManager()
         # Directly add to monitor
-        mgr.training_monitor.on_epoch_end(
+        mgr.monitor.on_epoch_end(
             epoch=1,
             loss=0.5,
             accuracy=0.75,
             learning_rate=0.01,
             hidden_units=0,
         )
-        mgr.training_monitor.on_epoch_end(
+        mgr.monitor.on_epoch_end(
             epoch=2,
             loss=0.4,
             accuracy=0.80,
@@ -577,7 +577,7 @@ class TestLifecycleWorkerCoordinator:
 class TestUpdateParamsAtomicity:
     """GAP-WS-28: update_params applies all keys or none — never half.
 
-    The race itself is closed by ``_training_lock`` (one writer at a time);
+    The race itself is closed by ``_lock`` (one writer at a time);
     these tests cover the all-or-nothing semantics for the case where a
     property setter rejects a value mid-loop. No setter currently raises,
     so we drive the path with a fake network that raises on a chosen key.
@@ -801,7 +801,7 @@ class TestRestoreForRetrain:
         mgr.shutdown()
 
     def test_clears_training_monitor_metrics(self, tmp_path):
-        """The training_monitor's metrics buffer is cleared."""
+        """The monitor's metrics buffer is cleared."""
         from unittest.mock import MagicMock, patch
 
         mgr = TrainingLifecycleManager()
@@ -810,7 +810,7 @@ class TestRestoreForRetrain:
         loaded.history = {}
         fake_file = tmp_path / "snap.h5"
         fake_file.write_bytes(b"")
-        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"), patch.object(mgr.training_monitor, "clear_metrics") as mock_clear:
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"), patch.object(mgr.monitor, "clear_metrics") as mock_clear:
             mgr.restore_for_retrain("snap")
             mock_clear.assert_called_once()
         mgr.shutdown()

--- a/src/tests/unit/api/test_lifecycle_manager_coverage.py
+++ b/src/tests/unit/api/test_lifecycle_manager_coverage.py
@@ -219,7 +219,7 @@ class TestSetWsManager:
         mock_ws = MagicMock()
         mgr._ws_manager = mock_ws
 
-        with patch.object(mgr.training_monitor, "register_callback") as mock_register:
+        with patch.object(mgr.monitor, "register_callback") as mock_register:
             mgr._register_ws_callbacks()
 
             assert mock_register.call_count == 5
@@ -296,7 +296,7 @@ class TestMonitoringHooks:
         y[:4, 0] = 1
         y[4:, 1] = 1
 
-        mgr._stop_requested.clear()
+        mgr._stop_event.clear()
         mgr.network.fit(x, y)
 
         # Regression assertion: without auto-reset, state machine stayed FAILED.
@@ -325,7 +325,7 @@ class TestMonitoringHooks:
         y[4:, 1] = 1
 
         # Exercise monitored_fit stop-event branch after terminal-state restart.
-        mgr._stop_requested.set()
+        mgr._stop_event.set()
         mgr.network.fit(x, y)
 
         # Regression assertion: without auto-reset, STOP was invalid from COMPLETED.

--- a/src/tests/unit/api/test_metrics_obs_wire_01.py
+++ b/src/tests/unit/api/test_metrics_obs_wire_01.py
@@ -75,7 +75,7 @@ class TestActiveSessionsGaugeInLifecycleManager:
             if fit_outcome == "failure":
                 raise RuntimeError("synthetic training failure")
             if fit_outcome == "cancelled":
-                mgr._stop_requested.set()
+                mgr._stop_event.set()
             return None
 
         mgr._restore_original_methods()

--- a/src/tests/unit/api/test_metrics_r5_4_pre.py
+++ b/src/tests/unit/api/test_metrics_r5_4_pre.py
@@ -342,7 +342,7 @@ class TestLifecycleManagerTerminalCounterIntegration:
                 raise RuntimeError("synthetic training failure")
             if fit_outcome == "cancelled":
                 # Simulate stop_training() landing mid-fit.
-                mgr._stop_requested.set()
+                mgr._stop_event.set()
             return None
 
         # Splice the fake into the slot where monitored_fit() captured

--- a/src/tests/unit/api/test_monitoring_hooks.py
+++ b/src/tests/unit/api/test_monitoring_hooks.py
@@ -66,11 +66,11 @@ class TestMonitoringHooks:
 
         assert manager._ws_manager is ws_mgr
         # Verify callbacks were registered
-        assert len(manager.training_monitor.callbacks["epoch_end"]) > 0
-        assert len(manager.training_monitor.callbacks["cascade_add"]) > 0
-        assert len(manager.training_monitor.callbacks["training_start"]) > 0
-        assert len(manager.training_monitor.callbacks["training_end"]) > 0
-        assert len(manager.training_monitor.callbacks["candidate_progress"]) > 0
+        assert len(manager.monitor.callbacks["epoch_end"]) > 0
+        assert len(manager.monitor.callbacks["cascade_add"]) > 0
+        assert len(manager.monitor.callbacks["training_start"]) > 0
+        assert len(manager.monitor.callbacks["training_end"]) > 0
+        assert len(manager.monitor.callbacks["candidate_progress"]) > 0
 
     def test_ws_callbacks_broadcast_on_epoch_end(self):
         """Epoch end callback broadcasts metrics via WebSocket."""
@@ -79,7 +79,7 @@ class TestMonitoringHooks:
         manager.set_ws_manager(ws_mgr)
 
         # Trigger epoch_end callback
-        manager.training_monitor.on_epoch_end(epoch=1, loss=0.5, accuracy=0.8, learning_rate=0.01)
+        manager.monitor.on_epoch_end(epoch=1, loss=0.5, accuracy=0.8, learning_rate=0.01)
 
         ws_mgr.broadcast_from_thread.assert_called()
         call_args = ws_mgr.broadcast_from_thread.call_args[0][0]
@@ -91,7 +91,7 @@ class TestMonitoringHooks:
         ws_mgr = MagicMock()
         manager.set_ws_manager(ws_mgr)
 
-        manager.training_monitor.on_training_start()
+        manager.monitor.on_training_start()
 
         ws_mgr.broadcast_from_thread.assert_called()
         call_args = ws_mgr.broadcast_from_thread.call_args[0][0]
@@ -103,7 +103,7 @@ class TestMonitoringHooks:
         ws_mgr = MagicMock()
         manager.set_ws_manager(ws_mgr)
 
-        manager.training_monitor.on_training_end()
+        manager.monitor.on_training_end()
 
         ws_mgr.broadcast_from_thread.assert_called()
         call_args = ws_mgr.broadcast_from_thread.call_args[0][0]
@@ -115,7 +115,7 @@ class TestMonitoringHooks:
         ws_mgr = MagicMock()
         manager.set_ws_manager(ws_mgr)
 
-        manager.training_monitor.on_cascade_add(hidden_unit_index=0, correlation=0.95)
+        manager.monitor.on_cascade_add(hidden_unit_index=0, correlation=0.95)
 
         ws_mgr.broadcast_from_thread.assert_called()
         call_args = ws_mgr.broadcast_from_thread.call_args[0][0]
@@ -196,7 +196,7 @@ class TestMonitoringHooks:
             "total_epochs": 200,
             "correlation": 0.51,
         }
-        manager.training_monitor.on_candidate_progress(progress)
+        manager.monitor.on_candidate_progress(progress)
 
         ws_mgr.broadcast_from_thread.assert_called()
         call_args = ws_mgr.broadcast_from_thread.call_args[0][0]
@@ -236,7 +236,7 @@ class TestMonitoringHooks:
         # No history data — should be a no-op
         manager._extract_and_record_metrics()
         assert manager._last_emitted_history_len == 0
-        assert manager.training_monitor.get_current_state()["total_metrics"] == 0
+        assert manager.monitor.get_current_state()["total_metrics"] == 0
 
     def test_extract_metrics_emits_new_entries(self):
         """_extract_and_record_metrics emits only new history entries."""
@@ -249,12 +249,12 @@ class TestMonitoringHooks:
 
         manager._extract_and_record_metrics()
         assert manager._last_emitted_history_len == 1
-        assert manager.training_monitor.get_current_state()["total_metrics"] == 1
+        assert manager.monitor.get_current_state()["total_metrics"] == 1
 
         # Call again — should be no-op (no new data)
         manager._extract_and_record_metrics()
         assert manager._last_emitted_history_len == 1
-        assert manager.training_monitor.get_current_state()["total_metrics"] == 1
+        assert manager.monitor.get_current_state()["total_metrics"] == 1
 
         # Add another entry
         manager.network.history["train_loss"].append(0.3)
@@ -262,7 +262,7 @@ class TestMonitoringHooks:
 
         manager._extract_and_record_metrics()
         assert manager._last_emitted_history_len == 2
-        assert manager.training_monitor.get_current_state()["total_metrics"] == 2
+        assert manager.monitor.get_current_state()["total_metrics"] == 2
 
     def test_extract_metrics_missing_accuracy_emits_none(self):
         """Missing train_accuracy should emit metrics with accuracy=None."""
@@ -274,7 +274,7 @@ class TestMonitoringHooks:
 
         manager._extract_and_record_metrics()
 
-        metrics = manager.training_monitor.get_recent_metrics(1)
+        metrics = manager.monitor.get_recent_metrics(1)
         assert len(metrics) == 1
         assert metrics[0]["loss"] == 0.42
         assert metrics[0]["accuracy"] is None
@@ -300,7 +300,7 @@ class TestMonitoringHooks:
             manager.network.fit(x, y)
 
             state = manager.training_state.get_state()
-            metrics = manager.training_monitor.get_recent_metrics(1)
+            metrics = manager.monitor.get_recent_metrics(1)
             assert state["status"] == "Completed"
             assert state["phase"] == "Idle"
             assert state["current_epoch"] == 3
@@ -361,8 +361,8 @@ class TestMonitoringHooks:
             assert state["second_candidate_id"] == 7
             assert state["second_candidate_correlation"] == 0.65
             assert state["all_correlations"] == [0.77, 0.65, 0.42]
-            assert manager.training_monitor.current_phase == "output"
-            assert manager.training_monitor.get_current_state()["current_hidden_units"] == 1
+            assert manager.monitor.current_phase == "output"
+            assert manager.monitor.get_current_state()["current_hidden_units"] == 1
             assert sm_state["phase"] == "OUTPUT"
         finally:
             CascadeCorrelationNetwork.grow_network = original_grow
@@ -413,7 +413,7 @@ class TestMonitoringHooks:
             # Queue starts as None — drain thread must discover it dynamically
             manager.network._persistent_progress_queue = None
             progress_events = []
-            manager.training_monitor.register_callback("candidate_progress", lambda **kw: progress_events.append(kw["progress"]))
+            manager.monitor.register_callback("candidate_progress", lambda **kw: progress_events.append(kw["progress"]))
 
             x = torch.randn(8, 2)
             y = torch.randn(8, 2)

--- a/src/tests/unit/api/test_snapshot_route_coverage.py
+++ b/src/tests/unit/api/test_snapshot_route_coverage.py
@@ -75,7 +75,7 @@ class TestSaveSnapshot:
     def test_save_snapshot_success(self, client):
         """save_snapshot should return success with snapshot data."""
         snapshot_data = {"snapshot_id": "snap-001", "description": "test snapshot", "created_at": "2026-04-01T00:00:00Z"}
-        with patch.object(client.app.state.lifecycle, "has_network", return_value=True), patch.object(client.app.state.lifecycle, "save_snapshot", return_value=snapshot_data):
+        with patch.object(client.app.state.lifecycle, "has_model", return_value=True), patch.object(client.app.state.lifecycle, "save_snapshot", return_value=snapshot_data):
             response = client.post("/v1/snapshots", json={"description": "test snapshot"})
             assert response.status_code == 200
             body = response.json()
@@ -86,7 +86,7 @@ class TestSaveSnapshot:
     def test_save_snapshot_success_no_body(self, client):
         """save_snapshot should work with no request body (default description)."""
         snapshot_data = {"snapshot_id": "snap-002", "description": "", "created_at": "2026-04-01T00:00:00Z"}
-        with patch.object(client.app.state.lifecycle, "has_network", return_value=True), patch.object(client.app.state.lifecycle, "save_snapshot", return_value=snapshot_data):
+        with patch.object(client.app.state.lifecycle, "has_model", return_value=True), patch.object(client.app.state.lifecycle, "save_snapshot", return_value=snapshot_data):
             response = client.post("/v1/snapshots")
             assert response.status_code == 200
             body = response.json()
@@ -94,14 +94,14 @@ class TestSaveSnapshot:
 
     def test_save_snapshot_no_network_returns_404(self, client):
         """save_snapshot should return 404 when no network exists."""
-        with patch.object(client.app.state.lifecycle, "has_network", return_value=False):
+        with patch.object(client.app.state.lifecycle, "has_model", return_value=False):
             response = client.post("/v1/snapshots", json={"description": "no net"})
             assert response.status_code == 404
             assert "No network created" in response.json()["error"]["message"]
 
     def test_save_snapshot_returns_none_gives_404(self, client):
         """save_snapshot should return 404 when save_snapshot returns None."""
-        with patch.object(client.app.state.lifecycle, "has_network", return_value=True), patch.object(client.app.state.lifecycle, "save_snapshot", return_value=None):
+        with patch.object(client.app.state.lifecycle, "has_model", return_value=True), patch.object(client.app.state.lifecycle, "save_snapshot", return_value=None):
             response = client.post("/v1/snapshots", json={"description": "will fail"})
             assert response.status_code == 404
             assert "No network available to snapshot" in response.json()["error"]["message"]
@@ -126,7 +126,7 @@ class TestSaveSnapshot:
             captured["thread"] = threading.current_thread().name
             return snapshot_data
 
-        with patch.object(client.app.state.lifecycle, "has_network", return_value=True), patch.object(client.app.state.lifecycle, "save_snapshot", side_effect=fake_save_snapshot):
+        with patch.object(client.app.state.lifecycle, "has_model", return_value=True), patch.object(client.app.state.lifecycle, "save_snapshot", side_effect=fake_save_snapshot):
             response = client.post("/v1/snapshots", json={"description": "thread check"})
             assert response.status_code == 200
             assert "thread" in captured, "save_snapshot was not invoked"
@@ -655,7 +655,7 @@ class TestReplaySnapshot:
             "train_accuracy": [],
             "value_accuracy": [],
         }
-        session = _ReplaySession(snapshot_id, history, lifecycle.training_monitor)
+        session = _ReplaySession(snapshot_id, history, lifecycle.monitor)
         lifecycle._replay_session = session
         lifecycle.state_machine.mark_replaying()
         return session

--- a/src/tests/unit/api/test_ws6_manager_model_wiring.py
+++ b/src/tests/unit/api/test_ws6_manager_model_wiring.py
@@ -47,7 +47,15 @@ def test_fresh_manager_holds_no_model():
     mgr = TrainingLifecycleManager()
     assert mgr.model is None
     assert mgr.network is None  # property returns None when there is no model
-    assert mgr.has_network() is False
+    assert mgr.has_model() is False
+
+
+def test_has_network_is_deprecated_alias_for_has_model():
+    """WS-6 B2a: has_network() is kept as a thin back-compat alias for has_model()."""
+    mgr = TrainingLifecycleManager()
+    assert mgr.has_network() is mgr.has_model() is False
+    mgr.network = _make_ccn()
+    assert mgr.has_network() is mgr.has_model() is True
 
 
 # ----- assignment site 2: create_network ------------------------------------------
@@ -58,7 +66,7 @@ def test_create_network_wraps_ccn_in_cascor_model():
     # The property exposes the *underlying* CCN (identity), not the wrapper.
     assert mgr.network is mgr.model.network
     assert type(mgr.network).__name__ == "CascadeCorrelationNetwork"
-    assert mgr.has_network() is True
+    assert mgr.has_model() is True
 
 
 # ----- assignment site 3: delete_network ------------------------------------------
@@ -68,7 +76,7 @@ def test_delete_network_clears_the_model():
     mgr.delete_network()
     assert mgr.model is None
     assert mgr.network is None
-    assert mgr.has_network() is False
+    assert mgr.has_model() is False
 
 
 # ----- assignment site 4: _load_snapshot_to_network (HDF5 re-wrap, H1) ------------

--- a/src/tests/unit/test_phase_2e_topology_correlation_phase.py
+++ b/src/tests/unit/test_phase_2e_topology_correlation_phase.py
@@ -78,7 +78,7 @@ class TestBugCC01TopologyBroadcast:
         if new_hidden > prev_hidden:
             for i in range(prev_hidden, new_hidden):
                 actual = float(getattr(mgr.network.hidden_units[i], "best_correlation", 0.0) or 0.0)
-                mgr.training_monitor.on_cascade_add(hidden_unit_index=i, correlation=actual)
+                mgr.monitor.on_cascade_add(hidden_unit_index=i, correlation=actual)
             topology_data = {
                 "hidden_units": new_hidden,
                 "input_size": mgr.network.input_size,
@@ -241,16 +241,15 @@ class TestBugCC07PhaseTracking:
         assert started is True
 
         # Install only the phase tracker (no network needed).
-        mgr._install_phase_tracker(mgr.training_monitor, mgr.state_machine)
+        mgr._install_phase_tracker(mgr.monitor, mgr.state_machine)
 
         mgr.state_machine.set_phase(TrainingPhase.CANDIDATE)
-        assert mgr.training_monitor.current_phase == "candidate"
+        assert mgr.monitor.current_phase == "candidate"
         mgr.state_machine.set_phase(TrainingPhase.OUTPUT)
-        assert mgr.training_monitor.current_phase == "output"
+        assert mgr.monitor.current_phase == "output"
 
     def test_manager_no_longer_assigns_current_phase_directly(self):
         """No manual `monitor.current_phase = "..."` assignments in manager.py."""
         manager_src = (Path(__file__).resolve().parents[2] / "api" / "lifecycle" / "manager.py").read_text()
         # Permit the on_phase_change call but forbid the dotted assignment.
         assert "monitor.current_phase =" not in manager_src
-        assert "training_monitor.current_phase =" not in manager_src

--- a/src/tests/unit/test_remaining_coverage_deep.py
+++ b/src/tests/unit/test_remaining_coverage_deep.py
@@ -305,7 +305,7 @@ class TestMonitoredFitStopEvent:
         assert original_fit is not None
 
         # Set the stop event before calling fit
-        mgr._stop_requested.set()
+        mgr._stop_event.set()
 
         # Mock the original fit to return immediately
         with patch.dict(mgr._original_methods, {"fit": MagicMock(return_value={"train_loss": [0.1]})}):
@@ -317,7 +317,7 @@ class TestMonitoredFitStopEvent:
             mgr._install_monitoring_hooks()
 
             # Set stop event
-            mgr._stop_requested.set()
+            mgr._stop_event.set()
 
             # Call the monitored fit
             mgr.network.fit(x, y)
@@ -345,7 +345,7 @@ class TestMonitoredFitStopEvent:
         mgr._install_monitoring_hooks()
 
         # Ensure stop event is NOT set
-        mgr._stop_requested.clear()
+        mgr._stop_event.clear()
 
         # Call the monitored fit
         mgr.network.fit(x, y)
@@ -675,7 +675,7 @@ class TestLifecycleManagerShutdownDeep:
         mgr = TrainingLifecycleManager()
         assert mgr._executor is None
         mgr.shutdown()
-        assert mgr._stop_requested.is_set()
+        assert mgr._stop_event.is_set()
 
     def test_shutdown_with_executor(self):
         """Shutdown with active executor cleans it up."""


### PR DESCRIPTION
## Summary

WS-6 B-phase, **PR-B2a** (second of B1→B4): converge the lifecycle manager's public attribute/method names to the future `ServiceLifecycleManager` subclass seam (plan §5/§6, juniper-ml #485). **Pure renames — behavior-preserving.** Builds on PR-B1 (#345, merged).

## Renames

Attribute-qualified — the helper classes `_WeightHistoryRecorder`/`_WeightCache`/`_ReplaySession` that already use these names are untouched:

| Old | New |
| --- | --- |
| `self.training_monitor` | `self.monitor` |
| `self._training_lock` | `self._lock` |
| `self._stop_requested` | `self._stop_event` |
| `self._network_params` | `self._params` |
| `has_network()` | `has_model()` (+ thin deprecated `has_network` alias) |

All ~160 in-repo call sites updated in the **same PR** (H2): 6 API route modules + ~18 test modules. String-form refs the attribute-dotted pass couldn't reach were fixed by hand:
- `getattr(lifecycle, "_stop_event")` in the golden-snapshot test
- `patch.object(..., "has_model")` ×5 in the snapshot-route tests — the routes now *call* `has_model`, so the patch must target it (not the alias)

Stale docstring/comment prose updated; the now-vacuous `training_monitor.current_phase` source-introspection assert dropped.

## Deferred (scope call)

The unused seam additions the plan also lists (`_dataset_name`/`_last_result`/`_last_error`/`join`) are **deferred to the A-phase** — YAGNI until consumed, and avoids adding dead code the 80% coverage gate would flag.

## Verification (JuniperCascor1)

| Lane | Result |
| --- | --- |
| `Golden / Snapshot Regression` | ✅ exit 0 |
| `model-core Conformance` | ✅ exit 0 |
| Full `src/tests/unit/api` + changed unit files | ✅ all pass |
| Changed integration tests (pause/stop, event-invariants, full-lifecycle, …) | ✅ all pass |
| black / isort / flake8 / mypy | ✅ clean |

No route projection, monitoring-mechanism, or `/ws/training` granularity change — those are PR-B3.

## Staging

B1 ✅ (#345 merged) → **B2a (this)** → B2b (signature/return convergence) → B3 (`on_event` sink — the crux, OQ-B1) → B4 (native conformance vs `CascorModel`; retire the test adapter).

## Refs

- Build plan: juniper-ml #485 · Decision: juniper-ml #475 (DR-1) · Predecessor: cascor #345 (B1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WLKsAKe4qSBkDL88Lq25PZ
