### PR TITLE
test(cascor-model): lift to per-file >=90 + pooled >=95 statement; add first CI coverage gate (C-5)

### DIFF
--- a/.github/workflows/ci-cascor-model.yml
+++ b/.github/workflows/ci-cascor-model.yml
@@ -57,14 +57,24 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install CPU torch + package + test extras
+      - name: Install CPU torch + package + test/full extras
         run: |
           pip install --upgrade "pip>=26.1.1"
           pip install --index-url https://download.pytorch.org/whl/cpu torch
-          pip install -e ".[test]"
+          pip install -e ".[test,full]"
 
-      - name: Run unit tests (incl. src drift-guard)
-        run: python -m pytest -v
+      - name: Run unit tests with coverage (incl. src drift-guard)
+        run: |
+          python -m pytest -v --cov=juniper_cascor_model --cov=candidate_unit --cov=utils --cov=log_config --cov=cascor_constants --cov-report=term-missing --cov-report=json:coverage.json
+
+      - name: Enforce per-file coverage gate (blocking)
+        # Per-file coverage rollout C-5 (juniper-ml
+        # notes/JUNIPER_ECOSYSTEM_PER_FILE_COVERAGE_ROLLOUT_SCOPING_2026-06-30.md):
+        # exit 1 if any source file's statement coverage < 90 OR a
+        # sub-module's pooled (statement-weighted) coverage < 95.
+        run: |
+          pip install "juniper-ci-tools>=0.6.0,<0.7.0"
+          juniper-coverage-gap-map --coverage-json coverage.json --enforce
 
   build:
     name: Build distribution

