### PR TITLE
docs(env): durable conda env-name convention — live JuniperCascor1 (audit F10)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 **Author**: Paul Calnon
 **License**: MIT License
 **Version**: 0.5.0
-**Last Updated**: 2026-06-21
+**Last Updated**: 2026-06-23
 
 ---
 
@@ -13,10 +13,10 @@
 
 ### Conda Environment
 
-> **Required:** Activate the `JuniperCascor` conda environment before running any commands.
+> **Required:** Activate the live `JuniperCascor1` conda environment before running any commands. The env name is **versioned** — rebuilds increment the suffix and rename the old env `*-DEPRECATED` (never activate those). Discover yours with `conda env list | grep JuniperCascor`.
 
 ```bash
-conda activate JuniperCascor
+conda activate JuniperCascor1   # live env; see the note above
 ```
 
 ### Essential Commands

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ PyTorch is excluded from the lockfile and installed separately in the Dockerfile
 ### Prerequisites
 
 - Python ≥ 3.12 (Docker image uses 3.14)
-- Conda environment `JuniperCascor`
+- Conda environment `JuniperCascor1` — the live env is **versioned** (rebuilds increment the suffix and rename the old env `*-DEPRECATED`; never activate those). Discover yours with `conda env list | grep JuniperCascor`.
 - A running `juniper-data` instance reachable at `JUNIPER_DATA_URL` (typically `http://localhost:8100`)
 
 ### Installation
@@ -145,8 +145,8 @@ PyTorch is excluded from the lockfile and installed separately in the Dockerfile
 ```bash
 git clone https://github.com/pcalnon/juniper-cascor.git
 cd juniper-cascor
-conda env create -f conf/conda_environment.yaml
-conda activate JuniperCascor
+conda env create -n JuniperCascor1 -f conf/conda_environment.yaml   # -n required: the YAML has no name: field
+conda activate JuniperCascor1
 pip install -e ".[ml,api,observability,test]"
 ```
 

--- a/docs/DEVELOPER_CHEATSHEET.md
+++ b/docs/DEVELOPER_CHEATSHEET.md
@@ -9,8 +9,10 @@
 **The following commands launch a full set of Juniper Project services: start services in the order listed below:**
 
 - juniper-data: cd /home/pcalnon/Development/python/Juniper/juniper-data && conda activate JuniperData && pip install -e ".[all]" && PYTHON_GIL=0 uvicorn juniper_data.api.app:app --host 0.0.0.0 --port 8100
-- juniper-cascor: cd /home/pcalnon/Development/python/Juniper/juniper-cascor/src && conda activate JuniperCascor && JUNIPER_CASCOR_PORT=8201 python server.py
-- juniper-canopy: cd /home/pcalnon/Development/python/Juniper/juniper-canopy/src && conda activate JuniperCanopy && CASCOR_SERVICE_URL="<http://localhost:8201>" uvicorn main:app --host 0.0.0.0 --port 8050
+- juniper-cascor: cd /home/pcalnon/Development/python/Juniper/juniper-cascor/src && conda activate JuniperCascor1 && JUNIPER_CASCOR_PORT=8201 python server.py
+- juniper-canopy: cd /home/pcalnon/Development/python/Juniper/juniper-canopy/src && conda activate JuniperCanopy1 && CASCOR_SERVICE_URL="<http://localhost:8201>" uvicorn main:app --host 0.0.0.0 --port 8050
+
+> **Conda env naming:** the live envs are **versioned** — `JuniperCascor1`, `JuniperCanopy1` (the bare `JuniperCascor` / `JuniperCanopy` are now `*-DEPRECATED` with a broken toolchain; `JuniperData` is unversioned). Discover yours with `conda env list | grep Juniper<App>` and use that name; rebuilds increment the suffix.
 
 **General list of useful Commands:**
 
@@ -38,7 +40,7 @@
 ## Service Operations
 
 ```bash
-conda activate JuniperCascor && cd juniper-cascor && pip install -e ".[all]"
+conda activate JuniperCascor1 && cd juniper-cascor && pip install -e ".[all]"
 cd src && python main.py                                       # native start
 curl -s http://localhost:8200/v1/health | python -m json.tool  # health
 docker compose --profile full up -d                            # Docker start
@@ -205,7 +207,7 @@ Levels: TRACE(5) -> VERBOSE(7) -> DEBUG(10) -> INFO(20) -> WARNING(30) -> ERROR(
 # Add dep: edit pyproject.toml, then regenerate lockfile
 uv pip compile pyproject.toml -o requirements.txt
 # Conda env
-conda create --name JuniperCascor --file conf/conda_environment.yaml
+conda create --name JuniperCascor1 --file conf/conda_environment.yaml
 ```
 
 Core: `torch`, `numpy`, `h5py`, `matplotlib`, `PyYAML`, `requests`

