### PR TITLE
chore(pre-commit): bump pre-commit-hooks v4.6.0→v6.0.0 (audit F7)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,7 +76,7 @@ repos:
   # General file checks
   # ═══════════════════════════════════════════════════════════════════════════
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
         name: Check YAML syntax


### PR DESCRIPTION
## Summary
Audit **F7** — fleet currency: bump `pre-commit/pre-commit-hooks` from `v4.6.0` to `v6.0.0` to align with canopy and juniper-data (already on v6, passing in CI).

## Safety
All hooks this repo uses from pre-commit-hooks are stable across the bump. v6.0.0 removed only `check-byte-order-marker` and `fix-encoding-pragma` (neither used here) and requires Python ≥ 3.9 (satisfied).

## Testing
`pre-commit run --all-files` passes on the worktree; the commit touches only `.pre-commit-config.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)