### PR TITLE
test(conformance): WS-6 PR-B4 — native conformance against production CascorModel

### DIFF
--- a/src/tests/conformance/cascor_model_core_adapter.py
+++ b/src/tests/conformance/cascor_model_core_adapter.py
@@ -1,171 +1,47 @@
-"""Test-only adapter: CascadeCorrelationNetwork -> juniper-model-core GrowableModel.
+"""Conformance fixtures for the cascor ↔ juniper-model-core gate (WS-6).
 
-OUT-13 (WS-6 trigger-gate, half 2). The model-core ``GrowableModel`` interface was designed
-with cascor as a reference implementer, but ``CascadeCorrelationNetwork``'s current surface
-does not implement that contract. This adapter bridges the gap so cascor can be run through
-the ``juniper_model_core.conformance`` kit — proving (pre-refactor) that cascor *can* conform.
-WS-6's interface-adoption phase later replaces this adapter with native conformance.
+OUT-13 introduced a **test-only** ``CascorModelCoreAdapter`` to prove cascor could satisfy the
+``juniper_model_core.GrowableModel`` contract *before* the refactor. WS-6 PR-B3 promoted that
+adapter into the **production** :class:`api.models.cascor_model.CascorModel`, and **PR-B4**
+retires the test-only adapter — the conformance suite now runs against the production wrapper
+("native conformance"). This module is reduced to the two fixtures the suite still needs:
 
-It is **test-only** (lives under ``src/tests/``, imports nothing into cascor production code).
+* :func:`make_cascor_conformance_model` — builds the canonical golden-config
+  ``CascadeCorrelationNetwork`` (seeded for determinism) and wraps it in the production
+  ``CascorModel``. In production the lifecycle manager owns construction + seeding; the
+  wrapper never re-seeds inside ``fit`` (plan §4.2), so this factory reproduces that
+  build-then-seed step before wrapping.
+* :func:`two_spiral_classification_dataset` — a classification ``ConformanceDataset`` from
+  OUT-12's frozen two-spiral (the kit's built-in fixtures are regression-only).
 
-Design decisions (ratified 2026-06-18, plan
-``juniper-ml/notes/JUNIPER_CASCOR_MODEL_CORE_CONFORMANCE_WIRING_PLAN_2026-06-18.md``):
-
-* **D-C3 — ``grow_step`` is a no-op.** cascor grows units *inside* ``fit()`` and exposes no
-  standalone "add one frozen unit" call; the conformance suite tolerates ``added=False``
-  (its growth test is guarded). cascor's real growth dynamics are pinned by the OUT-12
-  trajectory golden — conformance asserts the *interface*, OUT-12 asserts the *behavior*.
-* **on_event** — cascor's ``fit`` has no event sink, so events are reconstructed in legal
-  order (``training_start`` -> ``unit_added``×k -> ``training_end``) post-hoc from
-  ``network.history`` (the kit checks order, not timing).
-* **metrics** — ``{"accuracy", "loss"}`` (both valid classification keys).
+The filename is retained (the production ``CascorModel`` docstring references this path as its
+origin); it no longer defines an adapter class.
 """
 
 from __future__ import annotations
-
-from typing import Any
 
 import golden_support as gs  # OUT-12 determinism harness + frozen two-spiral
 import numpy as np
 import torch
 from juniper_model_core.conformance import ConformanceDataset
-from juniper_model_core.events import TrainingEvent
-from juniper_model_core.interfaces import GrowableModel, GrowthOutcome, TaskType, TrainResult
 
+from api.models.cascor_model import CascorModel
 from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
 
-# The canonical golden config (mirrors golden_support.GOLDEN_NET_CONFIG) so the conformance
-# run exercises the same small, fast, deterministic network as the golden suite.
-_NET_CONFIG = dict(gs.GOLDEN_NET_CONFIG)
 
+def make_cascor_conformance_model() -> CascorModel:
+    """The production ``CascorModel`` wrapping a freshly-built, seeded golden-config network.
 