--- a/juniper-cascor-model/CHANGELOG.md
+++ b/juniper-cascor-model/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **First CI coverage gate (per-file coverage rollout C-5).** `ci-cascor-model.yml` now
+  measures statement coverage across all five shipped packages (`juniper_cascor_model`,
+  `candidate_unit`, `utils`, `log_config`, `cascor_constants`) and runs the blocking
+  `juniper-coverage-gap-map --enforce` step — failing the build when any source file is
+  below 90% statement coverage or any sub-module's pooled (statement-weighted) coverage is
+  below 95%. Previously the package ran a bare `pytest -v` with no coverage gate (the
+  ecosystem's last no-gate outlier). See juniper-ml
+  `notes/JUNIPER_ECOSYSTEM_PER_FILE_COVERAGE_ROLLOUT_SCOPING_2026-06-30.md`.
+
+### Tests
+
+- **Lifted the package to the ratified coverage bars** (overall 72% → 99%). Added
+  real-instantiation coverage for the `Logger`/`LogConfig` bootstrap paths (custom-level
+  registration, YAML `dictConfig` success + best-effort fallback, the already-configured
+  short-circuit), TRACE-level candidate-training tests that exercise the level-gated
+  diagnostic branches, `dill`/`columnar` optional-dependency import guards, and ported the
+  drift-identical `candidate_unit` / `logger` / `utils` coverage suites from
+  `juniper-cascor/src`. The CI test job now installs the `[full]` extra so the `utils`
+  debug-helper paths are measured. No source files changed; existing tests untouched.
+
 ### Security
 
 - **Raised the `torch` floor to `>=2.10.0`** (was `>=2.0`) — the minimal pin that clears

--- a/juniper-cascor-model/tests/test_candidate_unit_coverage.py
+++ b/juniper-cascor-model/tests/test_candidate_unit_coverage.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python
+#####################################################################################################################################################################################################
+# Project:       Juniper
+# Sub-Project:   JuniperCascor
+# Application:   juniper_cascor
+# File Name:     test_candidate_unit_coverage.py
+# Author:        Paul Calnon
+#
+# Date Created:  2026-01-24
+# Last Modified: 2026-01-24
+#
+# License:       MIT License
+# Copyright:     Copyright (c) 2024-2026 Paul Calnon
+#
+# Description:
+#    Unit tests for CandidateUnit class to increase code coverage.
+#    Part of CASCOR-P2-001: Increase code coverage.
+#
+#####################################################################################################################################################################################################
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from candidate_unit.candidate_unit import CandidateTrainingResult, CandidateUnit
+
+
+@pytest.fixture
+def basic_candidate():
+    """Create a basic CandidateUnit for testing."""
+    return CandidateUnit(
+        CandidateUnit__input_size=2,
+        CandidateUnit__epochs=10,
+        CandidateUnit__learning_rate=0.01,
+        CandidateUnit__random_seed=42,
+        CandidateUnit__candidate_index=0,
+    )
+
+
+@pytest.fixture
+def sample_input():
+    """Create sample input tensor."""
+    return torch.randn(10, 2)
+
+
+@pytest.fixture
+def sample_residual_error():
+    """Create sample residual error tensor."""
+    return torch.randn(10, 2)
+
+
+class TestCandidateUnitInit:
+    """Tests for CandidateUnit initialization."""
+
+    def test_basic_initialization(self):
+        """Test basic CandidateUnit initialization."""
+        candidate = CandidateUnit(
+            CandidateUnit__input_size=3,
+            CandidateUnit__candidate_index=0,
+        )
+        assert candidate.input_size == 3
+        assert hasattr(candidate, "weights")
+        assert hasattr(candidate, "bias")
+
+    def test_initialization_with_custom_epochs(self):
+        """Test CandidateUnit initialization with custom epochs."""
+        candidate = CandidateUnit(
+            CandidateUnit__input_size=2,
+            CandidateUnit__epochs=100,
+            CandidateUnit__candidate_index=0,
+        )
+        assert candidate.epochs == 100
+
+    def test_initialization_with_custom_learning_rate(self):
+        """Test CandidateUnit initialization with custom learning rate."""
+        candidate = CandidateUnit(
+            CandidateUnit__input_size=2,
+            CandidateUnit__learning_rate=0.001,
+            CandidateUnit__candidate_index=0,
+        )
+        assert candidate.learning_rate == 0.001
+
+    def test_initialization_with_random_seed(self):
+        """Test CandidateUnit initialization with random seed for reproducibility."""
+        candidate1 = CandidateUnit(
+            CandidateUnit__input_size=2,
+            CandidateUnit__random_seed=42,
+            CandidateUnit__candidate_index=0,
+        )
+        candidate2 = CandidateUnit(
+            CandidateUnit__input_size=2,
+            CandidateUnit__random_seed=42,
+            CandidateUnit__candidate_index=0,
+        )
+        # Weights should be similar (within tolerance) with same seed
+        assert candidate1.weights.shape == candidate2.weights.shape
+
+    def test_initialization_with_uuid(self):
+        """Test CandidateUnit initialization with custom UUID."""
+        test_uuid = "test-uuid-abc123"
+        candidate = CandidateUnit(
+            CandidateUnit__input_size=2,
+            CandidateUnit__uuid=test_uuid,
+            CandidateUnit__candidate_index=0,
+        )
+        assert candidate.get_uuid() == test_uuid
+
+
+class TestCandidateUnitProperties:
+    """Tests for CandidateUnit properties and getters."""
+
+    def test_get_uuid(self, basic_candidate):
+        """Test get_uuid returns a string."""
+        uuid = basic_candidate.get_uuid()
+        assert isinstance(uuid, str)
+        assert len(uuid) > 0
+
+    def test_weights_shape(self, basic_candidate):
+        """Test weights tensor has correct shape."""
+        weights = basic_candidate.weights
+        assert isinstance(weights, torch.Tensor)
+        assert weights.shape[0] == basic_candidate.input_size
+
+    def test_bias_shape(self, basic_candidate):
+        """Test bias tensor has correct shape."""
+        bias = basic_candidate.bias
+        assert isinstance(bias, torch.Tensor)
+        # Bias should be a scalar or 1D tensor
+
+    def test_correlation_initial_value(self, basic_candidate):
+        """Test correlation starts at 0."""
+        assert basic_candidate.correlation == 0.0 or basic_candidate.correlation is None
+
+
+class TestCandidateUnitForward:
+    """Tests for CandidateUnit forward pass."""
+
+    def test_forward_basic(self, basic_candidate, sample_input):
+        """Test basic forward pass produces output."""
+        output = basic_candidate.forward(sample_input)
+        assert isinstance(output, torch.Tensor)
+        assert output.shape[0] == sample_input.shape[0]
+
+    def test_forward_preserves_batch_size(self, basic_candidate):
+        """Test forward preserves batch dimension."""
+        batch_sizes = [1, 5, 10, 32]
+        for batch_size in batch_sizes:
+            x = torch.randn(batch_size, basic_candidate.input_size)
+            output = basic_candidate.forward(x)
+            assert output.shape[0] == batch_size
+
+    def test_forward_output_is_1d_per_sample(self, basic_candidate, sample_input):
+        """Test forward output has correct dimensions."""
+        output = basic_candidate.forward(sample_input)
+        # Output should be (batch_size,) or (batch_size, 1)
+        assert len(output.shape) <= 2
+
+
+class TestCandidateUnitPickling:
+    """Tests for CandidateUnit pickling support."""
+
+    def test_getstate(self, basic_candidate):
+        """Test __getstate__ returns picklable dict."""
+        state = basic_candidate.__getstate__()
+        assert isinstance(state, dict)
+        # Logger should not be in state
+        assert "logger" not in state
+
+    def test_setstate(self, basic_candidate):
+        """Test __setstate__ restores instance."""
+        state = basic_candidate.__getstate__()
+        new_candidate = CandidateUnit.__new__(CandidateUnit)
+        new_candidate.__setstate__(state)
+        assert hasattr(new_candidate, "weights")
+        assert hasattr(new_candidate, "bias")
+
+    def test_pickle_roundtrip(self, basic_candidate):
+        """Test pickle/unpickle roundtrip."""
+        import pickle
+
+        pickled = pickle.dumps(basic_candidate)
+        unpickled = pickle.loads(pickled)
+        assert unpickled.input_size == basic_candidate.input_size
+        assert unpickled.epochs == basic_candidate.epochs
+
+
+class TestCandidateTrainingResult:
+    """Tests for CandidateTrainingResult dataclass."""
+
+    def test_create_basic_result(self):
+        """Test creating a basic CandidateTrainingResult."""
+        result = CandidateTrainingResult(
+            candidate_id=0,
+            candidate_uuid="test-uuid",
+            correlation=0.75,
+            candidate=None,
+            success=True,
+        )
+        assert result.candidate_id == 0
+        assert result.correlation == 0.75
+        assert result.success is True
+
+    def test_create_failed_result(self):
+        """Test creating a failed CandidateTrainingResult."""
+        result = CandidateTrainingResult(
+            candidate_id=1,
+            candidate_uuid="test-uuid-2",
+            correlation=0.0,
+            candidate=None,
+            success=False,
+            error_message="Training failed",
+        )
+        assert result.success is False
+        assert result.error_message == "Training failed"
+
+
+class TestActivationWithDerivative:
+    """Tests for ActivationWithDerivative class."""
+
+    def test_import_activation_with_derivative(self):
+        """Test ActivationWithDerivative can be imported."""
+        from candidate_unit.candidate_unit import ActivationWithDerivative
+
+        assert ActivationWithDerivative is not None
+
+    def test_create_with_tanh(self):
+        """Test creating ActivationWithDerivative with tanh."""
+        from candidate_unit.candidate_unit import ActivationWithDerivative
+
+        awd = ActivationWithDerivative(torch.tanh)
+        assert awd is not None
+        assert callable(awd)
+
+    def test_call_forward(self):
+        """Test calling ActivationWithDerivative for forward pass."""
+        from candidate_unit.candidate_unit import ActivationWithDerivative
+
+        awd = ActivationWithDerivative(torch.tanh)
+        x = torch.tensor([0.0, 0.5, 1.0])
+        output = awd(x, derivative=False)
+        expected = torch.tanh(x)
+        assert torch.allclose(output, expected)
+
+    def test_call_derivative(self):
+        """Test calling ActivationWithDerivative for derivative."""
+        from candidate_unit.candidate_unit import ActivationWithDerivative
+
+        awd = ActivationWithDerivative(torch.tanh)
+        x = torch.tensor([0.0, 0.5, 1.0])
+        deriv = awd(x, derivative=True)
+        # Derivative of tanh is 1 - tanh^2
+        expected = 1.0 - torch.tanh(x) ** 2
+        assert torch.allclose(deriv, expected)
+
+    def test_pickle_activation_with_derivative(self):
+        """Test ActivationWithDerivative can be pickled."""
+        import pickle
+
+        from candidate_unit.candidate_unit import ActivationWithDerivative
+
+        awd = ActivationWithDerivative(torch.tanh)
+        pickled = pickle.dumps(awd)
+        unpickled = pickle.loads(pickled)
+        # Test it still works after unpickling
+        x = torch.tensor([0.5])
+        assert torch.allclose(awd(x), unpickled(x))
+
+    def test_repr(self):
+        """Test ActivationWithDerivative __repr__."""
+        from candidate_unit.candidate_unit import ActivationWithDerivative
+
+        awd = ActivationWithDerivative(torch.tanh)
+        repr_str = repr(awd)
+        assert "ActivationWithDerivative" in repr_str
+        assert "tanh" in repr_str
+
+
+class TestCandidateUnitCorrelation:
+    """Tests for correlation calculation."""
+
+    def test_calculate_correlation_basic(self, basic_candidate, sample_input, sample_residual_error):
+        """Test basic correlation calculation."""
+        output = basic_candidate.forward(sample_input)
+        # Call _calculate_correlation if it exists
+        # Note: residual_error needs to be 1D (batch_size,) for _calculate_correlation
+        if hasattr(basic_candidate, "_calculate_correlation"):
+            # Take first column of residual error for single output correlation
+            residual_1d = sample_residual_error[:, 0]
+            result = basic_candidate._calculate_correlation(output, residual_1d)
+            assert result is not None
+
+    def test_correlation_range(self, basic_candidate, sample_input, sample_residual_error):
+        """Test correlation is in valid range [-1, 1]."""
+        output = basic_candidate.forward(sample_input)
+        if hasattr(basic_candidate, "_calculate_correlation"):
+            # Take first column of residual error for single output correlation
+            residual_1d = sample_residual_error[:, 0]
+            result = basic_candidate._calculate_correlation(output, residual_1d)
+            if isinstance(result, tuple) and len(result) > 0:
+                correlation = result[0]
+            else:
+                correlation = result
+            if correlation is not None:
+                assert -1.0 <= abs(float(correlation)) <= 1.0
+
+
+class TestCandidateProgressCallbacks:
+    """Tests for candidate training progress callback emissions."""
+
+    def test_train_emits_progress_callback_at_first_and_final_epoch(self):
+        """Progress callback should emit at epoch 1 and final epoch."""
+        candidate = CandidateUnit(
+            CandidateUnit__input_size=2,
+            CandidateUnit__output_size=2,
+            CandidateUnit__epochs=3,
+            CandidateUnit__early_stopping=False,
+            CandidateUnit__candidate_index=7,
+            CandidateUnit__uuid="candidate-progress-uuid",
+        )
+        x = torch.randn(6, 2)
+        residual_error = torch.randn(6, 2)
+        emitted = []
+
+        def progress_callback(**kwargs):
+            emitted.append(kwargs)
+
+        fake_result = CandidateTrainingResult(
+            candidate_id=7,
+            candidate_uuid="candidate-progress-uuid",
+            correlation=0.5,
+            candidate=candidate,
+            success=True,
+            best_corr_idx=0,
+            norm_output=torch.zeros(6),
+            norm_error=torch.zeros(6),
+            numerator=1.0,
+            denominator=1.0,
+        )
+
+        with patch.object(candidate, "_get_correlations", return_value=fake_result), patch.object(candidate, "_update_weights_and_bias", return_value=None), patch.object(candidate, "_display_training_progress", return_value=None):
+            candidate.train_detailed(
+                x=x,
+                epochs=3,
+                residual_error=residual_error,
+                progress_callback=progress_callback,
+            )
+
+        assert len(emitted) == 2
+        assert emitted[0]["candidate_id"] == 7
+        assert emitted[0]["candidate_uuid"] == "candidate-progress-uuid"
+        assert emitted[0]["epoch"] == 1
+        assert emitted[0]["total_epochs"] == 3
+        assert emitted[1]["epoch"] == 3
+        assert emitted[1]["total_epochs"] == 3
+
+    def test_train_uses_instance_progress_callback_fallback(self):
+        """When no explicit callback is passed, _progress_callback should be used."""
+        candidate = CandidateUnit(
+            CandidateUnit__input_size=2,
+            CandidateUnit__output_size=2,
+            CandidateUnit__epochs=1,
+            CandidateUnit__early_stopping=False,
+            CandidateUnit__candidate_index=11,
+            CandidateUnit__uuid="candidate-progress-fallback",
+        )
+        x = torch.randn(4, 2)
+        residual_error = torch.randn(4, 2)
+        emitted = []
+
+        candidate._progress_callback = lambda **kwargs: emitted.append(kwargs)
+
+        fake_result = CandidateTrainingResult(
+            candidate_id=11,
+            candidate_uuid="candidate-progress-fallback",
+            correlation=0.33,
+            candidate=candidate,
+            success=True,
+            best_corr_idx=0,
+            norm_output=torch.zeros(4),
+            norm_error=torch.zeros(4),
+            numerator=1.0,
+            denominator=1.0,
+        )
+
+        with patch.object(candidate, "_get_correlations", return_value=fake_result), patch.object(candidate, "_update_weights_and_bias", return_value=None), patch.object(candidate, "_display_training_progress", return_value=None):
+            candidate.train_detailed(
+                x=x,
+                epochs=1,
+                residual_error=residual_error,
+            )
+
+        assert len(emitted) == 1
+        assert emitted[0]["candidate_id"] == 11
+        assert emitted[0]["candidate_uuid"] == "candidate-progress-fallback"
+        assert emitted[0]["epoch"] == 1
+        assert emitted[0]["total_epochs"] == 1
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-m", "unit"])

--- a/juniper-cascor-model/tests/test_candidate_unit_coverage_deep.py
+++ b/juniper-cascor-model/tests/test_candidate_unit_coverage_deep.py
@@ -1,0 +1,889 @@
+#!/usr/bin/env python
+#####################################################################################################################################################################################################
+# Project:       Juniper
+# Sub-Project:   JuniperCascor
+# Application:   juniper_cascor
+# File Name:     test_candidate_unit_coverage_deep.py
+# Author:        Paul Calnon
+#
+# Date Created:  2026-03-12
+# Last Modified: 2026-03-12
+#
+# License:       MIT License
+# Copyright:     Copyright (c) 2024-2026 Paul Calnon
+#
+# Description:
+#    Deep coverage tests for CandidateUnit class targeting uncovered lines.
+#    Covers: ActivationWithDerivative edge cases, CUDA path mocking,
+#    _seed_random_generator None seeder, forward 1-D, train early stopping,
+#    train display progress exception, _get_correlation_abs_value,
+#    _calculate_abs_value, _calculate_correlation zero denominator,
+#    _update_weights_and_bias edge cases, _validate_correlation_params,
+#    setters, getters, UUID methods, clear_display_status/progress.
+#
+#####################################################################################################################################################################################################
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from candidate_unit.candidate_unit import ActivationWithDerivative, CandidateParametersUpdate, CandidateTrainingResult, CandidateUnit
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def candidate():
+    """Create a basic CandidateUnit for testing."""
+    return CandidateUnit(
+        _CandidateUnit__input_size=2,
+        _CandidateUnit__learning_rate=0.01,
+        _CandidateUnit__epochs=10,
+        _CandidateUnit__log_level_name="ERROR",
+        _CandidateUnit__random_seed=42,
+    )
+
+
+@pytest.fixture
+def candidate_early_stop():
+    """Create a CandidateUnit with early stopping enabled and low patience."""
+    return CandidateUnit(
+        _CandidateUnit__input_size=2,
+        _CandidateUnit__learning_rate=0.01,
+        _CandidateUnit__epochs=10,
+        _CandidateUnit__epochs_max=100,
+        _CandidateUnit__log_level_name="ERROR",
+        _CandidateUnit__random_seed=42,
+        _CandidateUnit__early_stopping=True,
+        _CandidateUnit__patience=2,
+    )
+
+
+@pytest.fixture
+def sample_input():
+    """Create sample 2D input tensor."""
+    torch.manual_seed(42)
+    return torch.randn(10, 2)
+
+
+@pytest.fixture
+def sample_residual_error():
+    """Create sample multi-output residual error tensor."""
+    torch.manual_seed(99)
+    return torch.randn(10, 2)
+
+
+# ===========================================================================
+# 1. ActivationWithDerivative edge cases
+# ===========================================================================
+
+
+class TestActivationWithDerivativeEdgeCases:
+    """Tests for ActivationWithDerivative fallback and numerical derivative paths."""
+
+    def test_activation_name_fallback_str(self):
+        """Line 207: _activation_name fallback when activation lacks __name__ and __class__."""
+        # Create an object that has neither __name__ nor __class__
+        # In practice, every Python object has __class__, so we test the __name__ path
+        # by providing an nn.Module instance (which has __class__ but no __name__)
+        act = torch.nn.Softplus()
+        awd = ActivationWithDerivative(act)
+        # Should use __class__.__name__ -> "Softplus"
+        assert awd._activation_name == "Softplus"
+
+    def test_numerical_derivative_for_unknown_activation(self):
+        """Lines 231-232: Numerical derivative for unknown activation functions."""
+
+        # Use a custom function that has __name__ but is not tanh/sigmoid/relu
+        def custom_square(x):
+            return x**2
+
+        awd = ActivationWithDerivative(custom_square)
+        assert awd._activation_name == "custom_square"
+
+        x = torch.tensor([1.0, 2.0, 3.0])
+        # derivative=True should use numerical approximation
+        result = awd(x, derivative=True)
+        # Derivative of x^2 is 2x; numerical approx uses eps=1e-6 so tolerance must account for float precision
+        expected = torch.tensor([2.0, 4.0, 6.0])
+        torch.testing.assert_close(result, expected, atol=0.5, rtol=0.1)
+
+    def test_numerical_derivative_for_lambda(self):
+        """Line 207: Lambda function lacking __name__ in some contexts."""
+        custom_fn = lambda x: x * 2  # noqa: E731
+        awd = ActivationWithDerivative(custom_fn)
+        # Lambda has __name__ = "<lambda>"
+        assert awd._activation_name == "<lambda>"
+
+        x = torch.tensor([1.0, 2.0])
+        result = awd(x, derivative=True)
+        # Derivative of 2x is 2; uses numerical approx with eps=1e-6 (float32 precision limits)
+        expected = torch.tensor([2.0, 2.0])
+        torch.testing.assert_close(result, expected, atol=0.5, rtol=0.1)
+
+    def test_activation_forward_pass_no_derivative(self):
+        """Test normal forward pass (derivative=False)."""
+        awd = ActivationWithDerivative(torch.tanh)
+        x = torch.tensor([0.0, 1.0, -1.0])
+        result = awd(x, derivative=False)
+        expected = torch.tanh(x)
+        torch.testing.assert_close(result, expected)
+
+
+# ===========================================================================
+# 2. _initialize_randomness CUDA path
+# ===========================================================================
+
+
+class TestInitializeRandomnessCUDA:
+    """Test CUDA seeding path in _initialize_randomness."""
+
+    def test_cuda_seeding_path(self, candidate):
+        """Lines 418-422: Mock torch.cuda.is_available to return True."""
+        with (
+            patch("torch.cuda.is_available", return_value=True),
+            patch("torch.cuda.manual_seed") as mock_cuda_seed,
+            patch("torch.rand", return_value=torch.tensor([0.5])),
+        ):
+            candidate._initialize_randomness(seed=42, max_value=10)
+            mock_cuda_seed.assert_called()
+
+
+# ===========================================================================
+# 3. _seed_random_generator with None seeder
+# ===========================================================================
+
+
+class TestSeedRandomGeneratorNoneSeeder:
+    """Test _seed_random_generator early return when seeder is None."""
+
+    def test_none_seeder_returns_early(self, candidate):
+        """Lines 442-443: Call with seeder=None, verify early return."""
+        # Should not raise, just return
+        candidate._seed_random_generator(seed=42, max_value=10, seeder=None, generator=None)
+
+
+# ===========================================================================
+# 4. forward() with 1-D tensor
+# ===========================================================================
+
+
+class TestForward1DTensor:
+    """Test forward pass with 1-D input tensor."""
+
+    def test_forward_1d_unsqueeze(self, candidate):
+        """Lines 562-563: Forward with 1-D tensor triggers unsqueeze."""
+        x = torch.randn(2)  # 1-D tensor, matches input_size=2
+        output = candidate.forward(x)
+        assert output.dim() >= 1
+        assert output.numel() >= 1
+
+    def test_forward_2d_normal(self, candidate):
+        """Forward with 2-D tensor does not unsqueeze."""
+        x = torch.randn(5, 2)
+        output = candidate.forward(x)
+        assert output.shape[0] == 5
+
+
+# ===========================================================================
+# 5. train() early stopping
+# ===========================================================================
+
+
+class TestTrainEarlyStopping:
+    """Test train with parameters that trigger early stopping."""
+
+    def test_early_stopping_triggers(self, candidate_early_stop):
+        """Lines 705-721, 716-718: Early stopping when correlation does not improve."""
+        x = torch.randn(10, 2)
+        # Create residual error that will produce near-constant correlation
+        residual_error = torch.zeros(10, 2)  # Zero error -> zero correlation -> no improvement
+
+        result = candidate_early_stop.train(
+            x=x,
+            epochs=50,
+            residual_error=residual_error,
+            learning_rate=0.01,
+            display_frequency=100,
+        )
+        # With zero residual error the correlation cannot improve, so
+        # early stopping should kick in well before 50 epochs
+        assert isinstance(result, float)
+
+
+# ===========================================================================
+# 6. train() display progress exception
+# ===========================================================================
+
+
+class TestTrainDisplayProgressException:
+    """Test error handling when _display_training_progress raises."""
+
+    def test_display_progress_exception_handled(self, candidate):
+        """Lines 731-735: Mock _display_training_progress to raise."""
+        x = torch.randn(10, 2)
+        residual_error = torch.randn(10, 2)
+
+        with patch.object(candidate, "_display_training_progress", side_effect=RuntimeError("Display error")):
+            # Should not raise - exception is caught and logged
+            result = candidate.train(
+                x=x,
+                epochs=3,
+                residual_error=residual_error,
+                learning_rate=0.01,
+                display_frequency=1,
+            )
+            assert isinstance(result, float)
+
+    def test_train_detailed_progress_callback_emits_first_and_last_epoch(self, candidate):
+        """Progress callback should emit at epoch 1 and final epoch."""
+        x = torch.randn(10, 2)
+        residual_error = torch.randn(10, 2)
+        events = []
+
+        result = candidate.train_detailed(
+            x=x,
+            epochs=3,
+            residual_error=residual_error,
+            learning_rate=0.01,
+            display_frequency=100,
+            progress_callback=lambda **kwargs: events.append(kwargs),
+        )
+
+        assert isinstance(result, CandidateTrainingResult)
+        assert len(events) >= 2
+        assert events[0]["epoch"] == 1
+        assert events[-1]["epoch"] == 3
+        assert events[-1]["total_epochs"] == 3
+
+    def test_train_detailed_uses_instance_progress_callback_fallback(self, candidate):
+        """train_detailed should use instance _progress_callback when not explicitly provided."""
+        x = torch.randn(10, 2)
+        residual_error = torch.randn(10, 2)
+        events = []
+        candidate._progress_callback = lambda **kwargs: events.append(kwargs)
+
+        result = candidate.train_detailed(
+            x=x,
+            epochs=2,
+            residual_error=residual_error,
+            learning_rate=0.01,
+            display_frequency=100,
+        )
+
+        assert isinstance(result, CandidateTrainingResult)
+        assert len(events) >= 2
+        assert events[0]["epoch"] == 1
+        assert events[-1]["epoch"] == 2
+
+
+# ===========================================================================
+# 6b. train() progress callback emission
+# ===========================================================================
+class TestTrainProgressCallback:
+    """Test progress callback wiring and throttling in train()."""
+
+    def test_progress_callback_emits_first_and_last_epoch(self, candidate):
+        """Progress callback should emit on epoch 1 and final epoch (throttled)."""
+        x = torch.randn(10, 2)
+        residual_error = torch.randn(10, 2)
+        observed = []
+
+        fake_training_result = CandidateTrainingResult(
+            correlation=0.42,
+            best_corr_idx=0,
+            all_correlations=[0.42],
+            norm_output=torch.randn(10),
+            norm_error=torch.randn(10),
+            numerator=1.0,
+            denominator=1.0,
+            success=True,
+        )
+
+        # Disable early stopping so all 51 epochs run (constant mock correlation
+        # would otherwise trigger early stop before the final epoch).
+        candidate.early_stopping = False
+
+        with (
+            patch.object(candidate, "_get_correlations", return_value=fake_training_result),
+            patch.object(candidate, "_update_weights_and_bias", return_value=MagicMock()),
+            patch.object(candidate, "_display_training_progress", return_value=None),
+        ):
+            candidate.train_detailed(
+                x=x,
+                epochs=51,
+                residual_error=residual_error,
+                learning_rate=0.01,
+                display_frequency=1000,
+                progress_callback=lambda **kwargs: observed.append(kwargs),
+            )
+
+        assert [item["epoch"] for item in observed] == [1, 51]
+        assert all(item["total_epochs"] == 51 for item in observed)
+
+    def test_progress_callback_falls_back_to_instance_attribute(self, candidate):
+        """When no callback arg is provided, train() should use self._progress_callback."""
+        x = torch.randn(10, 2)
+        residual_error = torch.randn(10, 2)
+        observed = []
+        candidate._progress_callback = lambda **kwargs: observed.append(kwargs)
+
+        fake_training_result = CandidateTrainingResult(
+            correlation=0.33,
+            best_corr_idx=0,
+            all_correlations=[0.33],
+            norm_output=torch.randn(10),
+            norm_error=torch.randn(10),
+            numerator=1.0,
+            denominator=1.0,
+            success=True,
+        )
+
+        with (
+            patch.object(candidate, "_get_correlations", return_value=fake_training_result),
+            patch.object(candidate, "_update_weights_and_bias", return_value=MagicMock()),
+            patch.object(candidate, "_display_training_progress", return_value=None),
+        ):
+            candidate.train(
+                x=x,
+                epochs=1,
+                residual_error=residual_error,
+                learning_rate=0.01,
+                display_frequency=1000,
+            )
+
+        assert len(observed) == 1
+        assert observed[0]["epoch"] == 1
+
+
+# ===========================================================================
+# 7. _get_correlation_abs_value with various types
+# ===========================================================================
+
+
+class TestGetCorrelationAbsValue:
+    """Test _get_correlation_abs_value with different correlation types.
+
+    NOTE: Line 951 evaluates len(correlation) in an f-string even when the
+    logger is a no-op, so every test item must support len().
+    """
+
+    def test_with_tensor_1d(self, candidate):
+        """Line 959: 1-D Tensor correlation (isinstance torch.Tensor branch)."""
+        candidate.correlations = [torch.tensor([-0.75])]
+        result = candidate._get_correlation_abs_value(index=0)
+        assert float(result) == pytest.approx(0.75, abs=1e-6)
+
+    def test_with_tuple(self, candidate):
+        """Line 957-958: Tuple of (tensor, int) — tuple/list branch."""
+        candidate.correlations = [(torch.tensor(-0.5), 0)]
+        result = candidate._get_correlation_abs_value(index=0)
+        assert float(result) == pytest.approx(0.5, abs=1e-6)
+
+    def test_with_list(self, candidate):
+        """Line 957-958: List of [float, int] — tuple/list branch."""
+        candidate.correlations = [[-0.3, 1]]
+        result = candidate._get_correlation_abs_value(index=0)
+        assert float(result) == pytest.approx(0.3, abs=1e-6)
+
+    def test_with_ndarray(self, candidate):
+        """Line 959: ndarray correlation."""
+        candidate.correlations = [np.array([-0.9])]
+        result = candidate._get_correlation_abs_value(index=0)
+        assert float(np.asarray(result).flat[0]) == pytest.approx(0.9, abs=1e-6)
+
+    def test_with_tuple_float_first(self, candidate):
+        """Line 957-958: Tuple with float as first element."""
+        candidate.correlations = [(-0.42, 1)]
+        result = candidate._get_correlation_abs_value(index=0)
+        assert float(result) == pytest.approx(0.42, abs=1e-6)
+
+
+# ===========================================================================
+# 8. _calculate_abs_value with various types
+# ===========================================================================
+
+
+class TestCalculateAbsValue:
+    """Test _calculate_abs_value with different value types."""
+
+    def test_torch_tensor(self, candidate):
+        """Line 986-987: Torch tensor."""
+        result = candidate._calculate_abs_value(torch.tensor(-3.0))
+        assert float(result) == pytest.approx(3.0)
+
+    def test_ndarray(self, candidate):
+        """Line 988-989: Numpy array."""
+        result = candidate._calculate_abs_value(np.array(-2.5))
+        assert float(result) == pytest.approx(2.5)
+
+    def test_float(self, candidate):
+        """Line 988-989: Float."""
+        result = candidate._calculate_abs_value(-1.5)
+        assert float(result) == pytest.approx(1.5)
+
+    def test_int(self, candidate):
+        """Line 988-989: Int."""
+        result = candidate._calculate_abs_value(-7)
+        assert float(result) == pytest.approx(7.0)
+
+    def test_unknown_type_fallback(self, candidate):
+        """Lines 990-992: Unknown type falls through to numpy abs."""
+        result = candidate._calculate_abs_value(np.float32(-4.0))
+        assert float(result) == pytest.approx(4.0)
+
+
+# ===========================================================================
+# 9. _calculate_correlation denominator zero/NaN
+# ===========================================================================
+
+
+class TestCalculateCorrelationDenomZero:
+    """Test _calculate_correlation when denominator is zero or NaN."""
+
+    def test_zero_denominator_constant_output(self, candidate):
+        """Lines 1066-1067: Constant output and constant error produce zero denominator."""
+        # Constant output: all same value -> std=0 -> denominator effectively 0
+        output = torch.ones(10)
+        residual_error = torch.ones(10)
+        correlation, norm_output, norm_error, num, den = candidate._calculate_correlation(output=output, residual_error=residual_error)
+        # With the epsilon, denominator won't be exactly zero but correlation
+        # should be near zero since numerator is zero (all centered values are 0)
+        assert abs(correlation) < 1e-3
+
+    def test_zero_residual_error(self, candidate):
+        """Zero residual error produces near-zero correlation."""
+        output = torch.randn(10)
+        residual_error = torch.zeros(10)
+        correlation, norm_output, norm_error, num, den = candidate._calculate_correlation(output=output, residual_error=residual_error)
+        assert abs(correlation) < 1e-3
+
+
+# ===========================================================================
+# 10. _update_weights_and_bias edge cases
+# ===========================================================================
+
+
+class TestUpdateWeightsAndBiasEdgeCases:
+    """Test _update_weights_and_bias with multi-output and gradient edge cases."""
+
+    def test_multi_output_negative_best_corr_idx(self, candidate, sample_input, sample_residual_error):
+        """Lines 1140-1141: Multi-output with best_corr_idx < 0 -> fallback warning."""
+        output = candidate.forward(sample_input)
+        params = CandidateParametersUpdate(
+            x=sample_input,
+            y=output,
+            residual_error=sample_residual_error,
+            learning_rate=0.01,
+            norm_output=output - output.mean(),
+            norm_error=sample_residual_error[:, 0] - sample_residual_error[:, 0].mean(),
+            best_corr_idx=-1,  # Invalid index -> fallback
+            numerator=0.0,
+            denominator=1.0,
+        )
+        result = candidate._update_weights_and_bias(candidate_parameters_update=params)
+        # Should not raise, should use column 0 as fallback
+        assert result is not None
+
+    def test_single_output_error(self, candidate, sample_input):
+        """Lines 1143-1145: Single output error path."""
+        output = candidate.forward(sample_input)
+        residual_error_1d = torch.randn(10)
+        params = CandidateParametersUpdate(
+            x=sample_input,
+            y=output,
+            residual_error=residual_error_1d,
+            learning_rate=0.01,
+            norm_output=output - output.mean(),
+            norm_error=residual_error_1d - residual_error_1d.mean(),
+            best_corr_idx=0,
+            numerator=0.0,
+            denominator=1.0,
+        )
+        result = candidate._update_weights_and_bias(candidate_parameters_update=params)
+        assert result is not None
+
+
+# ===========================================================================
+# 11. _validate_correlation_params validation errors
+# ===========================================================================
+
+
+class TestValidateCorrelationParams:
+    """Test each of the 6 validation paths in _validate_correlation_params."""
+
+    def test_none_output(self, candidate):
+        """Line 1236: None output raises ValueError."""
+        with pytest.raises(ValueError, match="must not be None"):
+            candidate._validate_correlation_params(output=None, residual_error=torch.randn(5))
+
+    def test_none_residual_error(self, candidate):
+        """Line 1236: None residual_error raises ValueError."""
+        with pytest.raises(ValueError, match="must not be None"):
+            candidate._validate_correlation_params(output=torch.randn(5), residual_error=None)
+
+    def test_non_tensor_residual_error(self, candidate):
+        """Line 1242: Non-tensor residual_error raises TypeError."""
+        # Use numpy array (has .shape but is not torch.Tensor)
+        with pytest.raises(TypeError, match="must be torch.Tensor"):
+            candidate._validate_correlation_params(output=torch.randn(5), residual_error=np.array([1.0, 2.0, 3.0, 4.0, 5.0]))
+
+    def test_non_tensor_output(self, candidate):
+        """Line 1242: Non-tensor output raises TypeError."""
+        # Use numpy array (has .shape but is not torch.Tensor)
+        with pytest.raises(TypeError, match="must be torch.Tensor"):
+            candidate._validate_correlation_params(output=np.array([1.0, 2.0, 3.0, 4.0, 5.0]), residual_error=torch.randn(5))
+
+    def test_mismatched_batch_sizes(self, candidate):
+        """Line 1248: Mismatched batch sizes raises ValueError."""
+        with pytest.raises(ValueError, match="same batch size"):
+            candidate._validate_correlation_params(output=torch.randn(5, 2), residual_error=torch.randn(10, 2))
+
+    def test_greater_than_2d_input(self, candidate):
+        """Line 1260: >2D input raises ValueError."""
+        with pytest.raises(ValueError, match="at most two dimensions"):
+            candidate._validate_correlation_params(output=torch.randn(5, 2, 3), residual_error=torch.randn(5, 2))
+
+    def test_greater_than_2d_residual(self, candidate):
+        """Line 1260: >2D residual_error raises ValueError."""
+        with pytest.raises(ValueError, match="at most two dimensions"):
+            candidate._validate_correlation_params(output=torch.randn(5, 2), residual_error=torch.randn(5, 2, 3))
+
+    def test_mismatched_features(self, candidate):
+        """Line 1270: Mismatched features when residual_error is 2D."""
+        with pytest.raises(ValueError, match="same number of features"):
+            candidate._validate_correlation_params(output=torch.randn(5, 2), residual_error=torch.randn(5, 3))
+
+    def test_valid_params_pass(self, candidate):
+        """Ensure valid parameters pass validation without raising."""
+        # 1D tensors
+        candidate._validate_correlation_params(output=torch.randn(5), residual_error=torch.randn(5))
+        # 2D tensors with matching features
+        candidate._validate_correlation_params(output=torch.randn(5, 2), residual_error=torch.randn(5, 2))
+
+
+# ===========================================================================
+# 12. Setter methods
+# ===========================================================================
+
+
+class TestSetterMethods:
+    """Test setter methods for CandidateUnit attributes."""
+
+    def test_set_correlation(self, candidate):
+        """Line 1371."""
+        candidate.set_correlation(0.95)
+        assert candidate.correlation == 0.95
+
+    def test_set_activation_fn(self, candidate):
+        """Line 1379."""
+        new_fn = torch.nn.ReLU()
+        candidate.set_activation_fn(new_fn)
+        assert candidate.activation_fn is new_fn
+
+    def test_set_activation_fn_base(self, candidate):
+        """Line 1387."""
+        new_fn = torch.sigmoid
+        candidate.set_activation_fn_base(new_fn)
+        assert candidate.activation_fn_base is new_fn
+
+    def test_set_bias(self, candidate):
+        """Line 1395."""
+        new_bias = torch.tensor([0.5])
+        candidate.set_bias(new_bias)
+        assert torch.equal(candidate.bias, new_bias)
+
+    def test_set_display_frequency(self, candidate):
+        """Line 1411."""
+        candidate.set_display_frequency(50)
+        assert candidate.display_frequency == 50
+
+    def test_set_epochs_max(self, candidate):
+        """Line 1419."""
+        candidate.set_epochs_max(200)
+        assert candidate.epochs_max == 200
+
+    def test_set_learning_rate(self, candidate):
+        """Line 1427."""
+        candidate.set_learning_rate(0.001)
+        assert candidate.learning_rate == 0.001
+
+    def test_set_logging_file_name(self, candidate):
+        """Line 1435."""
+        candidate.set_logging_file_name("test_log.log")
+        assert candidate.logging_file_name == "test_log.log"
+
+    def test_set_logging_level(self, candidate):
+        """Line 1443."""
+        candidate.set_logging_level(10)
+        assert candidate.logging_level == 10
+
+    def test_set_random_value_scale(self, candidate):
+        """Line 1451."""
+        candidate.set_random_value_scale(0.5)
+        assert candidate.random_value_scale == 0.5
+
+    def test_set_weights(self, candidate):
+        """Line 1459."""
+        new_weights = torch.tensor([1.0, 2.0])
+        candidate.set_weights(new_weights)
+        assert torch.equal(candidate.weights, new_weights)
+
+
+# ===========================================================================
+# 13. Getter methods
+# ===========================================================================
+
+
+class TestGetterMethods:
+    """Test getter methods for CandidateUnit attributes."""
+
+    def test_get_activation_fn(self, candidate):
+        """Line 1512."""
+        result = candidate.get_activation_fn()
+        assert result is not None
+
+    def test_get_activation_fn_base(self, candidate):
+        """Line 1520."""
+        result = candidate.get_activation_fn_base()
+        assert result is not None
+
+    def test_get_bias(self, candidate):
+        """Line 1528."""
+        result = candidate.get_bias()
+        assert isinstance(result, torch.Tensor)
+
+    def test_get_display_frequency(self, candidate):
+        """Line 1536."""
+        result = candidate.get_display_frequency()
+        assert isinstance(result, int)
+
+    def test_get_epochs_max(self, candidate):
+        """Line 1552."""
+        result = candidate.get_epochs_max()
+        assert isinstance(result, int)
+
+    def test_get_learning_rate(self, candidate):
+        """Line 1560."""
+        result = candidate.get_learning_rate()
+        assert isinstance(result, float)
+
+    def test_get_logging_file_name(self, candidate):
+        """Line 1568."""
+        candidate.set_logging_file_name("my_log.txt")
+        result = candidate.get_logging_file_name()
+        assert result == "my_log.txt"
+
+    def test_get_logging_level(self, candidate):
+        """Line 1576."""
+        candidate.set_logging_level(20)
+        result = candidate.get_logging_level()
+        assert result == 20
+
+    def test_get_random_value_scale(self, candidate):
+        """Line 1584."""
+        result = candidate.get_random_value_scale()
+        assert isinstance(result, float)
+
+    def test_get_weights(self, candidate):
+        """Line 1592."""
+        result = candidate.get_weights()
+        assert isinstance(result, torch.Tensor)
+        assert result.shape == (2,)
+
+    def test_get_correlation(self, candidate):
+        """Line 1504."""
+        result = candidate.get_correlation()
+        assert isinstance(result, float)
+
+
+# ===========================================================================
+# 14. UUID methods
+# ===========================================================================
+
+
+class TestUUIDMethods:
+    """Test set_uuid and get_uuid methods."""
+
+    def test_set_uuid_with_value(self):
+        """Lines 1461-1477: set_uuid with a valid UUID string."""
+        candidate = CandidateUnit(
+            CandidateUnit__input_size=2,
+            CandidateUnit__learning_rate=0.01,
+            CandidateUnit__epochs=10,
+            CandidateUnit__log_level_name="ERROR",
+            CandidateUnit__random_seed=42,
+            CandidateUnit__uuid="test-uuid-1234",
+        )
+        assert candidate.uuid == "test-uuid-1234"
+
+    def test_set_uuid_double_set_error(self, candidate):
+        """Lines 1473-1476: Double-set UUID triggers fatal and sys.exit(1)."""
+        # candidate already has a UUID set during __init__
+        assert candidate.uuid is not None
+        with pytest.raises(SystemExit) as exc_info:
+            candidate.set_uuid("new-uuid")
+        assert exc_info.value.code == 1
+
+    def test_get_uuid_lazy_initialization(self):
+        """Lines 1491-1493: get_uuid lazily initializes UUID if not set."""
+        candidate = CandidateUnit(
+            _CandidateUnit__input_size=2,
+            _CandidateUnit__learning_rate=0.01,
+            _CandidateUnit__epochs=10,
+            _CandidateUnit__log_level_name="ERROR",
+            _CandidateUnit__random_seed=42,
+        )
+        # UUID is set during __init__, but test the getter
+        uuid_val = candidate.get_uuid()
+        assert uuid_val is not None
+        assert isinstance(uuid_val, str)
+        assert len(uuid_val) > 0
+
+    def test_get_uuid_generates_when_none(self):
+        """Lines 1491-1493: get_uuid generates UUID when self.uuid is None."""
+        candidate = CandidateUnit(
+            _CandidateUnit__input_size=2,
+            _CandidateUnit__learning_rate=0.01,
+            _CandidateUnit__epochs=10,
+            _CandidateUnit__log_level_name="ERROR",
+            _CandidateUnit__random_seed=42,
+        )
+        # Force uuid to None to test lazy generation
+        candidate.uuid = None
+        uuid_val = candidate.get_uuid()
+        assert uuid_val is not None
+        assert len(uuid_val) > 0
+
+
+# ===========================================================================
+# 15. clear_display_status/progress
+# ===========================================================================
+
+
+class TestClearDisplayMethods:
+    """Test clear_display_status and clear_display_progress."""
+
+    def test_clear_display_status_with_attribute(self, candidate):
+        """Lines 1329-1344: Clear when attribute exists and is not None."""
+        candidate._candidate_display_status = MagicMock()
+        candidate.clear_display_status()
+        assert candidate._candidate_display_status is None
+
+    def test_clear_display_status_already_none(self, candidate):
+        """Lines 1342-1343: Clear when attribute is None already."""
+        candidate._candidate_display_status = None
+        candidate.clear_display_status()
+        assert candidate._candidate_display_status is None
+
+    def test_clear_display_status_no_attribute(self, candidate):
+        """Lines 1342-1343: Clear when attribute does not exist."""
+        if hasattr(candidate, "_candidate_display_status"):
+            delattr(candidate, "_candidate_display_status")
+        candidate.clear_display_status()
+        # Should not raise, should log warning
+
+    def test_clear_display_progress_with_attribute(self, candidate):
+        """Lines 1346-1361: Clear when attribute exists and is not None."""
+        candidate._candidate_display_progress = MagicMock()
+        candidate.clear_display_progress()
+        assert candidate._candidate_display_progress is None
+
+    def test_clear_display_progress_already_none(self, candidate):
+        """Lines 1359-1360: Clear when attribute is None already."""
+        candidate._candidate_display_progress = None
+        candidate.clear_display_progress()
+        assert candidate._candidate_display_progress is None
+
+    def test_clear_display_progress_no_attribute(self, candidate):
+        """Lines 1359-1360: Clear when attribute does not exist."""
+        if hasattr(candidate, "_candidate_display_progress"):
+            delattr(candidate, "_candidate_display_progress")
+        candidate.clear_display_progress()
+        # Should not raise, should log warning
+
+
+# ===========================================================================
+# Additional edge case coverage
+# ===========================================================================
+
+
+class TestActivationDerivativeKnownFunctions:
+    """Test ActivationWithDerivative derivative for known functions."""
+
+    def test_tanh_derivative(self):
+        """Line 223: tanh derivative path."""
+        awd = ActivationWithDerivative(torch.tanh)
+        x = torch.tensor([0.0, 1.0])
+        result = awd(x, derivative=True)
+        expected = 1.0 - torch.tanh(x) ** 2
+        torch.testing.assert_close(result, expected)
+
+    def test_sigmoid_derivative(self):
+        """Lines 225-226: sigmoid derivative path."""
+        awd = ActivationWithDerivative(torch.sigmoid)
+        x = torch.tensor([0.0, 1.0])
+        result = awd(x, derivative=True)
+        y = torch.sigmoid(x)
+        expected = y * (1.0 - y)
+        torch.testing.assert_close(result, expected)
+
+    def test_relu_derivative(self):
+        """Line 228: relu derivative path."""
+        awd = ActivationWithDerivative(torch.relu)
+        x = torch.tensor([-1.0, 0.0, 1.0])
+        result = awd(x, derivative=True)
+        expected = torch.tensor([0.0, 0.0, 1.0])
+        torch.testing.assert_close(result, expected)
+
+
+class TestActivationSerialization:
+    """Test ActivationWithDerivative pickle support."""
+
+    def test_getstate_setstate(self):
+        """Lines 236-244: __getstate__ and __setstate__ round trip."""
+        awd = ActivationWithDerivative(torch.tanh)
+        state = awd.__getstate__()
+        assert state == {"_activation_name": "tanh"}
+
+        awd2 = ActivationWithDerivative.__new__(ActivationWithDerivative)
+        awd2.__setstate__(state)
+        assert awd2._activation_name == "tanh"
+        # Verify the restored function works
+        x = torch.tensor([1.0])
+        result = awd2(x)
+        assert result.shape == (1,)
+
+    def test_repr(self):
+        """Line 248: __repr__."""
+        awd = ActivationWithDerivative(torch.tanh)
+        assert "tanh" in repr(awd)
+
+
+class TestSeedRandomGeneratorWithGenerator:
+    """Test _seed_random_generator when generator is None."""
+
+    def test_generator_none_skips_rolling(self, candidate):
+        """Lines 446-448: When generator is None, skip rolling."""
+        # Just verify no error
+        candidate._seed_random_generator(seed=42, max_value=10, seeder=lambda s: None, generator=None)
+
+
+class TestCandidateTrainingResultDataclass:
+    """Test CandidateTrainingResult defaults."""
+
+    def test_defaults(self):
+        """Verify dataclass default values."""
+        result = CandidateTrainingResult()
+        assert result.candidate_id == -1
+        assert result.correlation == 0.0
+        assert result.success is True
+        assert result.epochs_completed == 0
+        assert result.all_correlations == []

--- a/juniper-cascor-model/tests/test_candidate_unit_training_paths.py
+++ b/juniper-cascor-model/tests/test_candidate_unit_training_paths.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python
+#####################################################################################################################################################################################################
+# Project:       Juniper
+# Prototype:     Cascade Correlation Neural Network
+# File Name:     test_candidate_unit_training_paths.py
+# Author:        Paul Calnon
+#
+# Date Created:  2026-07-03
+#
+# License:       MIT License
+# Copyright:     Copyright (c) 2024-2026 Paul Calnon
+#
+# Description:
+#     Behavioral coverage for the CandidateUnit training hot-path branches that the
+#     existing contract/coverage suites leave unexercised: the payload-coercion guards,
+#     the log-level-gated diagnostic blocks (run once at TRACE so every ``_log_debug`` /
+#     ``_log_trace`` / ``_log_verbose`` guard evaluates truthy), the sequence-roll cap
+#     warning, the empty-correlation fallback, and display-function re-initialization.
+#     Part of the juniper-cascor-model per-file coverage rollout (C-5).
+#
+#####################################################################################################################################################################################################
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from candidate_unit.candidate_unit import CandidateParametersUpdate, CandidateUnit  # noqa: E402
+from cascor_constants.constants_candidates.constants_candidates import _PROJECT_MODEL_CANDIDATE_MAX_ROLL_COUNT  # noqa: E402
+from log_config.logger.logger import Logger  # noqa: E402
+
+
+def _make_candidate(**overrides):
+    params = {
+        "CandidateUnit__input_size": 2,
+        "CandidateUnit__output_size": 1,
+        "CandidateUnit__random_seed": 13,
+        "CandidateUnit__candidate_index": 1,
+        "CandidateUnit__display_frequency": 0,
+        "CandidateUnit__status_frequency": 0,
+        "CandidateUnit__random_value_scale": 0.01,
+        "CandidateUnit__log_level_name": "CRITICAL",
+    }
+    params.update(overrides)
+    return CandidateUnit(**params)
+
+
+class TestCoerceIntLike:
+    """The JSON-payload numeric coercion guard used by the seed/range APIs."""
+
+    def test_bool_is_rejected(self):
+        with pytest.raises(TypeError, match="not bool"):
+            CandidateUnit._coerce_int_like(True, "CandidateUnit__candidate_index")
+
+    def test_non_integer_float_is_rejected(self):
+        with pytest.raises(ValueError, match="integer-valued number"):
+            CandidateUnit._coerce_int_like(2.5, "CandidateUnit__random_seed")
+
+    def test_integer_valued_float_is_normalized(self):
+        assert CandidateUnit._coerce_int_like(4.0, "CandidateUnit__candidate_index") == 4
+
+
+class TestTrainDiagnosticPaths:
+    """Run a real training loop at TRACE so every level-gated diagnostic block executes."""
+
+    def test_train_at_trace_level_exercises_diagnostic_guards(self):
+        saved_level = Logger._log_level
+        try:
+            candidate = _make_candidate(
+                CandidateUnit__output_size=1,
+                CandidateUnit__log_level_name="TRACE",
+                CandidateUnit__early_stopping=True,
+                CandidateUnit__patience=1,
+                CandidateUnit__convergence_threshold=10.0,
+            )
+            # Multi-output residual so the _multi_output_correlation loop runs more than once.
+            x = torch.tensor([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]], dtype=torch.float32)
+            residual_error = torch.tensor(
+                [[-0.5, 0.1], [0.25, -0.2], [0.25, 0.3], [0.5, -0.4]],
+                dtype=torch.float32,
+            )
+
+            correlation = candidate.train(x=x, residual_error=residual_error, epochs=3, learning_rate=0.05)
+
+            assert isinstance(correlation, float)
+            assert 0.0 <= correlation <= 1.0
+            assert candidate.last_training_result.epochs_completed >= 1
+        finally:
+            Logger._log_level = saved_level
+
+
+class TestSequenceRollCap:
+    """The OOM-guard cap in _roll_sequence_number warns when the sequence overshoots."""
+
+    def test_roll_sequence_number_caps_and_warns(self):
+        candidate = _make_candidate()
+        calls = {"count": 0}
+
+        def _counting_generator(_low, _high):
+            calls["count"] += 1
+            return 0
+
+        # A sequence beyond the cap must clamp the roll count and log the cap warning,
+        # never iterate the full (potentially 2**32) sequence.
+        candidate._roll_sequence_number(
+            sequence=_PROJECT_MODEL_CANDIDATE_MAX_ROLL_COUNT + 5,
+            max_value=10,
+            generator=_counting_generator,
+        )
+
+        assert calls["count"] == _PROJECT_MODEL_CANDIDATE_MAX_ROLL_COUNT
+
+
+class TestEmptyCorrelationFallback:
+    """_get_correlations must degrade to an unsuccessful result when no outputs correlate."""
+
+    def test_zero_width_residual_yields_unsuccessful_result(self):
+        candidate = _make_candidate()
+        output = torch.zeros(4)
+        # A zero-feature residual makes the correlation loop empty -> best_idx < 0 branch.
+        residual_error = torch.zeros(4, 0)
+
+        result = candidate._get_correlations(output=output, residual_error=residual_error)
+
+        assert result.success is False
+        assert result.best_corr_idx == -1
+        assert result.correlation == 0.0
+        assert result.all_correlations == []
+
+
+class TestDisplayProgressReinit:
+    """_display_training_progress rebuilds its frequency checker if it was cleared."""
+
+    def test_display_progress_reinitializes_when_none(self):
+        candidate = _make_candidate(CandidateUnit__display_frequency=0)
+        candidate.clear_display_progress()
+        assert candidate._candidate_display_progress is None
+
+        update = CandidateParametersUpdate(
+            norm_output=torch.zeros(4),
+            norm_error=torch.zeros(4),
+        )
+        residual_error = torch.zeros(4, 1)
+
+        candidate._display_training_progress(0, update, residual_error)
+
+        # The checker must have been rebuilt (no longer None) by the re-init branch.
+        assert candidate._candidate_display_progress is not None

