### PR TITLE
test(cascor): per-file coverage lift 3 — API app factory (src/api/app.py) to 99% (C-5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   | `src/api/websocket/manager.py` | 275/308 = 89.29% | 308/308 = **100.00%** |
 
   The `src/api/websocket` sub-module clears the ratified ≥95% pooled bar: **88.17% → 99.37%** (842/955 → 949/955, statement-weighted).
-  
+
   - Overall cascor coverage 90.20% → 91.03%.
   - New fast unit tests (40 across `test_training_stream_coverage.py` [new], `test_control_stream_coverage.py`, and `test_websocket_manager.py`) drive the resume-handshake + replay arms (`training_stream._await_resume_frame` / `_handle_resume`), the control-path handshake gates / leaky-bucket rate-limit / invalid-params / heartbeat / idle-timeout branches (`control_stream`), and the manager's per-endpoint bookkeeping, per-IP accounting, pending-connection rejection, and defensive metric-emission guards (`manager`) — all via `AsyncMock` seams (no live sockets).
   - Measured on the CI `unit and not slow` subset (the gate basis) with `juniper-coverage-gap-map` (`juniper-ci-tools 0.6.0`, advisory).
@@ -126,6 +126,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Overall cascor statement coverage **90.20% → 91.12%**; files below the
     90% floor 8 → 6, sub-modules below the 95% pooled bar 9 → 7. See juniper-ml
     [`notes/JUNIPER_ECOSYSTEM_PER_FILE_COVERAGE_ROLLOUT_SCOPING_2026-06-30.md`](https://github.com/pcalnon/juniper-ml/blob/main/notes/JUNIPER_ECOSYSTEM_PER_FILE_COVERAGE_ROLLOUT_SCOPING_2026-06-30.md).
+
+- **Per-file coverage lift 3 (C-5) — API application factory (`src/api/app.py`).** Tests-only; no source changed, no CI gate flipped. Part 3 of the split under the ecosystem per-file coverage rollout (juniper-ml [`notes/JUNIPER_ECOSYSTEM_PER_FILE_COVERAGE_ROLLOUT_SCOPING_2026-06-30.md`](https://github.com/pcalnon/juniper-ml/blob/main/notes/JUNIPER_ECOSYSTEM_PER_FILE_COVERAGE_ROLLOUT_SCOPING_2026-06-30.md)); lifts the last sub-95 file in the `src/api` sub-module so the sub-module clears the ratified ≥95% pooled bar:
+
+  | File | Before (stmt) | After (stmt) |
+  |------|---------------|--------------|
+  | `src/api/app.py` | 208/245 = 84.90% | 243/245 = **99.18%** |
+
+  The `src/api` sub-module clears the ratified ≥95% pooled bar: **94.74% → 98.83%** (810/855 → 845/855, statement-weighted). Overall cascor statement coverage 93.42% → 93.70% (on the current base, which already includes #371's WebSocket lift). Eight new fast unit tests (extending `src/tests/unit/api/test_api_app_coverage_deep.py`) drive the previously-uncovered lifespan companion-service arms — the `auto_start_data_service` launch plus the reverse-order managed-service shutdown drain, and the `auto_start_canopy` task wiring plus its shutdown in-flight cancellation — the `_auto_start_canopy` background task (cascor-healthy / cascor-not-ready / launch-failure / exception paths), and the best-effort `_unregister_worker_metrics_collector` REGISTRY-exception arm — all via `AsyncMock` seams (no live subprocess or health poll). The two statements left uncovered are the import-time `importlib.metadata.PackageNotFoundError` version-fallback (reachable only by reimporting the module with the package uninstalled) — left as-is, no pragma. Measured on the CI `unit and not slow` subset (the gate basis) with `juniper-coverage-gap-map` (`juniper-ci-tools 0.6.0`, advisory). The blocking `--enforce` gate lands in the final PR of the split once every sub-module clears.
 
 ## [0.5.0] - 2026-05-22
 

--- a/src/tests/unit/api/test_api_app_coverage_deep.py
+++ b/src/tests/unit/api/test_api_app_coverage_deep.py
@@ -18,7 +18,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-from api.app import _auto_start_training, create_app
+from api.app import _auto_start_canopy, _auto_start_training, _unregister_worker_metrics_collector, create_app
 from api.settings import Settings
 
 pytestmark = pytest.mark.unit
@@ -471,3 +471,162 @@ class TestAppFactoryConfigurations:
         # Check key route prefixes exist
         assert any("/v1/health" in p for p in route_paths)
         assert any("/v1/network" in p for p in route_paths)
+
+
+# ------------------------------------------------------------------
+# _unregister_worker_metrics_collector — best-effort exception arm
+# (lines 118-119)
+# ------------------------------------------------------------------
+
+
+class TestUnregisterWorkerMetricsCollector:
+    """The shutdown-time collector unregister must swallow REGISTRY errors."""
+
+    def test_unregister_swallows_registry_exception(self):
+        """A ``REGISTRY.unregister`` failure is caught and logged, never raised (lines 118-119)."""
+        app = MagicMock()
+        # A non-None collector on app.state takes the function past the early return.
+        app.state.worker_metrics_collector = MagicMock(name="worker_metrics_collector")
+
+        with patch("prometheus_client.REGISTRY.unregister", side_effect=RuntimeError("registry down")) as mock_unregister:
+            # Best-effort contract: the RuntimeError is swallowed, not propagated.
+            _unregister_worker_metrics_collector(app)
+
+        mock_unregister.assert_called_once_with(app.state.worker_metrics_collector)
+
+
+# ------------------------------------------------------------------
+# Lifespan: auto_start_data_service block (lines 215, 221-232) plus the
+# managed-services shutdown drain (lines 295, 297)
+# ------------------------------------------------------------------
+
+
+class TestLifespanAutoStartDataService:
+    """Lifespan launches the juniper-data companion service when configured."""
+
+    def test_data_service_started_and_terminated(self):
+        """A successful start is tracked and terminated on shutdown (lines 215, 221-230, 295, 297)."""
+        settings = Settings(auto_start_data_service=True, auto_start=False, auto_start_canopy=False, metrics_enabled=False)
+        mock_svc = MagicMock(name="managed_data_service")
+
+        with patch("api.service_launcher.start_service", new=AsyncMock(return_value=mock_svc)) as mock_start:
+            app = create_app(settings)
+            with TestClient(app):
+                # Startup appended the launched service to managed_services.
+                assert mock_svc in app.state.managed_services
+
+        mock_start.assert_awaited_once()
+        # Shutdown drains managed_services in reverse start order (line 295) and logs (line 297).
+        mock_svc.terminate.assert_called_once_with()
+
+    def test_data_service_start_failure_logged(self):
+        """When start_service returns None the failure is logged and nothing is tracked (line 232)."""
+        settings = Settings(auto_start_data_service=True, auto_start=False, auto_start_canopy=False, metrics_enabled=False)
+
+        with patch("api.service_launcher.start_service", new=AsyncMock(return_value=None)) as mock_start:
+            app = create_app(settings)
+            with TestClient(app):
+                assert app.state.managed_services == []
+
+        mock_start.assert_awaited_once()
+
+
+# ------------------------------------------------------------------
+# Lifespan: auto_start_canopy task wiring + in-flight cancel at shutdown
+# (lines 253-256, 267-270)
+# ------------------------------------------------------------------
+
+
+class TestLifespanAutoStartCanopyWiring:
+    """Lifespan schedules the canopy auto-start task and cancels it if still running at shutdown."""
+
+    def test_canopy_task_created_and_cancelled_at_shutdown(self):
+        """auto_start_canopy schedules a tracked task; a still-pending task is cancelled on shutdown (lines 253-256, 267-270)."""
+        settings = Settings(auto_start_canopy=True, auto_start=False, auto_start_data_service=False, metrics_enabled=False)
+
+        async def _never_finishes(*args, **kwargs):
+            # Stay pending through the yield so the shutdown in-flight-cancellation branch runs.
+            await asyncio.sleep(30)
+
+        with patch("api.app._auto_start_canopy", new=_never_finishes):
+            app = create_app(settings)
+            with TestClient(app):
+                # The canopy coroutine is scheduled and tracked on app.state.startup_tasks (lines 253-256).
+                assert len(app.state.startup_tasks) == 1
+                assert app.state.startup_tasks[0].get_name() == "auto_start_canopy"
+            # Exiting TestClient runs shutdown, which cancels the still-pending task (lines 267-270).
+            assert app.state.startup_tasks[0].cancelled()
+
+
+# ------------------------------------------------------------------
+# _auto_start_canopy background task (lines 374-408)
+# ------------------------------------------------------------------
+
+
+class TestAutoStartCanopy:
+    """Direct-call coverage of the _auto_start_canopy background task.
+
+    Mirrors the ``_auto_start_training`` tests above: the handler is driven
+    directly with ``AsyncMock`` seams over ``api.service_launcher`` so no real
+    health poll or subprocess is launched. The ``app`` argument is unused by
+    the function body (it reads only ``settings`` + ``managed_services``), so a
+    bare ``MagicMock`` stands in for it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_canopy_full_success_path(self):
+        """Cascor healthy → canopy launched and tracked (lines 374-379, 389-396, 402-403)."""
+        settings = Settings(auto_start_canopy=True, auto_start=False)
+        managed_services: list = []
+        mock_svc = MagicMock(name="canopy_service")
+
+        with (
+            patch("api.service_launcher.wait_for_health", new=AsyncMock(return_value=True)) as mock_wait,
+            patch("api.service_launcher.start_service", new=AsyncMock(return_value=mock_svc)) as mock_start,
+        ):
+            await _auto_start_canopy(MagicMock(), settings, managed_services)
+
+        mock_wait.assert_awaited_once()
+        mock_start.assert_awaited_once()
+        assert managed_services == [mock_svc]
+
+    @pytest.mark.asyncio
+    async def test_canopy_aborts_when_cascor_not_healthy(self):
+        """Cascor never becomes healthy → early return, canopy not launched (lines 380-382)."""
+        settings = Settings(auto_start_canopy=True, auto_start=False)
+        managed_services: list = []
+
+        with (
+            patch("api.service_launcher.wait_for_health", new=AsyncMock(return_value=False)),
+            patch("api.service_launcher.start_service", new=AsyncMock()) as mock_start,
+        ):
+            await _auto_start_canopy(MagicMock(), settings, managed_services)
+
+        mock_start.assert_not_awaited()
+        assert managed_services == []
+
+    @pytest.mark.asyncio
+    async def test_canopy_start_failure_logged(self):
+        """start_service returns None → failure logged, nothing tracked (line 405)."""
+        settings = Settings(auto_start_canopy=True, auto_start=False)
+        managed_services: list = []
+
+        with (
+            patch("api.service_launcher.wait_for_health", new=AsyncMock(return_value=True)),
+            patch("api.service_launcher.start_service", new=AsyncMock(return_value=None)),
+        ):
+            await _auto_start_canopy(MagicMock(), settings, managed_services)
+
+        assert managed_services == []
+
+    @pytest.mark.asyncio
+    async def test_canopy_exception_is_swallowed(self):
+        """An exception inside the task body is caught and logged, never propagated (lines 407-408)."""
+        settings = Settings(auto_start_canopy=True, auto_start=False)
+        managed_services: list = []
+
+        with patch("api.service_launcher.wait_for_health", new=AsyncMock(side_effect=RuntimeError("health probe blew up"))):
+            # Must not raise — the broad except in _auto_start_canopy swallows it.
+            await _auto_start_canopy(MagicMock(), settings, managed_services)
+
+        assert managed_services == []


### PR DESCRIPTION
## Summary

Tests-only per-file coverage lift for `src/api/app.py`, **part 3** of the ratified split under the ecosystem per-file coverage rollout (Phase C-5, juniper-ml [`notes/JUNIPER_ECOSYSTEM_PER_FILE_COVERAGE_ROLLOUT_SCOPING_2026-06-30.md`](https://github.com/pcalnon/juniper-ml/blob/main/notes/JUNIPER_ECOSYSTEM_PER_FILE_COVERAGE_ROLLOUT_SCOPING_2026-06-30.md)). No production source changed, no CI gate flipped (the blocking `juniper-coverage-gap-map --enforce` step lands in the final PR of the split once every sub-module clears).

Lifts the last sub-95 file in the `src/api` sub-module so the sub-module clears the ratified ≥95% pooled bar.

## Coverage (CI `unit and not slow` subset, `--cov=src`, statement basis — the gate basis)

Measured on the rebased branch (base = current `main`, which already includes #368 and #371):

| Scope | Before | After |
|-------|--------|-------|
| `src/api/app.py` (file) | 208/245 = **84.90%** | 243/245 = **99.18%** |
| `src/api` sub-module (pooled) | 810/855 = **94.74%** | 845/855 = **98.83%** |
| overall cascor statement coverage | 93.42% | 93.70% |

Both ratified bars cleared: file ≥90 ✅ and `src/api` pooled ≥95 ✅. (`src/api/app.py` and the `src/api` direct-file pooled figures are unaffected by #371, which lifted the `src/api/websocket/` sub-directory.)

## What the new tests cover

Eight new fast unit tests extend `src/tests/unit/api/test_api_app_coverage_deep.py`, all inherit the module-level `pytest.mark.unit` (selectable by `-m "unit and not slow"`, so they run in the CI gate subset) and are driven with `AsyncMock` seams — no live subprocess, socket, or health poll:

- **`lifespan` `auto_start_data_service` arm** — companion juniper-data launch + the reverse-order managed-service shutdown drain (`app.py` lines 215, 221–232, 295, 297).
- **`lifespan` `auto_start_canopy` wiring** — task creation/tracking + the shutdown in-flight-task cancellation branch (lines 253–256, 267–270).
- **`_auto_start_canopy`** background task — cascor-healthy / cascor-not-ready / launch-failure / exception paths (lines 374–408).
- **`_unregister_worker_metrics_collector`** — best-effort `REGISTRY.unregister` exception arm (lines 118–119).

The two statements left uncovered (`app.py:35-36`) are the import-time `importlib.metadata.PackageNotFoundError` version fallback, reachable only by reimporting the module with the package uninstalled — left as-is, **no pragma / waiver / exclusion**.

Verified: none of these arms had prior coverage in *any* suite (unit, integration, or performance) — this is genuine first coverage, not a subset-scope artifact.

## Verification

- `python -m pytest -m "unit and not slow" src/tests/unit --cov=src` → all pass, exit 0; `app.py` 243/245 statement; `src/api` pooled 845/855.
- Mapper advisory (`juniper-coverage-gap-map`, `juniper-ci-tools 0.6.0`): `src/api` **98.83% pooled [ok]**; `app.py` no longer below any bar.
- `pre-commit run --all-files` green (black, isort, ruff-ASYNC, flake8, mypy, bandit, markdownlint, doc-links).
- No production code changed — `git diff origin/main` = the test file + the CHANGELOG entry only.

## Merge-order note

Sibling of the split: **#368 (lift 1) and #371 (lift 2, WebSocket) are both merged.** This branch is rebased onto current `main` (post-#371). Because CI runs on the PR **merge ref**, this diff also strips a single stray trailing-space that #371 left on a blank CHANGELOG continuation line (`--all-files` trailing-whitespace hook flagged it on `main`) — a one-character hygiene fix, no content change. `src/api/lifecycle` + `src/cascade_correlation` are later PRs in the split and are intentionally left untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvPNTfp4ydj1hPSSFudKoM