-class CascorModelCoreAdapter(GrowableModel):
-    """Presents ``CascadeCorrelationNetwork`` as a model-core ``GrowableModel``."""
-
-    task_type: TaskType = "classification"
-
-    def __init__(self, *, random_seed: int = 42, **config: Any) -> None:
-        self.random_seed = random_seed
-        self._config = {**_NET_CONFIG, **config, "random_seed": random_seed}
-        self._net: CascadeCorrelationNetwork | None = None
-        self._frozen = False
-        self._in_shape: tuple[int, ...] = ()
-        self._out_shape: tuple[int, ...] = ()
-
-    # ----- TrainableModel ------------------------------------------------------------
-    def fit(self, X, y, *, X_val=None, y_val=None, on_event=None, **kw) -> TrainResult:
-        gs.harden_determinism()
-        x = torch.as_tensor(np.asarray(X), dtype=torch.float32)
-        y_t = torch.as_tensor(np.asarray(y), dtype=torch.float32)
-        self._in_shape = (int(x.shape[1]),)
-        self._out_shape = (int(y_t.shape[1]),)
-
-        self._net = CascadeCorrelationNetwork(**self._config)
-        # Reseed post-construction (matches the validated golden sequence).
-        torch.manual_seed(self.random_seed)
-        np.random.seed(self.random_seed)
-
-        if X_val is not None and y_val is not None:
-            x_val = torch.as_tensor(np.asarray(X_val), dtype=torch.float32)
-            y_val_t = torch.as_tensor(np.asarray(y_val), dtype=torch.float32)
-            self._net.fit(x, y_t, x_val=x_val, y_val=y_val_t, early_stopping=False)
-        else:
-            self._net.fit(x, y_t, early_stopping=False)
-
-        if on_event is not None:
-            self._emit_events(on_event, int(x.shape[0]))
-
-        history = self._net.history
-        per_epoch = [{"loss": float(loss), "accuracy": float(acc)} for loss, acc in zip(history.get("train_loss", []), history.get("train_accuracy", []))]
-        return TrainResult(
-            final_metrics=self.metrics(),
-            n_epochs=max(1, len(history.get("train_loss", []))),
-            history=per_epoch or None,
-            stopped_reason=self._net._completion_reason,
-        )
-
-    def _emit_events(self, on_event, n_samples: int) -> None:
-        """Reconstruct a legal training-event sequence from the network history."""
-        seq = 0
-        on_event(TrainingEvent("training_start", {"n_samples": n_samples}, seq))
-        seq += 1
-        for entry in self._net.history.get("hidden_units_added", []):
-            unit_index = entry.get("unit_index", -1)
-            if unit_index < 0:  # skip the fit() sentinel {corr:0.0, shape:(), idx:-1}
-                continue
-            seq += 1
-            on_event(
-                TrainingEvent(
-                    "unit_added",
-                    {"n_units": unit_index + 1, "unit_id": f"h{unit_index}", "score": float(entry.get("correlation", 0.0))},
-                    seq,
-                )
-            )
-        seq += 1
-        on_event(TrainingEvent("training_end", {"metrics": self.metrics()}, seq))
-
-    def predict(self, X, **kw) -> np.ndarray:
-        if self._net is None:
-            raise RuntimeError("CascorModelCoreAdapter.predict called before fit")
-        x = torch.as_tensor(np.asarray(X), dtype=torch.float32)
-        with torch.no_grad():
-            out = self._net.predict(x)
-        # Raw class scores — never argmax (RK-6: label collapse is classification-only).
-        return out.detach().cpu().numpy()
-
-    def metrics(self) -> dict[str, float]:
-        history = self._net.history if self._net is not None else {}
-        accuracy = history.get("train_accuracy") or [0.0]
-        loss = history.get("train_loss") or [0.0]
-        return {"accuracy": float(accuracy[-1]), "loss": float(loss[-1])}
-
-    def describe_topology(self) -> dict[str, Any]:
-        n = self.n_units
-        nodes: list[dict[str, Any]] = [{"id": "input", "kind": "input", "frozen": True}]
-        for i in range(n):
-            nodes.append({"id": f"h{i}", "kind": "hidden", "frozen": True})
-        nodes.append({"id": "output", "kind": "output", "frozen": self._frozen})
-
-        edges: list[dict[str, Any]] = [{"src": "input", "dst": "output", "recurrent": False}]
-        for i in range(n):
-            edges.append({"src": "input", "dst": f"h{i}", "recurrent": False})
-            # Cascade architecture: each unit feeds all *later* units.
-            for j in range(i + 1, n):
-                edges.append({"src": f"h{i}", "dst": f"h{j}", "recurrent": False})
-            edges.append({"src": f"h{i}", "dst": "output", "recurrent": False})
-
-        return {
-            "model_type": "cascade_correlation",
-            "nodes": nodes,
-            "edges": edges,
-            "meta": {
-                "task_type": self.task_type,
-                "n_units": n,
-                "n_in": self._in_shape[0] if self._in_shape else 0,
-                "n_out": self._out_shape[0] if self._out_shape else 0,
-                "completion_reason": None if self._net is None else self._net._completion_reason,
-            },
-        }
-
-    @property
-    def input_shape(self) -> tuple[int, ...]:
-        return self._in_shape
-
-    @property
-    def output_shape(self) -> tuple[int, ...]:
-        return self._out_shape
-
-    # ----- GrowableModel -------------------------------------------------------------
-    @property
-    def n_units(self) -> int:
-        return 0 if self._net is None else len(getattr(self._net, "hidden_units", []))
-
-    def grow_step(self, **kw) -> GrowthOutcome:
-        # D-C3: cascor grows inside fit(); no standalone step. No-op (contract-legal).
-        return GrowthOutcome(added=False, n_units=self.n_units)
-
-    def freeze(self) -> None:
-        self._frozen = True
+    Uses the canonical golden config (``golden_support.GOLDEN_NET_CONFIG``, which pins
+    ``random_seed=42``) so the conformance run exercises the same small, fast, deterministic
+    network as the golden suite. Seeding happens here — not inside ``CascorModel.fit``, which
+    never re-seeds (plan §4.2) — so the contract run is reproducible.
+    """
+    gs.harden_determinism()
+    net = CascadeCorrelationNetwork(**gs.GOLDEN_NET_CONFIG)
+    torch.manual_seed(gs.GOLDEN_NET_CONFIG["random_seed"])
+    np.random.seed(gs.GOLDEN_NET_CONFIG["random_seed"])
+    return CascorModel(network=net)
 
 
 def two_spiral_classification_dataset() -> ConformanceDataset:

--- a/src/tests/conformance/test_model_core_conformance.py
+++ b/src/tests/conformance/test_model_core_conformance.py
@@ -1,7 +1,8 @@
-"""OUT-13 — cascor ↔ juniper-model-core interface conformance (WS-6 gate, half 2).
+"""OUT-13 / WS-6 PR-B4 — cascor ↔ juniper-model-core interface conformance (WS-6 gate, half 2).
 
-Runs the real ``CascadeCorrelationNetwork`` (via the test-only adapter) through the
-``juniper_model_core.conformance`` GrowableModel kit. Together with the OUT-12 golden suite
+Runs the **production** ``CascorModel`` (wrapping a real ``CascadeCorrelationNetwork``) through
+the ``juniper_model_core.conformance`` GrowableModel kit — "native conformance" (PR-B4 retired
+the test-only adapter). Together with the OUT-12 golden suite
 this forms the WS-6 trigger-gate: cascor may refactor onto the shared packages only if both
 stay green. Plan:
 ``juniper-ml/notes/JUNIPER_CASCOR_MODEL_CORE_CONFORMANCE_WIRING_PLAN_2026-06-18.md``.
@@ -14,22 +15,26 @@ Run (serial, GIL env):
 """
 
 import pytest