--- a/juniper-cascor-model/tests/test_log_config_coverage.py
+++ b/juniper-cascor-model/tests/test_log_config_coverage.py
@@ -1,0 +1,647 @@
+#!/usr/bin/env python
+"""
+Extended unit tests for LogConfig class to improve code coverage.
+
+Tests cover:
+- LogConfig class getters and setters
+- Serialization support (__getstate__, __setstate__)
+- UUID generation and management
+- Edge cases with different log levels
+"""
+
+import logging
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestLogConfigGetters:
+    """Tests for LogConfig getter methods using mocked LogConfig instance."""
+
+    @pytest.fixture
+    def mock_log_config(self):
+        """Create a mock LogConfig object with attributes set."""
+        mock = MagicMock()
+        mock.uuid = "test-uuid-12345"
+        mock.custom_logger = MagicMock()
+        mock.logger = MagicMock()
+        mock.log_file_name = "test.log"
+        mock.log_file_path = "/tmp/logs"
+        mock.log_config_file_name = "logging_config.yaml"
+        mock.log_config_file_path = "/tmp/config"
+        mock.log_formatter_string = "%(message)s"
+        mock.log_date_format = "%Y-%m-%d"
+        mock.log_message_default = "Default message"
+        mock.log_level = 20
+        mock.log_level_name = "INFO"
+        mock.log_level_logging_config = logging.INFO
+        mock.log_level_names_list = ["DEBUG", "INFO", "WARNING"]
+        mock.log_level_numbers_list = [10, 20, 30]
+        mock.log_level_methods_list = ["debug", "info", "warning"]
+        mock.log_level_numbers_dict = {"DEBUG": 10, "INFO": 20}
+        mock.log_level_methods_dict = {"DEBUG": "debug", "INFO": "info"}
+        mock.log_level_custom_names_list = ["TRACE", "VERBOSE"]
+        mock.log_allow_log_level_redefinition = True
+        return mock
+
+    def test_get_uuid_returns_uuid(self, mock_log_config):
+        """Test get_uuid returns the uuid."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_uuid(mock_log_config)
+        assert result == "test-uuid-12345"
+
+    def test_get_custom_logger_returns_logger(self, mock_log_config):
+        """Test get_custom_logger returns custom logger."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_custom_logger(mock_log_config)
+        assert result is mock_log_config.custom_logger
+
+    def test_get_logger_returns_logger(self, mock_log_config):
+        """Test get_logger returns logger."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_logger(mock_log_config)
+        assert result is mock_log_config.logger
+
+    def test_get_log_file_name_returns_name(self, mock_log_config):
+        """Test get_log_file_name returns file name."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_file_name(mock_log_config)
+        assert result == "test.log"
+
+    def test_get_log_file_path_returns_path(self, mock_log_config):
+        """Test get_log_file_path returns file path."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_file_path(mock_log_config)
+        assert result == "/tmp/logs"
+
+    def test_get_log_config_file_name_returns_name(self, mock_log_config):
+        """Test get_log_config_file_name returns config file name."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_config_file_name(mock_log_config)
+        assert result == "logging_config.yaml"
+
+    def test_get_log_config_file_path_returns_path(self, mock_log_config):
+        """Test get_log_config_file_path returns config file path."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_config_file_path(mock_log_config)
+        assert result == "/tmp/config"
+
+    def test_get_log_formatter_string_returns_string(self, mock_log_config):
+        """Test get_log_formatter_string returns formatter string."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_formatter_string(mock_log_config)
+        assert result == "%(message)s"
+
+    def test_get_log_date_format_returns_format(self, mock_log_config):
+        """Test get_log_date_format returns date format."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_date_format(mock_log_config)
+        assert result == "%Y-%m-%d"
+
+    def test_get_log_message_default_returns_message(self, mock_log_config):
+        """Test get_log_message_default returns default message."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_message_default(mock_log_config)
+        assert result == "Default message"
+
+    def test_get_log_level_returns_level(self, mock_log_config):
+        """Test get_log_level returns log level."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_level(mock_log_config)
+        assert result == 20
+
+    def test_get_log_level_name_returns_name(self, mock_log_config):
+        """Test get_log_level_name returns level name."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_level_name(mock_log_config)
+        assert result == "INFO"
+
+    def test_get_log_level_logging_config_returns_config(self, mock_log_config):
+        """Test get_log_level_logging_config returns logging config level."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_level_logging_config(mock_log_config)
+        assert result == logging.INFO
+
+    def test_get_log_level_names_list_returns_list(self, mock_log_config):
+        """Test get_log_level_names_list returns names list."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_level_names_list(mock_log_config)
+        assert result == ["DEBUG", "INFO", "WARNING"]
+
+    def test_get_log_level_numbers_list_returns_list(self, mock_log_config):
+        """Test get_log_level_numbers_list returns numbers list."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_level_numbers_list(mock_log_config)
+        assert result == [10, 20, 30]
+
+    def test_get_log_level_methods_list_returns_list(self, mock_log_config):
+        """Test get_log_level_methods_list returns methods list."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_level_methods_list(mock_log_config)
+        assert result == ["debug", "info", "warning"]
+
+    def test_get_log_level_numbers_dict_returns_dict(self, mock_log_config):
+        """Test get_log_level_numbers_dict returns numbers dict."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_level_numbers_dict(mock_log_config)
+        assert result == {"DEBUG": 10, "INFO": 20}
+
+    def test_get_log_level_methods_dict_returns_dict(self, mock_log_config):
+        """Test get_log_level_methods_dict returns methods dict."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_level_methods_dict(mock_log_config)
+        assert result == {"DEBUG": "debug", "INFO": "info"}
+
+    def test_get_log_level_custom_names_list_returns_list(self, mock_log_config):
+        """Test get_log_level_custom_names_list returns custom names list."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_level_custom_names_list(mock_log_config)
+        assert result == ["TRACE", "VERBOSE"]
+
+    def test_get_log_allow_log_level_redefinition_returns_bool(self, mock_log_config):
+        """Test get_log_allow_log_level_redefinition returns boolean."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_allow_log_level_redefinition(mock_log_config)
+        assert result is True
+
+
+class TestLogConfigGettersMissingAttributes:
+    """Tests for LogConfig getter methods when attributes are missing."""
+
+    @pytest.fixture
+    def empty_mock(self):
+        """Create a mock with no attributes."""
+        mock = MagicMock(spec=[])
+        return mock
+
+    def test_get_custom_logger_no_attribute(self, empty_mock):
+        """Test get_custom_logger returns None when attribute missing."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_custom_logger(empty_mock)
+        assert result is None
+
+    def test_get_logger_no_attribute(self, empty_mock):
+        """Test get_logger returns None when attribute missing."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_logger(empty_mock)
+        assert result is None
+
+    def test_get_log_file_name_no_attribute(self, empty_mock):
+        """Test get_log_file_name returns None when attribute missing."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_file_name(empty_mock)
+        assert result is None
+
+    def test_get_log_file_path_no_attribute(self, empty_mock):
+        """Test get_log_file_path returns None when attribute missing."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_file_path(empty_mock)
+        assert result is None
+
+    def test_get_log_config_file_name_no_attribute(self, empty_mock):
+        """Test get_log_config_file_name returns None when attribute missing."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_config_file_name(empty_mock)
+        assert result is None
+
+    def test_get_log_config_file_path_no_attribute(self, empty_mock):
+        """Test get_log_config_file_path returns None when attribute missing."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_config_file_path(empty_mock)
+        assert result is None
+
+    def test_get_log_formatter_string_no_attribute(self, empty_mock):
+        """Test get_log_formatter_string returns None when attribute missing."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_formatter_string(empty_mock)
+        assert result is None
+
+    def test_get_log_date_format_no_attribute(self, empty_mock):
+        """Test get_log_date_format returns None when attribute missing."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_date_format(empty_mock)
+        assert result is None
+
+    def test_get_log_message_default_no_attribute(self, empty_mock):
+        """Test get_log_message_default returns None when attribute missing."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_message_default(empty_mock)
+        assert result is None
+
+    def test_get_log_level_no_attribute(self, empty_mock):
+        """Test get_log_level returns None when attribute missing."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_level(empty_mock)
+        assert result is None
+
+    def test_get_log_level_name_no_attribute(self, empty_mock):
+        """Test get_log_level_name returns None when attribute missing."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_level_name(empty_mock)
+        assert result is None
+
+    def test_get_log_level_logging_config_no_attribute(self, empty_mock):
+        """Test get_log_level_logging_config returns None when attribute missing."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_level_logging_config(empty_mock)
+        assert result is None
+
+    def test_get_log_level_names_list_no_attribute(self, empty_mock):
+        """Test get_log_level_names_list returns None when attribute missing."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_level_names_list(empty_mock)
+        assert result is None
+
+    def test_get_log_level_numbers_list_no_attribute(self, empty_mock):
+        """Test get_log_level_numbers_list returns None when attribute missing."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_level_numbers_list(empty_mock)
+        assert result is None
+
+    def test_get_log_level_methods_list_no_attribute(self, empty_mock):
+        """Test get_log_level_methods_list returns None when attribute missing."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_level_methods_list(empty_mock)
+        assert result is None
+
+    def test_get_log_level_numbers_dict_no_attribute(self, empty_mock):
+        """Test get_log_level_numbers_dict returns None when attribute missing."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_level_numbers_dict(empty_mock)
+        assert result is None
+
+    def test_get_log_level_methods_dict_no_attribute(self, empty_mock):
+        """Test get_log_level_methods_dict returns None when attribute missing."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_level_methods_dict(empty_mock)
+        assert result is None
+
+    def test_get_log_level_custom_names_list_no_attribute(self, empty_mock):
+        """Test get_log_level_custom_names_list returns None when attribute missing."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_level_custom_names_list(empty_mock)
+        assert result is None
+
+    def test_get_log_allow_log_level_redefinition_no_attribute(self, empty_mock):
+        """Test get_log_allow_log_level_redefinition returns None when attribute missing."""
+        from log_config.log_config import LogConfig
+
+        result = LogConfig.get_log_allow_log_level_redefinition(empty_mock)
+        assert result is None
+
+
+class TestLogConfigSetters:
+    """Tests for LogConfig setter methods."""
+
+    @pytest.fixture
+    def mock_log_config(self):
+        """Create a mock LogConfig object for setter tests."""
+        mock = MagicMock()
+        mock.logger = MagicMock()
+        mock.logger.trace = MagicMock()
+        mock.logger.verbose = MagicMock()
+        mock.logger.debug = MagicMock()
+        mock.logger.fatal = MagicMock()
+        return mock
+
+    def test_set_custom_logger(self, mock_log_config):
+        """Test set_custom_logger sets the custom logger."""
+        from log_config.log_config import LogConfig
+
+        new_logger = MagicMock()
+        LogConfig.set_custom_logger(mock_log_config, new_logger)
+        assert mock_log_config.custom_logger == new_logger
+
+    def test_set_logger(self, mock_log_config):
+        """Test set_logger sets the logger."""
+        from log_config.log_config import LogConfig
+
+        new_logger = MagicMock()
+        LogConfig.set_logger(mock_log_config, new_logger)
+        assert mock_log_config.logger == new_logger
+
+    def test_set_log_file_name(self, mock_log_config):
+        """Test set_log_file_name sets the file name."""
+        from log_config.log_config import LogConfig
+
+        LogConfig.set_log_file_name(mock_log_config, "new_file.log")
+        assert mock_log_config.log_file_name == "new_file.log"
+
+    def test_set_log_file_path(self, mock_log_config):
+        """Test set_log_file_path sets the file path."""
+        from log_config.log_config import LogConfig
+
+        LogConfig.set_log_file_path(mock_log_config, "/new/path")
+        assert mock_log_config.log_file_path == "/new/path"
+
+    def test_set_log_config_file_name(self, mock_log_config):
+        """Test set_log_config_file_name sets the config file name."""
+        from log_config.log_config import LogConfig
+
+        LogConfig.set_log_config_file_name(mock_log_config, "new_config.yaml")
+        assert mock_log_config.log_config_file_name == "new_config.yaml"
+
+    def test_set_log_config_file_path(self, mock_log_config):
+        """Test set_log_config_file_path sets the config file path."""
+        from log_config.log_config import LogConfig
+
+        LogConfig.set_log_config_file_path(mock_log_config, "/new/config/path")
+        assert mock_log_config.log_config_file_path == "/new/config/path"
+
+    def test_set_log_formatter_string(self, mock_log_config):
+        """Test set_log_formatter_string sets the formatter string."""
+        from log_config.log_config import LogConfig
+
+        LogConfig.set_log_formatter_string(mock_log_config, "%(levelname)s - %(message)s")
+        assert mock_log_config.log_formatter_string == "%(levelname)s - %(message)s"
+
+    def test_set_log_date_format(self, mock_log_config):
+        """Test set_log_date_format sets the date format."""
+        from log_config.log_config import LogConfig
+
+        LogConfig.set_log_date_format(mock_log_config, "%H:%M:%S")
+        assert mock_log_config.log_date_format == "%H:%M:%S"
+
+    def test_set_log_message_default(self, mock_log_config):
+        """Test set_log_message_default sets the default message."""
+        from log_config.log_config import LogConfig
+
+        LogConfig.set_log_message_default(mock_log_config, "New default")
+        assert mock_log_config.log_message_default == "New default"
+
+    def test_set_log_level(self, mock_log_config):
+        """Test set_log_level sets the log level."""
+        from log_config.log_config import LogConfig
+
+        LogConfig.set_log_level(mock_log_config, 30)
+        assert mock_log_config.log_level == 30
+
+    def test_set_log_level_name(self, mock_log_config):
+        """Test set_log_level_name sets the level name."""
+        from log_config.log_config import LogConfig
+
+        LogConfig.set_log_level_name(mock_log_config, "WARNING")
+        assert mock_log_config.log_level_name == "WARNING"
+
+    def test_set_log_level_logging_config(self, mock_log_config):
+        """Test set_log_level_logging_config sets the logging config level."""
+        from log_config.log_config import LogConfig
+
+        LogConfig.set_log_level_logging_config(mock_log_config, logging.WARNING)
+        assert mock_log_config.log_level_logging_config == logging.WARNING
+
+    def test_set_log_level_names_list(self, mock_log_config):
+        """Test set_log_level_names_list sets the names list."""
+        from log_config.log_config import LogConfig
+
+        new_list = ["ERROR", "CRITICAL"]
+        LogConfig.set_log_level_names_list(mock_log_config, new_list)
+        assert mock_log_config.log_level_names_list == new_list
+
+    def test_set_log_level_numbers_list(self, mock_log_config):
+        """Test set_log_level_numbers_list sets the numbers list."""
+        from log_config.log_config import LogConfig
+
+        new_list = [40, 50]
+        LogConfig.set_log_level_numbers_list(mock_log_config, new_list)
+        assert mock_log_config.log_level_numbers_list == new_list
+
+    def test_set_log_level_methods_list(self, mock_log_config):
+        """Test set_log_level_methods_list sets the methods list."""
+        from log_config.log_config import LogConfig
+
+        new_list = ["error", "critical"]
+        LogConfig.set_log_level_methods_list(mock_log_config, new_list)
+        assert mock_log_config.log_level_methods_list == new_list
+
+    def test_set_log_level_numbers_dict(self, mock_log_config):
+        """Test set_log_level_numbers_dict sets the numbers dict."""
+        from log_config.log_config import LogConfig
+
+        new_dict = {"ERROR": 40, "CRITICAL": 50}
+        LogConfig.set_log_level_numbers_dict(mock_log_config, new_dict)
+        assert mock_log_config.log_level_numbers_dict == new_dict
+
+    def test_set_log_level_methods_dict(self, mock_log_config):
+        """Test set_log_level_methods_dict sets the methods dict."""
+        from log_config.log_config import LogConfig
+
+        new_dict = {"ERROR": "error", "CRITICAL": "critical"}
+        LogConfig.set_log_level_methods_dict(mock_log_config, new_dict)
+        assert mock_log_config.log_level_methods_dict == new_dict
+
+    def test_set_log_level_custom_names_list(self, mock_log_config):
+        """Test set_log_level_custom_names_list sets the custom names list."""
+        from log_config.log_config import LogConfig
+
+        new_list = ["CUSTOM1", "CUSTOM2"]
+        LogConfig.set_log_level_custom_names_list(mock_log_config, new_list)
+        assert mock_log_config.log_level_custom_names_list == new_list
+
+    def test_set_log_allow_log_level_redefinition(self, mock_log_config):
+        """Test set_log_allow_log_level_redefinition sets the flag."""
+        from log_config.log_config import LogConfig
+
+        LogConfig.set_log_allow_log_level_redefinition(mock_log_config, False)
+        assert mock_log_config.log_allow_log_level_redefinition is False
+
+
+class TestLogConfigSerialization:
+    """Tests for LogConfig serialization support."""
+
+    def test_getstate_removes_loggers(self):
+        """Test __getstate__ removes logger and custom_logger."""
+        from log_config.log_config import LogConfig
+
+        mock = MagicMock()
+        mock.__dict__ = {
+            "logger": MagicMock(),
+            "custom_logger": MagicMock(),
+            "log_level": 20,
+            "log_level_name": "INFO",
+        }
+
+        state = LogConfig.__getstate__(mock)
+
+        assert "logger" not in state
+        assert "custom_logger" not in state
+        assert state["log_level"] == 20
+        assert state["log_level_name"] == "INFO"
+
+    def test_setstate_restores_instance(self):
+        """Test __setstate__ restores instance from state."""
+        from log_config.log_config import LogConfig
+
+        mock = MagicMock()
+        mock.__dict__ = {}
+
+        state = {
+            "log_level": 20,
+            "log_level_name": "INFO",
+            "log_file_name": "test.log",
+        }
+
+        with patch.object(LogConfig, "__setstate__", lambda self, s: self.__dict__.update(s)):
+            LogConfig.__setstate__(mock, state)
+
+        assert mock.__dict__["log_level"] == 20
+        assert mock.__dict__["log_level_name"] == "INFO"
+
+    def test_setstate_creates_logger(self):
+        """Test __setstate__ creates new logger after unpickling."""
+        from log_config.log_config import LogConfig
+
+        class FakeLogConfig:
+            pass
+
+        obj = FakeLogConfig()
+        obj.__dict__ = {}
+
+        state = {"log_level_name": "DEBUG"}
+
+        LogConfig.__setstate__(obj, state)
+
+        assert obj.custom_logger is None
+        assert obj.logger is not None
+
+
+class TestLogConfigUUID:
+    """Tests for LogConfig UUID management."""
+
+    def test_generate_uuid_creates_valid_uuid(self):
+        """Test _generate_uuid creates a valid UUID string."""
+        from log_config.log_config import LogConfig
+
+        mock = MagicMock()
+        mock.logger = MagicMock()
+        mock.logger.trace = MagicMock()
+        mock.logger.verbose = MagicMock()
+
+        result = LogConfig._generate_uuid(mock)
+
+        assert isinstance(result, str)
+        assert len(result) == 36
+        assert result.count("-") == 4
+
+    def test_set_uuid_with_provided_uuid(self):
+        """Test set_uuid with a provided UUID value."""
+        from log_config.log_config import LogConfig
+
+        mock = MagicMock()
+        mock.logger = MagicMock()
+        mock.logger.trace = MagicMock()
+        mock.logger.verbose = MagicMock()
+        del mock.uuid
+
+        LogConfig.set_uuid(mock, "custom-uuid-value")
+
+        assert mock.uuid == "custom-uuid-value"
+
+    def test_set_uuid_generates_when_none(self):
+        """Test set_uuid generates UUID when None provided."""
+        from log_config.log_config import LogConfig
+
+        class FakeLogConfig:
+            def __init__(self):
+                self.logger = MagicMock()
+                self.logger.trace = MagicMock()
+                self.logger.verbose = MagicMock()
+
+            def _generate_uuid(self):
+                return "generated-uuid"
+
+        obj = FakeLogConfig()
+
+        LogConfig.set_uuid(obj, None)
+
+        assert obj.uuid == "generated-uuid"
+
+    def test_get_uuid_generates_if_not_set(self):
+        """Test get_uuid generates UUID if not already set."""
+        from log_config.log_config import LogConfig
+
+        mock = MagicMock()
+        mock.logger = MagicMock()
+        mock.logger.trace = MagicMock()
+        mock.logger.verbose = MagicMock()
+        mock.logger.debug = MagicMock()
+        mock.uuid = None
+
+        with patch.object(LogConfig, "set_uuid"):
+            with patch.object(LogConfig, "_generate_uuid", return_value="new-uuid"):
+                mock.uuid = "new-uuid"
+                result = LogConfig.get_uuid(mock)
+
+        assert result == "new-uuid"
+
+
+class TestLogConfigEdgeCases:
+    """Edge case tests for LogConfig class."""
+
+    def test_getter_returns_none_for_none_attribute(self):
+        """Test getters return None when attribute is None."""
+        from log_config.log_config import LogConfig
+
+        mock = MagicMock()
+        mock.log_file_name = None
+        mock.log_level = None
+
+        result_name = LogConfig.get_log_file_name(mock)
+        result_level = LogConfig.get_log_level(mock)
+
+        assert result_name is None
+        assert result_level is None
+
+    def test_setter_accepts_different_types(self):
+        """Test setters accept various types."""
+        from log_config.log_config import LogConfig
+
+        mock = MagicMock()
+
+        LogConfig.set_log_level(mock, 0)
+        assert mock.log_level == 0
+
+        LogConfig.set_log_level_names_list(mock, [])
+        assert mock.log_level_names_list == []
+
+        LogConfig.set_log_level_numbers_dict(mock, {})
+        assert mock.log_level_numbers_dict == {}

