### PR TITLE
fix(ci): docker smoke — opt into the published-container bind contract (heals main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -849,9 +849,15 @@ jobs:
           # in-container localhost:8100 default (which would only resolve
           # if cascor and juniper-data ran in the same container — they
           # don't here).
+          # The image default is loopback since #379 (safe bare-container
+          # default under the SEC-F22 bind guard), so the smoke must opt in
+          # to the documented published-container contract: bind 0.0.0.0
+          # inside the container (Docker NAT needs it to forward the
+          # published port) plus the fronting-auth attestation.
           docker run -d --name juniper-cascor-test \
             --network juniper-smoke \
             -e JUNIPER_DATA_URL=http://juniper-data:8100 \
+            -e JUNIPER_CASCOR_HOST=0.0.0.0 \
             -e JUNIPER_CASCOR_FRONTING_AUTH_ATTESTED=true \
             -p 127.0.0.1:8200:8200 \
             juniper-cascor:ci-${{ github.sha }}


### PR DESCRIPTION
## Summary

- Heals main's red **Docker Build & Smoke Test** (failing since the #379 merge, e.g. run 28757261573): #379 changed the image's baked default to `JUNIPER_CASCOR_HOST=127.0.0.1` (safe bare-container default under the SEC-F22 bind guard) but CI's smoke `docker run` was never opted into the new published-container contract. The container bound loopback internally — its in-container healthcheck passed, but the runner-side **Verify Health Endpoint** curl through the published port (`-p 127.0.0.1:8200:8200`) could not connect.
- Fix: add `-e JUNIPER_CASCOR_HOST=0.0.0.0` to the smoke's `docker run` (attestation was already present) — exactly the invocation #379's own README example documents for published containers. Publishing stays on the runner's loopback; no security-posture change.
- One file, +6 lines (env line + explanatory comment).

## Test plan

- [x] Root cause verified from run 28757261573 (failed step: `Verify Health Endpoint`; pre-#379 main run 28756532664 was green, both post-#379 runs red on exactly this job)
- [ ] This PR's own **Docker Build & Smoke Test** check passes (the fix proves itself in CI)
- [ ] All other checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvPNTfp4ydj1hPSSFudKoM