### PR TITLE
refactor(api): WS-6 PR-B2b — converge start_training signature + snapshot return shape

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -353,7 +353,7 @@ async def _auto_start_training(app: FastAPI, settings: Settings) -> None:
         logger.info(f"Auto-start: network created — {network_info['input_size']}x{network_info['output_size']}")
 
         # Start training
-        train_result = lifecycle.start_training(x=x_train, y=y_train)
+        train_result = lifecycle.start_training(X=x_train, y=y_train)
         logger.info(f"Auto-start: training initiated — {train_result}")
 
     except Exception:

--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -2066,18 +2066,19 @@ class TrainingLifecycleManager:
 
     def start_training(
         self,
-        x: Optional[torch.Tensor] = None,
+        X: Optional[torch.Tensor] = None,
         y: Optional[torch.Tensor] = None,
-        x_val: Optional[torch.Tensor] = None,
+        *,
+        X_val: Optional[torch.Tensor] = None,
         y_val: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> Dict[str, Any]:
         """Start training asynchronously.
 
         Args:
-            x: Training features tensor
+            X: Training features tensor
             y: Training targets tensor
-            x_val: Validation features
+            X_val: Validation features
             y_val: Validation targets
             **kwargs: TrainingParams body. Fields in ``_FIT_KWARGS`` are
                 forwarded to ``network.fit``; everything else is applied
@@ -2110,11 +2111,11 @@ class TrainingLifecycleManager:
             if self.state_machine.is_replaying():
                 raise RuntimeError("Cannot start training while replaying a snapshot — invoke /v1/snapshots/{id}/replay/control with action='stop' first")
 
-            if x is not None:
-                self._train_x = x
+            if X is not None:
+                self._train_x = X
                 self._train_y = y
-            if x_val is not None:
-                self._val_x = x_val
+            if X_val is not None:
+                self._val_x = X_val
                 self._val_y = y_val
 
             # FRONTEND_ISSUES_PLAN_2026-05-09 §3.5.1 / Issue #3 Phase 1 — if
@@ -3983,7 +3984,20 @@ class TrainingLifecycleManager:
             self.network.set_worker_coordinator(self._worker_coordinator)
         return True
 
-    def load_snapshot(self, snapshot_id: str) -> bool:
+    def _snapshot_result(self, *, loaded: bool, snapshot_id: str, operation: str, reason: Optional[str] = None) -> Dict[str, Any]:
+        """Status dict for the snapshot load/restore/resume verbs (WS-6 B2b return
+        convergence toward the ServiceLifecycleManager seam). Internal contract: the
+        snapshot routes build their own HTTP payload via ``_build_unified_payload`` and
+        consume only ``loaded`` for error-mapping."""
+        return {
+            "loaded": loaded,
+            "snapshot_id": snapshot_id,
+            "operation": operation,
+            "fsm_state": self.state_machine.status.name,
+            "reason": reason,
+        }
+
+    def load_snapshot(self, snapshot_id: str) -> Dict[str, Any]:
         """Load a network snapshot by ID (Restore semantics).
 
         Preserves the full snapshotted state — weights, topology, training
@@ -4006,11 +4020,11 @@ class TrainingLifecycleManager:
         # out from under an active replay thread.
         if self.state_machine.is_started() or self.state_machine.is_paused() or self.state_machine.is_replaying():
             self.logger.warning(f"load_snapshot rejected: lifecycle is {self.state_machine.status.name}")
-            return False
+            return self._snapshot_result(loaded=False, snapshot_id=snapshot_id, operation="restore", reason=f"rejected: lifecycle is {self.state_machine.status.name}")
 
         ok = self._load_snapshot_to_network(snapshot_id)
         if not ok:
-            return False
+            return self._snapshot_result(loaded=False, snapshot_id=snapshot_id, operation="restore", reason="snapshot not found or failed to load")
 
         # CAN-015d (B-4): transition to Investigating and clear any
         # state from prior snapshot operations. The user explicitly
@@ -4022,9 +4036,9 @@ class TrainingLifecycleManager:
         self.training_state.update_state(status="Stopped", phase="Idle")
         self._broadcast_training_state(force=True)
         self.logger.info(f"Snapshot restored: {snapshot_id} (FSM=Investigating)")
-        return True
+        return self._snapshot_result(loaded=True, snapshot_id=snapshot_id, operation="restore")
 
-    def restore_for_retrain(self, snapshot_id: str) -> bool:
+    def restore_for_retrain(self, snapshot_id: str) -> Dict[str, Any]:
         """Load a snapshot and reset training history for a fresh run (CAN-015a).
 
         Phase 6E Sprint B B-1. Loads the snapshot identically to
@@ -4051,10 +4065,10 @@ class TrainingLifecycleManager:
         """
         if self.state_machine.is_started() or self.state_machine.is_paused() or self.state_machine.is_replaying():
             self.logger.warning(f"restore_for_retrain rejected: lifecycle is {self.state_machine.status.name}")
-            return False
+            return self._snapshot_result(loaded=False, snapshot_id=snapshot_id, operation="retrain", reason=f"rejected: lifecycle is {self.state_machine.status.name}")
         ok = self._load_snapshot_to_network(snapshot_id)
         if not ok:
-            return False
+            return self._snapshot_result(loaded=False, snapshot_id=snapshot_id, operation="retrain", reason="snapshot not found or failed to load")
 
         # Clear history arrays on the network. ``getattr`` rather than direct
         # attribute access so a network that doesn't expose ``history`` yet
@@ -4095,9 +4109,9 @@ class TrainingLifecycleManager:
         self._broadcast_training_state(force=True)
 
         self.logger.info(f"Snapshot restored for retrain: {snapshot_id}")
-        return True
+        return self._snapshot_result(loaded=True, snapshot_id=snapshot_id, operation="retrain")
 
-    def resume_from_snapshot(self, snapshot_id: str) -> bool:
+    def resume_from_snapshot(self, snapshot_id: str) -> Dict[str, Any]:
         """Load a snapshot and prepare to continue training (CAN-015b).
 
         Phase 6E Sprint B B-2. Loads the snapshot identically to
@@ -4126,11 +4140,11 @@ class TrainingLifecycleManager:
         """
         if self.state_machine.is_started() or self.state_machine.is_paused() or self.state_machine.is_replaying():
             self.logger.warning(f"resume_from_snapshot rejected: lifecycle is {self.state_machine.status.name}")
-            return False
+            return self._snapshot_result(loaded=False, snapshot_id=snapshot_id, operation="resume", reason=f"rejected: lifecycle is {self.state_machine.status.name}")
 
         ok = self._load_snapshot_to_network(snapshot_id)
         if not ok:
-            return False
+            return self._snapshot_result(loaded=False, snapshot_id=snapshot_id, operation="resume", reason="snapshot not found or failed to load")
 
         # Compute the resume-point epoch from the loaded network's
         # history. Use the longest array's length so a snapshot that's
@@ -4165,7 +4179,7 @@ class TrainingLifecycleManager:
         self._broadcast_training_state(force=True)
 
         self.logger.info(f"Snapshot restored for resume: {snapshot_id} (resume_point_epoch={resume_point})")
-        return True
+        return self._snapshot_result(loaded=True, snapshot_id=snapshot_id, operation="resume")
 
     def start_replay(self, snapshot_id: str) -> bool:
         """Load a snapshot and start a replay session (CAN-015c).

--- a/src/api/routes/snapshots.py
+++ b/src/api/routes/snapshots.py
@@ -221,8 +221,8 @@ async def restore_snapshot(request: Request, snapshot_id: str) -> dict:
     # PERF-CC-01: serializer.load_network is synchronous HDF5 I/O. Run it
     # off the event loop so concurrent requests aren't blocked while the
     # snapshot is being read.
-    success = await asyncio.to_thread(lifecycle.load_snapshot, snapshot_id)
-    if not success:
+    result = await asyncio.to_thread(lifecycle.load_snapshot, snapshot_id)
+    if not result["loaded"]:
         raise HTTPException(status_code=404, detail=f"Snapshot '{snapshot_id}' not found or failed to load")
     payload = _build_unified_payload(
         lifecycle,
@@ -264,8 +264,8 @@ async def retrain_from_snapshot(request: Request, snapshot_id: str) -> dict:
     # PERF-CC-01: HDF5 I/O off the event loop, same as the other
     # snapshot routes. The reset side-effects (FSM, monitor, training_state)
     # are quick attribute writes — no need to fan out further.
-    success = await asyncio.to_thread(lifecycle.restore_for_retrain, snapshot_id)
-    if not success:
+    result = await asyncio.to_thread(lifecycle.restore_for_retrain, snapshot_id)
+    if not result["loaded"]:
         raise HTTPException(status_code=404, detail=f"Snapshot '{snapshot_id}' not found or failed to load")
     payload = _build_unified_payload(
         lifecycle,
@@ -310,8 +310,8 @@ async def resume_snapshot(request: Request, snapshot_id: str) -> dict:
     if lifecycle.state_machine.is_started() or lifecycle.state_machine.is_paused():
         raise HTTPException(status_code=409, detail=f"Cannot resume from snapshot while training is {lifecycle.state_machine.status.name}")
     # PERF-CC-01: HDF5 I/O off the event loop, same as the other snapshot routes.
-    success = await asyncio.to_thread(lifecycle.resume_from_snapshot, snapshot_id)
-    if not success:
+    result = await asyncio.to_thread(lifecycle.resume_from_snapshot, snapshot_id)
+    if not result["loaded"]:
         raise HTTPException(status_code=404, detail=f"Snapshot '{snapshot_id}' not found or failed to load")
     payload = _build_unified_payload(
         lifecycle,

--- a/src/api/routes/training.py
+++ b/src/api/routes/training.py
@@ -71,7 +71,7 @@ async def start_training(request: Request, body: TrainingStartRequest = None) ->
             kwargs["max_epochs"] = body.epochs
 
     try:
-        result = lifecycle.start_training(x=x, y=y, x_val=x_val, y_val=y_val, **kwargs)
+        result = lifecycle.start_training(X=x, y=y, X_val=x_val, y_val=y_val, **kwargs)
         return success_response(result)
     except (RuntimeError, ValueError) as e:
         # Surface the specific reason (no network created / training already in progress /

--- a/src/tests/unit/api/test_lifecycle_manager.py
+++ b/src/tests/unit/api/test_lifecycle_manager.py
@@ -205,7 +205,7 @@ class TestLifecycleManagerTrainingControl:
         """Start fails without network."""
         mgr = TrainingLifecycleManager()
         with pytest.raises(RuntimeError, match="No network created"):
-            mgr.start_training(x=torch.randn(10, 2), y=torch.randn(10, 2))
+            mgr.start_training(X=torch.randn(10, 2), y=torch.randn(10, 2))
 
     def test_start_training_without_data(self):
         """Start fails without training data."""
@@ -226,7 +226,7 @@ class TestLifecycleManagerTrainingControl:
         y[10:, 1] = 1
         # Mock the network's fit() to avoid actual training overhead (~4s)
         with patch.object(mgr.network, "fit", return_value={"train_loss": [0.5]}):
-            result = mgr.start_training(x=x, y=y)
+            result = mgr.start_training(X=x, y=y)
             assert result["status"] == "training_started"
             assert "timestamp" in result
             # Wait for background training to actually complete before shutdown
@@ -264,7 +264,7 @@ class TestLifecycleManagerTrainingControl:
         y[10:, 1] = 1
 
         with patch.object(mgr.network, "fit", return_value={"train_loss": [0.5]}) as mock_fit:
-            mgr.start_training(x=x, y=y, learning_rate=0.005, max_iterations=3)
+            mgr.start_training(X=x, y=y, learning_rate=0.005, max_iterations=3)
             if mgr._training_future is not None:
                 mgr._training_future.result(timeout=10)
 
@@ -295,7 +295,7 @@ class TestLifecycleManagerTrainingControl:
         # int budget, Literal-validated string, and a fit-shaped kwarg.
         with patch.object(mgr.network, "fit", return_value={"train_loss": [0.5]}) as mock_fit:
             mgr.start_training(
-                x=x,
+                X=x,
                 y=y,
                 learning_rate=0.003,
                 output_epochs=7,
@@ -698,7 +698,7 @@ class TestRestoreForRetrain:
         mgr = TrainingLifecycleManager()
         # Empty snapshots dir — no matching file.
         with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path):
-            assert mgr.restore_for_retrain("nonexistent-snapshot") is False
+            assert mgr.restore_for_retrain("nonexistent-snapshot")["loaded"] is False
         # No network was created — verify the call didn't accidentally make one.
         assert mgr.network is None
         mgr.shutdown()
@@ -713,7 +713,7 @@ class TestRestoreForRetrain:
         fake_file = tmp_path / "broken.h5"
         fake_file.write_bytes(b"not actually an hdf5 file")
         with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=None):
-            assert mgr.restore_for_retrain("broken") is False
+            assert mgr.restore_for_retrain("broken")["loaded"] is False
         # Original network is still installed — failed retrain doesn't
         # leave the lifecycle in a half-replaced state.
         assert mgr.network is original_network
@@ -735,7 +735,7 @@ class TestRestoreForRetrain:
         fake_file = tmp_path / "snap.h5"
         fake_file.write_bytes(b"")
         with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"):
-            assert mgr.restore_for_retrain("snap") is True
+            assert mgr.restore_for_retrain("snap")["loaded"] is True
 
         for key in ("train_loss", "value_loss", "train_accuracy", "value_accuracy"):
             assert loaded.history[key] == [], f"history[{key!r}] not cleared by retrain"
@@ -832,7 +832,7 @@ class TestRestoreForRetrain:
         fake_file = tmp_path / "snap.h5"
         fake_file.write_bytes(b"")
         with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"):
-            assert mgr.restore_for_retrain("snap") is True
+            assert mgr.restore_for_retrain("snap")["loaded"] is True
         mgr.shutdown()
 
     def test_tolerates_non_dict_history(self, tmp_path):
@@ -852,7 +852,7 @@ class TestRestoreForRetrain:
         fake_file = tmp_path / "snap.h5"
         fake_file.write_bytes(b"")
         with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"):
-            assert mgr.restore_for_retrain("snap") is True
+            assert mgr.restore_for_retrain("snap")["loaded"] is True
         mgr.shutdown()
 
     def test_load_snapshot_preserves_history_and_counters(self, tmp_path):
@@ -870,7 +870,7 @@ class TestRestoreForRetrain:
         fake_file = tmp_path / "snap.h5"
         fake_file.write_bytes(b"")
         with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"):
-            assert mgr.load_snapshot("snap") is True
+            assert mgr.load_snapshot("snap")["loaded"] is True
 
         # History on the loaded network is preserved — Restore is a load,
         # not a reset.
@@ -903,7 +903,7 @@ class TestResumeFromSnapshot:
 
         mgr = TrainingLifecycleManager()
         with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path):
-            assert mgr.resume_from_snapshot("nonexistent") is False
+            assert mgr.resume_from_snapshot("nonexistent")["loaded"] is False
         assert mgr.state_machine.is_stopped()
         assert not mgr.state_machine.is_resume_ready()
         mgr.shutdown()
@@ -917,7 +917,7 @@ class TestResumeFromSnapshot:
         mgr.state_machine.handle_command(Command.START)
         assert mgr.state_machine.is_started()
         with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path):
-            assert mgr.resume_from_snapshot("anything") is False
+            assert mgr.resume_from_snapshot("anything")["loaded"] is False
         assert mgr.state_machine.is_started()
         assert not mgr.state_machine.is_resume_ready()
         mgr.shutdown()
@@ -938,7 +938,7 @@ class TestResumeFromSnapshot:
         fake_file = tmp_path / "snap.h5"
         fake_file.write_bytes(b"")
         with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"):
-            assert mgr.resume_from_snapshot("snap") is True
+            assert mgr.resume_from_snapshot("snap")["loaded"] is True
 
         assert loaded.history["train_loss"] == [0.5, 0.4, 0.3]
         assert loaded.history["value_loss"] == [0.6, 0.5, 0.4]
@@ -1013,7 +1013,7 @@ class TestResumeFromSnapshot:
         fake_file = tmp_path / "snap.h5"
         fake_file.write_bytes(b"")
         with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"):
-            assert mgr.resume_from_snapshot("snap") is True
+            assert mgr.resume_from_snapshot("snap")["loaded"] is True
 
         assert mgr._resume_point_epoch == 0
         mgr.shutdown()
@@ -1033,7 +1033,7 @@ class TestResumeFromSnapshot:
         fake_file = tmp_path / "snap.h5"
         fake_file.write_bytes(b"")
         with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"):
-            assert mgr.resume_from_snapshot("snap") is True
+            assert mgr.resume_from_snapshot("snap")["loaded"] is True
 
         assert mgr._resume_point_epoch == 0
         mgr.shutdown()
@@ -1088,7 +1088,7 @@ class TestResumeFromSnapshot:
         y[:10, 0] = 1
         y[10:, 1] = 1
         with patch.object(mgr.network, "fit", return_value={"train_loss": [0.3]}):
-            mgr.start_training(x=x, y=y)
+            mgr.start_training(X=x, y=y)
             if mgr._training_future is not None:
                 mgr._training_future.result(timeout=10)
 
@@ -1116,7 +1116,7 @@ class TestResumeFromSnapshot:
         y[:10, 0] = 1
         y[10:, 1] = 1
         with patch.object(mgr.network, "fit", return_value={"train_loss": [0.3]}):
-            mgr.start_training(x=x, y=y)
+            mgr.start_training(X=x, y=y)
             if mgr._training_future is not None:
                 mgr._training_future.result(timeout=10)
 
@@ -1142,7 +1142,7 @@ class TestLoadSnapshotInvestigating:
         mgr.create_network(input_size=2, output_size=2)
         mgr.state_machine.handle_command(Command.START)
         with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path):
-            assert mgr.load_snapshot("anything") is False
+            assert mgr.load_snapshot("anything")["loaded"] is False
         # FSM still in Started — Restore didn't sneak through.
         assert mgr.state_machine.is_started()
         mgr.shutdown()
@@ -1158,7 +1158,7 @@ class TestLoadSnapshotInvestigating:
         fake_file = tmp_path / "snap.h5"
         fake_file.write_bytes(b"")
         with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.load_network", return_value=loaded), patch.object(mgr, "_restore_original_methods"), patch.object(mgr, "_install_monitoring_hooks"):
-            assert mgr.load_snapshot("snap") is True
+            assert mgr.load_snapshot("snap")["loaded"] is True
 
         assert mgr.state_machine.is_investigating()
         mgr.shutdown()
@@ -1199,7 +1199,7 @@ class TestLoadSnapshotInvestigating:
         x = torch.randn(20, 2)
         y = torch.zeros(20, 2)
         with pytest.raises(RuntimeError, match="Investigating"):
-            mgr.start_training(x=x, y=y)
+            mgr.start_training(X=x, y=y)
         # FSM unchanged — failed start didn't accidentally transition.
         assert mgr.state_machine.is_investigating()
         mgr.shutdown()
@@ -1554,7 +1554,7 @@ class TestReplayLifecycleIntegration:
                 x = torch.randn(20, 2)
                 y = torch.zeros(20, 2)
                 with pytest.raises(RuntimeError, match="replay"):
-                    mgr.start_training(x=x, y=y)
+                    mgr.start_training(X=x, y=y)
             finally:
                 mgr.stop_replay()
         mgr.shutdown()
@@ -1566,7 +1566,7 @@ class TestReplayLifecycleIntegration:
         with ctxs[0], ctxs[1], ctxs[2], ctxs[3]:
             try:
                 mgr.start_replay("snap")
-                assert mgr.load_snapshot("snap") is False
+                assert mgr.load_snapshot("snap")["loaded"] is False
             finally:
                 mgr.stop_replay()
         mgr.shutdown()

--- a/src/tests/unit/api/test_lifecycle_manager_coverage.py
+++ b/src/tests/unit/api/test_lifecycle_manager_coverage.py
@@ -361,11 +361,11 @@ class TestStartTrainingEdgeCases:
             y[:5, 0] = 1
             y[5:, 1] = 1
 
-            mgr.start_training(x=x, y=y)
+            mgr.start_training(X=x, y=y)
             started.wait(timeout=5)
 
             with pytest.raises(RuntimeError, match="already in progress"):
-                mgr.start_training(x=x, y=y)
+                mgr.start_training(X=x, y=y)
         finally:
             barrier.set()
             CascadeCorrelationNetwork.fit = original_class_fit
@@ -415,7 +415,7 @@ class TestShutdown:
         y[5:, 1] = 1
 
         with patch.object(mgr.network, "fit", return_value={"train_loss": [0.5]}):
-            mgr.start_training(x=x, y=y)
+            mgr.start_training(X=x, y=y)
             if mgr._training_future is not None:
                 mgr._training_future.result(timeout=10)
 

--- a/src/tests/unit/api/test_snapshot_route_coverage.py
+++ b/src/tests/unit/api/test_snapshot_route_coverage.py
@@ -202,7 +202,7 @@ class TestRestoreSnapshot:
 
     def test_restore_snapshot_success(self, client):
         """restore_snapshot should return success with restored status."""
-        with patch.object(client.app.state.lifecycle, "load_snapshot", return_value=True):
+        with patch.object(client.app.state.lifecycle, "load_snapshot", return_value={"loaded": True}):
             response = client.post("/v1/snapshots/snap-001/restore")
             assert response.status_code == 200
             body = response.json()
@@ -230,7 +230,7 @@ class TestRestoreSnapshot:
             "optimizer_type": "AdamW",
             "activation_function_name": "ReLU",
         }
-        with patch.object(client.app.state.lifecycle, "load_snapshot", return_value=True), patch.object(client.app.state.lifecycle, "get_training_params", return_value=fake_params):
+        with patch.object(client.app.state.lifecycle, "load_snapshot", return_value={"loaded": True}), patch.object(client.app.state.lifecycle, "get_training_params", return_value=fake_params):
             response = client.post("/v1/snapshots/snap-with-params/restore")
             assert response.status_code == 200
             body = response.json()
@@ -241,7 +241,7 @@ class TestRestoreSnapshot:
         """If ``get_training_params`` raises after a successful restore
         the route still returns 200 with the minimal payload — surfacing
         params is best-effort and must not undo a successful load."""
-        with patch.object(client.app.state.lifecycle, "load_snapshot", return_value=True), patch.object(client.app.state.lifecycle, "get_training_params", side_effect=RuntimeError("boom")):
+        with patch.object(client.app.state.lifecycle, "load_snapshot", return_value={"loaded": True}), patch.object(client.app.state.lifecycle, "get_training_params", side_effect=RuntimeError("boom")):
             response = client.post("/v1/snapshots/snap-fallback/restore")
             assert response.status_code == 200
             body = response.json()
@@ -253,14 +253,14 @@ class TestRestoreSnapshot:
 
     def test_restore_snapshot_not_found_returns_404(self, client):
         """restore_snapshot should return 404 when snapshot is not found."""
-        with patch.object(client.app.state.lifecycle, "load_snapshot", return_value=False):
+        with patch.object(client.app.state.lifecycle, "load_snapshot", return_value={"loaded": False}):
             response = client.post("/v1/snapshots/nonexistent/restore")
             assert response.status_code == 404
             assert "not found or failed to load" in response.json()["error"]["message"]
 
     def test_restore_snapshot_load_fails_returns_404(self, client):
         """restore_snapshot should return 404 when load_snapshot fails (returns False)."""
-        with patch.object(client.app.state.lifecycle, "load_snapshot", return_value=False):
+        with patch.object(client.app.state.lifecycle, "load_snapshot", return_value={"loaded": False}):
             response = client.post("/v1/snapshots/snap-bad/restore")
             assert response.status_code == 404
             assert "not found or failed to load" in response.json()["error"]["message"]
@@ -273,7 +273,7 @@ class TestRestoreSnapshot:
             import threading
 
             captured["thread"] = threading.current_thread().name
-            return True
+            return {"loaded": True}
 
         with patch.object(client.app.state.lifecycle, "load_snapshot", side_effect=fake_load_snapshot):
             response = client.post("/v1/snapshots/snap-thread/restore")
@@ -293,7 +293,7 @@ class TestRetrainFromSnapshot:
 
     def test_retrain_snapshot_success(self, client):
         """retrain route returns success with ``operation: retrain`` and ``status: ready``."""
-        with patch.object(client.app.state.lifecycle, "restore_for_retrain", return_value=True):
+        with patch.object(client.app.state.lifecycle, "restore_for_retrain", return_value={"loaded": True}):
             response = client.post("/v1/snapshots/snap-001/retrain")
             assert response.status_code == 200
             body = response.json()
@@ -311,7 +311,7 @@ class TestRetrainFromSnapshot:
             "optimizer_type": "AdamW",
             "activation_function_name": "ReLU",
         }
-        with patch.object(client.app.state.lifecycle, "restore_for_retrain", return_value=True), patch.object(client.app.state.lifecycle, "get_training_params", return_value=fake_params):
+        with patch.object(client.app.state.lifecycle, "restore_for_retrain", return_value={"loaded": True}), patch.object(client.app.state.lifecycle, "get_training_params", return_value=fake_params):
             response = client.post("/v1/snapshots/snap-with-params/retrain")
             assert response.status_code == 200
             body = response.json()
@@ -322,7 +322,7 @@ class TestRetrainFromSnapshot:
         """A failing ``get_training_params`` after a successful restore_for_retrain
         must NOT make the route appear failed — return 200 with the
         minimal payload, same defensive pattern as /restore."""
-        with patch.object(client.app.state.lifecycle, "restore_for_retrain", return_value=True), patch.object(client.app.state.lifecycle, "get_training_params", side_effect=RuntimeError("boom")):
+        with patch.object(client.app.state.lifecycle, "restore_for_retrain", return_value={"loaded": True}), patch.object(client.app.state.lifecycle, "get_training_params", side_effect=RuntimeError("boom")):
             response = client.post("/v1/snapshots/snap-fallback/retrain")
             assert response.status_code == 200
             body = response.json()
@@ -334,7 +334,7 @@ class TestRetrainFromSnapshot:
     def test_retrain_snapshot_not_found_returns_404(self, client):
         """When restore_for_retrain returns False (missing snapshot or
         deserializer failure) the route maps to 404, identical to /restore."""
-        with patch.object(client.app.state.lifecycle, "restore_for_retrain", return_value=False):
+        with patch.object(client.app.state.lifecycle, "restore_for_retrain", return_value={"loaded": False}):
             response = client.post("/v1/snapshots/nonexistent/retrain")
             assert response.status_code == 404
             assert "not found or failed to load" in response.json()["error"]["message"]
@@ -347,7 +347,7 @@ class TestRetrainFromSnapshot:
             import threading
 
             captured["thread"] = threading.current_thread().name
-            return True
+            return {"loaded": True}
 
         with patch.object(client.app.state.lifecycle, "restore_for_retrain", side_effect=fake_restore_for_retrain):
             response = client.post("/v1/snapshots/snap-thread/retrain")
@@ -383,7 +383,7 @@ class TestResumeSnapshot:
         lifecycle = client.app.state.lifecycle
         lifecycle._resume_point_epoch = 42
 
-        with patch.object(lifecycle, "resume_from_snapshot", return_value=True):
+        with patch.object(lifecycle, "resume_from_snapshot", return_value={"loaded": True}):
             response = client.post("/v1/snapshots/snap-001/resume")
             assert response.status_code == 200
             body = response.json()
@@ -402,7 +402,7 @@ class TestResumeSnapshot:
         }
         lifecycle = client.app.state.lifecycle
         lifecycle._resume_point_epoch = 7
-        with patch.object(lifecycle, "resume_from_snapshot", return_value=True), patch.object(lifecycle, "get_training_params", return_value=fake_params):
+        with patch.object(lifecycle, "resume_from_snapshot", return_value={"loaded": True}), patch.object(lifecycle, "get_training_params", return_value=fake_params):
             response = client.post("/v1/snapshots/snap-with-params/resume")
             assert response.status_code == 200
             body = response.json()
@@ -414,7 +414,7 @@ class TestResumeSnapshot:
         NOT make the route appear failed — same defensive pattern as /restore."""
         lifecycle = client.app.state.lifecycle
         lifecycle._resume_point_epoch = 0
-        with patch.object(lifecycle, "resume_from_snapshot", return_value=True), patch.object(lifecycle, "get_training_params", side_effect=RuntimeError("boom")):
+        with patch.object(lifecycle, "resume_from_snapshot", return_value={"loaded": True}), patch.object(lifecycle, "get_training_params", side_effect=RuntimeError("boom")):
             response = client.post("/v1/snapshots/snap-fallback/resume")
             assert response.status_code == 200
             body = response.json()
@@ -425,7 +425,7 @@ class TestResumeSnapshot:
     def test_resume_snapshot_not_found_returns_404(self, client):
         """When resume_from_snapshot returns False (missing snapshot or
         deserializer failure), the route maps to 404."""
-        with patch.object(client.app.state.lifecycle, "resume_from_snapshot", return_value=False):
+        with patch.object(client.app.state.lifecycle, "resume_from_snapshot", return_value={"loaded": False}):
             response = client.post("/v1/snapshots/nonexistent/resume")
             assert response.status_code == 404
             assert "not found or failed to load" in response.json()["error"]["message"]
@@ -466,7 +466,7 @@ class TestResumeSnapshot:
             import threading
 
             captured["thread"] = threading.current_thread().name
-            return True
+            return {"loaded": True}
 
         client.app.state.lifecycle._resume_point_epoch = 0
         with patch.object(client.app.state.lifecycle, "resume_from_snapshot", side_effect=fake_resume):
@@ -519,13 +519,13 @@ class TestUnifiedResponseShape:
         ``target_marker`` is one of "investigating", "stopped", "resume_ready".
         """
         if target_marker == "investigating":
-            return lambda *args, **kwargs: (lifecycle.state_machine.mark_investigating(), True)[1]
+            return lambda *args, **kwargs: (lifecycle.state_machine.mark_investigating(), {"loaded": True})[1]
         if target_marker == "resume_ready":
-            return lambda *args, **kwargs: (lifecycle.state_machine.mark_resume_ready(), True)[1]
+            return lambda *args, **kwargs: (lifecycle.state_machine.mark_resume_ready(), {"loaded": True})[1]
         if target_marker == "stopped":
             from api.lifecycle.state_machine import Command
 
-            return lambda *args, **kwargs: (lifecycle.state_machine.handle_command(Command.RESET), True)[1]
+            return lambda *args, **kwargs: (lifecycle.state_machine.handle_command(Command.RESET), {"loaded": True})[1]
         raise ValueError(f"unknown target_marker {target_marker!r}")
 
     def test_restore_response_includes_unified_fields(self, client):
@@ -572,7 +572,7 @@ class TestUnifiedResponseShape:
         def side_effect(snapshot_id):
             lifecycle.state_machine.mark_resume_ready()
             lifecycle._resume_point_epoch = 42
-            return True
+            return {"loaded": True}
 
         with patch.object(lifecycle, "resume_from_snapshot", side_effect=side_effect):
             response = client.post("/v1/snapshots/snap-003/resume")

--- a/src/tests/unit/test_remaining_coverage_deep.py
+++ b/src/tests/unit/test_remaining_coverage_deep.py
@@ -632,7 +632,7 @@ class TestStartTrainingEdgeCasesDeep:
         y_val[2:, 1] = 1
 
         with patch.object(mgr.network, "fit", return_value={"train_loss": [0.5]}):
-            result = mgr.start_training(x=x, y=y, x_val=x_val, y_val=y_val)
+            result = mgr.start_training(X=x, y=y, X_val=x_val, y_val=y_val)
             assert result["status"] == "training_started"
             assert mgr._val_x is x_val
             assert mgr._val_y is y_val
@@ -654,7 +654,7 @@ class TestStartTrainingEdgeCasesDeep:
         y[5:, 1] = 1
 
         with patch.object(mgr.network, "fit", return_value={"train_loss": [0.5]}):
-            mgr.start_training(x=x, y=y)
+            mgr.start_training(X=x, y=y)
             assert mgr._executor is not None
 
             if mgr._training_future is not None:
@@ -688,7 +688,7 @@ class TestLifecycleManagerShutdownDeep:
         y[5:, 1] = 1
 
         with patch.object(mgr.network, "fit", return_value={"train_loss": [0.5]}):
-            mgr.start_training(x=x, y=y)
+            mgr.start_training(X=x, y=y)
             if mgr._training_future is not None:
                 mgr._training_future.result(timeout=10)
 


### PR DESCRIPTION
## Summary

WS-6 B-phase, **PR-B2b** (third of B1→B4): converge `start_training`'s signature and the snapshot-method return shapes toward model-core's `fit()` and the `ServiceLifecycleManager` seam (plan §5/§6, juniper-ml #485). **Behavior-preserving.** Builds on PR-B2a (#346, merged).

## Changes

**`start_training` signature** — mirror model-core `fit(X, y, *, X_val=None, y_val=None, …)`:
- `x → X`, `x_val → X_val`; inserted keyword-only `*` (all callers use keywords, so safe).
- Updated the docstring, in-body refs, and all **15 keyword call sites** (`app.py`, `routes/training.py`, 12 test sites — including a multi-line call the first line-based pass missed; caught by the unit lane).
- **Deferred to the A-phase**: the unused `dataset_name` param + `**kwargs`→`**fit_kwargs` rename (YAGNI, consistent with the B2a deferrals).

**Snapshot return convergence** — `load_snapshot` / `restore_for_retrain` / `resume_from_snapshot` now return a status dict `{loaded, snapshot_id, operation, fsm_state, reason}` (via a new `_snapshot_result` helper) instead of `bool`:
- The 3 routes (`/restore`, `/retrain`, `/resume`) check `result["loaded"]` for the **same** 404/409 mapping and still build their own `_build_unified_payload` response — so **the HTTP responses are byte-identical** (internal-only change).
- `start_replay` stays `bool` (out of B2b scope).
- Updated the 14 manager-test assertions + the snapshot route-test mocks (`return_value`/`side_effect` → dicts).

## Verification (JuniperCascor1)

| Lane | Result |
| --- | --- |
| `Golden / Snapshot Regression` | ✅ exit 0 |
| `model-core Conformance` | ✅ exit 0 |
| Full `src/tests/unit/api` + `test_remaining_coverage_deep` | ✅ all pass |
| Integration (snapshot roundtrip, full-lifecycle, pause/stop, event-invariants, …) | ✅ all pass |
| black / isort / flake8 / mypy | ✅ clean |

Snapshot routes aren't golden-pinned, and the dict change is internal (routes build their own payloads) — no observable API change.

## Staging

B1 ✅ (#345) → B2a ✅ (#346) → **B2b (this)** → **B3** (the `on_event` sink — the crux; **OQ-B1** appetite is your call) → B4 (native conformance vs `CascorModel`; retire the test adapter).

## Refs

- Build plan: juniper-ml #485 · Decision: juniper-ml #475 (DR-1) · Predecessors: cascor #345 (B1), #346 (B2a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WLKsAKe4qSBkDL88Lq25PZ