--- a/juniper-cascor-model/tests/test_log_config_instantiation.py
+++ b/juniper-cascor-model/tests/test_log_config_instantiation.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python
+#####################################################################################################################################################################################################
+# Project:       Juniper
+# Prototype:     Cascade Correlation Neural Network
+# File Name:     test_log_config_instantiation.py
+# Author:        Paul Calnon
+#
+# Date Created:  2026-07-03
+#
+# License:       MIT License
+# Copyright:     Copyright (c) 2024-2026 Paul Calnon
+#
+# Description:
+#     Real-instantiation coverage for the resilient logging core shipped with
+#     juniper-cascor-model. The other logger/log_config suites exercise the
+#     getters/setters against ``Fake*`` subclasses that bypass ``__init__``;
+#     these tests drive the actual ``Logger.__init__`` and ``LogConfig.__init__``
+#     bootstrap paths (custom-level registration, YAML dictConfig success and the
+#     best-effort fallback, the already-configured short-circuit) so the package's
+#     first CI coverage gate (per-file >=90 / sub-module pooled >=95, C-5) reflects
+#     the bootstrap the distributed worker relies on. Every path is hermetic:
+#     config + log files are redirected to ``tmp_path`` and the global logging
+#     singleton state is snapshotted and restored, so the tests are order-independent.
+#
+#####################################################################################################################################################################################################
+
+from __future__ import annotations
+
+import logging
+import textwrap
+
+import pytest
+
+from log_config.log_config import LogConfig
+from log_config.logger.logger import Logger
+
+# A minimal, self-contained logging.config.dictConfig document with a FileHandler so the
+# __init__ handler-filename-override branch (absolute path injection) is exercised. The
+# FileHandler filename is overridden by Logger.__init__ to <log_file_path>/<log_file_name>.
+_VALID_LOG_CONFIG_YAML = textwrap.dedent(
+    """
+    version: 1
+    disable_existing_loggers: false
+    formatters:
+      simple:
+        format: "%(levelname)s %(message)s"
+    handlers:
+      console:
+        class: logging.StreamHandler
+        formatter: simple
+      file:
+        class: logging.FileHandler
+        filename: placeholder.log
+        formatter: simple
+    root:
+      level: INFO
+      handlers: [console, file]
+    """
+)
+
+
+@pytest.fixture
+def restore_logging_state():
+    """Snapshot and restore all global logging state mutated by real instantiation.
+
+    ``Logger.__init__`` flips the ``SingletonLoggingConfigured`` class flag, mutates the
+    class ``_log_level``, registers custom level names globally, and (on the dictConfig
+    success path) reconfigures the root logger's handlers. Restoring these keeps the tests
+    order-independent so they cannot leak into the ported logger/log_config suites.
+    """
+    saved_configured = Logger.SingletonLoggingConfigured
+    saved_level = Logger._log_level
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_root_level = root.level
+    try:
+        yield
+    finally:
+        Logger.SingletonLoggingConfigured = saved_configured
+        Logger._log_level = saved_level
+        root.handlers[:] = saved_handlers
+        root.setLevel(saved_root_level)
+
+
+class TestLoggerRealInstantiation:
+    """Drive the real ``Logger.__init__`` bootstrap (not the Fake* subclasses)."""
+
+    def test_missing_config_file_degrades_to_basic_configuration(self, tmp_path, restore_logging_state):
+        # A non-existent config file must be caught and degrade to a basic StreamHandler
+        # rather than raising — the resilient-logging contract (CW-05 gap #3).
+        Logger.SingletonLoggingConfigured = False
+        instance = Logger(
+            _Logger__log_config_file_path=str(tmp_path),
+            _Logger__log_config_file_name="does-not-exist.yaml",
+            _Logger__log_file_path=str(tmp_path),
+            _Logger__log_level_redefinition=True,
+        )
+
+        assert instance.handlers, "basic-configuration fallback must attach a handler"
+        assert instance.log_config_file_name == "does-not-exist.yaml"
+
+    def test_valid_config_applies_dictconfig_and_marks_configured(self, tmp_path, restore_logging_state):
+        # A valid dictConfig document applies successfully, overrides the FileHandler
+        # filename to an absolute path under the log dir, and flips the singleton flag.
+        (tmp_path / "logging_config.yaml").write_text(_VALID_LOG_CONFIG_YAML)
+        Logger.SingletonLoggingConfigured = False
+
+        instance = Logger(
+            _Logger__log_config_file_path=str(tmp_path),
+            _Logger__log_config_file_name="logging_config.yaml",
+            _Logger__log_file_path=str(tmp_path),
+            _Logger__log_level_redefinition=True,
+        )
+
+        assert Logger.is_configured() is True
+        assert instance.get_logger() is instance
+        # The FileHandler filename override + makedirs must have targeted the tmp log dir.
+        assert (tmp_path / "juniper_cascor.log").exists()
+
+    def test_second_instantiation_short_circuits_when_already_configured(self, tmp_path, restore_logging_state):
+        # Once configured globally, a subsequent Logger() must skip YAML configuration
+        # entirely (the ``else`` branch of the singleton guard).
+        (tmp_path / "logging_config.yaml").write_text(_VALID_LOG_CONFIG_YAML)
+        Logger.SingletonLoggingConfigured = True
+
+        instance = Logger(
+            _Logger__log_config_file_path=str(tmp_path),
+            _Logger__log_config_file_name="logging_config.yaml",
+            _Logger__log_file_path=str(tmp_path),
+            _Logger__log_level_redefinition=True,
+        )
+
+        assert Logger.is_configured() is True
+        assert instance.handlers
+
+    def test_instantiation_registers_custom_level_methods(self, tmp_path, restore_logging_state):
+        # With redefinition allowed, the custom-level registration loop must attach the
+        # dynamically-generated log methods (trace/verbose/fatal) onto the instance.
+        Logger.SingletonLoggingConfigured = False
+        instance = Logger(
+            _Logger__log_config_file_path=str(tmp_path),
+            _Logger__log_config_file_name="missing.yaml",
+            _Logger__log_file_path=str(tmp_path),
+            _Logger__log_level_redefinition=True,
+        )
+
+        for method_name in ("trace", "verbose", "fatal"):
+            assert callable(getattr(instance, method_name))
+
+
+class TestLoggerClassMethodEdges:
+    """Cover the residual class-method edges the ported suite leaves uncovered."""
+
+    def test_is_enabled_for_defaults_to_notset_when_level_unmappable(self, restore_logging_state):
+        # When the configured level name cannot be mapped to a number, isEnabledFor must
+        # fall back to NOTSET (0) so every level is considered enabled.
+        Logger._log_level = "NOT-A-REAL-LEVEL"
+        assert Logger.isEnabledFor(logging.CRITICAL) is True
+        assert Logger.isEnabledFor(0) is True
+
+    def test_set_level_round_trips_name_and_number(self, restore_logging_state):
+        Logger.set_level("DEBUG")
+        assert Logger.get_level() == "DEBUG"
+        # An invalid level resets to the configured default rather than raising.
+        Logger.set_level(object())
+        assert Logger.get_level() in Logger._level_names.values()
+
+
+class TestLogConfigRealInstantiation:
+    """Drive the real ``LogConfig.__init__`` bootstrap (constructs a Logger internally)."""
+
+    def test_log_config_constructs_and_exposes_uuid(self, tmp_path, restore_logging_state):
+        (tmp_path / "logging_config.yaml").write_text(_VALID_LOG_CONFIG_YAML)
+        Logger.SingletonLoggingConfigured = False
+
+        log_config = LogConfig(
+            _LogConfig__log_config_file_path=str(tmp_path),
+            _LogConfig__log_config_file_name="logging_config.yaml",
+            _LogConfig__log_file_path=str(tmp_path),
+        )
+
+        assert log_config.get_uuid()
+        assert log_config.get_logger() is not None
+        assert log_config.get_custom_logger() is not None
+        # A handful of the getters over the freshly-built instance.
+        assert log_config.get_log_file_path() == str(tmp_path)
+        assert log_config.get_log_level_name()
+
+    def test_log_config_get_uuid_generates_when_unset(self, tmp_path, restore_logging_state):
+        (tmp_path / "logging_config.yaml").write_text(_VALID_LOG_CONFIG_YAML)
+        Logger.SingletonLoggingConfigured = False
+        log_config = LogConfig(
+            _LogConfig__log_config_file_path=str(tmp_path),
+            _LogConfig__log_config_file_name="logging_config.yaml",
+            _LogConfig__log_file_path=str(tmp_path),
+        )
+
+        # Clearing the uuid forces the regeneration branch inside get_uuid().
+        log_config.uuid = None
+        regenerated = log_config.get_uuid()
+        assert regenerated
+        assert log_config.uuid == regenerated
+
+    def test_log_config_set_uuid_twice_is_fatal(self, tmp_path, restore_logging_state):
+        (tmp_path / "logging_config.yaml").write_text(_VALID_LOG_CONFIG_YAML)
+        Logger.SingletonLoggingConfigured = False
+        log_config = LogConfig(
+            _LogConfig__log_config_file_path=str(tmp_path),
+            _LogConfig__log_config_file_name="logging_config.yaml",
+            _LogConfig__log_file_path=str(tmp_path),
+        )
+
+        # UUID is already set by __init__; re-setting must fail closed (guards identity).
+        with pytest.raises(SystemExit):
+            log_config.set_uuid("a-second-uuid")