--- a/docs/ci_cd/ENVIRONMENT_SETUP.md
+++ b/docs/ci_cd/ENVIRONMENT_SETUP.md
@@ -195,6 +195,8 @@ Required secrets would be configured in:
 
 To reproduce the CI environment locally:
 
+> **Note:** CI and Docker use an **ephemeral** environment named `JuniperCascor` (created fresh from `conf/conda_environment.yaml` on each run, matching the workflow's `ENV_NAME`). That is intentional and separate from your **persistent local dev environment**, which is versioned (`JuniperCascor1`, …) — see [`../install/ENVIRONMENT_SETUP.md`](../install/ENVIRONMENT_SETUP.md). The throwaway name below is fine for one-off CI reproduction.
+
 ```bash
 # 1. Install Miniforge (provides mamba)
 # Linux/macOS:

--- a/docs/install/ENVIRONMENT_SETUP.md
+++ b/docs/install/ENVIRONMENT_SETUP.md
@@ -37,6 +37,30 @@ This guide covers setting up the development environment for the Juniper Cascor 
 
 ## Conda Environment Setup (Recommended)
 
+> **⚠️ Conda environment naming — read this first.**
+>
+> Juniper conda environments are **versioned across rebuilds**. This project's
+> live environment is currently **`JuniperCascor1`**; each full rebuild (per the
+> Juniper ecosystem conda-env rebuild procedure,
+> `juniper-ml/notes/JUNIPER_CONDA_ENV_REBUILD_PROCEDURE.md`) creates a new
+> suffixed environment (`JuniperCascor1` → `JuniperCascor2` → …) and renames the
+> previous one to `*-DEPRECATED`. A `*-DEPRECATED` environment has a broken or
+> partial toolchain (e.g. a broken `torch` import) — **never activate one**.
+>
+> Discover your live environment and substitute its name wherever this guide
+> writes `JuniperCascor1`:
+>
+> ```bash
+> conda env list | grep JuniperCascor
+> # Use the entry WITHOUT a "-DEPRECATED" suffix (e.g. JuniperCascor1).
+> ```
+>
+> The `conda env create -n <name> …` steps below name the environment
+> explicitly: `conf/conda_environment.yaml` intentionally has **no** `name:`
+> field, so the name always comes from `-n` / `--name` and stays consistent with
+> this convention. (CI and Docker use a separate *ephemeral* `JuniperCascor`
+> environment — see `docs/ci_cd/ENVIRONMENT_SETUP.md`.)
+
 ### Prerequisites
 
 Install [Miniconda](https://docs.conda.io/en/latest/miniconda.html) or [Anaconda](https://www.anaconda.com/download).
@@ -48,9 +72,9 @@ Install [Miniconda](https://docs.conda.io/en/latest/miniconda.html) or [Anaconda
 cd juniper-cascor
 
 # Create environment from yaml file
-conda env create -f conf/conda_environment.yaml --name JuniperCascor
+conda env create -f conf/conda_environment.yaml --name JuniperCascor1
 
-# Alternatively, create with explicit name
+# Alternatively, use a custom env name of your choice (then activate that name)
 conda env create -f conf/conda_environment.yaml -n cascor
 ```
 
@@ -58,11 +82,11 @@ conda env create -f conf/conda_environment.yaml -n cascor
 
 ```bash
 # Activate the environment
-conda activate JuniperCascor
+conda activate JuniperCascor1
 
 # Verify activation
 which python
-# Should show: /path/to/conda/envs/JuniperCascor/bin/python
+# Should show: /path/to/conda/envs/JuniperCascor1/bin/python
 ```
 
 ### Verifying Installation
@@ -89,8 +113,8 @@ conda env update -f conf/conda_environment.yaml --prune
 
 # Or recreate from scratch
 conda deactivate
-conda env remove -n JuniperCascor
-conda env create -f conf/conda_environment.yaml --name JuniperCascor
+conda env remove -n JuniperCascor1
+conda env create -f conf/conda_environment.yaml --name JuniperCascor1
 ```
 
 ---

--- a/docs/install/QUICK_START.md
+++ b/docs/install/QUICK_START.md
@@ -20,8 +20,10 @@ cd juniper-cascor
 
 ### 2. Create the Conda Environment
 
+> **Conda env naming:** the live env is **versioned** (currently `JuniperCascor1`); rebuilds increment the suffix and rename the old env `*-DEPRECATED` (never activate those). Discover yours with `conda env list | grep JuniperCascor`.
+
 ```bash
-conda env create -f conf/conda_environment.yaml
+conda env create -n JuniperCascor1 -f conf/conda_environment.yaml   # -n required: the YAML has no name: field
 ```
 
 This installs all dependencies including PyTorch, NumPy, pytest, and other required packages.
@@ -29,7 +31,7 @@ This installs all dependencies including PyTorch, NumPy, pytest, and other requi
 ### 3. Activate the Environment
 
 ```bash
-conda activate JuniperCascor
+conda activate JuniperCascor1
 ```
 
 ### 4. Start JuniperData Service

--- a/docs/testing/ENVIRONMENT_SETUP.md
+++ b/docs/testing/ENVIRONMENT_SETUP.md
@@ -29,11 +29,11 @@ pip install pytest pytest-cov pytest-timeout pytest-xdist
 conda install pytest pytest-cov pytest-timeout pytest-xdist -c conda-forge
 ```
 
-**From the project environment:**
+**From the project environment** (the live env is **versioned** — currently `JuniperCascor1`; discover yours with `conda env list | grep JuniperCascor`, and never activate a `*-DEPRECATED` env):
 
 ```bash
-conda env create -f conf/conda_environment.yaml
-conda activate JuniperCascor
+conda env create -n JuniperCascor1 -f conf/conda_environment.yaml   # -n required: the YAML has no name: field
+conda activate JuniperCascor1
 ```
 
 ### Additional Dependencies


### PR DESCRIPTION
## Summary

Durable fix for **audit finding F10** (stale conda env-name docs), mirroring the
canopy F10 PR. Cascor's dev-setup docs instruct developers to
`conda activate JuniperCascor`, but that bare env is now
`JuniperCascor-DEPRECATED` (broken `torch` toolchain); the live env is
`JuniperCascor1`. Instead of a bare→`1` bump that re-stales on the next rebuild,
this adds a **rebuild-proof naming convention**.

## What changed (6 dev-setup docs)

- **Convention note** — full in `docs/install/ENVIRONMENT_SETUP.md`; compact in
  `README.md`, `AGENTS.md`, `docs/DEVELOPER_CHEATSHEET.md`,
  `docs/install/QUICK_START.md`, `docs/testing/ENVIRONMENT_SETUP.md`. Explains
  the versioned naming (`JuniperCascor1` → `JuniperCascor2` → …), the
  `*-DEPRECATED` rename (never activate those), and a
  `conda env list | grep JuniperCascor` discovery step.
- All activate / verify / path / create commands point at the live
  `JuniperCascor1`.
- **Latent-bug fix:** nameless `conda env create -f conf/conda_environment.yaml`
  (README, QUICK_START, testing/ENV) actually errors — the YAML has **no
  `name:` field** — so these now pass `-n JuniperCascor1`.
- Cheatsheet cross-service launch: `conda activate JuniperCanopy` →
  `JuniperCanopy1` (sibling deprecation). `JuniperData` left as-is (unversioned,
  live).

## Verify-every-finding scope corrections (left unchanged)

- **`docs/ci_cd/ENVIRONMENT_SETUP.md`** — was in the scope-in file list, but on
  inspection **all** its env refs document the *ephemeral* CI / Docker
  environment: setup-miniconda `activate-environment: JuniperCascor`, the conda
  cache path, and the `Dockerfile.ci` `conda run -n JuniperCascor`. These mirror
  the real `ci.yml` (`ENV_NAME: JuniperCascor`) and are internally
  self-consistent — the handoff's scope-out category. Changing them would make
  the docs diverge from the real CI/Docker config. **One clarifying note added**
  so the "Local Reproduction" section doesn't contradict the install guide's
  "never activate bare `JuniperCascor`".
- Cheatsheet `Grafana: **JuniperCascor** (UID juniper-cascor)` is a
  dashboard/product name, not a conda env → unchanged.

## Testing

- `pre-commit run --files <7 changed files>` → **all hooks pass**, notably
  **markdownlint** (README + AGENTS; `docs/` is excluded from markdownlint in
  cascor) and **doc-link validation** (incl. the new
  `../install/ENVIRONMENT_SETUP.md` relative link in ci_cd).
- Grep audit confirms zero remaining command-form bare
  `conda activate JuniperCascor` / `envs/JuniperCascor` / `--name JuniperCascor`
  refs in the 6 scope-in files; the only surviving bare tokens are the intended
  discovery `grep` lines, convention prose, the ci_cd CI/Docker refs, and the
  Grafana name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
