### PR TITLE
test(cascor): per-file coverage lift 4 — lifecycle/manager.py to 98.96% (C-5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   | `src/api/websocket/manager.py` | 275/308 = 89.29% | 308/308 = **100.00%** |
 
   The `src/api/websocket` sub-module clears the ratified ≥95% pooled bar: **88.17% → 99.37%** (842/955 → 949/955, statement-weighted).
-  
+
   - Overall cascor coverage 90.20% → 91.03%.
   - New fast unit tests (40 across `test_training_stream_coverage.py` [new], `test_control_stream_coverage.py`, and `test_websocket_manager.py`) drive the resume-handshake + replay arms (`training_stream._await_resume_frame` / `_handle_resume`), the control-path handshake gates / leaky-bucket rate-limit / invalid-params / heartbeat / idle-timeout branches (`control_stream`), and the manager's per-endpoint bookkeeping, per-IP accounting, pending-connection rejection, and defensive metric-emission guards (`manager`) — all via `AsyncMock` seams (no live sockets).
   - Measured on the CI `unit and not slow` subset (the gate basis) with `juniper-coverage-gap-map` (`juniper-ci-tools 0.6.0`, advisory).
@@ -125,6 +125,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     (**86.90% → 95.69%** pooled).
   - Overall cascor statement coverage **90.20% → 91.12%**; files below the
     90% floor 8 → 6, sub-modules below the 95% pooled bar 9 → 7. See juniper-ml
+    [`notes/JUNIPER_ECOSYSTEM_PER_FILE_COVERAGE_ROLLOUT_SCOPING_2026-06-30.md`](https://github.com/pcalnon/juniper-ml/blob/main/notes/JUNIPER_ECOSYSTEM_PER_FILE_COVERAGE_ROLLOUT_SCOPING_2026-06-30.md).
+
+- **Per-file coverage rollout (Phase C-5) — cascor lift 4: `api/lifecycle/manager.py`.**
+  Tests-only; no source changed, no CI gate flipped (the
+  `juniper-coverage-gap-map --enforce` step lands in the final gate PR of the
+  split once every sub-module clears). Lifts the single largest cascor source
+  file — the `TrainingLifecycleManager` orchestrator (1632 statements) — to near-
+  full statement coverage of its previously-uncovered branches, clearing the
+  `api/lifecycle` sub-module. Part 4 of the split (after
+  [#368](https://github.com/pcalnon/juniper-cascor/pull/368) and
+  [#371](https://github.com/pcalnon/juniper-cascor/pull/371)); its scope is
+  disjoint from the concurrent websocket/app lifts. Measured on the CI
+  `unit and not slow` subset (`--cov=src`, statement basis — the gate basis).
+  - `src/api/lifecycle/manager.py`: **80.45% → 98.96%** statement
+    (1313/1632 → 1615/1632). New fast unit tests drive the module-level helper
+    classes (`_WeightHistoryRecorder` trigger/dedupe/decimation arms,
+    `_ReplaySession` + `_WeightCache` internals incl. the threaded `_run` driver,
+    `_PreSwapSnapshot`), the live dataset-swap surface (`swap_dataset_live` happy
+    path + cancel/validation/generic-error rollback arms, `_reload_dataset` via a
+    stubbed `juniper_data_client`, `_rollback_pre_swap_state`,
+    `_snapshot_abandoned_candidate_pool_size`), and the scattered manager branches
+    (network-active guards, the GAP-WS-21 broadcast-throttle + metric-emission
+    guards, interrupt-during-pause, candidate-progress drain break arms,
+    param-update triple-validation + atomic rollback, optimizer-state zeroing,
+    manual hidden-unit validation, snapshot save/load/list, restore/retrain/resume
+    edges, replay control validation, and shutdown teardown) — all via fakes /
+    `unittest.mock` seams (no training, no live sockets, no juniper-data I/O).
+  - The `src/api/lifecycle` sub-module clears the ratified ≥95% pooled bar:
+    **83.42% → 98.92%** (1625/1948 → 1927/1948, statement-weighted). Overall
+    cascor statement coverage **93.42% → 95.85%** (measured on the post-#371
+    base). The ~17 residual manager lines
+    are low-value defensive `except` arms + nested param-rollback branches, all
+    reachable by fast unit tests (none blocked by an excluded slow/integration
+    suite) — left un-chased since both the ≥90% file bar and the ≥95% pooled bar
+    clear with margin. New test files:
+    `src/tests/unit/api/test_lifecycle_weight_recorder.py`,
+    `test_lifecycle_replay_internals.py`, `test_lifecycle_manager_swap.py`,
+    `test_lifecycle_manager_coverage_ext.py`. See juniper-ml
     [`notes/JUNIPER_ECOSYSTEM_PER_FILE_COVERAGE_ROLLOUT_SCOPING_2026-06-30.md`](https://github.com/pcalnon/juniper-ml/blob/main/notes/JUNIPER_ECOSYSTEM_PER_FILE_COVERAGE_ROLLOUT_SCOPING_2026-06-30.md).
 
 ## [0.5.0] - 2026-05-22

--- a/src/tests/unit/api/test_lifecycle_manager_coverage_ext.py
+++ b/src/tests/unit/api/test_lifecycle_manager_coverage_ext.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python
+"""Extended branch coverage for ``TrainingLifecycleManager`` methods
+(per-file coverage lift 4, C-5).
+
+Covers the scattered previously-uncovered arms across the manager surface:
+network-guard rejections, the broadcast-throttle emission guard, the
+interrupt-during-pause path, live-monitoring event / metric-emission guards,
+the candidate-progress drain break arms, weight-recorder (re)attach,
+session-gauge emission guards, pause/resume happy paths, dataset-data with
+validation, param-update rollback, optimizer-state zeroing, manual hidden-unit
+validation, snapshot save/load/list, restore/retrain/resume edges, replay
+control validation, and shutdown teardown. All fast unit tests against real or
+lightly-faked networks — no training, no I/O.
+"""
+
+import threading
+import time
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from api.lifecycle.manager import InvalidCandidatePoolError, TrainingInterrupted, TrainingLifecycleManager
+from api.lifecycle.state_machine import Command
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def mgr():
+    m = TrainingLifecycleManager()
+    try:
+        yield m
+    finally:
+        m.shutdown()
+
+
+def _attach_network(m, net) -> None:
+    m.model = types.SimpleNamespace(network=net)
+
+
+class TestNetworkGuards:
+    """create/delete network reject while training is active."""
+
+    def test_create_network_rejected_while_started(self, mgr):
+        with patch.object(mgr.state_machine, "is_started", return_value=True):
+            with pytest.raises(RuntimeError, match="while training is active"):
+                mgr.create_network(input_size=2, output_size=2)
+
+    def test_delete_network_rejected_while_started(self, mgr):
+        with patch.object(mgr.state_machine, "is_started", return_value=True):
+            with pytest.raises(RuntimeError, match="while training is active"):
+                mgr.delete_network()
+
+
+class TestBroadcastThrottleGuard:
+    """The GAP-WS-21 coalescer's metric-emission guard is defensive."""
+
+    def test_coalesced_emission_failure_swallowed(self, mgr):
+        mgr._ws_manager = MagicMock()
+        mgr.training_state.update_state(status="Started")  # non-terminal
+        mgr._state_throttle_interval = 1.0
+        mgr._last_state_broadcast_time = time.monotonic()  # within throttle window
+        with patch("api.observability.ws_inc_state_throttle_coalesced", side_effect=RuntimeError("emit down")):
+            mgr._broadcast_training_state()  # throttled → emit attempt → swallowed
+        # Throttled: the state message itself was not broadcast.
+        mgr._ws_manager.broadcast_from_thread.assert_not_called()
+
+
+class TestAutoSnapCallback:
+    """``_maybe_auto_snap_callback`` no-metric short-circuit."""
+
+    def test_no_usable_metric_returns(self, mgr):
+        mgr._auto_snap_best = True
+        mgr._auto_snap_min_epochs = 0
+        with patch.object(mgr, "save_snapshot") as save:
+            mgr._maybe_auto_snap_callback(metrics={}, epoch=5, accuracy=None)
+        save.assert_not_called()
+
+
+class TestCheckForInterrupt:
+    """``_check_for_interrupt`` raises on stop signalled during pause."""
+
+    def test_stop_during_pause_raises(self, mgr):
+        mgr._stop_event.clear()
+        mgr._pause_event.clear()  # paused → enters the wait loop
+        timer = threading.Timer(0.05, mgr._stop_event.set)
+        timer.start()
+        try:
+            with pytest.raises(TrainingInterrupted):
+                mgr._check_for_interrupt()
+        finally:
+            timer.cancel()
+
+
+class TestHandleEventGuards:
+    """``_handle_event`` epoch_end step-duration emission guard."""
+
+    def test_step_duration_emission_failure_swallowed(self, mgr):
+        mgr.create_network(input_size=2, output_size=2)
+        mgr._step_timer_prev = 1.0  # prior timestamp → duration emitted
+        event = types.SimpleNamespace(type="epoch_end", payload={"metrics": {"loss": 0.5}, "epoch": 3})
+        with patch("api.lifecycle.manager.observe_training_step_duration", side_effect=RuntimeError("hist down")):
+            mgr._handle_event(event)  # emission failure swallowed
+
+
+class TestExtractMetricsGuards:
+    """``_extract_and_record_metrics`` counter / gauge emission guards."""
+
+    def _prime_history(self, mgr):
+        mgr.create_network(input_size=2, output_size=2)
+        mgr.network.history = {
+            "train_loss": [0.5],
+            "train_accuracy": [0.6],
+            "value_loss": [0.55],
+            "value_accuracy": [0.55],
+        }
+        mgr._last_emitted_history_len = 0
+
+    def test_counter_emission_failure_swallowed(self, mgr):
+        self._prime_history(mgr)
+        with patch("api.lifecycle.manager.record_training_epoch", side_effect=RuntimeError("counter down")):
+            mgr._extract_and_record_metrics()
+
+    def test_gauge_emission_failure_swallowed(self, mgr):
+        self._prime_history(mgr)
+        with patch("api.lifecycle.manager.set_training_loss", side_effect=RuntimeError("gauge down")):
+            mgr._extract_and_record_metrics()
+
+
+class TestDrainProgressQueue:
+    """``_drain_progress_queue`` break arms (best-effort)."""
+
+    def test_wait_exception_breaks(self, mgr):
+        stop_event = MagicMock()
+        stop_event.is_set.return_value = False
+        stop_event.wait.side_effect = RuntimeError("wait blew up")
+        network_ref = types.SimpleNamespace()  # no _persistent_progress_queue → _pq stays None
+        # Must return promptly (break) rather than loop forever.
+        TrainingLifecycleManager._drain_progress_queue(network_ref, stop_event, MagicMock(), MagicMock(), mgr)
+
+    def test_queue_get_exception_breaks(self, mgr):
+        stop_event = threading.Event()  # clear
+        bad_queue = MagicMock()
+        bad_queue.get.side_effect = RuntimeError("queue exploded")
+        network_ref = types.SimpleNamespace(_persistent_progress_queue=bad_queue)
+        TrainingLifecycleManager._drain_progress_queue(network_ref, stop_event, MagicMock(), MagicMock(), mgr)
+
+
+class TestAttachWeightRecorder:
+    """``_attach_weight_history_recorder`` no-network + re-init arms."""
+
+    def test_no_network_returns(self, mgr):
+        assert mgr.network is None
+        mgr._attach_weight_history_recorder()  # early return, no recorder created
+        assert mgr._weight_history_recorder is None
+
+    def test_reinit_existing_recorder(self, mgr):
+        mgr.create_network(input_size=2, output_size=2)
+        mgr._attach_weight_history_recorder()
+        first = mgr._weight_history_recorder
+        assert first is not None
+        # Second attach against the same network re-inits the existing recorder.
+        mgr._attach_weight_history_recorder()
+        assert mgr._weight_history_recorder is first
+
+
+class TestStartTrainingPendingReload:
+    """``start_training`` consumes a staged dataset config before running."""
+
+    def test_pending_config_is_reloaded(self, mgr):
+        mgr.create_network(input_size=2, output_size=2)
+        mgr._pending_dataset_config = {"dataset_type": "spiral"}
+        with patch.object(mgr, "_reload_dataset") as reload:
+            # No data supplied and the mocked reload doesn't set any → the
+            # subsequent "no training data" guard raises, but the pending
+            # config was consumed first.
+            with pytest.raises(ValueError, match="Training data not provided"):
+                mgr.start_training()
+        reload.assert_called_once()
+        assert mgr._pending_dataset_config is None
+
+
+class TestRunTrainingSessionGaugeGuards:
+    """``_run_training`` session-active gauge inc/dec guards are defensive."""
+
+    def test_inc_and_dec_emission_failures_swallowed(self, mgr):
+        mgr.create_network(input_size=2, output_size=2)
+        x = torch.zeros(4, 2)
+        y = torch.zeros(4, 2)
+        with patch.object(mgr.model, "fit"), patch("api.lifecycle.manager.inc_training_sessions", side_effect=RuntimeError("inc down")), patch("api.lifecycle.manager.dec_training_sessions", side_effect=RuntimeError("dec down")):
+            mgr._run_training(x, y, None, None)  # both guards exercised; completes cleanly
+        assert mgr.state_machine.status.name in {"COMPLETED", "STOPPED"}
+
+
+class TestPauseResumeHappyPath:
+    """pause/resume success transitions (FSM stubbed to the active states)."""
+
+    def test_pause_training_when_started(self, mgr):
+        mgr.state_machine = MagicMock()
+        mgr.state_machine.is_started.return_value = True
+        result = mgr.pause_training()
+        assert result["status"] == "paused"
+        assert not mgr._pause_event.is_set()
+
+    def test_resume_training_when_paused(self, mgr):
+        mgr.state_machine = MagicMock()
+        mgr.state_machine.is_paused.return_value = True
+        result = mgr.resume_training()
+        assert result["status"] == "resumed"
+        assert mgr._pause_event.is_set()
+
+
+class TestGetMetricsAndDataset:
+    """``get_metrics`` error guard + ``get_dataset_data`` validation branch."""
+
+    def test_get_metrics_history_error_returns_empty(self, mgr):
+        mgr.create_network(input_size=2, output_size=2)
+        bad_history = MagicMock()
+        bad_history.get.side_effect = RuntimeError("concurrent mutation")
+        mgr.network.history = bad_history
+        assert mgr.get_metrics() == {}
+
+    def test_get_dataset_data_includes_validation(self, mgr):
+        mgr._train_x = torch.randn(10, 2)
+        mgr._train_y = torch.randn(10, 2)
+        mgr._val_x = torch.randn(3, 2)
+        mgr._val_y = torch.randn(3, 2)
+        result = mgr.get_dataset_data()
+        assert "val_x" in result and "val_y" in result
+        assert len(result["val_x"]) == 3
+
+
+class TestUpdateParamsRollback:
+    """``_apply_params_unlocked`` triple validation + atomic rollback."""
+
+    def test_invalid_candidate_pool_triple_raises(self, mgr):
+        mgr.create_network(input_size=2, output_size=2)
+        with pytest.raises(InvalidCandidatePoolError):
+            mgr.update_params({"selected_candidates": 5, "candidate_pool_size": 2})
+
+    def test_rollback_reverts_optimizer_on_activation_failure(self, mgr):
+        net = types.SimpleNamespace(
+            config=types.SimpleNamespace(
+                optimizer_config=types.SimpleNamespace(optimizer_type="Adam"),
+                activation_function_name="Tanh",
+            ),
+            activation_function_name="Tanh",
+        )
+        # Re-init raises → the activation write fails after the optimizer write
+        # succeeded, so the rollback must revert optimizer_type back to Adam.
+        net._init_activation_function = MagicMock(side_effect=RuntimeError("reinit boom"))
+        _attach_network(mgr, net)
+        with pytest.raises(RuntimeError, match="reinit boom"):
+            mgr.update_params({"optimizer_type": "SGD", "activation_function_name": "ReLU"})
+        assert net.config.optimizer_config.optimizer_type == "Adam"
+
+
+class TestZeroOptimizerState:
+    """``_zero_optimizer_state_for`` zeroes running buffers, skips the rest."""
+
+    def test_zeroes_running_buffers_only(self, mgr):
+        param = object()
+        exp_avg = torch.ones(2, 2)
+        step = torch.tensor(5.0)  # 0-dim → skipped
+        optimizer = types.SimpleNamespace(state={param: {"exp_avg": exp_avg, "step": step, "note": "not-a-tensor"}})
+        net = types.SimpleNamespace(output_optimizer=optimizer)
+        _attach_network(mgr, net)
+        mgr._zero_optimizer_state_for(param)
+        assert torch.count_nonzero(optimizer.state[param]["exp_avg"]) == 0
+        assert optimizer.state[param]["step"].item() == 5.0  # untouched
+        assert optimizer.state[param]["note"] == "not-a-tensor"
+
+
+class TestAddHiddenUnitValidation:
+    """``add_hidden_unit_manual`` invalid-weights arm."""
+
+    def test_invalid_weights_returns_nan_inf(self, mgr):
+        mgr.create_network(input_size=2, output_size=2)
+        mgr.network.activation_functions_dict = {"Tanh": lambda x: x}
+        with patch.object(mgr.state_machine, "is_investigating", return_value=True):
+            result = mgr.add_hidden_unit_manual(weights=[[1.0, 2.0], [3.0]], activation="Tanh")
+        assert result["status"] == mgr._ADD_NAN_INF
+
+
+class TestSnapshotSaveLoad:
+    """save/load snapshot edges."""
+
+    def test_save_snapshot_no_network_returns_none(self, mgr):
+        assert mgr.save_snapshot() is None
+
+    def test_save_snapshot_serializer_failure_returns_none(self, mgr, tmp_path):
+        mgr.create_network(input_size=2, output_size=2)
+        fake_serializer = MagicMock()
+        fake_serializer.save_network.return_value = False
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer", return_value=fake_serializer):
+            assert mgr.save_snapshot(description="x") is None
+
+    def test_load_snapshot_injects_worker_coordinator(self, mgr, tmp_path):
+        (tmp_path / "snap_wc.h5").write_bytes(b"stub")
+        loaded_net = types.SimpleNamespace(set_worker_coordinator=MagicMock())
+        fake_serializer = MagicMock()
+        fake_serializer.load_network.return_value = loaded_net
+        mgr._worker_coordinator = MagicMock()
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer", return_value=fake_serializer), patch("api.lifecycle.manager.CascorModel", side_effect=lambda network: types.SimpleNamespace(network=network)):
+            ok = mgr._load_snapshot_to_network("snap_wc")
+        assert ok is True
+        loaded_net.set_worker_coordinator.assert_called_once_with(mgr._worker_coordinator)
+
+    def test_load_snapshot_not_found(self, mgr, tmp_path):
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path):
+            result = mgr.load_snapshot("does-not-exist")
+        assert result["loaded"] is False
+
+
+class TestRestoreRetrainResume:
+    """restore/retrain/resume rejection + tolerant-history edges."""
+
+    def test_restore_for_retrain_rejected_while_active(self, mgr):
+        with patch.object(mgr.state_machine, "is_started", return_value=True):
+            result = mgr.restore_for_retrain("snap")
+        assert result["loaded"] is False
+
+    def test_restore_for_retrain_history_reset_fallback(self, mgr):
+        class _NoDefaultList(list):
+            def __init__(self, *args):
+                if not args:
+                    raise TypeError("requires an argument")
+                super().__init__(args[0])
+
+        net = types.SimpleNamespace(history={"train_loss": _NoDefaultList([0.1, 0.2])})
+        _attach_network(mgr, net)
+        with patch.object(mgr, "_load_snapshot_to_network", return_value=True):
+            result = mgr.restore_for_retrain("snap")
+        assert result["loaded"] is True
+        # The un-reconstructable container fell back to a plain empty list.
+        assert net.history["train_loss"] == []
+
+    def test_resume_from_snapshot_tolerates_unsized_history(self, mgr):
+        net = types.SimpleNamespace(history={"train_loss": 5})  # int has no len()
+        _attach_network(mgr, net)
+        with patch.object(mgr, "_load_snapshot_to_network", return_value=True):
+            result = mgr.resume_from_snapshot("snap")
+        assert result["loaded"] is True
+        assert mgr._resume_point_epoch == 0
+
+
+class TestReplayControlAndStart:
+    """start_replay teardown-error arm + replay_control param validation."""
+
+    def test_start_replay_tolerates_prior_session_stop_error(self, mgr):
+        prior = MagicMock()
+        prior.stop.side_effect = RuntimeError("stuck thread")
+        mgr._replay_session = prior
+        net = types.SimpleNamespace(history={}, weight_history=None)
+        _attach_network(mgr, net)
+        with patch.object(mgr, "_load_snapshot_to_network", return_value=True):
+            ok = mgr.start_replay("snap")
+        assert ok is True
+        prior.stop.assert_called_once()
+
+    def test_replay_control_speed_requires_value(self, mgr):
+        mgr._replay_session = MagicMock()
+        with patch.object(mgr.state_machine, "is_replaying", return_value=True):
+            with pytest.raises(ValueError, match="speed requires"):
+                mgr.replay_control("speed")
+
+    def test_replay_control_range_requires_bounds(self, mgr):
+        mgr._replay_session = MagicMock()
+        with patch.object(mgr.state_machine, "is_replaying", return_value=True):
+            with pytest.raises(ValueError, match="range requires"):
+                mgr.replay_control("range", start=0)
+
+
+class TestSnapshotListing:
+    """list_snapshots / get_snapshot over a stubbed snapshots dir."""
+
+    def test_list_snapshots_returns_metadata(self, mgr, tmp_path):
+        (tmp_path / "snapshot_A.h5").write_bytes(b"a")
+        (tmp_path / "snapshot_B.h5").write_bytes(b"bb")
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path):
+            snaps = mgr.list_snapshots()
+        assert {s["id"] for s in snaps} == {"snapshot_A", "snapshot_B"}
+        assert all("size_bytes" in s and "modified" in s for s in snaps)
+
+    def test_get_snapshot_found_and_missing(self, mgr, tmp_path):
+        (tmp_path / "snapshot_C.h5").write_bytes(b"ccc")
+        with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path):
+            found = mgr.get_snapshot("snapshot_C")
+            missing = mgr.get_snapshot("snapshot_Z")
+        assert found is not None and found["id"] == "snapshot_C"
+        assert missing is None
+
+
+class TestShutdownTeardown:
+    """``shutdown`` drains an active replay session + executor."""
+
+    def test_shutdown_stops_replay_and_executor(self):
+        m = TrainingLifecycleManager()
+        replay = MagicMock()
+        replay.stop.side_effect = RuntimeError("stuck")  # tolerated
+        m._replay_session = replay
+        executor = MagicMock()
+        m._executor = executor
+        m.shutdown()  # single explicit shutdown (no fixture double-call)
+        replay.stop.assert_called_once()
+        # shutdown() nulls _executor after shutting it down; assert on the ref.
+        executor.shutdown.assert_called_once()
+        assert m._replay_session is None
+        assert m._executor is None

--- a/src/tests/unit/api/test_lifecycle_manager_swap.py
+++ b/src/tests/unit/api/test_lifecycle_manager_swap.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python
+"""Unit coverage for the live dataset-swap support surface of
+``TrainingLifecycleManager`` (per-file coverage lift 4, C-5).
+
+Targets the previously-uncovered swap helpers: ``_snapshot_abandoned_
+candidate_pool_size``, ``_rollback_pre_swap_state`` (incl. its best-effort
+exception arms), ``_reload_dataset`` (via a stubbed ``juniper_data_client``
+module — no network I/O), the ``swap_dataset_live`` concurrent-swap guard,
+``request_swap_cancel`` / ``_check_swap_cancel``, and the pending-dataset
+staging methods. All fast unit tests; the live network is faked so no
+training runs.
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import torch
+
+from api.lifecycle.manager import NoSwapInProgressError, SwapCancelledError, SwapInProgressError, TrainingLifecycleManager, _PreSwapSnapshot
+from api.lifecycle.state_machine import TrainingPhase
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def mgr():
+    m = TrainingLifecycleManager()
+    try:
+        yield m
+    finally:
+        m.shutdown()
+
+
+def _fake_network(**overrides) -> types.SimpleNamespace:
+    net = types.SimpleNamespace(
+        input_size=2,
+        output_size=2,
+        active_output_dim=2,
+        output_weights=torch.zeros(2, 2),
+        output_bias=torch.zeros(2),
+        hidden_units=[{"weights": torch.zeros(3)}],
+        candidate_pool_size=8,
+    )
+    for k, v in overrides.items():
+        setattr(net, k, v)
+    return net
+
+
+def _attach_network(m, net) -> None:
+    """Install a fake network without going through CascorModel wrapping."""
+    m.model = types.SimpleNamespace(network=net)
+
+
+class TestSnapshotAbandonedCandidatePoolSize:
+    """``_snapshot_abandoned_candidate_pool_size`` phase-gated read."""
+
+    def test_non_candidate_phase_returns_zero(self, mgr):
+        _attach_network(mgr, _fake_network())
+        # Fresh FSM is Idle, not CANDIDATE → 0 abandoned.
+        assert mgr._snapshot_abandoned_candidate_pool_size() == 0
+
+    def test_candidate_phase_returns_pool_size(self, mgr):
+        _attach_network(mgr, _fake_network(candidate_pool_size=16))
+        # The FSM only permits the CANDIDATE phase while STARTED; stub the
+        # phase read directly rather than driving a full training run.
+        fake_sm = MagicMock()
+        fake_sm.phase = TrainingPhase.CANDIDATE
+        mgr.state_machine = fake_sm
+        assert mgr._snapshot_abandoned_candidate_pool_size() == 16
+
+    def test_phase_read_exception_returns_zero(self, mgr):
+        _attach_network(mgr, _fake_network())
+
+        class _Boom:
+            @property
+            def phase(self):
+                raise RuntimeError("fsm unavailable")
+
+        mgr.state_machine = _Boom()
+        assert mgr._snapshot_abandoned_candidate_pool_size() == 0
+
+
+class TestRollbackPreSwapState:
+    """``_rollback_pre_swap_state`` restores tensors + sizes; arms are best-effort."""
+
+    def _make_pre(self, **overrides) -> _PreSwapSnapshot:
+        defaults = {
+            "train_x": torch.ones(4, 2),
+            "train_y": torch.zeros(4, 2),
+            "val_x": None,
+            "val_y": None,
+            "state_dict": None,
+            "input_size": 2,
+            "output_size": 2,
+            "dataset_config": {"dataset_type": "spiral"},
+            "active_output_dim": 2,
+            "output_weights": torch.full((2, 2), 3.0),
+            "output_bias": torch.full((2,), 1.0),
+            "hidden_unit_weights": [torch.full((3,), 5.0)],
+        }
+        defaults.update(overrides)
+        return _PreSwapSnapshot(**defaults)
+
+    def test_restores_tensors_sizes_and_config(self, mgr):
+        net = _fake_network(input_size=9, output_size=9, active_output_dim=1)
+        _attach_network(mgr, net)
+        pre = self._make_pre()
+        mgr._rollback_pre_swap_state(pre)
+        assert mgr._train_x is pre.train_x
+        assert net.input_size == 2
+        assert net.output_size == 2
+        assert net.active_output_dim == 2
+        assert torch.equal(net.output_weights.detach(), torch.full((2, 2), 3.0))
+        assert net.output_weights.requires_grad is True
+        assert torch.equal(net.hidden_units[0]["weights"], torch.full((3,), 5.0))
+        assert mgr._current_dataset_config == {"dataset_type": "spiral"}
+
+    def test_output_weights_clone_failure_is_logged_not_raised(self, mgr):
+        _attach_network(mgr, _fake_network())
+        bad = MagicMock()
+        bad.clone.side_effect = RuntimeError("clone failed")
+        pre = self._make_pre(output_weights=bad, output_bias=None, hidden_unit_weights=None)
+        mgr._rollback_pre_swap_state(pre)  # exception swallowed
+
+    def test_output_bias_clone_failure_is_logged_not_raised(self, mgr):
+        _attach_network(mgr, _fake_network())
+        bad = MagicMock()
+        bad.clone.side_effect = RuntimeError("clone failed")
+        pre = self._make_pre(output_weights=None, output_bias=bad, hidden_unit_weights=None)
+        mgr._rollback_pre_swap_state(pre)
+
+    def test_hidden_unit_restore_failure_is_logged_not_raised(self, mgr):
+        _attach_network(mgr, _fake_network())
+        bad = MagicMock()
+        bad.clone.side_effect = RuntimeError("clone failed")
+        pre = self._make_pre(output_weights=None, output_bias=None, hidden_unit_weights=[bad])
+        mgr._rollback_pre_swap_state(pre)
+
+    def test_state_dict_load_path_and_failure(self, mgr):
+        # A network exposing load_state_dict exercises the legacy nn.Module arm;
+        # make it raise so the best-effort except is covered too.
+        net = _fake_network(load_state_dict=MagicMock(side_effect=RuntimeError("bad state")))
+        _attach_network(mgr, net)
+        pre = self._make_pre(state_dict={"weights": 1}, output_weights=None, output_bias=None, hidden_unit_weights=None)
+        mgr._rollback_pre_swap_state(pre)
+        net.load_state_dict.assert_called_once()
+
+
+def _fake_data_client_module(*, arrays=None, create_raises=False, missing_key=False):
+    mod = types.ModuleType("juniper_data_client")
+    client = MagicMock()
+    if create_raises:
+        client.create_dataset.side_effect = RuntimeError("connection refused")
+    else:
+        client.create_dataset.return_value = {"dataset_id": "ds-42"}
+    if arrays is None:
+        arrays = {
+            "X_train": np.zeros((6, 2), dtype=np.float32),
+            "y_train": np.zeros((6, 2), dtype=np.float32),
+            "X_test": np.zeros((2, 2), dtype=np.float32),
+            "y_test": np.zeros((2, 2), dtype=np.float32),
+        }
+    if missing_key:
+        arrays = {k: v for k, v in arrays.items() if k != "X_train"}
+    client.download_artifact_npz.return_value = arrays
+    mod.JuniperDataClient = MagicMock(return_value=client)
+    return mod, client
+
+
+class TestReloadDataset:
+    """``_reload_dataset`` — juniper-data fetch path, fully stubbed."""
+
+    def test_import_error_raises_runtime_error(self, mgr):
+        with patch.dict(sys.modules, {"juniper_data_client": None}):
+            with pytest.raises(RuntimeError, match="juniper-data-client is not installed"):
+                mgr._reload_dataset(dataset_type="spiral")
+
+    def test_missing_dataset_type_raises(self, mgr):
+        mod, _ = _fake_data_client_module()
+        with patch.dict(sys.modules, {"juniper_data_client": mod}):
+            with pytest.raises(RuntimeError, match="missing required 'dataset_type'"):
+                mgr._reload_dataset(n_samples=100)  # no dataset_type
+
+    def test_happy_path_with_validation_arrays(self, mgr):
+        mod, client = _fake_data_client_module()
+        with patch.dict(sys.modules, {"juniper_data_client": mod}), patch("api.secrets.get_secret", return_value=None), patch("api.settings.Settings"):
+            mgr._reload_dataset(dataset_type="spiral", n_samples=6)
+        assert mgr._train_x is not None and mgr._train_x.shape[0] == 6
+        assert mgr._val_x is not None and mgr._val_x.shape[0] == 2
+        assert mgr._current_dataset_config["dataset_type"] == "spiral"
+
+    def test_happy_path_without_validation_arrays(self, mgr):
+        arrays = {
+            "X_train": np.zeros((5, 2), dtype=np.float32),
+            "y_train": np.zeros((5, 2), dtype=np.float32),
+        }
+        mod, client = _fake_data_client_module(arrays=arrays)
+        with patch.dict(sys.modules, {"juniper_data_client": mod}), patch("api.secrets.get_secret", return_value=None), patch("api.settings.Settings"):
+            mgr._reload_dataset(dataset_type="xor")
+        assert mgr._val_x is None and mgr._val_y is None
+
+    def test_generic_params_are_merged(self, mgr):
+        mod, client = _fake_data_client_module()
+        with patch.dict(sys.modules, {"juniper_data_client": mod}), patch("api.secrets.get_secret", return_value=None), patch("api.settings.Settings"):
+            mgr._reload_dataset(dataset_type="equities", params={"ticker": "AAPL"})
+        # The generic params dict was merged into the create_dataset params.
+        _, kwargs = client.create_dataset.call_args
+        assert kwargs["params"].get("ticker") == "AAPL"
+
+    def test_fetch_failure_raises_runtime_error(self, mgr):
+        mod, _ = _fake_data_client_module(create_raises=True)
+        with patch.dict(sys.modules, {"juniper_data_client": mod}), patch("api.secrets.get_secret", return_value=None), patch("api.settings.Settings"):
+            with pytest.raises(RuntimeError, match="juniper-data fetch failed"):
+                mgr._reload_dataset(dataset_type="spiral")
+
+    def test_missing_artifact_key_raises_runtime_error(self, mgr):
+        mod, _ = _fake_data_client_module(missing_key=True)
+        with patch.dict(sys.modules, {"juniper_data_client": mod}), patch("api.secrets.get_secret", return_value=None), patch("api.settings.Settings"):
+            with pytest.raises(RuntimeError, match="artifact missing required key"):
+                mgr._reload_dataset(dataset_type="spiral")
+
+
+class TestSwapConcurrencyAndCancel:
+    """``swap_dataset_live`` concurrent guard + cancel signalling."""
+
+    def test_concurrent_swap_raises_in_progress(self, mgr):
+        mgr._experimental_functions_enabled = True
+        mgr._swap_in_progress = True
+        with patch.object(mgr.state_machine, "is_started", return_value=True):
+            with pytest.raises(SwapInProgressError):
+                mgr.swap_dataset_live(dataset_type="spiral")
+
+    def test_request_swap_cancel_without_swap_raises(self, mgr):
+        assert mgr._swap_in_progress is False
+        with pytest.raises(NoSwapInProgressError):
+            mgr.request_swap_cancel()
+
+    def test_request_swap_cancel_sets_flag(self, mgr):
+        mgr._swap_in_progress = True
+        result = mgr.request_swap_cancel()
+        assert result["status"] == "cancel_requested"
+        assert mgr._swap_cancel_requested.is_set()
+
+    def test_check_swap_cancel_raises_when_signalled(self, mgr):
+        mgr._swap_cancel_requested.set()
+        with pytest.raises(SwapCancelledError):
+            mgr._check_swap_cancel()
+
+    def test_check_swap_cancel_noop_when_clear(self, mgr):
+        mgr._swap_cancel_requested.clear()
+        mgr._check_swap_cancel()  # no raise
+
+
+def _swap_network() -> types.SimpleNamespace:
+    """A live-swap-capable fake network (equal-dim, no real resize/fit)."""
+    net = types.SimpleNamespace(
+        input_size=2,
+        output_size=2,
+        active_output_dim=2,
+        output_weights=torch.zeros(2, 2),
+        output_bias=torch.zeros(2),
+        hidden_units=[{"weights": torch.zeros(3)}],
+        candidate_pool_size=8,
+    )
+    net._resize_network_for_dataset = MagicMock(return_value={"hidden_preserved": 1, "input_delta": 0, "output_delta": 0})
+    net.record_dataset_swap_event = MagicMock(return_value={"event": "dataset_swap", "id": 1})
+    return net
+
+
+def _reload_sets_equal_dim(mgr):
+    def _reload(**cfg):
+        mgr._train_x = torch.zeros(6, 2)
+        mgr._train_y = torch.zeros(6, 2)
+        mgr._current_dataset_config = {"dataset_type": cfg.get("dataset_type")}
+
+    return _reload
+
+
+class TestSwapDatasetLiveHappyPath:
+    """``swap_dataset_live`` end-to-end success path (network fully faked)."""
+
+    def test_swap_succeeds_and_broadcasts(self, mgr):
+        net = _swap_network()
+        _attach_network(mgr, net)
+        mgr._experimental_functions_enabled = True
+        mgr._ws_manager = MagicMock()
+        # A prior training future that raises on join exercises the
+        # future-drain except arm.
+        prior_future = MagicMock()
+        prior_future.result.side_effect = RuntimeError("worker already gone")
+        mgr._training_future = prior_future
+
+        with patch.object(mgr.state_machine, "is_started", return_value=True), patch.object(mgr, "save_snapshot", return_value={"id": "snap"}), patch.object(mgr, "_reload_dataset", side_effect=_reload_sets_equal_dim(mgr)), patch.object(mgr, "_run_training"):
+            result = mgr.swap_dataset_live(dataset_type="xor")
+
+        assert result["status"] == "swapped"
+        assert result["mode"] == "output_training_first"
+        net._resize_network_for_dataset.assert_called_once()
+        net.record_dataset_swap_event.assert_called_once()
+        mgr._ws_manager.broadcast_from_thread.assert_called()
+        # In-progress flag cleared in finally.
+        assert mgr._swap_in_progress is False
+
+    def test_swap_tolerates_record_event_failure(self, mgr):
+        net = _swap_network()
+        net.record_dataset_swap_event.side_effect = RuntimeError("history write failed")
+        _attach_network(mgr, net)
+        mgr._experimental_functions_enabled = True
+        mgr._training_future = None
+
+        with patch.object(mgr.state_machine, "is_started", return_value=True), patch.object(mgr, "save_snapshot", return_value={"id": "snap"}), patch.object(mgr, "_reload_dataset", side_effect=_reload_sets_equal_dim(mgr)), patch.object(mgr, "_run_training"):
+            result = mgr.swap_dataset_live(dataset_type="xor")
+        # The swap itself still succeeds even though the event record failed.
+        assert result["status"] == "swapped"
+
+
+class TestSwapDatasetLiveRollback:
+    """``swap_dataset_live`` cancel / validation / generic failure arms."""
+
+    def _base_patches(self, mgr):
+        return [
+            patch.object(mgr.state_machine, "is_started", return_value=True),
+            patch.object(mgr, "save_snapshot", return_value={"id": "snap"}),
+            patch.object(mgr, "_run_training"),
+        ]
+
+    def test_cancelled_swap_rolls_back(self, mgr):
+        net = _swap_network()
+        _attach_network(mgr, net)
+        mgr._experimental_functions_enabled = True
+        mgr._train_x = torch.ones(4, 2)
+        mgr._train_y = torch.zeros(4, 2)
+
+        def _reload(**cfg):
+            mgr._train_x = torch.zeros(6, 2)
+            mgr._train_y = torch.zeros(6, 2)
+            mgr._swap_cancel_requested.set()  # trip the post-fetch checkpoint
+
+        with patch.object(mgr.state_machine, "is_started", return_value=True), patch.object(mgr, "save_snapshot", return_value={"id": "snap"}), patch.object(mgr, "_run_training"), patch.object(mgr, "_reload_dataset", side_effect=_reload), patch.object(mgr, "_rollback_pre_swap_state") as rollback:
+            with pytest.raises(SwapCancelledError):
+                mgr.swap_dataset_live(dataset_type="xor")
+        rollback.assert_called_once()
+        assert mgr._swap_in_progress is False
+
+    def test_value_error_rolls_back(self, mgr):
+        net = _swap_network()
+        net._resize_network_for_dataset.side_effect = ValueError("shrink_unsupported")
+        _attach_network(mgr, net)
+        mgr._experimental_functions_enabled = True
+
+        with patch.object(mgr.state_machine, "is_started", return_value=True), patch.object(mgr, "save_snapshot", return_value={"id": "snap"}), patch.object(mgr, "_run_training"), patch.object(mgr, "_reload_dataset", side_effect=_reload_sets_equal_dim(mgr)), patch.object(mgr, "_rollback_pre_swap_state") as rollback:
+            with pytest.raises(ValueError):
+                mgr.swap_dataset_live(dataset_type="xor")
+        rollback.assert_called_once()
+
+    def test_generic_exception_rolls_back(self, mgr):
+        net = _swap_network()
+        _attach_network(mgr, net)
+        mgr._experimental_functions_enabled = True
+
+        def _reload(**cfg):
+            raise RuntimeError("juniper-data unreachable")
+
+        with patch.object(mgr.state_machine, "is_started", return_value=True), patch.object(mgr, "save_snapshot", return_value={"id": "snap"}), patch.object(mgr, "_run_training"), patch.object(mgr, "_reload_dataset", side_effect=_reload), patch.object(mgr, "_rollback_pre_swap_state") as rollback:
+            with pytest.raises(RuntimeError):
+                mgr.swap_dataset_live(dataset_type="xor")
+        rollback.assert_called_once()
+
+
+class TestPendingDatasetConfig:
+    """``stage_dataset_config`` / ``clear_pending_dataset_config``."""
+
+    def test_stage_records_config(self, mgr):
+        result = mgr.stage_dataset_config(dataset_type="spiral", n_samples=200)
+        assert result["status"] == "staged"
+        assert mgr.get_pending_dataset_config() == {"dataset_type": "spiral", "n_samples": 200}
+
+    def test_stage_empty_clears(self, mgr):
+        mgr.stage_dataset_config(dataset_type="spiral")
+        result = mgr.stage_dataset_config()  # empty cfg → cleared
+        assert result["status"] == "cleared"
+        assert mgr.get_pending_dataset_config() is None
+
+    def test_clear_pending_returns_discarded(self, mgr):
+        mgr.stage_dataset_config(dataset_type="xor")
+        result = mgr.clear_pending_dataset_config()
+        assert result["status"] == "cleared"
+        assert result["discarded"] == {"dataset_type": "xor"}
+        assert mgr.get_pending_dataset_config() is None

--- a/src/tests/unit/api/test_lifecycle_replay_internals.py
+++ b/src/tests/unit/api/test_lifecycle_replay_internals.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python
+"""Unit coverage for the module-level replay helpers in
+``api.lifecycle.manager`` (per-file coverage lift 4, C-5).
+
+Targets the previously-uncovered branches of ``_ReplaySession`` (the
+already-running ``start_thread`` guard, the ``_emit_frame`` monitor-None
+and subscriber-raises guards, and the playing arm of the ``_run`` driver
+loop) and the out-of-range per-unit slice branch of
+``_WeightCache._build_payload``. Threaded paths are exercised via a bounded
+poll and always torn down.
+"""
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from api.lifecycle.manager import _ReplaySession, _WeightCache
+
+pytestmark = pytest.mark.unit
+
+
+def _history(n: int = 5) -> dict:
+    return {
+        "train_loss": [1.0 / (i + 1) for i in range(n)],
+        "train_accuracy": [i / (n or 1) for i in range(n)],
+        "value_loss": [1.0 / (i + 1) for i in range(n)],
+        "value_accuracy": [i / (n or 1) for i in range(n)],
+    }
+
+
+def _wait_until(predicate, timeout: float = 5.0, interval: float = 0.02) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return predicate()
+
+
+class TestReplaySessionThread:
+    """``start_thread`` idempotency + the ``_run`` playing arm."""
+
+    def test_start_thread_idempotent_when_alive(self):
+        session = _ReplaySession("snap-idem", _history(0), MagicMock())
+        try:
+            session.start_thread()
+            first = session._thread
+            assert first is not None
+            # Second call sees a live thread and returns without spawning a new one.
+            session.start_thread()
+            assert session._thread is first
+        finally:
+            session.stop()
+
+    def test_run_playing_advances_to_boundary(self):
+        monitor = MagicMock()
+        session = _ReplaySession("snap-run", _history(5), monitor)
+        try:
+            session.start_thread()
+            session.set_speed(10.0)
+            session.play()
+            # The driver advances the time index while playing and auto-pauses
+            # at the range boundary (length - 1).
+            reached = _wait_until(lambda: session.time_index >= session.length - 1)
+            assert reached
+            # It emitted synthetic frames through the monitor while playing.
+            assert monitor._trigger_callbacks.call_count >= 1
+        finally:
+            session.stop()
+
+    def test_run_reverse_direction_pauses_at_lower_boundary(self):
+        monitor = MagicMock()
+        session = _ReplaySession("snap-rev", _history(5), monitor)
+        try:
+            session.seek(3)
+            session.start_thread()
+            session.set_speed(-10.0)
+            session.play()
+            reached = _wait_until(lambda: session.time_index <= session.range_start and session.paused)
+            assert reached
+        finally:
+            session.stop()
+
+
+class TestEmitFrameGuards:
+    """``_emit_frame`` short-circuits."""
+
+    def test_monitor_none_returns(self):
+        session = _ReplaySession("snap-none", _history(3), None)
+        # No monitor → emission is a no-op (must not raise).
+        session._emit_frame(0)
+
+    def test_index_out_of_range_returns(self):
+        monitor = MagicMock()
+        session = _ReplaySession("snap-oob", _history(3), monitor)
+        session._emit_frame(99)  # index >= length → no callback
+        monitor._trigger_callbacks.assert_not_called()
+
+    def test_subscriber_exception_is_swallowed(self):
+        monitor = MagicMock()
+        monitor._trigger_callbacks.side_effect = RuntimeError("subscriber blew up")
+        session = _ReplaySession("snap-raise", _history(3), monitor)
+        # A raising subscriber must not crash the (best-effort) emit path.
+        session._emit_frame(0)
+        monitor._trigger_callbacks.assert_called_once()
+
+
+class TestWeightCacheBuildPayload:
+    """``_WeightCache._build_payload`` out-of-range per-unit slice branch."""
+
+    def test_unit_slice_shorter_than_sample_index_is_skipped(self):
+        # Three samples, but the single hidden unit only carries one per-sample
+        # weight entry. Requesting sample 2 → local_idx (2) >= len(unit weights)
+        # (1) → the unit is skipped in the payload.
+        weight_history = {
+            "sampling_strategy": "adaptive",
+            "sampling_interval": 1,
+            "sample_indices": [0, 1, 2],
+            "output_weights": [[0.0], [1.0], [2.0]],
+            "output_bias": [[0.0], [0.0], [0.0]],
+            "hidden_units": [
+                {"first_sample_index": 0, "activation": "tanh", "weights": [[9.0]], "bias": [0.5]},
+            ],
+        }
+        cache = _WeightCache(weight_history)
+        payload = cache.get(2)
+        assert payload is not None
+        assert payload["sample_index"] == 2
+        # The under-length unit was skipped, leaving no hidden-unit slice.
+        assert payload["hidden_units"] == []
+
+    def test_unit_slice_present_is_included(self):
+        weight_history = {
+            "sampling_strategy": "adaptive",
+            "sampling_interval": 1,
+            "sample_indices": [0, 1],
+            "output_weights": [[0.0], [1.0]],
+            "output_bias": [[0.0], [0.0]],
+            "hidden_units": [
+                {"first_sample_index": 0, "activation": "tanh", "weights": [[9.0], [8.0]], "bias": [0.5, 0.6]},
+            ],
+        }
+        cache = _WeightCache(weight_history)
+        payload = cache.get(1)
+        assert payload is not None
+        assert len(payload["hidden_units"]) == 1
+        assert payload["hidden_units"][0]["bias"] == pytest.approx(0.6)

--- a/src/tests/unit/api/test_lifecycle_weight_recorder.py
+++ b/src/tests/unit/api/test_lifecycle_weight_recorder.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python
+"""Unit coverage for the module-level weight-history helpers in
+``api.lifecycle.manager`` (per-file coverage lift 4, C-5).
+
+Targets the previously-uncovered branches of ``_WeightHistoryRecorder``
+(trigger-callback guards, dedupe rewrite, per-unit slicing, tensor-copy
+edge cases, activation-name extraction, and cascade-aware decimation) and
+the ``_PreSwapSnapshot`` frozen container. All fast unit tests driving the
+helpers directly against lightweight fake networks — no training, no live
+sockets, no I/O.
+"""
+
+import logging
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from api.lifecycle.manager import _PreSwapSnapshot, _WeightHistoryRecorder
+
+pytestmark = pytest.mark.unit
+
+
+def _act_tanh(x):  # pragma: no cover - identity stand-in; only its __name__ is read
+    return x
+
+
+_act_tanh.__name__ = "tanh"
+
+
+def _make_unit(n_in: int = 3, bias: float = 0.25, activation=_act_tanh) -> dict:
+    """A hidden-unit dict shaped like ``cascade_correlation`` produces."""
+    return {
+        "weights": torch.arange(float(n_in)).reshape(n_in),
+        "bias": torch.tensor(bias),
+        "activation_fn": activation,
+    }
+
+
+def _make_network(*, hidden_units=None, config=None) -> types.SimpleNamespace:
+    net = types.SimpleNamespace()
+    net.config = config
+    net.hidden_units = list(hidden_units) if hidden_units is not None else []
+    net.output_weights = torch.ones(2, 2)
+    net.output_bias = torch.zeros(2)
+    return net
+
+
+def _make_recorder(*, hidden_units=None, sampling_interval=1, max_samples=1000, config=None):
+    net = _make_network(hidden_units=hidden_units, config=config)
+    monitor = MagicMock()
+    monitor.current_epoch = 0
+    return _WeightHistoryRecorder(net, monitor, sampling_interval=sampling_interval, max_samples=max_samples), net, monitor
+
+
+class TestPreSwapSnapshot:
+    """The frozen ``_PreSwapSnapshot`` container assigns every slot."""
+
+    def test_all_slots_assigned(self):
+        ow = torch.ones(2, 2)
+        ob = torch.zeros(2)
+        huw = [torch.ones(3)]
+        snap = _PreSwapSnapshot(
+            train_x=torch.ones(4, 2),
+            train_y=torch.zeros(4, 2),
+            val_x=None,
+            val_y=None,
+            state_dict={"k": 1},
+            input_size=2,
+            output_size=2,
+            dataset_config={"dataset_type": "spiral"},
+            active_output_dim=2,
+            output_weights=ow,
+            output_bias=ob,
+            hidden_unit_weights=huw,
+        )
+        assert snap.input_size == 2
+        assert snap.output_size == 2
+        assert snap.dataset_config == {"dataset_type": "spiral"}
+        assert snap.active_output_dim == 2
+        assert snap.output_weights is ow
+        assert snap.output_bias is ob
+        assert snap.hidden_unit_weights is huw
+        assert snap.state_dict == {"k": 1}
+
+
+class TestWeightRecorderInit:
+    """``__init__`` / ``_init_weight_history`` idempotency + config reads."""
+
+    def test_init_creates_weight_history_dict(self):
+        rec, net, _ = _make_recorder(sampling_interval=7)
+        assert isinstance(net.weight_history, dict)
+        assert net.weight_history["sampling_interval"] == 7
+        assert net.weight_history["sample_indices"] == []
+
+    def test_init_reads_config_defaults(self):
+        cfg = types.SimpleNamespace(weight_history_sampling_interval=13, weight_history_max_samples=77)
+        net = _make_network(config=cfg)
+        rec = _WeightHistoryRecorder(net, MagicMock())
+        assert rec.sampling_interval == 13
+        assert rec.max_samples == 77
+
+    def test_init_weight_history_is_idempotent_on_existing_dict(self):
+        rec, net, _ = _make_recorder(sampling_interval=5)
+        net.weight_history["sample_indices"].append(0)
+        rec.sampling_interval = 9
+        rec._init_weight_history()
+        # Existing samples preserved; interval refreshed.
+        assert net.weight_history["sample_indices"] == [0]
+        assert net.weight_history["sampling_interval"] == 9
+
+
+class TestOnEpochEnd:
+    """``_on_epoch_end`` periodic-trigger guards."""
+
+    def test_disabled_interval_is_noop(self):
+        rec, net, _ = _make_recorder(sampling_interval=0)
+        rec._on_epoch_end(epoch=10)
+        assert net.weight_history["sample_indices"] == []
+
+    def test_missing_epoch_returns(self):
+        rec, net, _ = _make_recorder(sampling_interval=1)
+        rec._on_epoch_end()  # no epoch kwarg
+        assert net.weight_history["sample_indices"] == []
+
+    def test_non_integer_epoch_returns(self):
+        rec, net, _ = _make_recorder(sampling_interval=1)
+        rec._on_epoch_end(epoch="not-an-int")
+        assert net.weight_history["sample_indices"] == []
+
+    def test_non_multiple_epoch_skipped(self):
+        rec, net, _ = _make_recorder(sampling_interval=50)
+        rec._on_epoch_end(epoch=7)
+        assert net.weight_history["sample_indices"] == []
+
+    def test_capture_exception_is_swallowed(self):
+        rec, net, _ = _make_recorder(sampling_interval=1)
+        with patch.object(rec, "_capture", side_effect=RuntimeError("boom")):
+            rec._on_epoch_end(epoch=2)  # multiple of interval → capture attempted
+
+    def test_capture_happy_path_records_sample(self):
+        rec, net, _ = _make_recorder(hidden_units=[_make_unit()], sampling_interval=1)
+        rec._on_epoch_end(epoch=4)
+        assert net.weight_history["sample_indices"] == [4]
+
+
+class TestOnCascadeAdd:
+    """``_on_cascade_add`` uses the monitor's ``current_epoch``."""
+
+    def test_none_epoch_returns(self):
+        rec, net, monitor = _make_recorder()
+        monitor.current_epoch = None
+        rec._on_cascade_add()
+        assert net.weight_history["sample_indices"] == []
+
+    def test_non_integer_epoch_returns(self):
+        rec, net, monitor = _make_recorder()
+        monitor.current_epoch = object()  # int() raises TypeError
+        rec._on_cascade_add()
+        assert net.weight_history["sample_indices"] == []
+
+    def test_capture_exception_swallowed(self):
+        rec, net, monitor = _make_recorder()
+        monitor.current_epoch = 3
+        with patch.object(rec, "_capture", side_effect=RuntimeError("boom")):
+            rec._on_cascade_add()
+
+    def test_missing_monitor_returns(self):
+        net = _make_network()
+        rec = _WeightHistoryRecorder(net, None, sampling_interval=1)
+        rec._on_cascade_add()  # monitor is None → early return
+        assert net.weight_history["sample_indices"] == []
+
+
+class TestCaptureTerminal:
+    """``capture_terminal`` marks the final sample cascade-equivalent."""
+
+    def test_non_integer_epoch_returns(self):
+        rec, net, monitor = _make_recorder()
+        monitor.current_epoch = "x"
+        rec.capture_terminal()
+        assert net.weight_history["sample_indices"] == []
+
+    def test_capture_exception_swallowed(self):
+        rec, net, monitor = _make_recorder()
+        monitor.current_epoch = 9
+        with patch.object(rec, "_capture", side_effect=ValueError("boom")):
+            rec.capture_terminal()
+
+    def test_happy_path_marks_cascade_epoch(self):
+        rec, net, monitor = _make_recorder(hidden_units=[_make_unit()])
+        monitor.current_epoch = 12
+        rec.capture_terminal()
+        assert 12 in net.weight_history["_cascade_epochs"]
+
+
+class TestCaptureMechanics:
+    """``_capture`` append + dedupe-rewrite paths."""
+
+    def test_append_then_dedupe_rewrite(self):
+        unit = _make_unit()
+        rec, net, _ = _make_recorder(hidden_units=[unit], sampling_interval=1)
+        # First capture at epoch 5 appends a fresh sample.
+        rec._capture(5, is_cascade_add=False)
+        assert net.weight_history["_captured_epochs"] == [5]
+        first_len = len(net.weight_history["output_weights"])
+        # Mutate the unit's weights, then re-capture the SAME epoch: the
+        # dedupe path (_write_sample_at) overwrites in place rather than
+        # appending, and the cascade flag is recorded.
+        unit["weights"] = torch.full((3,), 9.0)
+        rec._capture(5, is_cascade_add=True)
+        assert net.weight_history["_captured_epochs"] == [5]
+        assert len(net.weight_history["output_weights"]) == first_len
+        assert 5 in net.weight_history["_cascade_epochs"]
+
+    def test_rewrite_backfills_unit_added_after_first_sample(self):
+        """A unit added between a sample's first capture and its rewrite gets a slot."""
+        rec, net, _ = _make_recorder(hidden_units=[], sampling_interval=1)
+        rec._capture(5, is_cascade_add=False)  # 0 units → no hidden slices
+        # Grow a unit, then rewrite the same epoch → _append_hidden_unit_slices
+        # runs with rewrite=True and first_sample_index for the new unit.
+        net.hidden_units.append(_make_unit())
+        rec._capture(5, is_cascade_add=True)
+        assert len(net.weight_history["hidden_units"]) == 1
+
+    def test_capture_earlier_sample_after_later_unit_skips_negative_local(self):
+        """Rewriting an earlier sample whose index precedes a unit's first sample skips it."""
+        rec, net, _ = _make_recorder(hidden_units=[], sampling_interval=1)
+        rec._capture(1, is_cascade_add=False)  # sample index 0, no units
+        net.hidden_units.append(_make_unit())
+        rec._capture(2, is_cascade_add=False)  # sample index 1, unit first_sample_index=1
+        # Rewrite epoch 1 (sample index 0): unit's first_sample_index (1) > 0
+        # → local < 0 → the per-unit slice loop `continue`s.
+        rec._capture(1, is_cascade_add=True)
+        assert net.weight_history["hidden_units"][0]["first_sample_index"] == 1
+
+
+class TestTensorCopyHelpers:
+    """``_copy_unit`` / ``_tensor_to_numpy`` / ``_unit_activation_name`` edges."""
+
+    def test_copy_unit_out_of_range(self):
+        rec, net, _ = _make_recorder(hidden_units=[_make_unit()])
+        assert rec._copy_unit(99) == (None, None)
+
+    def test_copy_unit_none_bias_returns_zero(self):
+        unit = {"weights": torch.ones(3), "bias": None}
+        rec, net, _ = _make_recorder(hidden_units=[unit])
+        w, b = rec._copy_unit(0)
+        assert b == 0.0
+        assert w is not None
+
+    def test_copy_unit_object_attribute_access(self):
+        unit = types.SimpleNamespace(weights=torch.ones(3), bias=torch.tensor(0.5))
+        rec, net, _ = _make_recorder(hidden_units=[unit])
+        w, b = rec._copy_unit(0)
+        assert w is not None
+        assert b == pytest.approx(0.5)
+
+    def test_tensor_to_numpy_none(self):
+        assert _WeightHistoryRecorder._tensor_to_numpy(None) is None
+
+    def test_tensor_to_numpy_from_list(self):
+        arr = _WeightHistoryRecorder._tensor_to_numpy([1.0, 2.0, 3.0])
+        assert arr is not None
+        assert list(arr) == [1.0, 2.0, 3.0]
+
+    def test_unit_activation_name_out_of_range(self):
+        rec, net, _ = _make_recorder(hidden_units=[_make_unit()])
+        assert rec._unit_activation_name(99) == ""
+
+    def test_unit_activation_name_from_dict(self):
+        rec, net, _ = _make_recorder(hidden_units=[_make_unit(activation=_act_tanh)])
+        assert rec._unit_activation_name(0) == "tanh"
+
+    def test_unit_activation_name_non_dict_unit(self):
+        unit = types.SimpleNamespace(weights=torch.ones(3), bias=torch.tensor(0.0))
+        rec, net, _ = _make_recorder(hidden_units=[unit])
+        assert rec._unit_activation_name(0) == ""
+
+
+class TestDecimation:
+    """``_decimate`` enforces the soft cap while retaining cascade samples."""
+
+    def test_decimate_retains_cascade_and_reindexes_units(self):
+        unit = _make_unit()
+        rec, net, _ = _make_recorder(hidden_units=[unit], sampling_interval=1, max_samples=3)
+        # Capture epoch 0 as a cascade-add (retained), then non-cascade epochs
+        # 1..4. On the 4th append len(captured) > max_samples → decimation fires
+        # with a hidden unit present (exercises the per-unit re-index loop).
+        rec._capture(0, is_cascade_add=True)
+        for e in (1, 2, 3, 4):
+            rec._capture(e, is_cascade_add=False)
+        captured = net.weight_history["_captured_epochs"]
+        # Cascade sample (epoch 0) always survives decimation.
+        assert 0 in captured
+        # The soft cap dropped at least one non-cascade sample.
+        assert len(captured) < 5
+        # sampling_interval was bumped to reflect the decimation.
+        assert net.weight_history["sampling_interval"] >= 2


### PR DESCRIPTION
## Summary

Part 4 of the ratified **C-5 per-file coverage split** for juniper-cascor. Lifts the single largest cascor source file — `src/api/lifecycle/manager.py` (the `TrainingLifecycleManager` orchestrator, 1632 statements) — to near-full statement coverage, clearing the `src/api/lifecycle` sub-module against the ratified ≥95% pooled bar. **Tests only** — no production code changed, no CI gate step added (the `juniper-coverage-gap-map --enforce` gate lands in the final PR of the split once every sub-module clears).

Follows #368 (rc4_ring_buffer + routes/network) and #371 (websocket, merged); scope is disjoint from the concurrent #382 (app.py) lift.

## Coverage (CI `unit and not slow` subset, `--cov=src`, statement basis)

| Metric | Before | After |
|--------|--------|-------|
| `src/api/lifecycle/manager.py` (file) | 1313/1632 = **80.45%** | 1615/1632 = **98.96%** |
| `src/api/lifecycle` sub-module (pooled) | 1625/1948 = **83.42%** | 1927/1948 = **98.92%** |
| overall cascor (statement) | **93.42%** | **95.85%** |

Both gate bars clear with margin: the ≥90% file bar (**98.96%**) and the ≥95% pooled bar (**98.92%**, +76 covered over the 1851 needed). Measured on the post-#371 base; `manager.py` and the `lifecycle` sub-module are byte-identical to pre-#371 main (the *before* numbers hold), only the overall baseline shifted up because #371 lifted websocket.

## What the 100 new tests cover

Four new fast unit-test files under `src/tests/unit/api/`, all via fakes / `unittest.mock` seams (no training, no live sockets, no juniper-data I/O):

- **`test_lifecycle_weight_recorder.py`** — `_WeightHistoryRecorder` (trigger-callback guards, dedupe rewrite, per-unit slicing, tensor-copy edges, activation-name extraction, cascade-aware decimation) + `_PreSwapSnapshot`.
- **`test_lifecycle_replay_internals.py`** — `_ReplaySession` (the threaded `_run` driver via a bounded poll, `_emit_frame` guards) + `_WeightCache`.
- **`test_lifecycle_manager_swap.py`** — the live dataset-swap surface: `swap_dataset_live` happy path + cancel/validation/generic-error rollback arms, `_reload_dataset` (stubbed `juniper_data_client`), `_rollback_pre_swap_state`, `_snapshot_abandoned_candidate_pool_size`, `request_swap_cancel` / `_check_swap_cancel`, pending-dataset staging.
- **`test_lifecycle_manager_coverage_ext.py`** — scattered manager branches: network guards, broadcast-throttle + metric-emission guards, interrupt-during-pause, candidate-progress drain, weight-recorder (re)attach, session-gauge guards, pause/resume, dataset-data, param-update rollback, optimizer-state zeroing, manual hidden-unit validation, snapshot save/load/list, restore/retrain/resume edges, replay control, shutdown teardown.

## Flags / notes

- **No genuine production bugs found** in `manager.py` during the effort.
- **Residual (~17 lines, un-chased):** low-value defensive `except` arms (pre/post-swap snapshot + WS-broadcast failure tolerance) and the nested `_apply_params_unlocked` rollback branches (the test exercises the optimizer-key revert; the activation/lifecycle-key revert + inner-except are the residual). **All are reachable by fast unit tests — none is blocked by an excluded slow/integration suite.** Left un-chased because both bars already clear with margin (per the scoping doc §6, only a genuinely fast-unreachable cluster would be flagged; there is none here).
- **CHANGELOG hygiene:** this PR also strips a stray trailing-whitespace line that #371's merge left in the `[Unreleased] → Tests` section (one whitespace-only deletion). Without it, `pre-commit run --all-files` (the CI pre-commit job, ci.yml:101) is red on main at `bfc3f8f` — this keeps my PR's pre-commit green.
- **Merge-order:** the only overlap with in-flight siblings #382 (app.py) and #381 (notes-link chore) is the `[Unreleased] → Tests` / CHANGELOG region — a trivial textual rebase in whichever order they land. My diff does **not** touch `manager.py` source, so there is no code conflict.

## Verification

- Full CI-equivalent subset (`pytest -m "unit and not slow" src/tests/unit --cov=src`) green on the rebased tree — exit 0, coverage gate reached.
- 100 new tests pass; `--cov`-scoped numbers above computed on the statement basis (the ratified gate basis).
- `pre-commit run --all-files` clean (black, isort, flake8 + comprehensions, bandit, ruff async-audit, file hooks; mypy / markdownlint exclude `src/tests/` / CHANGELOG respectively).
- Required WS-6 Golden/Snapshot Regression + model-core Conformance gates: a tests-only diff keeps them green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvPNTfp4ydj1hPSSFudKoM