--- a/juniper-cascor-model/tests/test_logger_coverage.py
+++ b/juniper-cascor-model/tests/test_logger_coverage.py
@@ -1,0 +1,643 @@
+#!/usr/bin/env python
+"""
+Unit tests for log_config/logger/logger.py to improve code coverage.
+
+Tests cover:
+- Logger class methods (set_level, get_level, logging methods)
+- Level validation methods (_is_valid_level_name, _is_valid_level_number)
+- Level conversion methods (getLevelName, getLevelNumber, getLevelFrom)
+- Filter methods (_filter_by_level)
+- Instance getter/setter methods
+- UUID generation and management
+- Custom log level initialization
+"""
+import logging
+import os
+import sys
+import tempfile
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from log_config.logger.logger import Logger
+
+
+class TestLoggerClassMethods:
+    """Tests for Logger class-level methods."""
+
+    def test_is_configured_default(self):
+        """Test is_configured returns default value."""
+        original = Logger.SingletonLoggingConfigured
+        try:
+            Logger.SingletonLoggingConfigured = False
+            assert Logger.is_configured() is False
+        finally:
+            Logger.SingletonLoggingConfigured = original
+
+    def test_set_configured(self):
+        """Test set_configured sets the flag to True."""
+        original = Logger.SingletonLoggingConfigured
+        try:
+            Logger.SingletonLoggingConfigured = False
+            Logger.set_configured()
+            # assert Logger.SingletonLoggingConfigured is True
+            assert Logger.SingletonLoggingConfigured
+        finally:
+            Logger.SingletonLoggingConfigured = original
+
+
+class TestLoggerLevelValidation:
+    """Tests for level validation class methods."""
+
+    def test_is_valid_level_name_valid(self):
+        """Test _is_valid_level_name with valid level names."""
+        assert Logger._is_valid_level_name("DEBUG") is True
+        assert Logger._is_valid_level_name("INFO") is True
+        assert Logger._is_valid_level_name("WARNING") is True
+        assert Logger._is_valid_level_name("ERROR") is True
+        assert Logger._is_valid_level_name("CRITICAL") is True
+        assert Logger._is_valid_level_name("TRACE") is True
+        assert Logger._is_valid_level_name("VERBOSE") is True
+        assert Logger._is_valid_level_name("FATAL") is True
+
+    def test_is_valid_level_name_case_insensitive(self):
+        """Test _is_valid_level_name is case insensitive."""
+        assert Logger._is_valid_level_name("debug") is True
+        assert Logger._is_valid_level_name("Info") is True
+        assert Logger._is_valid_level_name("warning") is True
+
+    def test_is_valid_level_name_invalid(self):
+        """Test _is_valid_level_name with invalid level names."""
+        assert Logger._is_valid_level_name("INVALID") is False
+        assert Logger._is_valid_level_name("") is False
+        assert Logger._is_valid_level_name(None) is False
+        assert Logger._is_valid_level_name(123) is False
+
+    def test_is_valid_level_number_valid(self):
+        """Test _is_valid_level_number with valid level numbers."""
+        assert Logger._is_valid_level_number(1) is True
+        assert Logger._is_valid_level_number(5) is True
+        assert Logger._is_valid_level_number(10) is True
+        assert Logger._is_valid_level_number(20) is True
+        assert Logger._is_valid_level_number(30) is True
+        assert Logger._is_valid_level_number(40) is True
+        assert Logger._is_valid_level_number(50) is True
+        assert Logger._is_valid_level_number(60) is True
+
+    def test_is_valid_level_number_invalid(self):
+        """Test _is_valid_level_number with invalid level numbers."""
+        assert Logger._is_valid_level_number(999) is False
+        assert Logger._is_valid_level_number(-1) is False
+        assert Logger._is_valid_level_number(None) is False
+        assert Logger._is_valid_level_number("10") is False
+
+    def test_is_valid_level_with_name(self):
+        """Test is_valid_level with valid name."""
+        assert Logger.is_valid_level("DEBUG") is True
+        assert Logger.is_valid_level("INFO") is True
+
+    def test_is_valid_level_with_number(self):
+        """Test is_valid_level with valid number."""
+        assert Logger.is_valid_level(10) is True
+        assert Logger.is_valid_level(20) is True
+
+
+class TestLoggerLevelConversion:
+    """Tests for level conversion class methods."""
+
+    def test_get_level_number_valid_name(self):
+        """Test _get_level_number with valid name."""
+        assert Logger._get_level_number("DEBUG") == 10
+        assert Logger._get_level_number("INFO") == 20
+        assert Logger._get_level_number("WARNING") == 30
+        assert Logger._get_level_number("ERROR") == 40
+        assert Logger._get_level_number("CRITICAL") == 50
+        assert Logger._get_level_number("TRACE") == 1
+        assert Logger._get_level_number("VERBOSE") == 5
+        assert Logger._get_level_number("FATAL") == 60
+
+    def test_get_level_number_invalid(self):
+        """Test _get_level_number with invalid input."""
+        assert Logger._get_level_number("INVALID") is None
+        assert Logger._get_level_number(None) is None
+        assert Logger._get_level_number(123) is None
+
+    def test_get_level_name_valid_number(self):
+        """Test _get_level_name with valid number.
+
+        Note: _get_level_name returns None because _level_names is keyed by
+        string names (e.g., "DEBUG"), not by integer level numbers.
+        """
+        assert Logger._get_level_name(10) is None
+        assert Logger._get_level_name(20) is None
+        assert Logger._get_level_name(30) is None
+
+    def test_get_level_name_invalid(self):
+        """Test _get_level_name with invalid input."""
+        assert Logger._get_level_name(999) is None
+        assert Logger._get_level_name(None) is None
+        assert Logger._get_level_name("DEBUG") is None
+
+    def test_getLevelName_with_number(self):
+        """Test getLevelName with valid number returns None (by design)."""
+        assert Logger.getLevelName(10) is None
+        assert Logger.getLevelName(20) is None
+
+    def test_getLevelName_with_name(self):
+        """Test getLevelName with valid name returns the name."""
+        assert Logger.getLevelName("DEBUG") == "DEBUG"
+        assert Logger.getLevelName("INFO") == "INFO"
+
+    def test_getLevelName_invalid(self):
+        """Test getLevelName with invalid input."""
+        assert Logger.getLevelName("INVALID") is None
+        assert Logger.getLevelName(999) is None
+
+    def test_getLevelNumber_with_name(self):
+        """Test getLevelNumber with valid name."""
+        assert Logger.getLevelNumber("DEBUG") == 10
+        assert Logger.getLevelNumber("INFO") == 20
+
+    def test_getLevelNumber_with_number(self):
+        """Test getLevelNumber with valid number returns the number."""
+        assert Logger.getLevelNumber(10) == 10
+        assert Logger.getLevelNumber(20) == 20
+
+    def test_getLevelNumber_invalid(self):
+        """Test getLevelNumber with invalid input."""
+        assert Logger.getLevelNumber("INVALID") is None
+        assert Logger.getLevelNumber(999) is None
+
+    def test_getLevelFrom_with_name(self):
+        """Test getLevelFrom with valid name returns number."""
+        assert Logger.getLevelFrom("DEBUG") == 10
+        assert Logger.getLevelFrom("INFO") == 20
+
+    def test_getLevelFrom_with_number(self):
+        """Test getLevelFrom with valid number returns number."""
+        assert Logger.getLevelFrom(10) == 10
+
+    def test_getLevelFrom_invalid(self):
+        """Test getLevelFrom with invalid returns None."""
+        result = Logger.getLevelFrom("INVALID")
+        assert result is None
+
+
+class TestLoggerSetGetLevel:
+    """Tests for set_level and get_level class methods."""
+
+    def test_set_level_with_valid_name(self):
+        """Test set_level with valid level name."""
+        original = Logger._log_level
+        try:
+            Logger.set_level("DEBUG")
+            assert Logger._log_level == "DEBUG"
+
+            Logger.set_level("warning")
+            assert Logger._log_level == "WARNING"
+        finally:
+            Logger._log_level = original
+
+    def test_set_level_with_valid_number(self):
+        """Test set_level with valid level number.
+
+        Note: set_level uses _get_level_name which returns None for numbers
+        (since _level_names is keyed by strings), so it falls back to default.
+        """
+        original = Logger._log_level
+        try:
+            Logger.set_level(10)
+            from cascor_constants.constants import _LOGGER_LOG_LEVEL_NAME
+
+            assert Logger._log_level == _LOGGER_LOG_LEVEL_NAME
+
+            Logger.set_level(20)
+            assert Logger._log_level == _LOGGER_LOG_LEVEL_NAME
+        finally:
+            Logger._log_level = original
+
+    def test_set_level_with_invalid_uses_default(self):
+        """Test set_level with invalid input uses default."""
+        original = Logger._log_level
+        try:
+            Logger.set_level("INVALID")
+            from cascor_constants.constants import _LOGGER_LOG_LEVEL_NAME
+
+            assert Logger._log_level == _LOGGER_LOG_LEVEL_NAME
+        finally:
+            Logger._log_level = original
+
+    def test_get_level_returns_current(self):
+        """Test get_level returns current log level."""
+        original = Logger._log_level
+        try:
+            Logger._log_level = "ERROR"
+            assert Logger.get_level() == "ERROR"
+        finally:
+            Logger._log_level = original
+
+
+class TestLoggerFilterByLevel:
+    """Tests for _filter_by_level class method."""
+
+    def test_filter_by_level_allows_higher_level(self):
+        """Test _filter_by_level allows messages at or above log level."""
+        assert Logger._filter_by_level(level="ERROR", log_level="INFO") is True
+        assert Logger._filter_by_level(level="WARNING", log_level="DEBUG") is True
+        assert Logger._filter_by_level(level="INFO", log_level="INFO") is True
+
+    def test_filter_by_level_blocks_lower_level(self):
+        """Test _filter_by_level blocks messages below log level."""
+        assert Logger._filter_by_level(level="DEBUG", log_level="INFO") is False
+        assert Logger._filter_by_level(level="INFO", log_level="WARNING") is False
+
+    def test_filter_by_level_invalid_level(self):
+        """Test _filter_by_level with invalid level returns False."""
+        assert Logger._filter_by_level(level="INVALID", log_level="INFO") is False
+        assert Logger._filter_by_level(level="INFO", log_level="INVALID") is False
+        assert Logger._filter_by_level(level=None, log_level="INFO") is False
+
+
+class TestLoggerLoggingMethods:
+    """Tests for logging methods (trace, verbose, debug, info, etc.)."""
+
+    @patch.object(Logger, "_log_at_level")
+    def test_trace_calls_log_at_level(self, mock_log):
+        """Test trace method calls _log_at_level."""
+        Logger.trace("Test trace message")
+        mock_log.assert_called_once()
+        call_kwargs = mock_log.call_args
+        assert call_kwargs[1]["level"] == "TRACE"
+        assert call_kwargs[1]["message"] == "Test trace message"
+
+    @patch.object(Logger, "_log_at_level")
+    def test_verbose_calls_log_at_level(self, mock_log):
+        """Test verbose method calls _log_at_level."""
+        Logger.verbose("Test verbose message")
+        mock_log.assert_called_once()
+        assert mock_log.call_args[1]["level"] == "VERBOSE"
+
+    @patch.object(Logger, "_log_at_level")
+    def test_debug_calls_log_at_level(self, mock_log):
+        """Test debug method calls _log_at_level."""
+        Logger.debug("Test debug message")
+        mock_log.assert_called_once()
+        assert mock_log.call_args[1]["level"] == "DEBUG"
+
+    @patch.object(Logger, "_log_at_level")
+    def test_info_calls_log_at_level(self, mock_log):
+        """Test info method calls _log_at_level."""
+        Logger.info("Test info message")
+        mock_log.assert_called_once()
+        assert mock_log.call_args[1]["level"] == "INFO"
+
+    @patch.object(Logger, "_log_at_level")
+    def test_warning_calls_log_at_level(self, mock_log):
+        """Test warning method calls _log_at_level."""
+        Logger.warning("Test warning message")
+        mock_log.assert_called_once()
+        assert mock_log.call_args[1]["level"] == "WARNING"
+
+    @patch.object(Logger, "_log_at_level")
+    def test_error_calls_log_at_level(self, mock_log):
+        """Test error method calls _log_at_level."""
+        Logger.error("Test error message")
+        mock_log.assert_called_once()
+        assert mock_log.call_args[1]["level"] == "ERROR"
+
+    @patch.object(Logger, "_log_at_level")
+    def test_critical_calls_log_at_level(self, mock_log):
+        """Test critical method calls _log_at_level."""
+        Logger.critical("Test critical message")
+        mock_log.assert_called_once()
+        assert mock_log.call_args[1]["level"] == "CRITICAL"
+
+    @patch.object(Logger, "_log_at_level")
+    def test_fatal_calls_log_at_level(self, mock_log):
+        """Test fatal method calls _log_at_level."""
+        Logger.fatal("Test fatal message")
+        mock_log.assert_called_once()
+        assert mock_log.call_args[1]["level"] == "FATAL"
+
+
+class TestLoggerInstanceMethods:
+    """Tests for Logger instance methods (getters/setters)."""
+
+    @pytest.fixture
+    def mock_logger_instance(self):
+        """Create a mock Logger instance with necessary attributes."""
+        mock = MagicMock(spec=Logger)
+        mock.uuid = "test-uuid-12345"
+        mock.logger = MagicMock()
+        mock.log_file_name = "test.log"
+        mock.log_file_path = "/tmp/logs"
+        mock.level = 20
+        mock.log_level = 20
+        mock.log_level_name = "INFO"
+        mock.log_date_format = "%Y-%m-%d"
+        mock.log_formatter_string = "%(message)s"
+        mock.log_message_default = "Default"
+        mock.log_level_custom_names_list = ["TRACE", "VERBOSE"]
+        mock.log_level_numbers_dict = {"DEBUG": 10, "INFO": 20}
+        mock.log_level_methods_dict = {"DEBUG": "debug", "INFO": "info"}
+        mock.log_allow_log_level_redefinition = True
+        return mock
+
+    def test_get_uuid(self, mock_logger_instance):
+        """Test get_uuid returns the UUID."""
+        result = Logger.get_uuid(mock_logger_instance)
+        assert result == "test-uuid-12345"
+
+    def test_get_logger(self, mock_logger_instance):
+        """Test get_logger returns self."""
+        mock_logger_instance.get_logger = lambda: mock_logger_instance
+        result = mock_logger_instance.get_logger()
+        assert result is mock_logger_instance
+
+    def test_get_log_file_name(self, mock_logger_instance):
+        """Test get_log_file_name returns file name."""
+        result = Logger.get_log_file_name(mock_logger_instance)
+        assert result == "test.log"
+
+    def test_get_log_file_path(self, mock_logger_instance):
+        """Test get_log_file_path returns file path."""
+        result = Logger.get_log_file_path(mock_logger_instance)
+        assert result == "/tmp/logs"
+
+    def test_get_log_level(self, mock_logger_instance):
+        """Test get_log_level returns log level."""
+        result = Logger.get_log_level(mock_logger_instance)
+        assert result == 20
+
+    def test_get_log_level_name(self, mock_logger_instance):
+        """Test get_log_level_name returns level name."""
+        result = Logger.get_log_level_name(mock_logger_instance)
+        assert result == "INFO"
+
+    def test_get_log_date_format(self, mock_logger_instance):
+        """Test get_log_date_format returns date format."""
+        result = Logger.get_log_date_format(mock_logger_instance)
+        assert result == "%Y-%m-%d"
+
+    def test_get_log_formatter_string(self, mock_logger_instance):
+        """Test get_log_formatter_string returns formatter string."""
+        result = Logger.get_log_formatter_string(mock_logger_instance)
+        assert result == "%(message)s"
+
+    def test_get_log_message_default(self, mock_logger_instance):
+        """Test get_log_message_default returns default message."""
+        result = Logger.get_log_message_default(mock_logger_instance)
+        assert result == "Default"
+
+    def test_get_log_level_custom_names_list(self, mock_logger_instance):
+        """Test get_log_level_custom_names_list returns custom names."""
+        result = Logger.get_log_level_custom_names_list(mock_logger_instance)
+        assert result == ["TRACE", "VERBOSE"]
+
+    def test_get_log_level_numbers_dict(self, mock_logger_instance):
+        """Test get_log_level_numbers_dict returns numbers dict."""
+        result = Logger.get_log_level_numbers_dict(mock_logger_instance)
+        assert result == {"DEBUG": 10, "INFO": 20}
+
+    def test_get_log_level_methods_dict(self, mock_logger_instance):
+        """Test get_log_level_methods_dict returns methods dict."""
+        result = Logger.get_log_level_methods_dict(mock_logger_instance)
+        assert result == {"DEBUG": "debug", "INFO": "info"}
+
+    def test_get_log_allow_log_level_redefinition(self, mock_logger_instance):
+        """Test get_log_allow_log_level_redefinition returns flag."""
+        result = Logger.get_log_allow_log_level_redefinition(mock_logger_instance)
+        assert result is True
+
+
+class TestLoggerInstanceSetters:
+    """Tests for Logger instance setter methods."""
+
+    @pytest.fixture
+    def mock_instance(self):
+        """Create a mock instance for setter tests."""
+        return MagicMock()
+
+    def test_set_logger(self, mock_instance):
+        """Test set_logger sets the logger."""
+        new_logger = MagicMock()
+        Logger.set_logger(mock_instance, new_logger)
+        assert mock_instance.logger == new_logger
+
+    def test_set_log_file_name(self, mock_instance):
+        """Test set_log_file_name sets the file name."""
+        Logger.set_log_file_name(mock_instance, "new.log")
+        assert mock_instance.log_file_name == "new.log"
+
+    def test_set_log_file_path(self, mock_instance):
+        """Test set_log_file_path sets the file path."""
+        Logger.set_log_file_path(mock_instance, "/new/path")
+        assert mock_instance.log_file_path == "/new/path"
+
+    def test_set_log_date_format(self, mock_instance):
+        """Test set_log_date_format sets the date format."""
+        Logger.set_log_date_format(mock_instance, "%H:%M:%S")
+        assert mock_instance.log_date_format == "%H:%M:%S"
+
+    def test_set_log_formatter_string(self, mock_instance):
+        """Test set_log_formatter_string sets the formatter string."""
+        Logger.set_log_formatter_string(mock_instance, "%(levelname)s: %(message)s")
+        assert mock_instance.log_formatter_string == "%(levelname)s: %(message)s"
+
+    def test_set_log_message_default(self, mock_instance):
+        """Test set_log_message_default sets the default message."""
+        Logger.set_log_message_default(mock_instance, "New default")
+        assert mock_instance.log_message_default == "New default"
+
+    def test_set_log_level_custom_names_list(self, mock_instance):
+        """Test set_log_level_custom_names_list sets the custom names."""
+        Logger.set_log_level_custom_names_list(mock_instance, ["CUSTOM1"])
+        assert mock_instance.log_level_custom_names_list == ["CUSTOM1"]
+
+    def test_set_log_level_numbers_dict(self, mock_instance):
+        """Test set_log_level_numbers_dict sets the numbers dict."""
+        Logger.set_log_level_numbers_dict(mock_instance, {"CUSTOM": 25})
+        assert mock_instance.log_level_numbers_dict == {"CUSTOM": 25}
+
+    def test_set_log_level_methods_dict(self, mock_instance):
+        """Test set_log_level_methods_dict sets the methods dict."""
+        Logger.set_log_level_methods_dict(mock_instance, {"CUSTOM": "custom"})
+        assert mock_instance.log_level_methods_dict == {"CUSTOM": "custom"}
+
+    def test_set_log_allow_log_level_redefinition(self, mock_instance):
+        """Test set_log_allow_log_level_redefinition sets the flag.
+
+        Note: The setter uses `or None` which makes False become None.
+        """
+        Logger.set_log_allow_log_level_redefinition(mock_instance, False)
+        assert mock_instance.log_allow_log_level_redefinition is None
+
+        Logger.set_log_allow_log_level_redefinition(mock_instance, True)
+        assert mock_instance.log_allow_log_level_redefinition is True
+
+
+class TestLoggerMissingAttributes:
+    """Tests for getter methods when attributes are missing."""
+
+    @pytest.fixture
+    def empty_mock(self):
+        """Create a mock with no attributes."""
+        # mock = MagicMock(spec=[])
+        # return mock
+        return MagicMock(spec=[])
+
+    def test_get_log_file_name_missing(self, empty_mock):
+        """Test get_log_file_name returns None when missing."""
+        result = Logger.get_log_file_name(empty_mock)
+        assert result is None
+
+    def test_get_log_file_path_missing(self, empty_mock):
+        """Test get_log_file_path returns None when missing."""
+        result = Logger.get_log_file_path(empty_mock)
+        assert result is None
+
+    def test_get_level_missing(self, empty_mock):
+        """Test _get_level returns None when missing."""
+        result = Logger._get_level(empty_mock)
+        assert result is None
+
+    def test_get_log_level_missing(self, empty_mock):
+        """Test get_log_level returns None when missing."""
+        result = Logger.get_log_level(empty_mock)
+        assert result is None
+
+    def test_get_log_level_name_missing(self, empty_mock):
+        """Test get_log_level_name returns None when missing."""
+        result = Logger.get_log_level_name(empty_mock)
+        assert result is None
+
+    def test_get_log_date_format_missing(self, empty_mock):
+        """Test get_log_date_format returns None when missing."""
+        result = Logger.get_log_date_format(empty_mock)
+        assert result is None
+
+    def test_get_log_formatter_string_missing(self, empty_mock):
+        """Test get_log_formatter_string returns None when missing."""
+        result = Logger.get_log_formatter_string(empty_mock)
+        assert result is None
+
+    def test_get_log_message_default_missing(self, empty_mock):
+        """Test get_log_message_default returns None when missing."""
+        result = Logger.get_log_message_default(empty_mock)
+        assert result is None
+
+    def test_get_log_level_custom_names_list_missing(self, empty_mock):
+        """Test get_log_level_custom_names_list returns None when missing."""
+        result = Logger.get_log_level_custom_names_list(empty_mock)
+        assert result is None
+
+    def test_get_log_level_numbers_dict_missing(self, empty_mock):
+        """Test get_log_level_numbers_dict returns None when missing."""
+        result = Logger.get_log_level_numbers_dict(empty_mock)
+        assert result is None
+
+    def test_get_log_level_methods_dict_missing(self, empty_mock):
+        """Test get_log_level_methods_dict returns None when missing."""
+        result = Logger.get_log_level_methods_dict(empty_mock)
+        assert result is None
+
+    def test_get_log_allow_log_level_redefinition_missing(self, empty_mock):
+        """Test get_log_allow_log_level_redefinition returns None when missing."""
+        result = Logger.get_log_allow_log_level_redefinition(empty_mock)
+        assert result is None
+
+
+class TestLoggerUUID:
+    """Tests for Logger UUID methods."""
+
+    def test_generate_uuid_creates_valid_uuid(self):
+        """Test _generate_uuid creates a valid UUID string."""
+        mock_instance = MagicMock()
+        result = Logger._generate_uuid(mock_instance)
+
+        assert isinstance(result, str)
+        assert len(result) == 36
+        assert result.count("-") == 4
+
+    def test_set_uuid_with_provided_value(self):
+        """Test set_uuid with a provided UUID value."""
+
+        class FakeLogger:
+            def _generate_uuid(self):
+                return "fallback-uuid"
+
+        obj = FakeLogger()
+        Logger.set_uuid(obj, "custom-uuid-value")
+        assert obj.uuid == "custom-uuid-value"
+
+    def test_set_uuid_generates_when_none(self):
+        """Test set_uuid generates UUID when None provided."""
+
+        class FakeLogger:
+            def _generate_uuid(self):
+                return "generated-uuid"
+
+        obj = FakeLogger()
+        Logger.set_uuid(obj, None)
+        assert obj.uuid == "generated-uuid"
+
+
+class TestLoggerHelperMethods:
+    """Tests for Logger helper class methods."""
+
+    def test_date_returns_callable(self):
+        """Test _date returns a callable that formats dates."""
+        import datetime
+
+        formatter = Logger._date("%Y-%m-%d")
+        test_date = datetime.datetime(2025, 1, 15)
+        result = formatter(test_date)
+        assert result == "2025-01-15"
+
+    def test_get_log_level_returns_callable(self):
+        """Test _get_log_level returns a callable."""
+        level_func = Logger._get_log_level(config_lvl=10, norm_lvl=20)
+        assert callable(level_func)
+        assert level_func(True) == 20
+        assert level_func(False) == 10
+
+    def test_get_log_level_check_returns_callable(self):
+        """Test _get_log_level_check returns a callable."""
+        level_func = Logger._get_log_level_check(config_lvl=10, norm_lvl=20)
+        assert callable(level_func)
+
+
+class TestLoggerDictMethods:
+    """Tests for Logger dict generation methods."""
+
+    def test_console_dict_returns_dict(self):
+        """Test _console_dict returns a dictionary."""
+        import datetime
+        from inspect import currentframe
+
+        result = Logger._console_dict(
+            frame=currentframe(),
+            tsp=datetime.datetime.now(),
+            level="INFO",
+            message="Test message",
+        )
+        assert isinstance(result, dict)
+        assert "INFO" in result.values()
+        assert "Test message" in result.values()
+
+    def test_file_dict_returns_dict(self):
+        """Test _file_dict returns a dictionary."""
+        import datetime
+        from inspect import currentframe
+
+        result = Logger._file_dict(
+            frame=currentframe(),
+            tsp=datetime.datetime.now(),
+            level="DEBUG",
+            message="Debug message",
+        )
+        assert isinstance(result, dict)
+        assert "DEBUG" in result.values()
+        assert "Debug message" in result.values()

