### PR TITLE
fix(cascor): SEC-F17 — raise torch floor to >=2.10.0 (CVE-2025-3001)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,9 @@ dependencies = [
 
 [project.optional-dependencies]
 ml = [
-    "torch>=2.0.0",
+    # SEC-F17 (CVE-2025-3001, lstm_cell memory corruption, fixed 2.10.0):
+    # floor raised 2.0.0 -> 2.10.0 to exclude the vulnerable 2.0-2.9 range.
+    "torch>=2.10.0",
     "h5py>=3.0.0",
     "matplotlib>=3.5.0",
     "PyYAML>=6.0",

--- a/requirements.lock
+++ b/requirements.lock
@@ -4,7 +4,7 @@ annotated-doc==0.0.4
     # via fastapi
 annotated-types==0.7.0
     # via pydantic
-anyio==4.14.0
+anyio==4.14.1
     # via
     #   starlette
     #   watchfiles
@@ -16,21 +16,21 @@ certifi==2026.6.17
     #   sentry-sdk
 charset-normalizer==3.4.7
     # via requests
-click==8.4.1
+click==8.4.2
     # via uvicorn
 contourpy==1.3.3
     # via matplotlib
 cuda-bindings==13.3.1
     # via torch
-cuda-pathfinder==1.5.5
+cuda-pathfinder==1.5.6
     # via cuda-bindings
 cuda-toolkit==13.0.2
     # via torch
 cycler==0.12.1
     # via matplotlib
-fastapi==0.138.0
+fastapi==0.139.0
     # via juniper-cascor (pyproject.toml)
-filelock==3.29.4
+filelock==3.29.5
     # via torch
 fonttools==4.63.0
     # via matplotlib
@@ -50,11 +50,11 @@ jinja2==3.1.6
     # via torch
 juniper-cascor-protocol==0.1.0
     # via juniper-cascor (pyproject.toml)
-juniper-data==0.8.0
+juniper-data==0.9.0
     # via juniper-cascor (pyproject.toml)
 juniper-data-client==0.4.2
     # via juniper-cascor (pyproject.toml)
-juniper-model-core==0.2.0
+juniper-model-core==0.3.0
     # via juniper-cascor (pyproject.toml)
 juniper-observability==0.4.0
     # via juniper-cascor (pyproject.toml)
@@ -68,7 +68,7 @@ mpmath==1.3.0
     # via sympy
 networkx==3.6.1
     # via torch
-numpy==2.4.6
+numpy==2.5.0
     # via
     #   juniper-cascor (pyproject.toml)
     #   contourpy
@@ -120,7 +120,7 @@ nvidia-nvtx==13.0.85
     # via cuda-toolkit
 packaging==26.2
     # via matplotlib
-pillow==12.2.0
+pillow==12.3.0
     # via matplotlib
 prometheus-client==0.25.0
     # via juniper-cascor (pyproject.toml)
@@ -152,7 +152,7 @@ pyyaml==6.0.3
     #   uvicorn
 requests==2.34.2
     # via juniper-data-client
-sentry-sdk==2.63.0
+sentry-sdk==2.64.0
     # via juniper-cascor (pyproject.toml)
 setuptools==81.0.0
     # via torch
@@ -167,7 +167,7 @@ sympy==1.14.0
     # via torch
 triton==3.7.1
     # via torch
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   fastapi
     #   pydantic


### PR DESCRIPTION
## Summary

Remediates **SEC-F17** (Medium) from the Juniper stack security audit: raises the `torch`
security floor from `>=2.0.0` to `>=2.10.0` to exclude the range affected by **CVE-2025-3001**
(`lstm_cell` memory corruption, fixed in torch 2.10.0).

## Finding

The CVE-2025-3001 fix floor `torch>=2.10.0` was declared **only** in the two model subpackages
(`juniper-cascor-model`, `juniper-recurrence-model`). The app/worker packages declared
`torch>=2.0.0`, which permits the vulnerable 2.0-2.9 range. The installed wheel is `2.12.0+cpu`
(live-verified), so the exposure is **latent / declared-minimum**, not live — but the declared
minimum should not admit a known-vulnerable version.

In this repo `torch` is declared in the **`[ml]`** optional-dependency extra (`pyproject.toml`).
This PR bumps that single line to `>=2.10.0` and adds an inline CVE-rationale comment. The two
model subpackages already comply and are untouched.

## Lockfile / freshness gate — no regen required

`requirements.lock` is compiled with `--no-emit-package torch`, so `torch` is never a pinned line;
the floor bump does not alter any pin. Verified locally by running the exact CI compile+diff with
the pinned `uv 0.11.8` (`--extra ml --extra api --extra observability --extra juniper-data
--index-strategy unsafe-best-match --no-emit-package torch --constraint requirements.lock`) — the
sorted-pin diff is **empty (gate green)**, and the resolved torch version is unchanged (2.12.0
already satisfies both floors). `lockfile-update.yml` also auto-regenerates the lock on any
`pull_request` touching `pyproject.toml`, so it may add its own independent commit; that is
orthogonal to this change.

## Verification (local)

- `pre-commit run --files pyproject.toml` → green (`check-toml` passed)
- All dependency strings parse as valid PEP 508 requirements; `torch` specifier now `>=2.10.0`
- Lockfile Freshness gate (exact CI command) → empty pin diff, green

## Out of scope — flagged for owner triage

Other `torch` references in this repo, for completeness of the SEC-F17 "everywhere torch is
declared" review:

- `conf/requirements.txt`, `conf/requirements_ci.txt`, `conf/requirements-pip.txt`: `torch==2.12.1`
  (exact pin, above the fix) — **safe**.
- `conf/conda_environment.yaml:86` pins `torch=2.9.1` (and `libtorch=2.9.1`), which is **below** the
  2.10.0 CVE fix. This is a local-dev conda env spec (the CI env `conda_environment_ci.yaml` uses
  `2.11.0`, which is safe). Bumping a conda exact-pin is a separate, non-trivial change (env re-solve)
  and is **not** addressed by this focused pyproject PR — flagged here as a possible SEC-F17 follow-up.

## Reference

- `juniper-ml` `notes/JUNIPER_STACK_SECURITY_AUDIT_PLAN_2026-07-02.md` §4.6 — **SEC-F17**
- CVE-2025-3001 (torch `lstm_cell` memory corruption, fixed 2.10.0)

**Owner-gated — do NOT auto-merge.**

---
Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX5ToumBaABH3QutQC86sM