-from conformance.cascor_model_core_adapter import CascorModelCoreAdapter, two_spiral_classification_dataset
+from conformance.cascor_model_core_adapter import make_cascor_conformance_model, two_spiral_classification_dataset
 from juniper_model_core.conformance import GrowableModelConformance
+
+from api.models.cascor_model import CascorModel
 
 
 @pytest.mark.integration
 @pytest.mark.slow
 @pytest.mark.conformance
 class TestCascorConformance(GrowableModelConformance):
-    """CascadeCorrelationNetwork satisfies the model-core GrowableModel contract.
+    """The production ``CascorModel`` satisfies the model-core GrowableModel contract.
 
     Inherits ~13 contract assertions from ``GrowableModelConformance``; supplies the three
     factory hooks. The base class is not named ``Test*`` so pytest collects only this subclass.
+    PR-B4: ``make_model`` returns the production ``CascorModel`` (native conformance), not the
+    retired test-only adapter.
     """
 
-    def make_model(self) -> CascorModelCoreAdapter:
-        return CascorModelCoreAdapter()
+    def make_model(self) -> CascorModel:
+        return make_cascor_conformance_model()
 
     def make_dataset(self):
         return two_spiral_classification_dataset()


### PR DESCRIPTION
## Summary

WS-6 **PR-B4** — the final B-phase step. Points the model-core `GrowableModel` conformance kit at
the **production `CascorModel`** (was the test-only adapter), so conformance now exercises production
code — **native conformance** — and retires the `CascorModelCoreAdapter` that was promoted to
production in PR-B3.2 (#353).

## What changed (test-only; production untouched)

- **`src/tests/conformance/test_model_core_conformance.py`** — `make_model()` now returns the production
  `CascorModel` via a new `make_cascor_conformance_model()` factory (was `CascorModelCoreAdapter()`).
  `make_dataset` / `make_serializer` (D-C4, `None`) unchanged.
- **`src/tests/conformance/cascor_model_core_adapter.py`** — reduced to the two fixtures the suite still
  needs: `two_spiral_classification_dataset` (kept verbatim) and the new `make_cascor_conformance_model`
  (builds + seeds the golden-config `CascadeCorrelationNetwork`, then wraps it in `CascorModel`). The
  `CascorModelCoreAdapter` class is deleted (−119 net lines). The filename is intentionally retained —
  the production `CascorModel` docstring references this path as its origin.

Build-then-seed lives in the factory because, in production, the lifecycle manager owns construction +
seeding and `CascorModel.fit` never re-seeds (plan §4.2).

## Gates (JuniperCascor1, serial)

| Gate | Result |
|---|---|
| model-core Conformance (now vs production `CascorModel`) | ✅ **13 passed** |
| Golden / Snapshot Regression | ✅ untouched (conformance-only change) |
| pre-commit (black / isort / flake8 / bandit, test-scoped) | ✅ |

## B-phase complete

B1/B2a/B2b (#345/#346/#347) · B3.1/B3.2/B3.3 (#352/#353/#355) · **B4 (this)** — the on_event migration is
done and conformance is native. **A-phase (6a)** remains deferred (DR-1; needs `juniper-service-core` 0.2.0).

Plan: [`juniper-ml#485`](https://github.com/pcalnon/juniper-ml/pull/485) §5 PR-B4. Predecessor: #355 (B3.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TamrB9XnFkxNkVsKehd1fS