--- a/juniper-cascor-model/tests/test_logger_extended.py
+++ b/juniper-cascor-model/tests/test_logger_extended.py
@@ -1,0 +1,531 @@
+#!/usr/bin/env python
+"""
+Extended unit tests for log_config/logger/logger.py to cover remaining uncovered lines.
+
+Target lines:
+- 406: _filter_by_level with invalid level returns False
+- 563-566: __init__ config fallback when _Logger__log_config is None
+- 602-604: __init__ exception handling for config file reading
+- 626-627: __init__ fallback to basic logging configuration
+- 726-727: _init_custom_log_levels skips invalid custom level with warning
+- 780, 783, 786, 789: _init_validate_custom_log_level warning branches
+- 812: _init_log_method returns no-op lambda when level_number is None
+- 844-848: log_for_level function calls _log with correct stacklevel
+- 897-903: update_log_level branches
+- 998-1000: set_log_level_name with sync_level=True
+- 1100-1101: set_uuid when uuid already set exits
+- 1115: get_uuid auto-generates uuid when None
+- 1127: get_logger returns self
+"""
+import logging
+import os
+import sys
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from log_config.logger.logger import Logger
+
+
+class TestFilterByLevelInvalid:
+    """Tests for _filter_by_level with invalid levels (line 406)."""
+
+    def test_filter_by_level_invalid_level_returns_false(self):
+        """Test _filter_by_level returns False when level is invalid."""
+        result = Logger._filter_by_level(level="INVALID_LEVEL", log_level="INFO")
+        assert result is False
+
+    def test_filter_by_level_invalid_log_level_returns_false(self):
+        """Test _filter_by_level returns False when log_level is invalid."""
+        result = Logger._filter_by_level(level="INFO", log_level="INVALID_LEVEL")
+        assert result is False
+
+    def test_filter_by_level_both_invalid_returns_false(self):
+        """Test _filter_by_level returns False when both are invalid."""
+        result = Logger._filter_by_level(level="INVALID1", log_level="INVALID2")
+        assert result is False
+
+    def test_filter_by_level_none_level_returns_false(self):
+        """Test _filter_by_level returns False when level is None."""
+        result = Logger._filter_by_level(level=None, log_level="INFO")
+        assert result is False
+
+    def test_filter_by_level_none_log_level_returns_false(self):
+        """Test _filter_by_level returns False when log_level is None."""
+        result = Logger._filter_by_level(level="INFO", log_level=None)
+        assert result is False
+
+
+class TestInitValidateCustomLogLevel:
+    """Tests for _init_validate_custom_log_level warning branches (lines 780, 783, 786, 789)."""
+
+    @pytest.fixture
+    def mock_logger_instance(self):
+        """Create a mock Logger instance for testing validation."""
+        mock = MagicMock()
+        mock.log_level_numbers_dict = {"TRACE": 1, "DEBUG": 10, "INFO": 20}
+        return mock
+
+    def test_validate_custom_log_level_name_is_none(self, mock_logger_instance):
+        """Test warning when custom_log_level_name is None (line 780)."""
+        with patch.object(Logger, "warning") as mock_warning:
+            result = Logger._init_validate_custom_log_level(
+                mock_logger_instance,
+                custom_log_level_name=None,
+                custom_log_level_number=25,
+                custom_log_level_method="custom",
+                allow_redefinition=True,
+            )
+            assert result is False
+            mock_warning.assert_called()
+            call_args = str(mock_warning.call_args)
+            assert "name is invalid" in call_args
+
+    def test_validate_custom_log_level_number_is_none(self, mock_logger_instance):
+        """Test warning when custom_log_level_number is None (line 783)."""
+        with patch.object(Logger, "warning") as mock_warning:
+            result = Logger._init_validate_custom_log_level(
+                mock_logger_instance,
+                custom_log_level_name="CUSTOM",
+                custom_log_level_number=None,
+                custom_log_level_method="custom",
+                allow_redefinition=True,
+            )
+            assert result is False
+            mock_warning.assert_called()
+            call_args = str(mock_warning.call_args)
+            assert "number is invalid" in call_args
+
+    def test_validate_custom_log_level_method_is_none(self, mock_logger_instance):
+        """Test warning when custom_log_level_method is None (line 786)."""
+        with patch.object(Logger, "warning") as mock_warning:
+            result = Logger._init_validate_custom_log_level(
+                mock_logger_instance,
+                custom_log_level_name="CUSTOM",
+                custom_log_level_number=25,
+                custom_log_level_method=None,
+                allow_redefinition=True,
+            )
+            assert result is False
+            mock_warning.assert_called()
+            call_args = str(mock_warning.call_args)
+            assert "method" in call_args.lower()
+
+    def test_validate_custom_log_level_redefinition_disabled(self, mock_logger_instance):
+        """Test warning when level exists and allow_redefinition=False (line 789)."""
+        mock_logger_instance.EXISTING = True
+        with patch.object(Logger, "warning") as mock_warning:
+            result = Logger._init_validate_custom_log_level(
+                mock_logger_instance,
+                custom_log_level_name="EXISTING",
+                custom_log_level_number=25,
+                custom_log_level_method="existing_method",
+                allow_redefinition=False,
+            )
+            assert result is False
+            mock_warning.assert_called()
+            call_args = str(mock_warning.call_args)
+            assert "redefinition" in call_args.lower()
+
+    def test_validate_custom_log_level_name_not_string(self, mock_logger_instance):
+        """Test warning when custom_log_level_name is not a string."""
+        with patch.object(Logger, "warning") as mock_warning:
+            result = Logger._init_validate_custom_log_level(
+                mock_logger_instance,
+                custom_log_level_name=123,
+                custom_log_level_number=25,
+                custom_log_level_method="custom",
+                allow_redefinition=True,
+            )
+            assert result is False
+
+    def test_validate_custom_log_level_number_not_int(self, mock_logger_instance):
+        """Test warning when custom_log_level_number is not an int."""
+        with patch.object(Logger, "warning") as mock_warning:
+            result = Logger._init_validate_custom_log_level(
+                mock_logger_instance,
+                custom_log_level_name="CUSTOM",
+                custom_log_level_number="25",
+                custom_log_level_method="custom",
+                allow_redefinition=True,
+            )
+            assert result is False
+
+    def test_validate_custom_log_level_method_not_string(self, mock_logger_instance):
+        """Test warning when custom_log_level_method is not a string."""
+        with patch.object(Logger, "warning") as mock_warning:
+            result = Logger._init_validate_custom_log_level(
+                mock_logger_instance,
+                custom_log_level_name="CUSTOM",
+                custom_log_level_number=25,
+                custom_log_level_method=123,
+                allow_redefinition=True,
+            )
+            assert result is False
+
+
+class TestInitLogMethod:
+    """Tests for _init_log_method (lines 812, 844-848)."""
+
+    @pytest.fixture
+    def mock_logger_instance(self):
+        """Create a mock Logger instance."""
+        mock = MagicMock()
+        mock.isEnabledFor = MagicMock(return_value=True)
+        mock._log = MagicMock()
+        return mock
+
+    def test_init_log_method_level_number_none_returns_noop(self, mock_logger_instance):
+        """Test _init_log_method returns no-op lambda when level_number is None (line 812)."""
+        with patch.object(Logger, "debug"):
+            result = Logger._init_log_method(
+                mock_logger_instance,
+                level_number=None,
+                level_name="CUSTOM",
+            )
+            assert callable(result)
+            result("test message")
+
+    def test_init_log_method_level_name_none_returns_noop(self, mock_logger_instance):
+        """Test _init_log_method returns no-op lambda when level_name is None."""
+        with patch.object(Logger, "debug"):
+            result = Logger._init_log_method(
+                mock_logger_instance,
+                level_number=25,
+                level_name=None,
+            )
+            assert callable(result)
+            result("test message")
+
+    def test_init_log_method_both_none_returns_noop(self, mock_logger_instance):
+        """Test _init_log_method returns no-op lambda when both are None."""
+        with patch.object(Logger, "debug"):
+            result = Logger._init_log_method(
+                mock_logger_instance,
+                level_number=None,
+                level_name=None,
+            )
+            assert callable(result)
+            result("test message")
+
+    def test_log_for_level_calls_log_with_stacklevel(self, mock_logger_instance):
+        """Test log_for_level function calls _log with correct stacklevel (lines 844-848)."""
+        with patch.object(Logger, "debug"):
+            log_method = Logger._init_log_method(
+                mock_logger_instance,
+                level_number=25,
+                level_name="CUSTOM",
+            )
+            log_method("test message")
+            mock_logger_instance._log.assert_called_once()
+            call_args = mock_logger_instance._log.call_args
+            assert call_args[0][0] == 25
+            assert call_args[0][1] == "test message"
+            assert call_args[1].get("stacklevel") == 2
+
+    def test_log_for_level_not_called_when_disabled(self, mock_logger_instance):
+        """Test log_for_level does not call _log when level is disabled."""
+        mock_logger_instance.isEnabledFor.return_value = False
+        with patch.object(Logger, "debug"):
+            log_method = Logger._init_log_method(
+                mock_logger_instance,
+                level_number=25,
+                level_name="CUSTOM",
+            )
+            log_method("test message")
+            mock_logger_instance._log.assert_not_called()
+
+
+class TestInitCustomLogLevels:
+    """Tests for _init_custom_log_levels (lines 726-727)."""
+
+    @pytest.fixture
+    def mock_logger_instance(self):
+        """Create a mock Logger instance for testing."""
+        mock = MagicMock()
+        mock.log_level_numbers_dict = {"TRACE": 1, "DEBUG": 10, "INFO": 20}
+        return mock
+
+    def test_init_custom_log_levels_skips_invalid(self, mock_logger_instance):
+        """Test _init_custom_log_levels skips invalid levels with warning (lines 726-727)."""
+        custom_names = ["INVALID_LEVEL"]
+        numbers_dict = {}
+        methods_dict = {}
+
+        with patch.object(Logger, "debug"), patch.object(Logger, "warning") as mock_warning:
+            mock_logger_instance._init_validate_custom_log_level = MagicMock(return_value=False)
+            Logger._init_custom_log_levels(
+                mock_logger_instance,
+                custom_names_list=custom_names,
+                numbers_dict=numbers_dict,
+                methods_dict=methods_dict,
+                allow_redefinition=False,
+            )
+            mock_warning.assert_called()
+
+
+class TestUpdateLogLevel:
+    """Tests for update_log_level branches (lines 897-903)."""
+
+    @pytest.fixture
+    def mock_logger_instance(self):
+        """Create a mock Logger instance."""
+        mock = MagicMock()
+        mock.logger = MagicMock()
+        mock.log_level_numbers_dict = {"TRACE": 1, "DEBUG": 10, "INFO": 20, "WARNING": 30}
+        return mock
+
+    def test_update_log_level_with_log_level(self, mock_logger_instance):
+        """Test update_log_level with log_level parameter (lines 898-899)."""
+        Logger.update_log_level(mock_logger_instance, log_level=20)
+        mock_logger_instance.set_log_level.assert_called_once_with(log_level=20, sync_level_name=True)
+
+    def test_update_log_level_with_log_level_name(self, mock_logger_instance):
+        """Test update_log_level with log_level_name parameter (lines 900-901)."""
+        Logger.update_log_level(mock_logger_instance, log_level_name="WARNING")
+        mock_logger_instance.set_log_level_name.assert_called_once_with(log_level_name="WARNING", sync_level=True)
+
+    def test_update_log_level_no_parameters_warns(self, mock_logger_instance):
+        """Test update_log_level with no parameters warns (lines 902-903)."""
+        Logger.update_log_level(mock_logger_instance)
+        mock_logger_instance.warning.assert_called_once()
+        call_args = str(mock_logger_instance.warning.call_args)
+        assert "No valid log level" in call_args
+
+
+class TestSetLogLevelName:
+    """Tests for set_log_level_name with sync_level=True (lines 998-1000)."""
+
+    @pytest.fixture
+    def mock_logger_instance(self):
+        """Create a mock Logger instance."""
+        mock = MagicMock()
+        mock.log_level = 20
+        mock.log_level_numbers_dict = {"TRACE": 1, "DEBUG": 10, "INFO": 20, "WARNING": 30, "ERROR": 40}
+        mock.get_name_from_level = MagicMock(return_value="INFO")
+        mock.debug = MagicMock()
+        mock.set_log_level = MagicMock()
+        return mock
+
+    def test_set_log_level_name_with_sync_level_true(self, mock_logger_instance):
+        """Test set_log_level_name syncs level when sync_level=True (lines 998-1000)."""
+        Logger.set_log_level_name(mock_logger_instance, log_level_name="WARNING", sync_level=True)
+        mock_logger_instance.set_log_level.assert_called_once_with(log_level=30, sync_level_name=False)
+
+    def test_set_log_level_name_with_sync_level_false(self, mock_logger_instance):
+        """Test set_log_level_name does not sync level when sync_level=False."""
+        Logger.set_log_level_name(mock_logger_instance, log_level_name="WARNING", sync_level=False)
+        mock_logger_instance.set_log_level.assert_not_called()
+
+    def test_set_log_level_name_with_none(self, mock_logger_instance):
+        """Test set_log_level_name with None does not sync."""
+        Logger.set_log_level_name(mock_logger_instance, log_level_name=None, sync_level=True)
+        mock_logger_instance.set_log_level.assert_not_called()
+
+
+class TestSetUuidAlreadySet:
+    """Tests for set_uuid when uuid already set (lines 1100-1101)."""
+
+    def test_set_uuid_already_set_exits(self):
+        """Test set_uuid exits when uuid is already set (lines 1100-1101)."""
+        mock_instance = MagicMock()
+        mock_instance.uuid = "existing-uuid-12345"
+        mock_instance.fatal = MagicMock()
+
+        with patch("sys.exit") as mock_exit:
+            Logger.set_uuid(mock_instance, "new-uuid")
+            mock_instance.fatal.assert_called_once()
+            call_args = str(mock_instance.fatal.call_args)
+            assert "already set" in call_args.lower()
+            mock_exit.assert_called_once_with(1)
+
+    def test_set_uuid_sets_when_none(self):
+        """Test set_uuid sets uuid when uuid is None."""
+        mock_instance = MagicMock()
+        mock_instance.uuid = None
+        mock_instance._generate_uuid = MagicMock(return_value="generated-uuid")
+
+        Logger.set_uuid(mock_instance, None)
+        assert mock_instance.uuid == "generated-uuid"
+
+    def test_set_uuid_sets_provided_value(self):
+        """Test set_uuid sets provided value when uuid is None."""
+        mock_instance = MagicMock()
+        mock_instance.uuid = None
+
+        Logger.set_uuid(mock_instance, "provided-uuid")
+        assert mock_instance.uuid == "provided-uuid"
+
+
+class TestGetUuidAutoGenerate:
+    """Tests for get_uuid auto-generating uuid (line 1115)."""
+
+    def test_get_uuid_auto_generates_when_none(self):
+        """Test get_uuid auto-generates uuid when None (line 1115)."""
+        mock_instance = MagicMock()
+        mock_instance.uuid = None
+        mock_instance.set_uuid = MagicMock()
+
+        def side_effect(*args):
+            mock_instance.uuid = "auto-generated-uuid"
+
+        mock_instance.set_uuid.side_effect = side_effect
+        result = Logger.get_uuid(mock_instance)
+        mock_instance.set_uuid.assert_called_once()
+        assert result == "auto-generated-uuid"
+
+    def test_get_uuid_returns_existing(self):
+        """Test get_uuid returns existing uuid without generating."""
+        mock_instance = MagicMock()
+        mock_instance.uuid = "existing-uuid"
+
+        result = Logger.get_uuid(mock_instance)
+        assert result == "existing-uuid"
+
+
+class TestGetLogger:
+    """Tests for get_logger returning self (line 1127)."""
+
+    def test_get_logger_returns_self(self):
+        """Test get_logger returns self (line 1127)."""
+        mock_instance = MagicMock()
+        result = Logger.get_logger(mock_instance)
+        assert result is mock_instance
+
+
+class TestInitConfigFallback:
+    """Tests for __init__ config fallback (lines 563-566, 626-627)."""
+
+    def test_init_uses_logging_config_when_log_config_none(self):
+        """Test __init__ uses logging.config when _Logger__log_config is None (lines 563-566)."""
+        original_configured = Logger.SingletonLoggingConfigured
+        try:
+            Logger.SingletonLoggingConfigured = True
+            with patch.object(Logger, "debug"), patch.object(Logger, "warning") as mock_warning, patch.object(Logger, "info"), patch.object(Logger, "_init_custom_log_levels"), patch.object(Logger, "set_logger"), patch.object(Logger, "set_log_level"), patch.object(Logger, "addHandler"), patch("logging.Logger.__init__", return_value=None):
+                mock_instance = MagicMock(spec=Logger)
+                mock_instance.handlers = []
+                mock_instance.log_level_logging_config = 20
+                mock_instance.log_file_name = "test.log"
+                mock_instance.log_config_file = "/nonexistent/path.yaml"
+                mock_instance.log_formatter_string = "%(message)s"
+                mock_instance.log_date_format = "%Y-%m-%d"
+                mock_instance.log_level_custom_names_list = []
+                mock_instance.log_level_numbers_dict = {}
+                mock_instance.log_level_methods_dict = {}
+                mock_instance.log_level_redefinition = True
+
+        finally:
+            Logger.SingletonLoggingConfigured = original_configured
+
+    def test_init_fallback_to_basic_logging(self):
+        """Test __init__ falls back to basic logging when configs invalid (lines 626-627)."""
+        original_configured = Logger.SingletonLoggingConfigured
+        try:
+            Logger.SingletonLoggingConfigured = False
+            with patch.object(Logger, "debug"), patch.object(Logger, "warning") as mock_warning, patch.object(Logger, "info"), patch.object(Logger, "error"), patch.object(Logger, "_init_custom_log_levels"), patch.object(Logger, "set_logger"), patch.object(Logger, "set_log_level"), patch.object(Logger, "addHandler"), patch("builtins.open", side_effect=Exception("File not found")), patch("traceback.print_exc"), patch("logging.Logger.__init__", return_value=None):
+                pass
+        finally:
+            Logger.SingletonLoggingConfigured = original_configured
+
+
+class TestInitExceptionHandling:
+    """Tests for __init__ exception handling (lines 602-604)."""
+
+    def test_init_handles_config_file_exception(self):
+        """Test __init__ handles exception when reading config file (lines 602-604)."""
+        original_configured = Logger.SingletonLoggingConfigured
+        try:
+            Logger.SingletonLoggingConfigured = False
+            with patch.object(Logger, "debug"), patch.object(Logger, "warning"), patch.object(Logger, "info"), patch.object(Logger, "error") as mock_error, patch.object(Logger, "_init_custom_log_levels"), patch.object(Logger, "set_logger"), patch.object(Logger, "set_log_level"), patch.object(Logger, "addHandler"), patch("builtins.open", side_effect=FileNotFoundError("Config file not found")), patch("traceback.print_exc") as mock_traceback, patch("logging.Logger.__init__", return_value=None):
+                pass
+        finally:
+            Logger.SingletonLoggingConfigured = original_configured
+
+
+class TestLogForLevelStackLevel:
+    """Additional tests for log_for_level stacklevel behavior."""
+
+    def test_log_for_level_preserves_custom_stacklevel(self):
+        """Test log_for_level preserves custom stacklevel if provided."""
+        mock_instance = MagicMock()
+        mock_instance.isEnabledFor = MagicMock(return_value=True)
+        mock_instance._log = MagicMock()
+
+        with patch.object(Logger, "debug"):
+            log_method = Logger._init_log_method(
+                mock_instance,
+                level_number=25,
+                level_name="CUSTOM",
+            )
+            log_method("test message", stacklevel=5)
+            mock_instance._log.assert_called_once()
+            call_kwargs = mock_instance._log.call_args[1]
+            assert call_kwargs.get("stacklevel") == 5
+
+    def test_log_for_level_with_args(self):
+        """Test log_for_level passes args correctly."""
+        mock_instance = MagicMock()
+        mock_instance.isEnabledFor = MagicMock(return_value=True)
+        mock_instance._log = MagicMock()
+
+        with patch.object(Logger, "debug"):
+            log_method = Logger._init_log_method(
+                mock_instance,
+                level_number=25,
+                level_name="CUSTOM",
+            )
+            log_method("test %s", "message")
+            mock_instance._log.assert_called_once()
+            call_args = mock_instance._log.call_args[0]
+            assert call_args[1] == "test %s"
+            assert call_args[2] == ("message",)
+
+
+class TestValidateCustomLogLevelEdgeCases:
+    """Edge case tests for _init_validate_custom_log_level."""
+
+    @pytest.fixture
+    def mock_logger_instance(self):
+        """Create a mock Logger instance."""
+        mock = MagicMock()
+        return mock
+
+    def test_validate_with_existing_method_attribute(self, mock_logger_instance):
+        """Test validation fails when method attribute already exists."""
+        mock_logger_instance.existing_method = lambda: None
+        with patch.object(Logger, "warning") as mock_warning, patch.object(Logger, "debug"):
+            result = Logger._init_validate_custom_log_level(
+                mock_logger_instance,
+                custom_log_level_name="NEW_LEVEL",
+                custom_log_level_number=25,
+                custom_log_level_method="existing_method",
+                allow_redefinition=False,
+            )
+            assert result is False
+
+    def test_validate_success_with_valid_inputs(self, mock_logger_instance):
+        """Test validation succeeds with valid inputs."""
+        with patch.object(Logger, "debug"):
+            result = Logger._init_validate_custom_log_level(
+                mock_logger_instance,
+                custom_log_level_name="CUSTOM_LEVEL",
+                custom_log_level_number=25,
+                custom_log_level_method="custom_method",
+                allow_redefinition=True,
+            )
+            assert result is True
+
+    def test_validate_with_allow_redefinition_true(self, mock_logger_instance):
+        """Test validation succeeds when allow_redefinition=True even if exists."""
+        mock_logger_instance.EXISTING_LEVEL = True
+        with patch.object(Logger, "debug"):
+            result = Logger._init_validate_custom_log_level(
+                mock_logger_instance,
+                custom_log_level_name="EXISTING_LEVEL",
+                custom_log_level_number=25,
+                custom_log_level_method="existing_method",
+                allow_redefinition=True,
+            )
+            assert result is True

