### PR TITLE
test(cascor): per-file coverage lift 5 — cascade_correlation.py to 97.36% (C-5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Tests
 
+- **Per-file coverage lift 5 (C-5) — core CasCor engine
+  (`src/cascade_correlation/cascade_correlation.py`).** Tests-only; no source
+  changed, no CI gate flipped (the `juniper-coverage-gap-map --enforce` step
+  lands in the final gate PR of the split once every sub-module clears). Part 5
+  of the split under the ecosystem per-file coverage rollout (juniper-ml
+  [`notes/JUNIPER_ECOSYSTEM_PER_FILE_COVERAGE_ROLLOUT_SCOPING_2026-06-30.md`](https://github.com/pcalnon/juniper-ml/blob/main/notes/JUNIPER_ECOSYSTEM_PER_FILE_COVERAGE_ROLLOUT_SCOPING_2026-06-30.md));
+  lifts the single largest and lowest-coverage cascor source file — the
+  5905-line `CascadeCorrelationNetwork` training engine — clearing the
+  `src/cascade_correlation` sub-module. Its scope is disjoint from the
+  concurrent app-factory ([#382](https://github.com/pcalnon/juniper-cascor/pull/382))
+  and lifecycle ([#383](https://github.com/pcalnon/juniper-cascor/pull/383))
+  lifts. Measured on the CI `unit and not slow` subset (`--cov=src`, statement
+  basis — the gate basis).
+
+  | Scope | Before (stmt) | After (stmt) |
+  |-------|---------------|--------------|
+  | `src/cascade_correlation/cascade_correlation.py` (file) | 1991/2232 = 89.20% | 2173/2232 = **97.36%** |
+  | `src/cascade_correlation` (sub-module, pooled) | 1991/2232 = 89.20% | 2173/2232 = **97.36%** |
+
+  The `src/cascade_correlation` sub-module clears the ratified ≥95% pooled bar
+  (its only statement-bearing file dominates the pool; the package
+  `__init__.py` is a zero-statement re-export). Overall cascor statement
+  coverage **91.95% → 93.52%** (measured on the post-#371 base; the remaining
+  sub-95 siblings `src/api/app.py` and `src/api/lifecycle/` are #382 / #383's
+  scope, not touched here).
+  - 47 new fast unit tests across five files in
+    `src/tests/unit/cascade_correlation/` (`test_worker_pool_teardown_coverage.py`,
+    `test_candidate_results_coverage.py`, `test_worker_execution_coverage.py`,
+    `test_serialization_error_paths_coverage.py`,
+    `test_accuracy_residual_growth_coverage.py`) drive the previously-uncovered
+    branch families: the persistent worker-pool teardown / SIGKILL escalation +
+    active/pending SharedMemory cleanup (`_shutdown_worker_pool` and its
+    callees), the `SharedTrainingMemory` reconstruct/close/unlink edges and
+    `CandidateTrainingManager.start` validation, the candidate result
+    validation / stale-round + invalid-result discard / sequential-fallback
+    arms, the static worker helpers (`_worker_loop` instrumentation branches,
+    `_process_worker_task`, `_publish_failure_result`, `train_candidate_worker`,
+    `_build_candidate_inputs`, `_train_candidate_unit`), the HDF5
+    save/load/verify error handlers + `save_object`, and the accuracy /
+    residual-masking / network-growth validation + debug-gated arms — all via
+    fakes / `unittest.mock` seams (no worker processes, no live training, no
+    real h5py I/O; a single deterministic /dev/shm round-trip).
+  - Measured with `juniper-coverage-gap-map` (`juniper-ci-tools 0.6.0`,
+    advisory).
+  - **Findings flagged, not fixed** (a tests-only PR does not touch the core
+    engine; all ~59 residual lines leave both bars cleared with margin): (1)
+    `restore_snapshot` (line 4756) is a `@classmethod` that calls
+    `cls.__dict__.update(...)` on a read-only `mappingproxy`, so it always
+    raises and returns `False` — the success path (4757–4758) is unreachable;
+    (2) `list_hdf5_snapshots` (line 5014) calls `HDF5Utils.list_hdf5_files`,
+    which is not defined anywhere in the codebase, so every existing-directory
+    call raises `AttributeError` and returns `[]` — the success path
+    (5015–5016) is unreachable; (3) `calculate_accuracy`'s `if x is None or y
+    is None:` guard (5381–5384) is dead code (the None-defaulting at 5375–5376
+    makes `x` / `y` never `None`); (4) `_init_logging_system` (632–658) is
+    bypassed suite-wide by the autouse `_cache_logging_system` conftest fixture,
+    so its real body is not reachable from the unit subset. The rest (the
+    TaskDistributor local/remote nested dispatch in `_execute_candidate_training`,
+    the `_execute_parallel_training` finally-close, the `grow_network`
+    validate-except + debug logs, and a handful of one-line defensive
+    `except` / log arms) are all fast-unit-reachable — left un-chased only
+    because both the ≥90% file bar and the ≥95% pooled bar clear with a
+    ~2.3-point margin.
+
 - **Per-file coverage lift 2 (C-5) — WebSocket layer (`src/api/websocket/`).** Tests-only; no source changed, no CI gate flipped. Part 2 of the split under the ecosystem per-file coverage rollout (juniper-ml [`notes/JUNIPER_ECOSYSTEM_PER_FILE_COVERAGE_ROLLOUT_SCOPING_2026-06-30.md`](https://github.com/pcalnon/juniper-ml/blob/main/notes/JUNIPER_ECOSYSTEM_PER_FILE_COVERAGE_ROLLOUT_SCOPING_2026-06-30.md)); lifts the three lowest-coverage WebSocket source files — the sub-module recommended next after PR-1 ([#368](https://github.com/pcalnon/juniper-cascor/pull/368)) — to full statement coverage of their previously-uncovered branches:
 
   | File | Before (stmt) | After (stmt) |
@@ -95,7 +159,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   | `src/api/websocket/manager.py` | 275/308 = 89.29% | 308/308 = **100.00%** |
 
   The `src/api/websocket` sub-module clears the ratified ≥95% pooled bar: **88.17% → 99.37%** (842/955 → 949/955, statement-weighted).
-  
+
   - Overall cascor coverage 90.20% → 91.03%.
   - New fast unit tests (40 across `test_training_stream_coverage.py` [new], `test_control_stream_coverage.py`, and `test_websocket_manager.py`) drive the resume-handshake + replay arms (`training_stream._await_resume_frame` / `_handle_resume`), the control-path handshake gates / leaky-bucket rate-limit / invalid-params / heartbeat / idle-timeout branches (`control_stream`), and the manager's per-endpoint bookkeeping, per-IP accounting, pending-connection rejection, and defensive metric-emission guards (`manager`) — all via `AsyncMock` seams (no live sockets).
   - Measured on the CI `unit and not slow` subset (the gate basis) with `juniper-coverage-gap-map` (`juniper-ci-tools 0.6.0`, advisory).

--- a/src/tests/unit/cascade_correlation/test_accuracy_residual_growth_coverage.py
+++ b/src/tests/unit/cascade_correlation/test_accuracy_residual_growth_coverage.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+"""Coverage for accuracy, residual-error, metric-emission, and network-growth
+edges (per-file coverage lift 5, C-5).
+
+Drives the previously-uncovered validation / defensive / debug-gated arms of
+``CascadeCorrelationNetwork`` on small deterministic networks:
+
+* ``calculate_residual_error`` — the non-tensor-input reset and the P2-1d
+  active-output-dim residual masking.
+* ``_emit_candidate_correlation`` — the swallowed metric-emission failure.
+* ``calculate_accuracy`` — the output-not-a-tensor and output-batch-mismatch
+  rejections (via a patched ``forward``).
+* ``_accuracy`` — the sample-count mismatch rejection.
+* ``add_unit`` — the stale-candidate weight-dimension mismatch + the
+  debug-gated logging branches.
+* ``add_units_as_layer`` — the per-candidate weight-mismatch skip.
+* ``_add_best_candidate`` — the ``INFO``-gated entry log with a ``None``
+  candidate.
+
+The debug/info-gated branches are reached by swapping in a ``MagicMock``
+logger (whose ``isEnabledFor`` is truthy) — the suite's default no-op logger
+filters below WARNING.
+"""
+
+import logging
+import types
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import torch
+
+from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork  # noqa: F401  (import parity / readability)
+from cascade_correlation.cascade_correlation_exceptions.cascade_correlation_exceptions import ValidationError
+
+pytestmark = pytest.mark.unit
+
+
+class TestCalculateResidualError:
+    def test_non_tensor_inputs_reset_to_empty(self, simple_network):
+        # Non-None, non-tensor inputs survive the None-defaulting and hit the
+        # type-reset branch.
+        residual = simple_network.calculate_residual_error("not-a-tensor", "also-not")
+        assert isinstance(residual, torch.Tensor)
+        assert residual.shape[0] == 0
+
+    def test_active_output_dim_masks_residual_tail(self, simple_network):
+        net = simple_network
+        net.active_output_dim = 1  # output_size is 2 -> mask column 1
+        x = torch.zeros(4, 2)
+        y = torch.ones(4, 2)
+        residual = net.calculate_residual_error(x, y)
+        assert residual.shape == (4, 2)
+        # The inactive tail column was zeroed.
+        assert torch.count_nonzero(residual[:, 1:]) == 0
+
+
+class TestEmitCandidateCorrelation:
+    def test_emission_failure_swallowed(self, simple_network):
+        with patch("api.observability.set_candidate_correlation", side_effect=RuntimeError("gauge down")):
+            # Must not raise — metric emission is best-effort.
+            simple_network._emit_candidate_correlation(0.42)
+
+
+class TestCalculateAccuracyValidation:
+    def test_non_tensor_output_rejected(self, simple_network):
+        net = simple_network
+        # A numpy array has ``.shape`` (so the pre-check debug log survives) but
+        # is not a ``torch.Tensor`` -> the type-rejection arm.
+        with patch.object(net, "forward", return_value=np.zeros((4, 2))):
+            with pytest.raises(ValueError, match="Output tensor must be of type torch.Tensor"):
+                net.calculate_accuracy(torch.zeros(4, 2), torch.zeros(4, 2))
+
+    def test_output_batch_mismatch_rejected(self, simple_network):
+        net = simple_network
+        # Same feature dim, different sample count -> the shape[0] mismatch arm.
+        with patch.object(net, "forward", return_value=torch.zeros(3, 2)):
+            with pytest.raises(ValueError, match="compatible shapes"):
+                net.calculate_accuracy(torch.zeros(4, 2), torch.zeros(4, 2))
+
+
+class TestAccuracyValidation:
+    def test_sample_count_mismatch_rejected(self, simple_network):
+        with pytest.raises(ValueError, match="same number of samples"):
+            simple_network._accuracy(y=torch.zeros(4, 2), output=torch.zeros(3, 2))
+
+
+class TestAddUnit:
+    def test_stale_candidate_weight_mismatch_raises(self, simple_network):
+        net = simple_network
+        x = torch.zeros(4, 2)
+        # Fresh network: candidate_input width == input_size == 2; give the
+        # candidate a mismatched (size-3) weight vector.
+        candidate = types.SimpleNamespace(weights=torch.zeros(3), bias=torch.zeros(1), correlation=0.5)
+        with pytest.raises(ValidationError, match="weight dimension mismatch"):
+            net.add_unit(candidate, x)
+
+    def test_debug_gated_logging_branches(self, simple_network):
+        net = simple_network
+        net.logger = MagicMock()
+        net.logger.isEnabledFor.return_value = True  # force the debug branches
+        x = torch.zeros(4, 2)
+        candidate = types.SimpleNamespace(weights=torch.zeros(2), bias=torch.zeros(1), correlation=0.5)
+        before = len(net.hidden_units)
+        net.add_unit(candidate, x)
+        assert len(net.hidden_units) == before + 1
+        # The debug-gated new-unit output computation ran.
+        assert net.logger.isEnabledFor.call_args_list  # isEnabledFor was consulted
+        assert net.logger.isEnabledFor.call_args_list[0].args == (logging.DEBUG,)
+
+
+class TestAddUnitsAsLayer:
+    def test_mismatched_candidate_skipped(self, simple_network):
+        net = simple_network
+        x = torch.zeros(4, 2)
+        before = len(net.hidden_units)
+        mismatched = types.SimpleNamespace(candidate=types.SimpleNamespace(weights=torch.zeros(3)))
+        net.add_units_as_layer([mismatched], x)
+        # The single mismatched candidate was skipped -> no unit added.
+        assert len(net.hidden_units) == before
+
+
+class TestAddBestCandidate:
+    def test_info_gated_log_with_none_candidate(self, simple_network):
+        net = simple_network
+        net.logger = MagicMock()
+        net.logger.isEnabledFor.return_value = True  # force the INFO entry log
+        train_loss, train_accuracy = net._add_best_candidate(best_candidate=None)
+        assert train_loss is None and train_accuracy is None
+        net.logger.isEnabledFor.assert_any_call(logging.INFO)

--- a/src/tests/unit/cascade_correlation/test_candidate_results_coverage.py
+++ b/src/tests/unit/cascade_correlation/test_candidate_results_coverage.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python
+"""Coverage for candidate result collection, validation, and task generation
+(per-file coverage lift 5, C-5).
+
+Drives the previously-uncovered arms of the candidate-training result pipeline
+on ``CascadeCorrelationNetwork``:
+
+* ``_validate_training_result`` — the security / bounds rejections
+  (non-numeric correlation, NaN candidate weights, elevated + over-limit
+  weight magnitudes).
+* ``_collect_training_results`` — the invalid-result discard, the stale-round
+  discard, and the stale-summary log.
+* ``_execute_sequential_training`` — the per-task exception fallback.
+* ``_process_training_results`` — the success-vs-threshold mismatch log.
+* ``train_candidates`` — the ``CandidateTrainingError`` re-raise and the
+  generic-error ``TrainingError`` wrap.
+* ``_generate_candidate_tasks`` — the SharedMemory-creation-failed fallback
+  to full (non-shared) task tuples.
+
+All fast unit tests with fakes / ``unittest.mock`` seams — no worker processes.
+"""
+
+import datetime
+from queue import Empty
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+import cascade_correlation.cascade_correlation as cc_mod
+from candidate_unit.candidate_unit import CandidateTrainingResult, CandidateUnit
+from cascade_correlation.cascade_correlation import CandidateTrainingError, TrainingError
+
+pytestmark = pytest.mark.unit
+
+
+def _candidate_with_weights(weights, bias=0.0):
+    cu = CandidateUnit(CandidateUnit__input_size=len(weights))
+    cu.weights = torch.tensor(weights, dtype=torch.float32)
+    cu.bias = torch.tensor([bias], dtype=torch.float32)
+    return cu
+
+
+class _ScriptedQueue:
+    """Result-queue stand-in yielding a scripted sequence, then ``Empty``."""
+
+    def __init__(self, items):
+        self._items = list(items)
+
+    def get(self, timeout=None):
+        if self._items:
+            return self._items.pop(0)
+        raise Empty()
+
+    def qsize(self):
+        return len(self._items)
+
+    def empty(self):
+        return not self._items
+
+
+class _DeadWorker:
+    def is_alive(self):
+        return False
+
+
+class TestValidateTrainingResult:
+    """``_validate_training_result`` security / bounds rejections."""
+
+    def test_non_numeric_correlation_rejected(self, simple_network):
+        result = CandidateTrainingResult()
+        result.correlation = "not-a-number"
+        assert simple_network._validate_training_result(result) is False
+
+    def test_candidate_with_nan_weights_rejected(self, simple_network):
+        result = CandidateTrainingResult(correlation=0.5)
+        result.candidate = _candidate_with_weights([float("nan")])
+        assert simple_network._validate_training_result(result) is False
+
+    def test_elevated_weight_magnitude_warns_but_passes(self, simple_network):
+        # 100 < |w| <= 1000 -> elevated warning, still valid.
+        result = CandidateTrainingResult(correlation=0.5)
+        result.candidate = _candidate_with_weights([200.0])
+        assert simple_network._validate_training_result(result) is True
+
+    def test_over_limit_weight_magnitude_rejected(self, simple_network):
+        # |w| > _RESULT_MAX_WEIGHT_MAGNITUDE (1000) -> rejected.
+        result = CandidateTrainingResult(correlation=0.5)
+        result.candidate = _candidate_with_weights([2000.0])
+        assert simple_network._validate_training_result(result) is False
+
+
+class TestCollectTrainingResults:
+    """``_collect_training_results`` invalid / stale discard paths."""
+
+    def test_invalid_and_stale_results_discarded(self, simple_network):
+        valid = CandidateTrainingResult(candidate_id=7, correlation=0.5, round_id="R1")
+        stale = CandidateTrainingResult(candidate_id=8, correlation=0.5, round_id="OTHER")
+        queue = _ScriptedQueue([object(), stale, valid])  # invalid, stale, then good
+        results = simple_network._collect_training_results(
+            queue,
+            num_tasks=1,
+            round_id="R1",
+            workers=[_DeadWorker()],
+        )
+        assert len(results) == 1
+        assert results[0].candidate_id == 7
+
+
+class TestExecuteSequentialTraining:
+    """``_execute_sequential_training`` per-task exception fallback."""
+
+    def test_task_exception_appends_placeholder(self, simple_network):
+        task = (0, (0, 1, 2, 3, "cand-uuid", 5), None)
+        with patch.object(simple_network, "train_candidate_worker", side_effect=RuntimeError("task boom")):
+            results = simple_network._execute_sequential_training([task])
+        assert len(results) == 1
+        # Placeholder tuple: (candidate_index, candidate_uuid, 0.0, None)
+        assert results[0] == (0, "cand-uuid", 0.0, None)
+
+
+class TestProcessTrainingResults:
+    """``_process_training_results`` success-vs-threshold mismatch log."""
+
+    def test_success_count_differs_from_threshold_count(self, simple_network):
+        net = simple_network
+        net.correlation_threshold = 0.5
+        above = CandidateTrainingResult(candidate_id=0, candidate_uuid="u0", correlation=0.9, success=True)
+        above.candidate = _candidate_with_weights([0.1, 0.2])
+        below = CandidateTrainingResult(candidate_id=1, candidate_uuid="u1", correlation=0.1, success=True)
+        below.candidate = _candidate_with_weights([0.1, 0.2])
+        tasks = [(0, None, None), (1, None, None)]
+        stats = net._process_training_results([above, below], tasks, datetime.datetime.now())
+        # Both succeeded, only one cleared the 0.5 threshold.
+        assert stats.success_count == 2
+        assert stats.successful_candidates == 1
+
+
+class TestTrainCandidatesErrorArms:
+    """``train_candidates`` error propagation arms."""
+
+    def test_candidate_training_error_reraised(self, simple_network):
+        net = simple_network
+        x = torch.zeros(4, 2)
+        y = torch.zeros(4, 2)
+        with patch.object(net, "_generate_candidate_tasks", return_value=[]), patch.object(net, "_execute_candidate_training", side_effect=CandidateTrainingError("irrecoverable")):
+            with pytest.raises(CandidateTrainingError):
+                net.train_candidates(x, y, torch.zeros(4, 2))
+
+    def test_generic_error_wrapped_as_training_error(self, simple_network):
+        net = simple_network
+        x = torch.zeros(4, 2)
+        y = torch.zeros(4, 2)
+        with patch.object(net, "_generate_candidate_tasks", return_value=[]), patch.object(net, "_execute_candidate_training", side_effect=ValueError("boom")):
+            with pytest.raises(TrainingError):
+                net.train_candidates(x, y, torch.zeros(4, 2))
+
+
+class TestGenerateCandidateTasksFallback:
+    """``_generate_candidate_tasks`` SharedMemory-failure fallback."""
+
+    def test_shared_memory_failure_falls_back_to_full_tasks(self, simple_network):
+        net = simple_network
+        candidate_input = torch.zeros(4, 3)
+        y = torch.zeros(4, 2)
+        residual = torch.zeros(4, 2)
+
+        failing_block = MagicMock()
+        failing_block.get_metadata.side_effect = RuntimeError("shm metadata boom")
+        failing_block.close_and_unlink.side_effect = RuntimeError("cleanup boom")
+
+        with patch.object(cc_mod, "SharedTrainingMemory", return_value=failing_block):
+            tasks = net._generate_candidate_tasks(candidate_input, y, residual)
+
+        assert len(tasks) == net.candidate_pool_size
+        # Fallback path: training_inputs is the full tuple, not a shm-metadata dict.
+        training_inputs = tasks[0][2]
+        assert isinstance(training_inputs, tuple)
+        # The failed block was removed from the active set during cleanup.
+        assert failing_block not in net._active_shm_blocks

--- a/src/tests/unit/cascade_correlation/test_serialization_error_paths_coverage.py
+++ b/src/tests/unit/cascade_correlation/test_serialization_error_paths_coverage.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+"""Coverage for HDF5 serialization error / edge paths
+(per-file coverage lift 5, C-5).
+
+Drives the previously-uncovered arms of the ``CascadeCorrelationNetwork``
+HDF5 helpers via a serializer seam that raises:
+
+* ``_save_to_hdf5`` — the outer exception handler (serializer construction /
+  save failure -> ``False``).
+* ``_load_from_hdf5`` — the outer exception handler (-> ``None``).
+* ``verify_hdf5_file`` — the outer exception handler (-> ``{"valid": False}``).
+* ``save_object`` — the default-snapshot-directory branch + successful save.
+
+All fast unit tests: the serializer is patched, so no real h5py I/O runs.
+
+Note (finding, not covered here): ``list_hdf5_snapshots``'s success path
+(the ``self.logger.info(...); return hdf5_files`` after the directory check) is
+unreachable — it calls ``HDF5Utils.list_hdf5_files``, which is not defined
+anywhere in the codebase, so every existing-directory call raises
+``AttributeError`` and falls through to the ``except`` -> ``return []``. Left
+un-chased (reported upstream) rather than covered by mocking in a fictional
+helper.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
+
+pytestmark = pytest.mark.unit
+
+
+class _Objectify:
+    """Serializable stand-in with the ``__name__`` + ``get_uuid`` surface
+    ``save_object`` reads."""
+
+    __name__ = "LiftFiveObject"
+
+    def get_uuid(self):
+        return "obj-uuid-123"
+
+
+class TestSaveToHdf5ErrorPath:
+    def test_serializer_failure_returns_false(self, simple_network, tmp_path):
+        target = tmp_path / "net.h5"
+        with patch("snapshots.snapshot_serializer.CascadeHDF5Serializer", side_effect=RuntimeError("serializer down")):
+            assert simple_network._save_to_hdf5(filepath=target) is False
+
+
+class TestLoadFromHdf5ErrorPath:
+    def test_serializer_failure_returns_none(self, tmp_path):
+        target = tmp_path / "net.h5"
+        target.write_bytes(b"stub")
+        with patch("snapshots.snapshot_serializer.CascadeHDF5Serializer", side_effect=RuntimeError("serializer down")):
+            assert CascadeCorrelationNetwork._load_from_hdf5(filepath=target) is None
+
+
+class TestVerifyHdf5FileErrorPath:
+    def test_serializer_failure_returns_invalid_dict(self, simple_network, tmp_path):
+        target = tmp_path / "net.h5"
+        with patch("snapshots.snapshot_serializer.CascadeHDF5Serializer", side_effect=RuntimeError("verify down")):
+            result = simple_network.verify_hdf5_file(target)
+        assert result["valid"] is False
+        assert "error" in result
+
+
+class TestSaveObjectDefaultDir:
+    def test_default_snapshot_dir_and_successful_save(self, simple_network, tmp_path):
+        net = simple_network
+        net.cascade_correlation_network_snapshots_dir = str(tmp_path)
+        with patch.object(net, "_save_to_hdf5", return_value=True):
+            snapshot_path = net.save_object(objectify=_Objectify(), snapshot_dir=None)
+        assert snapshot_path is not None
+        assert snapshot_path.name.startswith("LiftFiveObject_snapshot_")
+        assert snapshot_path.suffix == ".h5"

--- a/src/tests/unit/cascade_correlation/test_worker_execution_coverage.py
+++ b/src/tests/unit/cascade_correlation/test_worker_execution_coverage.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python
+"""Coverage for the multiprocessing worker execution path
+(per-file coverage lift 5, C-5).
+
+Drives the previously-uncovered arms of the static worker helpers on
+``CascadeCorrelationNetwork`` without spawning real processes:
+
+* ``_worker_loop`` — the RC-4 instrumentation-queue branches (worker.started /
+  task_received / task_done emits) and the shared-training-inputs log, driven
+  by a scripted in-process task queue that feeds one task then a sentinel.
+* ``_process_worker_task`` — the RC-3 lightweight-task reconstruction branch.
+* ``_publish_failure_result`` — the success-put log and the generic put-error
+  swallow.
+* ``train_candidate_worker`` — the worker-id retrieval failure fallback.
+* ``_build_candidate_inputs`` — the OPT-5 SharedMemory ``OSError`` re-raise
+  (triggers the sequential fallback in the caller).
+* ``_train_candidate_unit`` — the training-exception failure result.
+
+All fast unit tests with fakes / ``unittest.mock`` seams.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+import cascade_correlation.cascade_correlation as cc_mod
+from candidate_unit.candidate_unit import CandidateTrainingResult
+from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
+from log_config.logger.logger import Logger
+
+pytestmark = pytest.mark.unit
+
+
+class _SeqTaskQueue:
+    """Task-queue stand-in yielding a preset sequence via ``get``."""
+
+    def __init__(self, items):
+        self._items = list(items)
+
+    def get(self, timeout=None):
+        from queue import Empty
+
+        if self._items:
+            return self._items.pop(0)
+        raise Empty()
+
+
+class _PutQueue:
+    """Result-queue stand-in recording (or failing) ``put`` calls."""
+
+    def __init__(self, *, error=None):
+        self.puts = []
+        self._error = error
+
+    def put(self, item, timeout=None):
+        if self._error is not None:
+            raise self._error
+        self.puts.append(item)
+
+
+class TestWorkerLoop:
+    """``_worker_loop`` instrumentation-queue + shared-inputs branches."""
+
+    def test_instrumented_loop_processes_one_task_then_sentinel(self):
+        task = (0, ("cdata",), "training-inputs", "round-1")
+        task_queue = _SeqTaskQueue([task, None])  # one task, then shutdown sentinel
+        result_queue = MagicMock()
+        instrumentation_queue = MagicMock()
+
+        with patch("parallelism.rc4_ring_buffer.set_worker_queue"), patch("parallelism.rc4_ring_buffer.emit"), patch.object(CascadeCorrelationNetwork, "_process_worker_task") as mock_process:
+            CascadeCorrelationNetwork._worker_loop(
+                task_queue,
+                result_queue,
+                parallel=True,
+                task_queue_timeout=0.01,
+                worker_thread_count=1,
+                shared_training_inputs=("shared",),
+                progress_queue=None,
+                instrumentation_queue=instrumentation_queue,
+            )
+
+        mock_process.assert_called_once()
+
+
+class TestProcessWorkerTask:
+    """``_process_worker_task`` RC-3 lightweight-task reconstruction."""
+
+    def test_lightweight_task_reconstructed_with_shared_inputs(self):
+        result_queue = _PutQueue()
+        dummy_result = MagicMock(correlation=0.5, success=True)
+        with patch("parallelism.rc4_ring_buffer.emit"), patch.object(CascadeCorrelationNetwork, "train_candidate_worker", return_value=dummy_result) as mock_worker:
+            CascadeCorrelationNetwork._process_worker_task(
+                task=(3, ("candidate-data",)),  # 2-element lightweight task
+                shared_training_inputs=("shared-training",),
+                progress_queue=None,
+                result_queue=result_queue,
+                parallel=False,
+                logger=Logger,
+            )
+        # The lightweight task was expanded into a full 3-tuple.
+        full_task = mock_worker.call_args.kwargs["task_data_input"]
+        assert full_task == (3, ("candidate-data",), ("shared-training",))
+        assert result_queue.puts == [dummy_result]
+
+
+class TestPublishFailureResult:
+    """``_publish_failure_result`` put success + generic error swallow."""
+
+    def test_publish_success(self):
+        queue = _PutQueue()
+        task = (2, (0, 1, 2, 3, "cand-uuid", 5), None)
+        CascadeCorrelationNetwork._publish_failure_result(task, RuntimeError("orig"), queue, Logger)
+        assert len(queue.puts) == 1
+        published = queue.puts[0]
+        assert published.candidate_id == 2
+        assert published.candidate_uuid == "cand-uuid"
+
+    def test_publish_generic_error_swallowed(self):
+        queue = _PutQueue(error=RuntimeError("queue exploded"))
+        task = (2, (0, 1, 2, 3, "cand-uuid", 5), None)
+        # Must not propagate.
+        CascadeCorrelationNetwork._publish_failure_result(task, RuntimeError("orig"), queue, Logger)
+
+
+class TestTrainCandidateWorker:
+    """``train_candidate_worker`` worker-id retrieval fallback."""
+
+    def test_worker_id_retrieval_failure_uses_defaults(self):
+        with patch.object(cc_mod.mp, "current_process", side_effect=RuntimeError("no proc")):
+            # parallel=True forces the mp.current_process() path; with no task
+            # data the method short-circuits after the id fallback.
+            result = CascadeCorrelationNetwork.train_candidate_worker(task_data_input=None, parallel=True)
+        assert result == (None, None, 0.0, None)
+
+
+class TestBuildCandidateInputs:
+    """``_build_candidate_inputs`` OPT-5 SharedMemory OSError re-raise."""
+
+    def test_missing_shared_memory_reraises_oserror(self):
+        candidate_data = (0, 3, "Tanh", 1.0, "cand-uuid", 42, 1_000_000, 1_000_000)
+        training_inputs = {
+            "shm_name": "juniper_train_does_not_exist_lift5",
+            "candidate_epochs": 1,
+            "candidate_learning_rate": 0.1,
+            "candidate_display_frequency": 1,
+        }
+        task = (0, candidate_data, training_inputs)
+        with pytest.raises(OSError):
+            CascadeCorrelationNetwork._build_candidate_inputs(task_data_input=task, worker_id=0, worker_uuid="w")
+
+
+class TestTrainCandidateUnit:
+    """``_train_candidate_unit`` training-exception failure result."""
+
+    def test_training_exception_returns_failure_result(self):
+        candidate = MagicMock()
+        candidate.get_uuid.return_value = "cand-uuid"
+        candidate.train_detailed.side_effect = RuntimeError("train boom")
+        result = CascadeCorrelationNetwork._train_candidate_unit(
+            candidate=candidate,
+            candidate_uuid="cand-uuid",
+            candidate_index=3,
+            candidate_input=torch.zeros(4, 2),
+            candidate_epochs=1,
+            residual_error=torch.zeros(4, 2),
+            candidate_learning_rate=0.1,
+            candidate_display_frequency=1,
+        )
+        assert isinstance(result, CandidateTrainingResult)
+        assert result.success is False
+        assert result.candidate_id == 3

--- a/src/tests/unit/cascade_correlation/test_worker_pool_teardown_coverage.py
+++ b/src/tests/unit/cascade_correlation/test_worker_pool_teardown_coverage.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python
+"""Coverage for the persistent worker-pool teardown + SharedMemory lifecycle
+(per-file coverage lift 5, C-5).
+
+Exercises the previously-uncovered teardown / cleanup arms of
+``CascadeCorrelationNetwork`` that only run during pool shutdown or process
+exit — worker join / terminate / SIGKILL escalation
+(``_terminate_workers``), active + pending SharedMemory block cleanup
+(``_cleanup_shared_memory_blocks`` / ``_cleanup_shared_memory`` /
+``_cleanup_pending_shared_memory``), shutdown-sentinel dispatch
+(``_send_shutdown_sentinels``), and the top-level ``_shutdown_worker_pool``
+orchestrator — plus the ``SharedTrainingMemory`` close / unlink / reconstruct
+edges and ``CandidateTrainingManager.start`` method validation.
+
+All fast unit tests driven by fakes / ``unittest.mock`` seams — no real worker
+processes, no /dev/shm churn beyond a single deterministic round-trip.
+"""
+
+import signal
+import struct
+from multiprocessing.managers import BaseManager
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+import cascade_correlation.cascade_correlation as cc_mod
+from cascade_correlation.cascade_correlation import CandidateTrainingManager, SharedTrainingMemory
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeWorker:
+    """Minimal ``multiprocessing.Process`` stand-in for teardown tests.
+
+    ``is_alive`` pops from a preset sequence so each test can script the
+    join / terminate / SIGKILL escalation deterministically.
+    """
+
+    def __init__(self, name, alive_sequence, pid=999_999):
+        self.name = name
+        self.pid = pid
+        self._alive = list(alive_sequence)
+        self.terminated = False
+
+    def is_alive(self):
+        return self._alive.pop(0) if self._alive else False
+
+    def join(self, timeout=None):
+        return None
+
+    def terminate(self):
+        self.terminated = True
+
+
+class _FakeShm:
+    """SharedMemory-block stand-in recording close / unlink calls."""
+
+    def __init__(self, *, raise_on=()):
+        self.closed = False
+        self.unlinked = False
+        self._raise_on = set(raise_on)
+
+    def close_and_unlink(self):
+        if "close_and_unlink" in self._raise_on:
+            raise RuntimeError("close_and_unlink boom")
+        self.closed = True
+        self.unlinked = True
+
+    def close(self):
+        if "close" in self._raise_on:
+            raise RuntimeError("close boom")
+        self.closed = True
+
+    def unlink(self):
+        if "unlink" in self._raise_on:
+            raise RuntimeError("unlink boom")
+        self.unlinked = True
+
+
+class _FakeQueue:
+    """Task-queue stand-in: records ``put`` calls, optionally raising."""
+
+    def __init__(self, *, raise_on_put=False):
+        self.puts = []
+        self._raise_on_put = raise_on_put
+
+    def put(self, item, timeout=None):
+        if self._raise_on_put:
+            raise RuntimeError("queue put boom")
+        self.puts.append(item)
+
+
+class TestShutdownWorkerPool:
+    """``_shutdown_worker_pool`` orchestration + its callees."""
+
+    def test_full_teardown_with_escalation_and_shm(self, simple_network):
+        net = simple_network
+        graceful = _FakeWorker("graceful", [False])
+        escalate = _FakeWorker("escalate", [True, True])  # join fails, terminate fails -> SIGKILL
+        net._persistent_workers = [graceful, escalate]
+        net._persistent_task_queue = _FakeQueue()
+        net._persistent_pool_size = 2
+        active = _FakeShm()
+        pending = _FakeShm()
+        net._active_shm_blocks = [active]
+        net._pending_shm_unlinks = [pending]
+
+        with patch.object(cc_mod.os, "kill") as mock_kill:
+            net._shutdown_worker_pool()
+
+        # Escalation reached SIGKILL for the non-graceful worker only.
+        mock_kill.assert_called_once_with(escalate.pid, signal.SIGKILL)
+        assert escalate.terminated is True
+        assert graceful.terminated is False
+        # Sentinels were dispatched (one per worker).
+        assert net._persistent_task_queue is None  # reset after shutdown
+        assert net._persistent_workers == []
+        assert net._persistent_pool_size == 0
+        # SharedMemory blocks cleaned.
+        assert active.closed and active.unlinked
+        assert pending.unlinked
+
+    def test_early_return_when_no_workers(self, simple_network):
+        net = simple_network
+        net._persistent_workers = []
+        # Must return promptly without touching queues.
+        net._shutdown_worker_pool()
+        assert net._persistent_workers == []
+
+
+class TestTerminateWorkers:
+    """``_terminate_workers`` SIGKILL-raises defensive arm."""
+
+    def test_sigkill_failure_swallowed(self, simple_network):
+        net = simple_network
+        stubborn = _FakeWorker("stubborn", [True, True])
+        net._persistent_workers = [stubborn]
+        with patch.object(cc_mod.os, "kill", side_effect=OSError("no such process")):
+            # Must not propagate — cleanup is best-effort.
+            net._terminate_workers()
+        assert stubborn.terminated is True
+
+
+class TestSendShutdownSentinels:
+    """``_send_shutdown_sentinels`` put-failure defensive arm."""
+
+    def test_put_failure_swallowed(self, simple_network):
+        net = simple_network
+        net._persistent_workers = [_FakeWorker("w0", [False]), _FakeWorker("w1", [False])]
+        net._persistent_task_queue = _FakeQueue(raise_on_put=True)
+        # Every put raises; the method swallows each and completes.
+        net._send_shutdown_sentinels()
+
+    def test_noop_when_no_task_queue(self, simple_network):
+        net = simple_network
+        net._persistent_task_queue = None
+        net._send_shutdown_sentinels()  # nothing to do
+
+
+class TestSharedMemoryCleanup:
+    """``_cleanup_shared_memory_blocks`` / ``_cleanup_shared_memory`` /
+    ``_cleanup_pending_shared_memory`` — happy + swallowed-exception arms."""
+
+    def test_cleanup_blocks_swallows_exceptions(self, simple_network):
+        net = simple_network
+        good_active = _FakeShm()
+        bad_active = _FakeShm(raise_on={"close_and_unlink"})
+        good_pending = _FakeShm()
+        bad_pending = _FakeShm(raise_on={"unlink"})
+        net._active_shm_blocks = [good_active, bad_active]
+        net._pending_shm_unlinks = [good_pending, bad_pending]
+
+        net._cleanup_shared_memory_blocks()
+
+        assert good_active.closed and good_active.unlinked
+        assert good_pending.unlinked
+        assert net._active_shm_blocks == []
+        assert net._pending_shm_unlinks == []
+
+    def test_cleanup_shared_memory_emergency_swallows_exceptions(self, simple_network):
+        net = simple_network
+        good = _FakeShm()
+        bad = _FakeShm(raise_on={"close_and_unlink"})
+        pend_good = _FakeShm()
+        pend_bad = _FakeShm(raise_on={"unlink"})
+        net._active_shm_blocks = [good, bad]
+        net._pending_shm_unlinks = [pend_good, pend_bad]
+
+        net._cleanup_shared_memory()
+
+        assert good.closed and good.unlinked
+        assert pend_good.unlinked
+        assert net._active_shm_blocks == []
+        assert net._pending_shm_unlinks == []
+
+    def test_cleanup_pending_swallows_exceptions(self, simple_network):
+        net = simple_network
+        good = _FakeShm()
+        bad = _FakeShm(raise_on={"unlink"})
+        net._pending_shm_unlinks = [good, bad]
+
+        net._cleanup_pending_shared_memory()
+
+        assert good.unlinked
+        assert net._pending_shm_unlinks == []
+
+
+class TestSharedTrainingMemoryReconstruct:
+    """``SharedTrainingMemory.reconstruct_tensors`` edges (real /dev/shm)."""
+
+    def test_roundtrip_including_zero_dim_tensor(self):
+        stm = SharedTrainingMemory(
+            tensors=[torch.zeros(3, 2), torch.ones(3), torch.tensor(5.0)],
+            name_suffix="lift5rt",
+        )
+        try:
+            tensors, handle = SharedTrainingMemory.reconstruct_tensors(stm.get_metadata())
+            try:
+                assert [tuple(t.shape) for t in tensors] == [(3, 2), (3,), ()]
+            finally:
+                handle.close()
+        finally:
+            stm.close_and_unlink()
+
+    def test_invalid_magic_closes_and_raises(self):
+        # Raw block with a deliberately wrong header magic.
+        from multiprocessing.shared_memory import SharedMemory as _SM
+
+        raw = _SM(name="juniper_train_lift5bad", create=True, size=SharedTrainingMemory.HEADER_SIZE + 8)
+        try:
+            struct.pack_into("<4sBB58x", raw.buf, 0, b"XXXX", 1, 0)
+            with pytest.raises(ValueError, match="Invalid SharedMemory block header"):
+                SharedTrainingMemory.reconstruct_tensors({"shm_name": "juniper_train_lift5bad"})
+        finally:
+            raw.close()
+            raw.unlink()
+
+    def test_legacy_python312_attach_branch(self):
+        # Force the < 3.13 attach path (no ``track=`` kwarg) via a patched
+        # version tuple; the real block still round-trips on the live runtime.
+        stm = SharedTrainingMemory(tensors=[torch.zeros(2, 2)], name_suffix="lift5py312")
+        try:
+            with patch.object(cc_mod.sys, "version_info", (3, 12, 0)):
+                tensors, handle = SharedTrainingMemory.reconstruct_tensors(stm.get_metadata())
+            handle.close()
+            assert tuple(tensors[0].shape) == (2, 2)
+        finally:
+            stm.close_and_unlink()
+
+
+class TestSharedTrainingMemoryCloseUnlink:
+    """``SharedTrainingMemory.close`` / ``unlink`` swallow underlying errors."""
+
+    def _detached_stm(self):
+        # Build without allocating /dev/shm so we can inject a raising handle.
+        stm = object.__new__(SharedTrainingMemory)
+        stm._closed = False
+        stm._unlinked = False
+        return stm
+
+    def test_close_swallows_exception(self):
+        stm = self._detached_stm()
+        stm._shm = MagicMock()
+        stm._shm.close.side_effect = RuntimeError("close failed")
+        stm.close()
+        assert stm._closed is True
+
+    def test_unlink_swallows_exception(self):
+        stm = self._detached_stm()
+        stm._shm = MagicMock()
+        stm._shm.unlink.side_effect = RuntimeError("unlink failed")
+        stm.unlink()
+        assert stm._unlinked is True
+
+
+class TestCandidateTrainingManagerStart:
+    """``CandidateTrainingManager.start`` method validation + delegation."""
+
+    def test_start_with_no_method_delegates_to_super(self):
+        mgr = CandidateTrainingManager()
+        with patch.object(BaseManager, "start", return_value="started") as super_start:
+            result = mgr.start()
+        assert result == "started"
+        super_start.assert_called_once()
+
+    def test_start_with_valid_method_but_unavailable_context_raises(self):
+        mgr = CandidateTrainingManager()
+        with patch.object(cc_mod.mp, "get_context", side_effect=RuntimeError("no ctx")):
+            with pytest.raises(NotImplementedError, match="not implemented on this platform"):
+                mgr.start(method="forkserver")
+
+    def test_start_with_invalid_method_raises_value_error(self):
+        mgr = CandidateTrainingManager()
+        with pytest.raises(ValueError, match="Invalid start method"):
+            mgr.start(method="bogus")


### PR DESCRIPTION
## Summary

Part 5 (the final real lift) of the ratified **C-5 per-file coverage split** for juniper-cascor. Lifts the single largest and lowest-coverage cascor source file — `src/cascade_correlation/cascade_correlation.py` (the 5905-line `CascadeCorrelationNetwork` training engine) — from 89.20% to **97.36%** statement coverage, clearing the `src/cascade_correlation` sub-module against the ratified ≥95% pooled bar. **Tests only** — no production code changed, no CI gate step added (the `juniper-coverage-gap-map --enforce` gate lands in the final PR of the split once every sub-module clears).

Follows #368 (rc4_ring_buffer + routes/network) and #371 (websocket), both merged; scope is disjoint from the concurrent #382 (app.py) and #383 (lifecycle/manager.py) lifts.

## Coverage (CI `unit and not slow` subset, `--cov=src`, statement basis)

| Metric | Before | After |
|--------|--------|-------|
| `src/cascade_correlation/cascade_correlation.py` (file) | 1991/2232 = **89.20%** | 2173/2232 = **97.36%** |
| `src/cascade_correlation` sub-module (pooled) | 1991/2232 = **89.20%** | 2173/2232 = **97.36%** |
| overall cascor (statement) | **91.95%** | **93.52%** |

Both gate bars clear with margin: the ≥90% file bar (**97.36%**) and the ≥95% pooled bar (**97.36%**, +52 covered over the 2121 needed for 95.03%). The `src/cascade_correlation` package `__init__.py` is a zero-statement re-export, so the sub-module pool equals the file. Measured on the post-#371 base; `cascade_correlation.py` is byte-identical to pre-#371 main (the *before* number holds), only the overall baseline shifted because #371 lifted websocket. The remaining sub-95 siblings (`src/api/app.py`, `src/api/lifecycle/`) are #382 / #383's scope — untouched here.

## What the 47 new tests cover

Five new fast unit-test files under `src/tests/unit/cascade_correlation/`, all via fakes / `unittest.mock` seams (no worker processes, no live training, no real h5py I/O; a single deterministic `/dev/shm` round-trip):

- **`test_worker_pool_teardown_coverage.py`** — the persistent worker-pool teardown chain (`_shutdown_worker_pool` → `_send_shutdown_sentinels` / `_terminate_workers` join→terminate→SIGKILL escalation / `_cleanup_shared_memory_blocks`), `_cleanup_shared_memory` + `_cleanup_pending_shared_memory`, the `SharedTrainingMemory` reconstruct (incl. the invalid-magic + 0-dim + Python-<3.13 attach branches) / close / unlink edges, and `CandidateTrainingManager.start` method validation.
- **`test_candidate_results_coverage.py`** — `_validate_training_result` (non-numeric correlation, NaN weights, elevated + over-limit magnitude), `_collect_training_results` (invalid-result + stale-round discard), `_execute_sequential_training` per-task fallback, `_process_training_results` success-vs-threshold mismatch, the `train_candidates` `CandidateTrainingError` re-raise / generic `TrainingError` wrap, and the `_generate_candidate_tasks` SharedMemory-failure fallback.
- **`test_worker_execution_coverage.py`** — the static worker helpers: `_worker_loop` instrumentation-queue branches, `_process_worker_task` RC-3 lightweight-task reconstruction, `_publish_failure_result`, `train_candidate_worker` id-retrieval fallback, `_build_candidate_inputs` OPT-5 `OSError` re-raise, `_train_candidate_unit` failure result.
- **`test_serialization_error_paths_coverage.py`** — the HDF5 `_save_to_hdf5` / `_load_from_hdf5` / `verify_hdf5_file` exception handlers + `save_object` default-dir path.
- **`test_accuracy_residual_growth_coverage.py`** — `calculate_residual_error` (non-tensor reset + P2-1d active-output-dim masking), `_emit_candidate_correlation` swallow, `calculate_accuracy` / `_accuracy` output validation, `add_unit` (stale-candidate mismatch + debug-gated branches), `add_units_as_layer` skip, `_add_best_candidate` INFO-gated log.

## Flags / findings (reported, not fixed — a tests-only PR does not touch the core engine)

Two genuine latent bugs surfaced while mapping residuals. Both leave their method's success path unreachable; neither is fixed here (the split is strictly tests-only):

1. **`restore_snapshot` (line 4756) is a `@classmethod` that calls `cls.__dict__.update(...)`** — `cls.__dict__` is a read-only `mappingproxy`, so every load-then-restore raises `'mappingproxy' object has no attribute 'update'` and returns `False`. The success path (4757–4758) is unreachable; `restore_snapshot` can never actually restore a network.
2. **`list_hdf5_snapshots` (line 5014) calls `HDF5Utils.list_hdf5_files`, which is not defined anywhere in the codebase** — every existing-directory call raises `AttributeError` and falls through to `except` → `return []`. The success path (5015–5016) is unreachable; the method can never list snapshots.

Additional non-bug residual notes:

- **`calculate_accuracy` 5381–5384 is dead defensive code** — the `if x is None or y is None:` guard sits *after* the None-defaulting at 5375–5376 (`x = (x, torch.empty(...))[x is None]`), so `x` / `y` are never `None` there.
- **`_init_logging_system` (632–658) is bypassed suite-wide** by the autouse session fixture `_cache_logging_system` (`src/tests/conftest.py`), which swaps in `_fast_init_logging_system` for the whole unit run — its real body is not reachable from the CI subset.
- The remaining ~42 residual lines (the TaskDistributor local/remote nested dispatch in `_execute_candidate_training`, the `_execute_parallel_training` finally-close, the `grow_network` validate-except + debug logs, the `_stop_workers` time-deadline break, and a scatter of one-line defensive `except` / debug arms) are **all fast-unit-reachable — none is blocked by an excluded slow/integration/GPU suite** (per the scoping doc §6, only a genuinely fast-unreachable cluster would be flagged; there is none here). Left un-chased only because both bars clear with a ~2.3-point margin.

## Merge-order / hygiene

- **CHANGELOG:** this PR also strips a stray trailing-whitespace line that #371's squash left in the `[Unreleased] → Tests` section (one whitespace-only deletion). Without it, `pre-commit run --all-files` (the CI pre-commit job) is red on `main` at `bfc3f8f` — this keeps my merge ref green. #382 / #383 carry the same strip, so expect a trivial one-line CHANGELOG rebase depending on merge order; my diff adds a new `### Tests` bullet at the top of `[Unreleased]` and touches **no** `cascade_correlation.py` source, so there is no code conflict with any sibling.

## Verification

- Full CI-equivalent subset (`pytest -m "unit and not slow" src/tests/unit --cov=src`) green — exit 0, coverage gate (80%) reached at 93.52%, 0 failures.
- 47 new tests pass; the file / sub-module / overall numbers above computed with `juniper-coverage-gap-map` (`juniper-ci-tools 0.6.0`, advisory) on the statement basis (the ratified gate basis).
- `pre-commit run --all-files` clean (black, isort, flake8 + relaxed test lane, bandit, mypy, async-audit, markdownlint, yamllint, file hooks).
- Required WS-6 Golden/Snapshot Regression + model-core Conformance gates: a tests-only diff (new `@pytest.mark.unit` files only) keeps them green.

## Requirements

_No tracked JR-* requirement applies (per-file coverage rollout is tracked in the juniper-ml scoping doc, not the JR-ID index)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvPNTfp4ydj1hPSSFudKoM
