### PR TITLE
ci: enforce blocking per-file coverage gate for cascor-protocol (rollout C-1)

### DIFF
--- a/.github/workflows/ci-protocol.yml
+++ b/.github/workflows/ci-protocol.yml
@@ -60,7 +60,12 @@ jobs:
 
       - name: Run unit tests with coverage
         run: |
-          python -m pytest --cov=juniper_cascor_protocol --cov-report=term-missing --cov-fail-under=95
+          python -m pytest --cov=juniper_cascor_protocol --cov-report=term-missing --cov-report=json:coverage.json --cov-fail-under=95
+
+      - name: Enforce per-file coverage gate (blocking)
+        run: |
+          pip install "juniper-ci-tools>=0.6.0,<0.7.0"
+          juniper-coverage-gap-map --coverage-json coverage.json --enforce
 
   build:
     name: Build distribution


### PR DESCRIPTION
## Summary

Work-unit **C-1** of the per-file coverage rollout (Phase C of the juniper-ml test-suite audit) — the "free wins": turn ON a **blocking** per-file coverage gate for **`juniper-cascor-protocol`** (`.github/workflows/ci-protocol.yml`, pkg `juniper_cascor_protocol`), one of the three already-gate-ready units. No coverage work; this wires the enforcing gate and locks the bar.

The enabler (`juniper-ci-tools 0.6.0`, `juniper-coverage-gap-map --enforce`) shipped in juniper-ml C-0 (pcalnon/juniper-ml#595) and is live on PyPI.

## What changed (`ci-protocol.yml`)

1. The existing `Run unit tests with coverage` step now also emits a JSON report: `--cov-report=json:coverage.json` (added alongside `--cov-report=term-missing`; `--cov-fail-under=95` unchanged).
2. A new **blocking** step is appended to the **same required `test` job**:

```yaml
      - name: Enforce per-file coverage gate (blocking)
        run: |
          pip install "juniper-ci-tools>=0.6.0,<0.7.0"
          juniper-coverage-gap-map --coverage-json coverage.json --enforce
```

`--enforce` exits 1 when any source file's **statement** coverage `< 90%` OR any packaged sub-module's **pooled** (statement-weighted) coverage `< 95%` (tool defaults 90 / 95); exit 0 when clean. Because `build` has `needs: test`, a gate failure fails the required check and skips `build`.

## Re-measure (mandatory pre-flight) — passes `--enforce` today

Fresh venv, `pip install -e "juniper-cascor-protocol[test]" juniper-ci-tools==0.6.0`, package-form `--cov`, 2026-07-01:

| Unit | overall (pooled) | files <90 (stmt) | sub-modules pooled<95 | tests | `--enforce` exit |
|------|------------------|------------------|------------------------|-------|------------------|
| `juniper-cascor-protocol` | 98.94% | 0 | 0 / 3 (100 / 98.29 / 100) | 60 passed | **0** |

## Verification

- Re-measured `--enforce` → **exit 0** (above).
- `pre-commit run --files .github/workflows/ci-protocol.yml` → **Passed** (check-yaml, yamllint, fix-EOF, trailing-whitespace).

## Notes / non-goals

- No test weakened, disabled, or deleted.
- Nothing published; not merged (owner merges).

Scoping (in juniper-ml): `notes/JUNIPER_ECOSYSTEM_PER_FILE_COVERAGE_ROLLOUT_SCOPING_2026-06-30.md` (§5, C-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