--- a/juniper-cascor-model/tests/test_utils_coverage.py
+++ b/juniper-cascor-model/tests/test_utils_coverage.py
@@ -1,0 +1,569 @@
+#!/usr/bin/env python
+"""
+Tests for utils/utils.py to increase code coverage.
+"""
+import os
+import sys
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import torch
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from utils.utils import _init_content_list, _object_attributes_to_table, check_object_pickleability, convert_to_numpy, convert_to_tensor, display_object_attributes, display_progress, get_class_distribution, lambda_raise_, load_dataset, save_dataset
+
+
+
+class TestSaveDataset:
+    """Tests for save_dataset function."""
+
+    def test_save_dataset_basic(self):
+        """Test saving a basic dataset."""
+        x = torch.randn(10, 2)
+        y = torch.randint(0, 2, (10,))
+
+        with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+            temp_file = f.name
+
+        try:
+            save_dataset(x, y, temp_file)
+            assert os.path.exists(temp_file)
+
+            # Verify the saved data
+            loaded = torch.load(temp_file)
+            assert "x" in loaded
+            assert "y" in loaded
+            torch.testing.assert_close(loaded["x"], x)
+            torch.testing.assert_close(loaded["y"], y)
+        finally:
+            if os.path.exists(temp_file):
+                os.unlink(temp_file)
+
+
+class TestDisplayProgress:
+    """Tests for display_progress function."""
+
+    def test_display_progress_returns_lambda(self):
+        """Test that display_progress returns a lambda function."""
+        result = display_progress(10)
+        assert callable(result)
+
+    def test_display_progress_lambda_true_at_frequency(self):
+        """Test lambda returns True at display frequency."""
+        check_fn = display_progress(5)
+        # At epoch 4 (0-indexed), (4+1) % 5 == 0, so should be True
+        assert check_fn(4) is True
+        assert check_fn(9) is True
+
+    def test_display_progress_lambda_false_not_at_frequency(self):
+        """Test lambda returns False when not at display frequency."""
+        check_fn = display_progress(5)
+        assert check_fn(0) is False
+        assert check_fn(1) is False
+        assert check_fn(2) is False
+
+    def test_display_progress_zero_frequency(self):
+        """Test display_progress with zero frequency."""
+        check_fn = display_progress(0)
+        assert check_fn(0) is False
+        assert check_fn(5) is False
+
+
+class TestLambdaRaise:
+    """Tests for lambda_raise_ function."""
+
+    def test_lambda_raise_raises_exception(self):
+        """Test that lambda_raise_ raises the given exception."""
+        with pytest.raises(ValueError, match="test error"):
+            lambda_raise_(ValueError("test error"))
+
+    def test_lambda_raise_raises_type_error(self):
+        """Test that lambda_raise_ raises TypeError."""
+        with pytest.raises(TypeError, match="wrong type"):
+            lambda_raise_(TypeError("wrong type"))
+
+
+class TestGetClassDistribution:
+    """Tests for get_class_distribution function."""
+
+    def test_get_class_distribution_one_hot(self):
+        """Test class distribution with one-hot encoded targets."""
+        y = torch.tensor(
+            [
+                [1, 0],
+                [1, 0],
+                [0, 1],
+                [0, 1],
+                [0, 1],
+            ]
+        )
+        dist = get_class_distribution(y)
+        assert dist[0] == 2
+        assert dist[1] == 3
+
+    def test_get_class_distribution_indices(self):
+        """Test class distribution with class indices."""
+        y = torch.tensor([0, 0, 1, 1, 1, 2])
+        dist = get_class_distribution(y)
+        assert dist[0] == 2
+        assert dist[1] == 3
+        assert dist[2] == 1
+
+
+class TestConvertToNumpy:
+    """Tests for convert_to_numpy function."""
+
+    def test_convert_tensors_to_numpy(self):
+        """Test converting tensors to numpy arrays."""
+        x = torch.randn(10, 2)
+        y = torch.randn(10, 1)
+
+        x_np, y_np = convert_to_numpy(x, y)
+
+        assert isinstance(x_np, np.ndarray)
+        assert isinstance(y_np, np.ndarray)
+        np.testing.assert_array_almost_equal(x_np, x.numpy())
+        np.testing.assert_array_almost_equal(y_np, y.numpy())
+
+    def test_convert_already_numpy(self):
+        """Test that numpy arrays pass through unchanged."""
+        x = np.random.randn(10, 2)
+        y = np.random.randn(10, 1)
+
+        x_np, y_np = convert_to_numpy(x, y)
+
+        assert x_np is x
+        assert y_np is y
+
+
+class TestConvertToTensor:
+    """Tests for convert_to_tensor function."""
+
+    def test_convert_numpy_to_tensors(self):
+        """Test converting numpy arrays to tensors."""
+        x = np.random.randn(10, 2).astype(np.float32)
+        y = np.random.randn(10, 1).astype(np.float32)
+
+        x_t, y_t = convert_to_tensor(x, y)
+
+        assert isinstance(x_t, torch.Tensor)
+        assert isinstance(y_t, torch.Tensor)
+        np.testing.assert_array_almost_equal(x_t.numpy(), x)
+        np.testing.assert_array_almost_equal(y_t.numpy(), y)
+
+    def test_convert_already_tensor(self):
+        """Test that tensors pass through unchanged."""
+        x = torch.randn(10, 2)
+        y = torch.randn(10, 1)
+
+        x_t, y_t = convert_to_tensor(x, y)
+
+        assert x_t is x
+        assert y_t is y
+
+
+class TestDisplayObjectAttributes:
+    """Tests for display_object_attributes function."""
+
+    def test_display_object_attributes_with_none(self):
+        """Test with None object name."""
+        result = display_object_attributes(None)
+        # Result may be None or False depending on implementation
+        assert result is None or result is False or isinstance(result, str)
+
+
+class TestObjectAttributesToTable:
+    """Tests for _object_attributes_to_table function."""
+
+    def test_object_attributes_to_table_none_inputs(self):
+        """Test with None inputs - should return None or False."""
+        result = _object_attributes_to_table(None, None, False)
+        # The function may return None or False depending on walrus operator result
+        assert result is None or result is False
+
+
+class TestInitContentList:
+    """Tests for _init_content_list function."""
+
+    def test_init_content_list_true(self):
+        """Test with True validity check."""
+        result = _init_content_list(True)
+        assert result == []
+
+    def test_init_content_list_false(self):
+        """Test with False validity check."""
+        result = _init_content_list(False)
+        assert result is None
+
+
+try:
+    import dill
+
+    HAS_DILL = True
+except ImportError:
+    HAS_DILL = False
+
+
+class TestCheckObjectPickleability:
+    """Tests for check_object_pickleability function."""
+
+    @pytest.mark.skipif(not HAS_DILL, reason="Requires dill package")
+    def test_check_object_pickleability_none(self):
+        """Test with None instance - early return path."""
+        result = check_object_pickleability(None)
+        assert result is False
+
+    @pytest.mark.skipif(not HAS_DILL, reason="Requires dill package")
+    def test_check_object_pickleability_no_dict(self):
+        """Test with object that has no __dict__ - early return path."""
+        result = check_object_pickleability(42)
+        assert result is False
+
+
+class TestLoadDataset:
+    """Tests for load_dataset function.
+
+    Pre-BUG-CC-12 fix this read files as YAML, which never
+    round-tripped a real ``save_dataset`` payload. Tests now exercise
+    the corrected ``torch.load(weights_only=True)`` path against real
+    ``save_dataset`` output.
+    """
+
+    def test_load_dataset_round_trip(self):
+        """save_dataset → load_dataset returns the same tensors."""
+        x = torch.randn(10, 3)
+        y = torch.randint(0, 2, (10,))
+
+        with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+            temp_file = f.name
+
+        try:
+            save_dataset(x, y, temp_file)
+            loaded_x, loaded_y = load_dataset(temp_file)
+            torch.testing.assert_close(loaded_x, x)
+            torch.testing.assert_close(loaded_y, y)
+        finally:
+            if os.path.exists(temp_file):
+                os.unlink(temp_file)
+
+    def test_load_dataset_returns_tensors(self):
+        """The returned values are torch.Tensor, not lists or numpy."""
+        x = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        y = torch.tensor([0.0, 1.0])
+
+        with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+            temp_file = f.name
+
+        try:
+            save_dataset(x, y, temp_file)
+            loaded_x, loaded_y = load_dataset(temp_file)
+            assert isinstance(loaded_x, torch.Tensor)
+            assert isinstance(loaded_y, torch.Tensor)
+        finally:
+            if os.path.exists(temp_file):
+                os.unlink(temp_file)
+
+    def test_load_dataset_accepts_pathlib(self):
+        """``file_path`` works with pathlib.Path as well as str."""
+        from pathlib import Path
+
+        x = torch.randn(5, 2)
+        y = torch.randint(0, 2, (5,))
+
+        with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+            temp_file = f.name
+        path_obj = Path(temp_file)
+
+        try:
+            save_dataset(x, y, path_obj)
+            loaded_x, loaded_y = load_dataset(path_obj)
+            torch.testing.assert_close(loaded_x, x)
+            torch.testing.assert_close(loaded_y, y)
+        finally:
+            if os.path.exists(temp_file):
+                os.unlink(temp_file)
+
+
+class TestDisplayProgressNegativeEpoch:
+    """Tests for display_progress with negative epoch (line 116)."""
+
+    def test_display_progress_negative_epoch_raises(self):
+        """Test that negative epoch raises ValueError via lambda."""
+        check_fn = display_progress(5)
+        with pytest.raises(ValueError, match="Epoch must be a positive integer"):
+            check_fn(-1)
+
+    def test_display_progress_negative_epoch_minus_two(self):
+        """Test that epoch -2 raises ValueError."""
+        check_fn = display_progress(10)
+        with pytest.raises(ValueError):
+            check_fn(-2)
+
+
+class TestObjectAttributesToTableWithData:
+    """Tests for _object_attributes_to_table with actual data (lines 209-222).
+
+    Note: The walrus operator in line 208 has a precedence bug that causes issues,
+    so these tests document the actual behavior paths that get exercised.
+    """
+
+    def test_object_attributes_to_table_with_none_inputs(self):
+        """Test with None inputs - exercises the validity check path."""
+        result = _object_attributes_to_table(None, None, False)
+        assert result is None or result is False
+
+    def test_object_attributes_to_table_with_partial_none(self):
+        """Test with partial None inputs."""
+        result = _object_attributes_to_table({"a": 1}, None, False)
+        assert result is None or result is False
+
+    def test_object_attributes_to_table_with_none_private_attrs(self):
+        """Test with None private_attrs."""
+        result = _object_attributes_to_table({"a": 1}, ["a"], None)
+        assert result is None or result is False
+
+
+class TestDisplayObjectAttributesWithModule:
+    """Tests for display_object_attributes with valid module (lines 191-194)."""
+
+    def test_display_object_attributes_with_invalid_private_attrs_type(self):
+        """Test with non-bool private_attrs - exercises early return path."""
+        result = display_object_attributes("os", private_attrs="not_a_bool")
+        assert result is None or result is False
+
+    def test_display_object_attributes_with_nonexistent_module(self):
+        """Test with non-existent module - exercises error path."""
+        try:
+            result = display_object_attributes("nonexistent_module_xyz_123")
+            assert result is None
+        except ModuleNotFoundError:
+            pass
+
+
+class TestColumnarImportFallback:
+    """Tests for HAS_COLUMNAR import fallback (lines 53-55)."""
+
+    def test_init_content_list_true_returns_empty_list(self):
+        """Test _init_content_list with True returns empty list."""
+        result = _init_content_list(True)
+        assert result == []
+
+    def test_init_content_list_false_returns_none(self):
+        """Test _init_content_list with False returns None."""
+        result = _init_content_list(False)
+        assert result is None
+
+
+class TestGetClassDistributionEdgeCases:
+    """Additional edge case tests for get_class_distribution."""
+
+    def test_get_class_distribution_single_class(self):
+        """Test with all same class."""
+        y = torch.tensor([0, 0, 0, 0, 0])
+        dist = get_class_distribution(y)
+        assert len(dist) == 1
+        assert dist[0] == 5
+
+    def test_get_class_distribution_2d_single_column(self):
+        """Test with 2D tensor but single column (class indices)."""
+        y = torch.tensor([[0], [1], [1], [0], [2]])
+        dist = get_class_distribution(y)
+        assert dist[0] == 2
+        assert dist[1] == 2
+        assert dist[2] == 1
+
+
+class TestConvertFunctionsEdgeCases:
+    """Edge case tests for convert functions."""
+
+    def test_convert_to_numpy_mixed_types(self):
+        """Test with one tensor and one numpy array."""
+        x = torch.randn(5, 2)
+        y = np.random.randn(5, 1)
+        x_np, y_np = convert_to_numpy(x, y)
+        assert isinstance(x_np, np.ndarray)
+        assert y_np is y
+
+    def test_convert_to_tensor_mixed_types(self):
+        """Test with one numpy and one tensor."""
+        x = np.random.randn(5, 2).astype(np.float32)
+        y = torch.randn(5, 1)
+        x_t, y_t = convert_to_tensor(x, y)
+        assert isinstance(x_t, torch.Tensor)
+        assert y_t is y
+
+
+class TestColumnarImportPath:
+    """Tests for columnar import handling (lines 53-55)."""
+
+    def test_has_columnar_is_boolean(self):
+        """Test that HAS_COLUMNAR is a boolean."""
+        from utils.utils import HAS_COLUMNAR
+
+        assert isinstance(HAS_COLUMNAR, bool)
+
+    def test_columnar_import_fallback_behavior(self):
+        """Test behavior when columnar may or may not be available."""
+        from utils.utils import HAS_COLUMNAR, col
+
+        if HAS_COLUMNAR:
+            assert col is not None
+        else:
+            assert col is None
+
+
+class TestObjectAttributesToTableValidData:
+    """Tests for _object_attributes_to_table with valid data (lines 209-222).
+
+    Note: The function has a walrus operator precedence bug in line 208 that causes
+    content to be assigned False instead of [] when called with valid parameters.
+    These tests document the actual behavior.
+    """
+
+    def test_object_attributes_table_with_none_obj_dict(self):
+        """Test table generation with None obj_dict returns None/False."""
+        result = _object_attributes_to_table(None, ["key"], False)
+        assert result is None or result is False
+
+    def test_object_attributes_table_with_none_keys(self):
+        """Test table generation with None keys returns None/False."""
+        result = _object_attributes_to_table({"a": 1}, None, False)
+        assert result is None or result is False
+
+    def test_object_attributes_table_all_none(self):
+        """Test table generation with all None returns None/False."""
+        result = _object_attributes_to_table(None, None, None)
+        assert result is None or result is False
+
+
+class TestCheckObjectPickleabilityExtended:
+    """Extended tests for check_object_pickleability (lines 253-263)."""
+
+    @pytest.mark.skipif(not HAS_DILL, reason="Requires dill package")
+    def test_check_object_pickleability_with_simple_object(self):
+        """Test with a simple pickleable object."""
+
+        class SimpleClass:
+            def __init__(self):
+                self.value = 42
+                self.name = "test"
+
+        obj = SimpleClass()
+        result = check_object_pickleability(obj)
+        assert result is True
+
+    @pytest.mark.skipif(not HAS_DILL, reason="Requires dill package")
+    def test_check_object_pickleability_with_unpickleable_attr(self):
+        """Test with object containing unpickleable attribute."""
+
+        class UnpickleableClass:
+            def __init__(self):
+                self.value = 42
+                self.unpickleable = lambda x: x
+
+        obj = UnpickleableClass()
+        result = check_object_pickleability(obj)
+        assert isinstance(result, bool)
+
+    @pytest.mark.skipif(not HAS_DILL, reason="Requires dill package")
+    def test_check_object_pickleability_iterates_dict(self):
+        """Test that function iterates through __dict__ keys."""
+
+        class MultiAttrClass:
+            def __init__(self):
+                self.a = 1
+                self.b = "two"
+                self.c = [3, 4, 5]
+                self.d = {"key": "value"}
+
+        obj = MultiAttrClass()
+        result = check_object_pickleability(obj)
+        assert result is True
+
+
+class TestDisplayObjectAttributesModulePath:
+    """Tests for display_object_attributes with real modules (lines 191-194).
+
+    BUG-CC-11 (fixed): the walrus-operator precedence bug on line 208 previously
+    bound ``content`` to a bool, so every call with valid inputs raised
+    ``AttributeError: 'bool' object has no attribute 'append'``. With the
+    parenthesized walrus, ``content`` now receives the list and the function
+    renders a table instead of crashing. These tests lock in the fixed behavior.
+    """
+
+    def test_display_object_attributes_with_json_module(self):
+        """'json' module has a small, bounded __dict__ so columnar formatting is fast."""
+        result = display_object_attributes("json", private_attrs=False)
+        assert result is not None
+        assert isinstance(result, str)
+        # ``dumps`` is a public attribute of the json module and must appear in the table.
+        assert "dumps" in result
+
+    def test_display_object_attributes_private_true_renders_small_module(self):
+        """With private_attrs=True, private keys are included in the rendered table."""
+        # Avoid ``sys`` here: its __dict__ is large enough that columnar formatting
+        # can exceed the 60s default pytest timeout on slow runners.
+        result = display_object_attributes("json", private_attrs=True)
+        assert result is not None
+        assert isinstance(result, str)
+
+
+class TestObjectAttributesTableColumnarPath:
+    """Tests for _object_attributes_to_table columnar formatting (lines 217-222).
+
+    BUG-CC-11 (fixed): the walrus-operator precedence bug on line 208 previously
+    caused ``_object_attributes_to_table`` to crash on valid input and to return
+    ``False`` when ``private_attrs`` was ``None`` (because the boolean walrus
+    result propagated through). After the fix, valid inputs render a string and
+    a ``None`` validity input short-circuits to ``None``.
+    """
+
+    def test_table_with_none_private_attrs(self):
+        """None validity input short-circuits to a None table (no content list)."""
+        # _init_content_list(False) -> None, so `(content := None) is not None` is False
+        # and the function returns None without entering the loop.
+        result = _object_attributes_to_table({"name": "test"}, ["name"], None)
+        assert result is None
+
+    def test_table_all_params_valid_renders_string(self):
+        """With valid inputs, the post-fix walrus binds ``content`` to a list and renders a string."""
+        obj_dict = {"a": 1, "b": 2}
+        keys = ["a", "b"]
+        result = _object_attributes_to_table(obj_dict, keys, False)
+        assert result is not None
+        assert isinstance(result, str)
+        assert "a" in result and "b" in result
+
+
+class TestCheckPickleabilityLogging:
+    """Tests for check_object_pickleability logging paths (lines 256-262)."""
+
+    @pytest.mark.skipif(not HAS_DILL, reason="Requires dill package")
+    def test_pickleability_logs_attributes(self):
+        """Test that function logs attribute information."""
+
+        class LogTestClass:
+            def __init__(self):
+                self.attr1 = "value1"
+                self.attr2 = [1, 2, 3]
+
+        obj = LogTestClass()
+        result = check_object_pickleability(obj)
+        assert isinstance(result, bool)
+
+    @pytest.mark.skipif(not HAS_DILL, reason="Requires dill package")
+    def test_pickleability_with_mixed_attributes(self):
+        """Test with object having mix of pickleable and potentially problematic attrs."""
+
+        class MixedClass:
+            def __init__(self):
+                self.simple = 42
+                self.tensor = torch.randn(3, 3)
+                self.numpy_arr = np.array([1, 2, 3])
+
+        obj = MixedClass()
+        result = check_object_pickleability(obj)
+        assert isinstance(result, bool)

