### PR TITLE
test(cascor): per-file coverage lift 1 — rc4_ring_buffer + routes/network to 100% (C-5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **SEC-F10 (HO-5) — runtime training-parameter bounds are now enforced on the `PATCH` *and* WebSocket update paths.** `TrainingParams` (the `POST /v1/training/start` model) always carried both floors and ceilings (e.g. `learning_rate` `le=10.0`, `candidate_pool_size` `le=256`, `max_hidden_units` `le=10_000`, `patience` `le=100_000`, `epochs_max`/`candidate_epochs`/`output_epochs` `le=1_000_000`), but the two *runtime*-update paths did not: `TrainingParamUpdateRequest` (`PATCH /v1/training/params`) declared only lower bounds, and the `set_params` WebSocket command (`/ws/control`) routed the raw JSON dict straight to `TrainingLifecycleManager.update_params` with no Pydantic model at all — only a downstream key-whitelist + candidate-pool check, neither of which range-checks scalar fields. A runtime update could therefore push an out-of-range value (live-confirmed: `max_hidden_units=999999999`) onto a running network. **Fix**: (1) `src/api/models/training.py` mirrors every `le=` ceiling from `TrainingParams` onto the corresponding `TrainingParamUpdateRequest` field (12 fields; fields stay `Optional` for partial-update semantics), so an out-of-range PATCH is rejected with 422 at the request boundary; (2) `src/api/websocket/control_stream.py` validates the incoming `set_params` payload through `TrainingParamUpdateRequest(**params)` before `update_params` and, on failure, returns a clean `command_response{status:"error", code:"invalid_params"}` ack (the WS analogue of the REST 422) without dropping the connection. A new `TestParamModelBoundsParity` guard pins the two models' shared-field numeric bounds in lock-step so the divergence cannot silently reopen. Regression coverage: `src/tests/unit/api/test_api_runtime_params.py` (over-ceiling + below-floor → 422, in-range/exact-ceiling → 200, model-bounds parity) and `src/tests/integration/api/test_ws_control_set_params.py` (WS over-ceiling / negative rejected and **not** applied to the live network; in-range still applied). Ref: juniper-ml [`notes/JUNIPER_STACK_SECURITY_AUDIT_PLAN_2026-07-02.md`](https://github.com/pcalnon/juniper-ml/blob/main/notes/JUNIPER_STACK_SECURITY_AUDIT_PLAN_2026-07-02.md) §4.3 / §5.2.
 
+### Tests
+
+- **Per-file coverage rollout (Phase C-5) — worst-first lift, part 1 of a
+  multi-PR sequence.** Lifts the two lowest-coverage source files to full
+  statement coverage, clearing the two sub-modules they dominate. No source
+  files changed; no gate flipped yet (the `juniper-coverage-gap-map --enforce`
+  CI step lands in the final gate PR once every sub-module clears). Measured on
+  the CI `unit and not slow` subset (`--cov=src`), the gate basis.
+  - `parallelism/rc4_ring_buffer.py`: **30.16% → 100%** statement — the
+    RC-4 instrumentation ring buffer is disabled-by-default (its `ENABLED`
+    flag reads `CASCOR_RC4_RING_BUFFER` at import), so a normal run
+    short-circuits every body; the new `src/tests/unit/test_rc4_ring_buffer_coverage.py`
+    drives the enabled paths by monkeypatching the module flag (never the
+    environment, so the conftest RC-4 fixtures stay inert) with per-test
+    global isolation. This clears the ecosystem's **worst** cascor
+    sub-module, `parallelism` (**69.01% → 100%** pooled).
+  - `api/routes/network.py`: **51.38% → 100%** statement — the three CAN-015h
+    handlers (`patch_weights` / `add_hidden_unit` / `delete_hidden_unit`) were
+    uncovered status→HTTP-code dispatch; `src/tests/unit/api/test_network_route_coverage.py`
+    gains a case per branch (including the defensive unmapped-sentinel 500),
+    each driven by mocking the lifecycle method to return a crafted status
+    dict (sentinels resolved off the real lifecycle instance to stay
+    drift-proof). This clears the `api/routes` sub-module
+    (**86.90% → 95.69%** pooled).
+  - Overall cascor statement coverage **90.20% → 91.12%**; files below the
+    90% floor 8 → 6, sub-modules below the 95% pooled bar 9 → 7. See juniper-ml
+    [`notes/JUNIPER_ECOSYSTEM_PER_FILE_COVERAGE_ROLLOUT_SCOPING_2026-06-30.md`](https://github.com/pcalnon/juniper-ml/blob/main/notes/JUNIPER_ECOSYSTEM_PER_FILE_COVERAGE_ROLLOUT_SCOPING_2026-06-30.md).
+
 ## [0.5.0] - 2026-05-22
 
 **Note on version history**: `pyproject.toml` was bumped 0.3.17 → 0.4.0 on 2026-03-03 in preparation for a 0.4.0 release that was never cut to PyPI (the `[0.4.0]` section below documents the work that *would have* shipped). This 0.5.0 release rolls up both that work and the subsequent ~2.5 months of changes (469 commits since `v0.3.17`) into a single PyPI release. Subsequent entries in this section list the additional work landed since 2026-03-03.

--- a/src/tests/unit/api/test_network_route_coverage.py
+++ b/src/tests/unit/api/test_network_route_coverage.py
@@ -7,6 +7,17 @@ Covers:
 - create_network: RuntimeError path (lines 25-26)
 - delete_network: RuntimeError path (lines 45-46)
 - get_topology: None topology path (line 57)
+- patch_weights (CAN-015h-1): every lifecycle-status -> HTTP-code branch,
+  including the defensive unmapped-sentinel 500 path
+- add_hidden_unit (CAN-015h-2): every status branch + unmapped 500
+- delete_hidden_unit (CAN-015h-3): every status branch + unmapped 500
+
+The CAN-015h status-dispatch branches are the bulk of the file's coverage
+gap; each is driven by mocking the lifecycle method to return a crafted
+status dict (sentinels resolved off the real lifecycle instance so the test
+never drifts from the manager's constants). Part of the per-file coverage
+rollout (Phase C-5); see juniper-ml
+``notes/JUNIPER_ECOSYSTEM_PER_FILE_COVERAGE_ROLLOUT_SCOPING_2026-06-30.md``.
 """
 
 import os
@@ -86,3 +97,129 @@ class TestGetTopologyErrors:
             response = client.get("/v1/network/topology")
             assert response.status_code == 500
             assert "Failed to extract topology" in response.json()["error"]["message"]
+
+
+# A body that satisfies PatchWeightsRequest / AddHiddenUnitRequest validation.
+# Contents are irrelevant because the lifecycle call is always mocked; the
+# handler is reached only after FastAPI validates the request body.
+_PATCH_BODY = {"target": "output", "field": "weights", "values": [[1.0]]}
+_ADD_BODY = {"weights": [0.1, 0.2, 0.3]}
+
+
+class TestPatchWeightsRoute:
+    """Tests for patch_weights (CAN-015h-1) status -> HTTP-code dispatch."""
+
+    def test_patch_weights_ok_returns_200(self, client):
+        lc = client.app.state.lifecycle
+        with patch.object(lc, "patch_weights", return_value={"status": lc._PATCH_OK}), patch.object(lc, "get_network_info", return_value={"input_size": 2}):
+            response = client.patch("/v1/network/weights", json=_PATCH_BODY)
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "success"
+        assert body["data"]["operation"] == "patch_weights"
+        assert "fsm_state" in body["data"]
+
+    @pytest.mark.parametrize(
+        "status_attr,expected_code",
+        [
+            ("_PATCH_NO_NETWORK", 404),
+            ("_PATCH_FSM_REJECTED", 409),
+            ("_PATCH_HIDDEN_UNIT_OUT_OF_RANGE", 404),
+            ("_PATCH_NAN_INF", 422),
+            ("_PATCH_BAD_TARGET", 400),
+            ("_PATCH_SHAPE_MISMATCH", 400),
+        ],
+    )
+    def test_patch_weights_error_status_maps_to_http(self, client, status_attr, expected_code):
+        lc = client.app.state.lifecycle
+        status = getattr(lc, status_attr)
+        with patch.object(lc, "patch_weights", return_value={"status": status, "detail": "patch boom"}):
+            response = client.patch("/v1/network/weights", json=_PATCH_BODY)
+        assert response.status_code == expected_code
+        assert response.json()["error"]["message"] == "patch boom"
+
+    def test_patch_weights_unmapped_status_returns_500(self, client):
+        lc = client.app.state.lifecycle
+        with patch.object(lc, "patch_weights", return_value={"status": "totally_unexpected"}):
+            response = client.patch("/v1/network/weights", json=_PATCH_BODY)
+        assert response.status_code == 500
+        assert "unexpected status" in response.json()["error"]["message"]
+
+
+class TestAddHiddenUnitRoute:
+    """Tests for add_hidden_unit (CAN-015h-2) status -> HTTP-code dispatch."""
+
+    def test_add_hidden_unit_ok_returns_200(self, client):
+        lc = client.app.state.lifecycle
+        result = {"status": lc._ADD_OK, "unit_index": 1, "num_hidden_units": 2}
+        with patch.object(lc, "add_hidden_unit_manual", return_value=result), patch.object(lc, "get_network_info", return_value={"input_size": 2}):
+            response = client.post("/v1/network/hidden-units", json=_ADD_BODY)
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert data["operation"] == "add_hidden_unit"
+        assert data["unit_index"] == 1
+        assert data["num_hidden_units"] == 2
+
+    @pytest.mark.parametrize(
+        "status_attr,expected_code",
+        [
+            ("_ADD_NO_NETWORK", 404),
+            ("_ADD_FSM_REJECTED", 409),
+            ("_ADD_AT_CAP", 409),
+            ("_ADD_NAN_INF", 422),
+            ("_ADD_BAD_ACTIVATION", 422),
+            ("_ADD_BAD_SHAPE", 400),
+        ],
+    )
+    def test_add_hidden_unit_error_status_maps_to_http(self, client, status_attr, expected_code):
+        lc = client.app.state.lifecycle
+        status = getattr(lc, status_attr)
+        with patch.object(lc, "add_hidden_unit_manual", return_value={"status": status, "detail": "add boom"}):
+            response = client.post("/v1/network/hidden-units", json=_ADD_BODY)
+        assert response.status_code == expected_code
+        assert response.json()["error"]["message"] == "add boom"
+
+    def test_add_hidden_unit_unmapped_status_returns_500(self, client):
+        lc = client.app.state.lifecycle
+        with patch.object(lc, "add_hidden_unit_manual", return_value={"status": "totally_unexpected"}):
+            response = client.post("/v1/network/hidden-units", json=_ADD_BODY)
+        assert response.status_code == 500
+        assert "unexpected status" in response.json()["error"]["message"]
+
+
+class TestDeleteHiddenUnitRoute:
+    """Tests for delete_hidden_unit (CAN-015h-3) status -> HTTP-code dispatch."""
+
+    def test_delete_hidden_unit_ok_returns_200(self, client):
+        lc = client.app.state.lifecycle
+        result = {"status": lc._REMOVE_OK, "removed_index": 0, "num_hidden_units": 1}
+        with patch.object(lc, "remove_hidden_unit_manual", return_value=result), patch.object(lc, "get_network_info", return_value={"input_size": 2}):
+            response = client.delete("/v1/network/hidden-units/0")
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert data["operation"] == "remove_hidden_unit"
+        assert data["removed_index"] == 0
+        assert data["num_hidden_units"] == 1
+
+    @pytest.mark.parametrize(
+        "status_attr,expected_code",
+        [
+            ("_REMOVE_NO_NETWORK", 404),
+            ("_REMOVE_OUT_OF_RANGE", 404),
+            ("_REMOVE_FSM_REJECTED", 409),
+        ],
+    )
+    def test_delete_hidden_unit_error_status_maps_to_http(self, client, status_attr, expected_code):
+        lc = client.app.state.lifecycle
+        status = getattr(lc, status_attr)
+        with patch.object(lc, "remove_hidden_unit_manual", return_value={"status": status, "detail": "remove boom"}):
+            response = client.delete("/v1/network/hidden-units/3")
+        assert response.status_code == expected_code
+        assert response.json()["error"]["message"] == "remove boom"
+
+    def test_delete_hidden_unit_unmapped_status_returns_500(self, client):
+        lc = client.app.state.lifecycle
+        with patch.object(lc, "remove_hidden_unit_manual", return_value={"status": "totally_unexpected"}):
+            response = client.delete("/v1/network/hidden-units/0")
+        assert response.status_code == 500
+        assert "unexpected status" in response.json()["error"]["message"]

--- a/src/tests/unit/test_rc4_ring_buffer_coverage.py
+++ b/src/tests/unit/test_rc4_ring_buffer_coverage.py
@@ -1,0 +1,227 @@
+"""Unit tests for parallelism/rc4_ring_buffer.py to raise code coverage.
+
+The module is **disabled by default** (its ``ENABLED`` flag is read from
+``CASCOR_RC4_RING_BUFFER`` at import time), so in a normal test run every
+public function short-circuits on ``if not ENABLED`` and the real bodies are
+never measured. These tests drive the enabled paths by monkeypatching the
+module-level ``ENABLED`` flag (never the environment, so the conftest RC-4
+fixtures — which key off the env var — stay inert) and isolate the module
+globals per test so the suite stays order-independent.
+
+Part of the per-file coverage rollout (Phase C-5); see juniper-ml
+``notes/JUNIPER_ECOSYSTEM_PER_FILE_COVERAGE_ROLLOUT_SCOPING_2026-06-30.md``.
+"""
+
+import os
+import queue as _queue
+import sys
+from collections import deque
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from parallelism import rc4_ring_buffer as rc4
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeQueue:
+    """Deterministic stand-in for a ``multiprocessing.Queue``.
+
+    Avoids the real queue's background feeder thread so ``put_nowait`` /
+    ``get_nowait`` behave synchronously and tests stay deterministic.
+    ``force_full=True`` makes every ``put_nowait`` raise ``queue.Full`` to
+    exercise ``emit``'s drop-on-overflow guard.
+    """
+
+    def __init__(self, maxsize: int = 0, force_full: bool = False):
+        self._items: list = []
+        self._maxsize = maxsize
+        self._force_full = force_full
+
+    def put_nowait(self, item) -> None:
+        if self._force_full or (self._maxsize and len(self._items) >= self._maxsize):
+            raise _queue.Full()
+        self._items.append(item)
+
+    def get_nowait(self):
+        if not self._items:
+            raise _queue.Empty()
+        return self._items.pop(0)
+
+
+class _FakeCtx:
+    """Minimal ``multiprocessing.context``-like object for ``init_parent_queue``."""
+
+    def __init__(self):
+        self.queue_calls = 0
+
+    def Queue(self, maxsize: int = 0) -> _FakeQueue:  # noqa: N802 - mirrors mp API
+        self.queue_calls += 1
+        return _FakeQueue(maxsize=maxsize)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_module_state(monkeypatch):
+    """Reset the module globals per test and restore them afterwards.
+
+    Defaults to ``ENABLED=False``; tests that exercise the active paths flip
+    it to ``True`` with their own ``monkeypatch.setattr``.
+    """
+    monkeypatch.setattr(rc4, "_BUFFER", deque(maxlen=10_000))
+    monkeypatch.setattr(rc4, "_INSTRUMENTATION_QUEUE", None)
+    monkeypatch.setattr(rc4, "ENABLED", False)
+
+
+def _enable(monkeypatch):
+    monkeypatch.setattr(rc4, "ENABLED", True)
+
+
+class TestIsEnabled:
+    def test_returns_flag_value(self, monkeypatch):
+        assert rc4.is_enabled() is False
+        _enable(monkeypatch)
+        assert rc4.is_enabled() is True
+
+
+class TestInitParentQueue:
+    def test_disabled_returns_none_and_leaves_global_unset(self):
+        ctx = _FakeCtx()
+        assert rc4.init_parent_queue(ctx) is None
+        assert ctx.queue_calls == 0
+        assert rc4._INSTRUMENTATION_QUEUE is None
+
+    def test_creates_queue_once_and_is_idempotent(self, monkeypatch):
+        _enable(monkeypatch)
+        ctx = _FakeCtx()
+
+        first = rc4.init_parent_queue(ctx)
+        assert first is not None
+        assert rc4._INSTRUMENTATION_QUEUE is first
+        assert ctx.queue_calls == 1
+
+        # Second call is a no-op: same queue, no new Queue() construction.
+        second = rc4.init_parent_queue(ctx)
+        assert second is first
+        assert ctx.queue_calls == 1
+
+
+class TestSetWorkerQueue:
+    def test_installs_queue_into_module_global(self):
+        sentinel = _FakeQueue()
+        rc4.set_worker_queue(sentinel)
+        assert rc4._INSTRUMENTATION_QUEUE is sentinel
+
+
+class TestEmit:
+    def test_disabled_is_a_noop(self):
+        rc4.emit("ignored", k="v")
+        assert len(rc4._BUFFER) == 0
+
+    def test_enabled_posts_to_queue_when_present(self, monkeypatch):
+        _enable(monkeypatch)
+        fake = _FakeQueue()
+        rc4.set_worker_queue(fake)
+
+        rc4.emit("worker_event", candidate=3)
+
+        record = fake.get_nowait()
+        ts, pid, event, payload = record
+        assert isinstance(ts, int)
+        assert pid == os.getpid()
+        assert event == "worker_event"
+        assert payload == {"candidate": 3}
+        # Nothing leaked into the parent deque.
+        assert len(rc4._BUFFER) == 0
+
+    def test_enabled_full_queue_is_swallowed(self, monkeypatch):
+        _enable(monkeypatch)
+        rc4.set_worker_queue(_FakeQueue(force_full=True))
+
+        # Must not raise even though put_nowait raises queue.Full.
+        rc4.emit("dropped", n=1)
+        assert len(rc4._BUFFER) == 0
+
+    def test_enabled_appends_to_buffer_when_no_queue(self, monkeypatch):
+        _enable(monkeypatch)
+        rc4.emit("parent_event", value=42)
+
+        assert len(rc4._BUFFER) == 1
+        ts, pid, event, payload = rc4._BUFFER[0]
+        assert event == "parent_event"
+        assert payload == {"value": 42}
+
+
+class TestDrainToBuffer:
+    def test_disabled_returns_zero(self):
+        assert rc4.drain_to_buffer() == 0
+
+    def test_enabled_without_queue_returns_zero(self, monkeypatch):
+        _enable(monkeypatch)
+        assert rc4.drain_to_buffer() == 0
+
+    def test_enabled_drains_queue_into_buffer(self, monkeypatch):
+        _enable(monkeypatch)
+        fake = _FakeQueue()
+        fake.put_nowait((1, 111, "a", {}))
+        fake.put_nowait((2, 222, "b", {}))
+        rc4.set_worker_queue(fake)
+
+        drained = rc4.drain_to_buffer()
+        assert drained == 2
+        assert len(rc4._BUFFER) == 2
+        # Queue emptied.
+        assert rc4.drain_to_buffer() == 0
+
+
+class TestDumpSorted:
+    def test_empty_returns_sentinel(self, monkeypatch):
+        _enable(monkeypatch)
+        assert rc4.dump_sorted() == "<empty>"
+
+    def test_orders_by_timestamp_and_formats(self, monkeypatch):
+        _enable(monkeypatch)
+        # Insert out of order; dump must sort ascending by the ns timestamp.
+        rc4._BUFFER.append((2_000, 222, "second", {"b": 2}))
+        rc4._BUFFER.append((1_000, 111, "first", {"a": 1}))
+
+        out = rc4.dump_sorted()
+        lines = out.splitlines()
+        assert len(lines) == 2
+        # First (earliest) line is offset 0 and carries its pid/event/payload.
+        assert "first" in lines[0]
+        assert "pid=" in lines[0]
+        assert "a=1" in lines[0]
+        assert "second" in lines[1]
+        assert "b=2" in lines[1]
+        # Earliest event sorts first.
+        assert lines[0].index("first") >= 0 and lines[1].index("second") >= 0
+
+
+class TestReset:
+    def test_disabled_is_a_noop(self):
+        rc4._BUFFER.append((1, 1, "keep", {}))
+        rc4.reset()  # ENABLED is False -> buffer untouched
+        assert len(rc4._BUFFER) == 1
+
+    def test_enabled_clears_buffer_without_queue(self, monkeypatch):
+        _enable(monkeypatch)
+        rc4._BUFFER.append((1, 1, "gone", {}))
+        rc4.reset()
+        assert len(rc4._BUFFER) == 0
+
+    def test_enabled_clears_buffer_and_drains_pending_queue(self, monkeypatch):
+        _enable(monkeypatch)
+        rc4._BUFFER.append((1, 1, "gone", {}))
+        fake = _FakeQueue()
+        fake.put_nowait((9, 9, "pending", {}))
+        rc4.set_worker_queue(fake)
+
+        rc4.reset()
+
+        assert len(rc4._BUFFER) == 0
+        # The lingering queue event was drained (and discarded) during reset.
+        assert fake.get_nowait.__self__ is fake  # queue object still usable
+        with pytest.raises(_queue.Empty):
+            fake.get_nowait()


### PR DESCRIPTION
## Summary

**Phase C-5** of the ecosystem per-file coverage rollout (juniper-ml
[`notes/JUNIPER_ECOSYSTEM_PER_FILE_COVERAGE_ROLLOUT_SCOPING_2026-06-30.md`](https://github.com/pcalnon/juniper-ml/blob/main/notes/JUNIPER_ECOSYSTEM_PER_FILE_COVERAGE_ROLLOUT_SCOPING_2026-06-30.md)),
unit **`juniper-cascor`** — the largest unit in the ecosystem. As the scoping doc anticipated (§5 C-5, §6 heavy-env), this is a **C-4-style split**: this PR is **part 1 — a worst-first lift**, no gate. The final `--enforce` gate PR lands after every sub-module clears.

**Tests only. No source files changed. No CI gate flipped.** The blocking `juniper-coverage-gap-map --enforce` step is deliberately **not** added yet (it lands in the last PR of the sequence); until then the ratified bars are measured advisory-only.

This PR lifts the **two lowest-coverage source files** to full statement coverage, each of which also **clears the sub-module it dominates** (including the ecosystem's worst cascor sub-module, `parallelism` at 69%):

| File | Before (stmt) | After (stmt) |
|------|--------------|--------------|
| `src/parallelism/rc4_ring_buffer.py` | 19/63 = **30.16%** | 63/63 = **100%** |
| `src/api/routes/network.py` | 56/109 = **51.38%** | 109/109 = **100%** |

Overall cascor statement coverage **90.20% → 91.12%**; files below the 90% floor **8 → 6**; sub-modules below the 95% pooled bar **9 → 7**.

## Ratified bars (measurement)

Every source file **≥ 90% statement**; every packaged sub-module **pooled ≥ 95% statement-weighted** (never mean-of-files). Measured with `juniper-coverage-gap-map` from `juniper-ci-tools 0.6.0` (advisory mode this PR) against a fresh `--cov=src --cov-report=json` run of the **CI gate subset** (`pytest -m "unit and not slow" src/tests/unit`), i.e. exactly what the gate will see.

## What changed

- **`src/tests/unit/test_rc4_ring_buffer_coverage.py`** (new, 16 tests). The RC-4 multiprocessing-race ring buffer is **disabled by default** — its module-level `ENABLED` flag reads `CASCOR_RC4_RING_BUFFER` at import time, so a normal test run short-circuits every function on `if not ENABLED` and the real bodies are never measured. The new tests drive the enabled paths by **monkeypatching the module `ENABLED` attribute** (never the environment, so the conftest RC-4 fixtures — which key off the env var — stay inert) and **isolate the module globals per test** (`_BUFFER`, `_INSTRUMENTATION_QUEUE`, `ENABLED`) so the suite is order-independent. Covers `is_enabled` / `init_parent_queue` (idempotent create + disabled) / `set_worker_queue` / `emit` (queue, buffer, and full-queue drop) / `drain_to_buffer` / `dump_sorted` (empty + ordered-format) / `reset`. A deterministic `_FakeQueue`/`_FakeCtx` avoids the real `multiprocessing.Queue` feeder thread.
- **`src/tests/unit/api/test_network_route_coverage.py`** (extended, +21 tests). The three CAN-015h handlers (`patch_weights` / `add_hidden_unit` / `delete_hidden_unit`) were entirely uncovered status→HTTP-code dispatch. Added one case per branch — success, every mapped error code, and the **defensive unmapped-sentinel 500** — each driven by mocking the lifecycle method to return a crafted status dict. Sentinels are resolved off the **real lifecycle instance** (`lc._PATCH_OK`, …) so the tests can't drift from the manager's constants. Uses the file's existing `create_app` + `TestClient` fixture pattern.
- **`CHANGELOG.md`** — `[Unreleased] → Tests` entry.

## Before → after: sub-modules cleared this PR (pooled, statement-weighted)

| Sub-module | Before pooled | After pooled | Status |
|------------|---------------|--------------|--------|
| `src/parallelism` | **69.01%** (98/142) | **100.00%** (142/142) | ✅ cleared (was worst) |
| `src/api/routes` | **86.90%** (524/603) | **95.69%** (577/603) | ✅ cleared |

Every other file and sub-module is numerically unchanged (no regressions).

## Full measured ledger (after this PR — advisory `--enforce` still FAILs, by design)

**Files still below 90% statement (6):**

| Statement % | File | Covered/Stmts |
|------------|------|---------------|
| 73.08% | `src/api/websocket/training_stream.py` | 114/156 |
| 80.45% | `src/api/lifecycle/manager.py` | 1313/1632 |
| 83.42% | `src/api/websocket/control_stream.py` | 161/193 |
| 84.90% | `src/api/app.py` | 208/245 |
| 89.20% | `src/cascade_correlation/cascade_correlation.py` | 1991/2232 |
| 89.29% | `src/api/websocket/manager.py` | 275/308 |

**Sub-modules still below 95% pooled (7):**

| Pooled % | Sub-module | Covered/Stmts | Driver |
|----------|-----------|---------------|--------|
| 83.42% | `src/api/lifecycle` | 1625/1948 | `manager.py` |
| 88.17% | `src/api/websocket` | 842/955 | `training_stream` + `control_stream` + `manager` |
| 89.20% | `src/cascade_correlation` | 1991/2232 | `cascade_correlation.py` |
| 92.05% | `src` (top level) | 81/88 | `main.py` (all files already ≥90; pooled-only gap) |
| 93.82% | `src/candidate_unit` | 531/566 | `candidate_unit.py` (≥90 file, +7 stmts to clear) |
| 94.31% | `src/utils` | 116/123 | `activation.py`/`utils.py` (≥90 files, +1 stmt) |
| 94.74% | `src/api` | 810/855 | `app.py` (lifting `app.py`≥90 also clears this) |

## Recommended remaining split (worst-first → gate last)

1. **PR-2 — `src/api/websocket/`** (`training_stream` 73% + `control_stream` 83% + `manager` 89%) → clears `src/api/websocket` (88.17% pooled). Coherent whole-layer chunk, 3 files.
2. **PR-3 — `src/api/app.py`** (84.90%→≥90) → also clears the `src/api` sub-module (94.74%).
3. **PR-4 — `src/api/lifecycle/manager.py`** (80.45%, **1632 stmts** — the single biggest lift, ~+155 covered) → clears `src/api/lifecycle`. Its own PR.
4. **PR-5 — `src/cascade_correlation/cascade_correlation.py`** (89.20%, **2232 stmts**, needs the file to ~95% ≈ +129 covered) → clears `src/cascade_correlation`. Core-algorithm file; its own PR.
5. **PR-6 — small pooled-only nudges**: `src` top-level (`main.py`), `src/candidate_unit`, `src/utils` — each already has all files ≥90 but pooled <95; a handful of statements clears all three.
6. **Final gate PR** — wire the blocking `juniper-coverage-gap-map --enforce` step into `ci.yml`'s `unit-tests` job (pin `juniper-ci-tools>=0.6.0,<0.7.0`, mirroring the C-5 wiring in cascor-model PR #365) once every sub-module clears.

## Flags / caveats

- **Subset-scope (scoping §6).** Measured on the CI `unit and not slow` subset (the gate basis), so files reachable only via integration / slow / GPU tests would read lower here. The two files lifted in this PR are fully exercised by fast unit tests — no subset-scope gap for them. Later PRs (esp. `manager.py`, `cascade_correlation.py`) should watch for lines reachable only by excluded suites and cover them with real fast unit tests, never a blanket `--omit`.
- **No exclusions / waivers used.** `rc4_ring_buffer.py` is real, shipped, reachable code (imported by `cascade_correlation` hooks + conftest), so it is **tested, not omitted** — consistent with §2 "prefer small real tests over exclusion." Zero waivers.
- **`backups/` dirs are not measured** — coverage's `source=["src"]` never imports the archived `src/**/backups/*.py`, and they aren't packaged (`[tool.setuptools.packages.find] exclude=["backups*"]`), so they never appear in the report. No `--omit` needed.

## Testing

- `pytest -m "unit and not slow" src/tests/unit --cov=src` → **green**, gate 80% reached (91.12%). Ran in the live `JuniperCascor1` env (py3.13 + torch 2.11) from the worktree; coverage artifacts kept in `/tmp`.
- New/extended tests: **41 passed** in isolation; the two target files measure **100% statement**.
- `pre-commit run --files …` → **green** (black, isort, flake8-tests, bandit-tests, async-route audit, doc-links).
- Required WS-6 gates (Golden Regression / Conformance) untouched — tests-only change.

## Not done (by rule)

No source changes, no version bump, no pyproject edits, no gate flipped; no existing test weakened, disabled, or deleted. **Do not merge — owner-gated.**