--- a/juniper-cascor-model/tests/test_utils_extended.py
+++ b/juniper-cascor-model/tests/test_utils_extended.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python
+"""
+Extended unit tests for utils/utils.py to improve code coverage.
+
+Tests cover:
+- Fallback formatting in _object_attributes_to_table when columnar is not available (HAS_COLUMNAR=False)
+- check_object_pickleability with non-pickleable attributes (return False path)
+- display_object_attributes with various objects
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import torch
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+
+
+class TestColumnarFallbackFormatting:
+    """Tests for _object_attributes_to_table fallback when columnar is not available."""
+
+    def test_fallback_formatting_without_columnar(self):
+        """Test fallback formatting when HAS_COLUMNAR=False."""
+        with patch("utils.utils.HAS_COLUMNAR", False), patch("utils.utils.col", None):
+            from utils.utils import _init_content_list
+
+            content = _init_content_list(True)
+            assert content == []
+
+            content.append(["attr1", "value1"])
+            content.append(["attr2", "value2"])
+
+            headers = ["Attribute", "Attribute Value"]
+            result = "\n".join([f"{headers[0]}: {row[0]}, {headers[1]}: {row[1]}" for row in content])
+
+            assert "Attribute: attr1, Attribute Value: value1" in result
+            assert "Attribute: attr2, Attribute Value: value2" in result
+
+    def test_fallback_formatting_empty_content(self):
+        """Test fallback formatting with empty content list."""
+        with patch("utils.utils.HAS_COLUMNAR", False), patch("utils.utils.col", None):
+            content = []
+            headers = ["Attribute", "Attribute Value"]
+            result = "\n".join([f"{headers[0]}: {row[0]}, {headers[1]}: {row[1]}" for row in content]) if content else None
+
+            assert result is None
+
+    def test_fallback_formatting_single_attribute(self):
+        """Test fallback formatting with single attribute."""
+        with patch("utils.utils.HAS_COLUMNAR", False), patch("utils.utils.col", None):
+            content = [["name", "test_value"]]
+            headers = ["Attribute", "Attribute Value"]
+            result = "\n".join([f"{headers[0]}: {row[0]}, {headers[1]}: {row[1]}" for row in content])
+
+            assert result == "Attribute: name, Attribute Value: test_value"
+
+    def test_fallback_formatting_with_complex_values(self):
+        """Test fallback formatting with complex attribute values."""
+        with patch("utils.utils.HAS_COLUMNAR", False), patch("utils.utils.col", None):
+            content = [
+                ["list_attr", [1, 2, 3]],
+                ["dict_attr", {"key": "value"}],
+                ["none_attr", None],
+            ]
+            headers = ["Attribute", "Attribute Value"]
+            result = "\n".join([f"{headers[0]}: {row[0]}, {headers[1]}: {row[1]}" for row in content])
+
+            assert "list_attr" in result
+            assert "[1, 2, 3]" in result
+            assert "dict_attr" in result
+            assert "{'key': 'value'}" in result
+            assert "none_attr" in result
+
+
+try:
+    import dill
+
+    HAS_DILL = True
+except ImportError:
+    HAS_DILL = False
+
+
+class TestCheckObjectPickleabilityFalsePath:
+    """Tests for check_object_pickleability returning False with non-pickleable attributes."""
+
+    @pytest.mark.skipif(not HAS_DILL, reason="Requires dill package")
+    def test_non_pickleable_socket(self):
+        """Test with object containing socket (non-pickleable)."""
+        import socket
+
+        from utils.utils import check_object_pickleability
+
+        class SocketClass:
+            def __init__(self):
+                self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                self.name = "test"
+
+        obj = SocketClass()
+        try:
+            result = check_object_pickleability(obj)
+            assert isinstance(result, bool)
+        finally:
+            obj.sock.close()
+
+    @pytest.mark.skipif(not HAS_DILL, reason="Requires dill package")
+    def test_non_pickleable_generator(self):
+        """Test with object containing a generator."""
+        from utils.utils import check_object_pickleability
+
+        class GeneratorClass:
+            def __init__(self):
+                self.generator = (x for x in range(10))
+                self.value = 42
+
+        obj = GeneratorClass()
+        result = check_object_pickleability(obj)
+        assert isinstance(result, bool)
+
+    @pytest.mark.skipif(not HAS_DILL, reason="Requires dill package")
+    def test_non_pickleable_thread_lock(self):
+        """Test with object containing a thread lock."""
+        import threading
+
+        from utils.utils import check_object_pickleability
+
+        class LockClass:
+            def __init__(self):
+                self.lock = threading.Lock()
+                self.value = "test"
+
+        obj = LockClass()
+        result = check_object_pickleability(obj)
+        assert isinstance(result, bool)
+
+    @pytest.mark.skipif(not HAS_DILL, reason="Requires dill package")
+    def test_pickleability_returns_false_for_problematic_attr(self):
+        """Test that function returns False when any attribute is not pickleable."""
+        import dill
+
+        from utils.utils import check_object_pickleability
+
+        class ProblematicClass:
+            def __init__(self):
+                self.simple = 42
+                self.problematic = lambda x: x  # lambdas are typically not pickleable with pickle
+
+        obj = ProblematicClass()
+        result = check_object_pickleability(obj)
+        assert isinstance(result, bool)
+
+    @pytest.mark.skipif(not HAS_DILL, reason="Requires dill package")
+    def test_pickleability_all_attrs_pickleable(self):
+        """Test that function returns True when all attributes are pickleable."""
+        from utils.utils import check_object_pickleability
+
+        class SimpleClass:
+            def __init__(self):
+                self.a = 1
+                self.b = "two"
+                self.c = [1, 2, 3]
+
+        obj = SimpleClass()
+        result = check_object_pickleability(obj)
+        assert result is True
+
+    @pytest.mark.skipif(not HAS_DILL, reason="Requires dill package")
+    def test_pickleability_iterates_all_attributes(self):
+        """Test that function iterates through all __dict__ keys."""
+        from utils.utils import check_object_pickleability
+
+        class MultiAttrClass:
+            def __init__(self):
+                self.attr1 = 1
+                self.attr2 = 2
+                self.attr3 = 3
+                self.attr4 = 4
+                self.attr5 = 5
+
+        obj = MultiAttrClass()
+        result = check_object_pickleability(obj)
+        assert result is True
+
+
+class TestDisplayObjectAttributesVariousObjects:
+    """Tests for display_object_attributes with various objects."""
+
+    def test_display_object_attributes_with_logging_module(self):
+        """Test with 'logging' module."""
+        from utils.utils import display_object_attributes
+
+        try:
+            result = display_object_attributes("logging", private_attrs=False)
+            assert result is None or isinstance(result, str) or result is False
+        except AttributeError:
+            pass
+
+    def test_display_object_attributes_with_none_object(self):
+        """Test with None as object_name."""
+        from utils.utils import display_object_attributes
+
+        result = display_object_attributes(None)
+        assert result is None or result is False
+
+    def test_display_object_attributes_with_empty_string(self):
+        """Test with empty string as object_name."""
+        from utils.utils import display_object_attributes
+
+        try:
+            result = display_object_attributes("")
+            assert result is None or result is False
+        except (ModuleNotFoundError, ValueError):
+            pass
+
+    def test_display_object_attributes_with_nonexistent_module(self):
+        """Test with non-existent module name."""
+        from utils.utils import display_object_attributes
+
+        try:
+            result = display_object_attributes("nonexistent_module_xyz_123")
+            assert result is None
+        except ModuleNotFoundError:
+            pass
+
+    def test_display_object_attributes_private_attrs_true(self):
+        """Test with private_attrs=True."""
+        from utils.utils import display_object_attributes
+
+        try:
+            result = display_object_attributes("os", private_attrs=True)
+            assert result is None or isinstance(result, str) or result is False
+        except AttributeError:
+            pass
+
+    def test_display_object_attributes_private_attrs_false(self):
+        """Test with private_attrs=False."""
+        from utils.utils import display_object_attributes
+
+        try:
+            result = display_object_attributes("os", private_attrs=False)
+            assert result is None or isinstance(result, str) or result is False
+        except AttributeError:
+            pass
+
+
+class TestObjectAttributesToTableColumnarPath:
+    """Tests for _object_attributes_to_table with columnar available and unavailable."""
+
+    def test_table_with_columnar_available(self):
+        """Test table generation when columnar is available."""
+        from utils.utils import HAS_COLUMNAR
+
+        if HAS_COLUMNAR:
+            from utils.utils import _init_content_list
+
+            content = _init_content_list(True)
+            content.append(["test_attr", "test_value"])
+
+    def test_table_fallback_path_directly(self):
+        """Test the fallback formatting path directly."""
+        content = [["attr1", "value1"], ["attr2", 42], ["attr3", [1, 2, 3]]]
+        headers = ["Attribute", "Attribute Value"]
+
+        result = "\n".join([f"{headers[0]}: {row[0]}, {headers[1]}: {row[1]}" for row in content]) if content else None
+
+        assert "attr1" in result
+        assert "value1" in result
+        assert "attr2" in result
+        assert "42" in result
+        assert "attr3" in result
+
+    def test_table_with_private_attributes_filtered(self):
+        """Test that private attributes are filtered when private_attrs=False."""
+        obj_dict = {"public_attr": 1, "_private_attr": 2, "__dunder__": 3}
+        keys = list(obj_dict.keys())
+        private_attrs = False
+
+        content = []
+        for key in keys:
+            if key.startswith("_") and not private_attrs:
+                continue
+            content.append([key, obj_dict.get(key)])
+
+        assert len(content) == 1
+        assert content[0][0] == "public_attr"
+
+    def test_table_with_private_attributes_included(self):
+        """Test that private attributes are included when private_attrs=True."""
+        obj_dict = {"public_attr": 1, "_private_attr": 2, "__dunder__": 3}
+        keys = list(obj_dict.keys())
+        private_attrs = True
+
+        content = []
+        for key in keys:
+            if key.startswith("_") and not private_attrs:
+                continue
+            content.append([key, obj_dict.get(key)])
+
+        assert len(content) == 3
+
+
+class TestInitContentListEdgeCases:
+    """Edge case tests for _init_content_list function."""
+
+    def test_init_content_list_with_truthy_value(self):
+        """Test _init_content_list with various truthy values."""
+        from utils.utils import _init_content_list
+
+        assert _init_content_list(True) == []
+        assert _init_content_list(1) == []
+        assert _init_content_list("non-empty") == []
+
+    def test_init_content_list_with_falsy_value(self):
+        """Test _init_content_list with various falsy values."""
+        from utils.utils import _init_content_list
+
+        assert _init_content_list(False) is None
+        assert _init_content_list(0) is None
+        assert _init_content_list("") is None
+        assert _init_content_list(None) is None
+
+
+class TestCheckObjectPickleabilityEdgeCases:
+    """Edge case tests for check_object_pickleability function."""
+
+    @pytest.mark.skipif(not HAS_DILL, reason="Requires dill package")
+    def test_object_with_empty_dict(self):
+        """Test with object that has empty __dict__."""
+        from utils.utils import check_object_pickleability
+
+        class EmptyClass:
+            pass
+
+        obj = EmptyClass()
+        result = check_object_pickleability(obj)
+        assert result is True
+
+    @pytest.mark.skipif(not HAS_DILL, reason="Requires dill package")
+    def test_object_with_torch_tensor(self):
+        """Test with object containing torch tensor."""
+        from utils.utils import check_object_pickleability
+
+        class TensorClass:
+            def __init__(self):
+                self.tensor = torch.randn(3, 3)
+                self.value = 42
+
+        obj = TensorClass()
+        result = check_object_pickleability(obj)
+        assert isinstance(result, bool)
+
+    @pytest.mark.skipif(not HAS_DILL, reason="Requires dill package")
+    def test_object_with_numpy_array(self):
+        """Test with object containing numpy array."""
+        from utils.utils import check_object_pickleability
+
+        class NumpyClass:
+            def __init__(self):
+                self.array = np.array([1, 2, 3, 4, 5])
+                self.value = "test"
+
+        obj = NumpyClass()
+        result = check_object_pickleability(obj)
+        assert result is True
+
+    @pytest.mark.skipif(not HAS_DILL, reason="Requires dill package")
+    def test_none_instance(self):
+        """Test with None instance."""
+        from utils.utils import check_object_pickleability
+
+        result = check_object_pickleability(None)
+        assert result is False
+
+    @pytest.mark.skipif(not HAS_DILL, reason="Requires dill package")
+    def test_primitive_without_dict(self):
+        """Test with primitive type that has no __dict__."""
+        from utils.utils import check_object_pickleability
+
+        result = check_object_pickleability(42)
+        assert result is False
+
+        result = check_object_pickleability("string")
+        assert result is False
+
+        result = check_object_pickleability([1, 2, 3])
+        assert result is False
+
+
+class TestHasColumnarImport:
+    """Tests for HAS_COLUMNAR import flag."""
+
+    def test_has_columnar_is_boolean(self):
+        """Test that HAS_COLUMNAR is a boolean."""
+        from utils.utils import HAS_COLUMNAR
+
+        assert isinstance(HAS_COLUMNAR, bool)
+
+    def test_col_matches_has_columnar(self):
+        """Test that col is None when HAS_COLUMNAR is False, and not None when True."""
+        from utils.utils import HAS_COLUMNAR, col
+
+        if HAS_COLUMNAR:
+            assert col is not None
+        else:
+            assert col is None

--- a/juniper-cascor-model/tests/test_utils_extended.py
+++ b/juniper-cascor-model/tests/test_utils_extended.py
@@ -195,8 +195,10 @@ class TestDisplayObjectAttributesVariousObjects:
         try:
             result = display_object_attributes("logging", private_attrs=False)
             assert result is None or isinstance(result, str) or result is False
-        except AttributeError:
-            pass
+        except AttributeError as exc:
+            # Some environments/object layouts may raise AttributeError here;
+            # assert explicitly to avoid silently swallowing the exception.
+            assert str(exc) is not None
 
     def test_display_object_attributes_with_none_object(self):
         """Test with None as object_name."""

--- a/juniper-cascor-model/tests/test_utils_extended.py
+++ b/juniper-cascor-model/tests/test_utils_extended.py
@@ -212,8 +212,9 @@ class TestDisplayObjectAttributesVariousObjects:
         try:
             result = display_object_attributes("")
             assert result is None or result is False
-        except (ModuleNotFoundError, ValueError):
-            pass
+        except (ModuleNotFoundError, ValueError) as exc:
+            with pytest.raises(type(exc)):
+                display_object_attributes("")
 
     def test_display_object_attributes_with_nonexistent_module(self):
         """Test with non-existent module name."""

--- a/juniper-cascor-model/tests/test_utils_extended.py
+++ b/juniper-cascor-model/tests/test_utils_extended.py
@@ -223,7 +223,8 @@ class TestDisplayObjectAttributesVariousObjects:
             result = display_object_attributes("nonexistent_module_xyz_123")
             assert result is None
         except ModuleNotFoundError:
-            pass
+            with pytest.raises(ModuleNotFoundError):
+                display_object_attributes("nonexistent_module_xyz_123")
 
     def test_display_object_attributes_private_attrs_true(self):
         """Test with private_attrs=True."""

--- a/juniper-cascor-model/tests/test_utils_extended.py
+++ b/juniper-cascor-model/tests/test_utils_extended.py
@@ -245,7 +245,8 @@ class TestDisplayObjectAttributesVariousObjects:
             result = display_object_attributes("os", private_attrs=False)
             assert result is None or isinstance(result, str) or result is False
         except AttributeError:
-            pass
+            with pytest.raises(AttributeError):
+                display_object_attributes("os", private_attrs=False)
 
 
 class TestObjectAttributesToTableColumnarPath:

--- a/juniper-cascor-model/tests/test_utils_extended.py
+++ b/juniper-cascor-model/tests/test_utils_extended.py
@@ -234,7 +234,8 @@ class TestDisplayObjectAttributesVariousObjects:
             result = display_object_attributes("os", private_attrs=True)
             assert result is None or isinstance(result, str) or result is False
         except AttributeError:
-            pass
+            with pytest.raises(AttributeError):
+                display_object_attributes("os", private_attrs=True)
 
     def test_display_object_attributes_private_attrs_false(self):
         """Test with private_attrs=False."""

--- a/juniper-cascor-model/tests/test_utils_optional_deps.py
+++ b/juniper-cascor-model/tests/test_utils_optional_deps.py
@@ -55,7 +55,7 @@ class TestCheckObjectPickleabilityDillGuard:
     """check_object_pickleability must raise a clear ImportError when dill is unavailable."""
 
     def test_missing_dill_raises_actionable_import_error(self):
-        from utils.utils import check_object_pickleability
+        import utils.utils as utils_module
 
         class _Holder:
             def __init__(self):
@@ -64,7 +64,7 @@ class TestCheckObjectPickleabilityDillGuard:
         # Masking ``dill`` in sys.modules makes the in-function ``import dill`` fail.
         with patch.dict(sys.modules, {"dill": None}):
             with pytest.raises(ImportError, match="requires the 'dill' package"):
-                check_object_pickleability(_Holder())
+                utils_module.check_object_pickleability(_Holder())
 
 
 class TestSoftmaxScalarGuard:

--- a/juniper-cascor-model/tests/test_utils_optional_deps.py
+++ b/juniper-cascor-model/tests/test_utils_optional_deps.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+#####################################################################################################################################################################################################
+# Project:       Juniper
+# Prototype:     Cascade Correlation Neural Network
+# File Name:     test_utils_optional_deps.py
+# Author:        Paul Calnon
+#
+# Date Created:  2026-07-03
+#
+# License:       MIT License
+# Copyright:     Copyright (c) 2024-2026 Paul Calnon
+#
+# Description:
+#     Coverage for the optional-dependency edges of the candidate-core utils layer:
+#     the ``columnar`` import-guard fallback, the ``check_object_pickleability`` dill
+#     ImportError path, and the 0-dimensional Softmax activation guard. These exercise
+#     the branches that only run when an optional helper is absent (or a scalar pre-
+#     activation is passed), which the happy-path suites cannot reach. Part of the
+#     juniper-cascor-model per-file coverage rollout (C-5).
+#
+#####################################################################################################################################################################################################
+
+from __future__ import annotations
+
+import importlib
+import sys
+from unittest.mock import patch
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+
+class TestColumnarImportGuard:
+    """The module-level columnar import must degrade to the string-formatting fallback."""
+
+    def test_reload_without_columnar_sets_fallback_flags(self):
+        import utils.utils as utils_module
+
+        # Force the ``import columnar`` at module import time to fail, then reload so the
+        # except branch (HAS_COLUMNAR = False; col = None) executes. Always reload back to
+        # the real module state so downstream tests keep the genuine columnar binding.
+        try:
+            with patch.dict(sys.modules, {"columnar": None}):
+                importlib.reload(utils_module)
+                assert utils_module.HAS_COLUMNAR is False
+                assert utils_module.col is None
+        finally:
+            importlib.reload(utils_module)
+
+        assert utils_module.HAS_COLUMNAR is True
+
+
+class TestCheckObjectPickleabilityDillGuard:
+    """check_object_pickleability must raise a clear ImportError when dill is unavailable."""
+
+    def test_missing_dill_raises_actionable_import_error(self):
+        from utils.utils import check_object_pickleability
+
+        class _Holder:
+            def __init__(self):
+                self.value = 1
+
+        # Masking ``dill`` in sys.modules makes the in-function ``import dill`` fail.
+        with patch.dict(sys.modules, {"dill": None}):
+            with pytest.raises(ImportError, match="requires the 'dill' package"):
+                check_object_pickleability(_Holder())
+
+
+class TestSoftmaxScalarGuard:
+    """The Softmax activation wrapper must tolerate a 0-dimensional pre-activation."""
+
+    def test_zero_dim_softmax_returns_ones_like(self):
+        from utils.activation import ActivationWithDerivative
+
+        wrapper = ActivationWithDerivative(torch.nn.Softmax(dim=1))
+        scalar = torch.tensor(2.0)
+
+        result = wrapper(scalar)
+
+        assert result.dim() == 0
+        assert torch.equal(result, torch.ones_like(scalar))


### PR DESCRIPTION
## Summary

Lifts **`juniper-cascor-model`** to the ratified per-file coverage bars (every source file **>=90% statement**, every sub-module **pooled >=95% statement-weighted**) and adds the package's **first CI coverage gate**. This is **Phase C-5** of the ecosystem per-file coverage rollout (juniper-ml `notes/JUNIPER_ECOSYSTEM_PER_FILE_COVERAGE_ROLLOUT_SCOPING_2026-06-30.md`, §5 row C-5): `juniper-cascor-model` was the **ecosystem's last no-gate outlier** — CI ran a bare `pytest -v` with no coverage measurement at all.

Overall statement coverage: **71.98% -> 98.93%** (40 -> **425 tests**, ~53s). No source-file changes, no version bump, no pyproject changes.

## Per-file: before -> after (statement basis, all five shipped packages)

| File | Before | After |
|------|--------|-------|
| `candidate_unit/candidate_unit.py` | 435/566 (76.86%) | 557/566 (**98.41%**) |
| `log_config/log_config.py` | 0/161 (**0.00%**) | 159/161 (**98.76%**) |
| `log_config/logger/logger.py` | 205/418 (49.04%) | 415/418 (**99.28%**) |
| `utils/activation.py` | 43/52 (82.69%) | 51/52 (**98.08%**) |
| `utils/utils.py` | 42/72 (58.33%) | 72/72 (**100%**) |
| `cascor_constants/constants.py` | 470/476 (98.74%) | 470/476 (98.74%) — unchanged |

Every other file was already at 100%. Remaining per-file misses are unreachable/exit paths (`activation.py:114` dead `str()` fallback; `log_config.py:151-152` sys.exit-on-Logger-failure; `logger.py:406/535/579`; a few defensive `candidate_unit` branches) — all well within the 90% floor.

## Sub-module pooled: before -> after (the binding gate, statement-weighted)

| Sub-module | Before pooled | After pooled |
|------------|---------------|--------------|
| `candidate_unit` | 76.86% | **98.41%** |
| `log_config` | 0.00% | **98.76%** |
| `log_config/logger` | 49.04% | **99.28%** |
| `utils` | 68.80% | **99.20%** |
| `cascor_constants` | 98.74% | 98.74% |
| `juniper_cascor_model` | 100% | 100% |
| all `cascor_constants/constants_*` | 100% | 100% |

`juniper-coverage-gap-map --coverage-json coverage.json --enforce` exits **0** (local, ci-tools 0.6.0): `Enforcing gate: PASS (per-file statement >= 90.0%, sub-module pooled >= 95.0%)`.

## The 0% file: `log_config/log_config.py` disposition — real tests, NOT a waiver

Investigated per the scoping doc §2 waiver path. Verdict: **reachable, shipped API — covered with real tests; no `--omit`, no `# pragma`, no deletion.**

Evidence it is live API (not a dead duplicate):
- `src/spiral_problem/spiral_problem.py:111` — `from log_config.log_config import LogConfig`, instantiated at `spiral_problem.py:249`.
- cascor's own `src/tests/unit/test_log_config_coverage.py` (714 lines) already tests `LogConfig` extensively.
- It ships as part of the top-level `log_config` package (`pyproject.toml [tool.setuptools.packages.find]`).

It scored 0% here only because the cascor-model `tests/` never imported it (the smoke suite touched only `log_config.logger.logger`). Fixed by porting `test_log_config_coverage.py` and adding `test_log_config_instantiation.py` (drives the real `LogConfig.__init__`/`Logger.__init__` bootstrap).

## What changed

**New tests only (`juniper-cascor-model/tests/`):**
- Ported the drift-identical `candidate_unit` / `logger` / `utils` coverage suites verbatim from `juniper-cascor/src/tests/unit/` (the canonical house tests for this verbatim-extracted code); stripped the repo-unregistered `@pytest.mark.unit` marker to match cascor-model's marker-free suite.
- `test_log_config_instantiation.py` — real `Logger`/`LogConfig` bootstrap (custom-level registration, YAML `dictConfig` success + best-effort fallback, already-configured short-circuit). The ported suites use `Fake*` subclasses that bypass `__init__`; these drive the real path. Hermetic: config/log files redirected to `tmp_path`, global logging singleton state snapshotted + restored (order-independent).
- `test_candidate_unit_training_paths.py` — TRACE-level training so every `_log_debug`/`_log_trace`/`_log_verbose`-gated diagnostic block executes, plus coercion guards, the roll-count cap warning, the empty-correlation fallback, and display re-init.
- `test_utils_optional_deps.py` — `dill`/`columnar` import-guard branches + the 0-D Softmax activation guard.

**CI gate wiring (`.github/workflows/ci-cascor-model.yml`):**
- pytest now emits `--cov=...` (all five packages) + `--cov-report=json:coverage.json`.
- New blocking `Enforce per-file coverage gate` step: `juniper-coverage-gap-map --coverage-json coverage.json --enforce` (mirrors the C-1 `ci-protocol.yml` wiring, comment updated to C-5).
- Test job installs the existing `[full]` extra (`dill`, `columnar`) so the `utils` debug-helper paths are measured in CI (local == CI parity).

**CHANGELOG.md:** `[Unreleased]` Added/Tests entries.

## Testing

- `pytest -v --cov=... --cov-report=json:coverage.json` -> **425 passed**, overall **98.93%**.
- `juniper-coverage-gap-map --coverage-json coverage.json --enforce` -> **exit 0, PASS**.
- src drift-guard (`tests/test_drift.py`) unaffected (no source touched) and still green.
- Ran in a fresh CPU-torch venv; coverage artifacts kept out of the tree.

## Not done (out of scope / by rule)

No source changes, no version bump, no pyproject edits; no existing test weakened or deleted. **Do not merge** — owner-gated.