### PR TITLE
fix(cascor): repair latent snapshot restore/listing defects, dead accuracy guard, unexercised logging init

### DIFF
--- a/src/cascade_correlation/cascade_correlation.py
+++ b/src/cascade_correlation/cascade_correlation.py
@@ -4725,14 +4725,14 @@ class CascadeCorrelationNetwork:
         cls,
         snapshot_path: Union[str, pl.Path] = None,
         restore_multiprocessing: bool = True,
-    ) -> bool:
+    ) -> Union["CascadeCorrelationNetwork", bool]:
         """
-        Restore the network state from a snapshot file.
+        Restore a network from a snapshot file.
         Args:
             snapshot_path: Path to the snapshot file
             restore_multiprocessing: Whether to restore multiprocessing state
         Returns:
-            bool: Success status
+            The restored CascadeCorrelationNetwork on success; False on failure
         """
         logger = Logger
         try:
@@ -4752,10 +4752,8 @@ class CascadeCorrelationNetwork:
                 logger.error(f"CascadeCorrelationNetwork: restore_snapshot: Failed to load network from snapshot: {snapshot_path}")
                 return False
 
-            # Copy loaded network state into current instance
-            cls.__dict__.update(loaded_network.__dict__)
             logger.info(f"CascadeCorrelationNetwork: restore_snapshot: Restored snapshot from {snapshot_path}")
-            return True
+            return loaded_network
         except Exception as e:
             logger.error(f"CascadeCorrelationNetwork: restore_snapshot: Error restoring snapshot: {e}")
             import traceback
@@ -5377,12 +5375,6 @@ class CascadeCorrelationNetwork:
         accuracy = 0.0
 
         # Validate input tensors
-        if x is None or y is None:
-            self.logger.error("CascadeCorrelationNetwork: calculate_accuracy: Missing required tensors for accuracy calculation, using safe defaults.")
-            self.logger.debug(f"CascadeCorrelationNetwork: calculate_accuracy: input size: {self.input_size}, output size: {self.output_size}")
-            x = torch.empty(0, self.input_size)
-            y = torch.empty(0, self.output_size)
-            # raise ValueError("CascadeCorrelationNetwork: calculate_accuracy: Missing required tensors for accuracy calculation.")
         if not (isinstance(x, torch.Tensor) and isinstance(y, torch.Tensor)):
             self.logger.error(f"CascadeCorrelationNetwork: calculate_accuracy: Input and target tensors must be of type torch.Tensor. Input (x): {type(x)}, Target (y): {type(y)}")
             raise ValueError("CascadeCorrelationNetwork: calculate_accuracy: Input and target tensors must be of type torch.Tensor.")

--- a/src/snapshots/snapshot_utils.py
+++ b/src/snapshots/snapshot_utils.py
@@ -8,7 +8,7 @@ import datetime
 import os
 import shutil
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import h5py
 
@@ -61,6 +61,21 @@ class HDF5Utils:
 
         Logger.info(f"HDF5Utils: Created backup at {backup_path}")
         return backup_path
+
+    @staticmethod
+    def list_hdf5_files(directory: Union[str, Path]) -> List[Path]:
+        """
+        List all HDF5 files (.h5 / .hdf5) in a directory.
+
+        Args:
+            directory: Directory to search
+
+        Returns:
+            Sorted list of HDF5 file paths (empty if the directory does not exist)
+        """
+        if not os.path.isdir(directory):
+            return []
+        return sorted(Path(directory, filename) for filename in os.listdir(directory) if filename.endswith((".h5", ".hdf5")))
 
     @staticmethod
     def list_networks_in_directory(directory: str) -> List[Dict[str, Any]]:

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -810,6 +810,22 @@ def _fast_init_logging_system(self):
     self.logger = _noop_logger
 
 
+_REAL_INIT_LOGGING_SYSTEM = None  # the genuine method, captured by _cache_logging_system before it patches the class
+
+
+@pytest.fixture
+def real_init_logging_system():
+    """Hand tests the genuine (un-patched) CascadeCorrelationNetwork._init_logging_system.
+
+    The autouse session fixture _cache_logging_system replaces the method
+    suite-wide for speed, which previously left the real body unexercised by
+    any unit test (regressions in it were invisible). Tests that need the real
+    body request this fixture and invoke it explicitly on a constructed network.
+    """
+    assert _REAL_INIT_LOGGING_SYSTEM is not None, "_cache_logging_system must capture the original method before tests run"
+    return _REAL_INIT_LOGGING_SYSTEM
+
+
 @pytest.fixture(autouse=True, scope="session")
 def _warmup_torch():
     """Trigger lazy initialization of torch internals during collection.
@@ -844,7 +860,9 @@ def _cache_logging_system():
     """
     from log_config.logger.logger import Logger
 
+    global _REAL_INIT_LOGGING_SYSTEM
     original_init = CascadeCorrelationNetwork._init_logging_system
+    _REAL_INIT_LOGGING_SYSTEM = original_init
     CascadeCorrelationNetwork._init_logging_system = _fast_init_logging_system
 
     # Patch CandidateUnit to use no-op logger (it normally sets self.logger = Logger,

--- a/src/tests/unit/cascade_correlation/test_serialization_error_paths_coverage.py
+++ b/src/tests/unit/cascade_correlation/test_serialization_error_paths_coverage.py
@@ -13,13 +13,11 @@ HDF5 helpers via a serializer seam that raises:
 
 All fast unit tests: the serializer is patched, so no real h5py I/O runs.
 
-Note (finding, not covered here): ``list_hdf5_snapshots``'s success path
-(the ``self.logger.info(...); return hdf5_files`` after the directory check) is
-unreachable — it calls ``HDF5Utils.list_hdf5_files``, which is not defined
-anywhere in the codebase, so every existing-directory call raises
-``AttributeError`` and falls through to the ``except`` -> ``return []``. Left
-un-chased (reported upstream) rather than covered by mocking in a fictional
-helper.
+Note: ``list_hdf5_snapshots``'s success path used to be unreachable —
+``HDF5Utils.list_hdf5_files`` was undefined, so every existing-directory call
+raised ``AttributeError`` and fell through to the ``except`` -> ``return []``.
+The helper now exists (``snapshots/snapshot_utils.py``) and the success path
+is pinned by ``tests/unit/test_latent_defect_repairs.py``.
 """
 
 from unittest.mock import patch

--- a/src/tests/unit/test_latent_defect_repairs.py
+++ b/src/tests/unit/test_latent_defect_repairs.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python
+"""Regression tests for the 2026-07 latent-defect repairs (defects verified on main @ 0a44938).
+
+Pins the REAL success behavior that was previously unreachable:
+
+1. ``restore_snapshot`` — used to execute ``cls.__dict__.update(...)`` on the
+   read-only class ``mappingproxy``, so every load-then-restore raised
+   ``AttributeError``, fell into the ``except``, and returned ``False``; the
+   success path was dead code. It now returns the restored network. The
+   round-trip test below fails against the pre-fix code (it gets ``False``).
+2. ``list_hdf5_snapshots`` — used to call the undefined
+   ``HDF5Utils.list_hdf5_files``, so every existing-directory call raised
+   ``AttributeError`` and returned ``[]`` via the ``except`` fallback. The
+   helper now exists; the listing tests below fail against the pre-fix code.
+3. ``calculate_accuracy`` — the dead ``if x is None or y is None:`` guard
+   (unreachable after the tuple-index defaulting above it) was removed; the
+   valid-tensor behavior is pinned unchanged here.
+4. ``_init_logging_system`` — the real body was monkey-patched away for the
+   entire unit run by the autouse ``_cache_logging_system`` fixture; the test
+   below executes the genuine method via the ``real_init_logging_system``
+   conftest fixture so regressions in it are visible again, while the
+   suite-wide fast-logging fixture stays in place for every other test.
+"""
+import pathlib
+
+import pytest
+import torch
+
+from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
+from cascade_correlation.cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
+from snapshots.snapshot_utils import HDF5Utils
+
+pytestmark = pytest.mark.unit
+
+
+def _make_config(**overrides):
+    defaults = {
+        "input_size": 2,
+        "output_size": 2,
+        "random_seed": 42,
+        "candidate_pool_size": 2,
+        "candidate_epochs": 3,
+        "output_epochs": 3,
+        "max_hidden_units": 2,
+        "patience": 1,
+    }
+    defaults.update(overrides)
+    return CascadeCorrelationConfig(**defaults)
+
+
+def _make_network(**overrides):
+    return CascadeCorrelationNetwork(config=_make_config(**overrides))
+
+
+# ---------------------------------------------------------------------------
+# Defect 1: restore_snapshot must actually deliver a restored network
+# ---------------------------------------------------------------------------
+class TestRestoreSnapshotRoundTrip:
+    """restore_snapshot success path: save to tmp_path, restore, compare state."""
+
+    def test_restore_snapshot_round_trip_returns_restored_network(self, tmp_path):
+        """A saved snapshot restores to a network whose state matches the original."""
+        network = _make_network()
+        snapshot_path = network.create_snapshot(snapshot_dir=tmp_path)
+        assert snapshot_path is not None
+        assert snapshot_path.exists()
+
+        restored = CascadeCorrelationNetwork.restore_snapshot(snapshot_path=snapshot_path, restore_multiprocessing=False)
+
+        assert restored is not False, "restore_snapshot returned False for a valid snapshot (the pre-fix dead success path)"
+        assert isinstance(restored, CascadeCorrelationNetwork)
+        assert restored is not network
+        assert restored.input_size == network.input_size
+        assert restored.output_size == network.output_size
+        assert len(restored.hidden_units) == len(network.hidden_units)
+        assert torch.equal(restored.output_weights.detach(), network.output_weights.detach())
+        if network.output_bias is not None:
+            assert torch.equal(restored.output_bias.detach(), network.output_bias.detach())
+
+    def test_restore_snapshot_failure_paths_still_return_false(self, tmp_path):
+        """The pinned False-on-error contract is preserved by the fix."""
+        assert CascadeCorrelationNetwork.restore_snapshot(snapshot_path=None) is False
+        assert CascadeCorrelationNetwork.restore_snapshot(snapshot_path=tmp_path / "missing.h5") is False
+
+
+# ---------------------------------------------------------------------------
+# Defect 2: list_hdf5_snapshots / HDF5Utils.list_hdf5_files must actually list
+# ---------------------------------------------------------------------------
+class TestListHdf5Snapshots:
+    """Success path: HDF5 files in an existing directory are returned."""
+
+    def test_list_hdf5_files_returns_hdf5_paths(self, tmp_path):
+        """HDF5Utils.list_hdf5_files returns the .h5/.hdf5 paths, sorted, and nothing else."""
+        (tmp_path / "a.h5").touch()
+        (tmp_path / "b.hdf5").touch()
+        (tmp_path / "not_a_snapshot.txt").touch()
+
+        files = HDF5Utils.list_hdf5_files(tmp_path)
+
+        assert [p.name for p in files] == ["a.h5", "b.hdf5"]
+        assert all(isinstance(p, pathlib.Path) for p in files)
+        assert all(p.parent == tmp_path for p in files)
+
+    def test_list_hdf5_files_missing_directory_returns_empty(self, tmp_path):
+        """A nonexistent directory yields an empty list, not an exception."""
+        assert HDF5Utils.list_hdf5_files(tmp_path / "does_not_exist") == []
+
+    def test_list_hdf5_snapshots_returns_files_in_existing_directory(self, tmp_path):
+        """list_hdf5_snapshots reaches its success path (pre-fix: except-fallback to [])."""
+        network = _make_network()
+        (tmp_path / "snap_one.h5").touch()
+        (tmp_path / "snap_two.hdf5").touch()
+        (tmp_path / "readme.txt").touch()
+
+        files = network.list_hdf5_snapshots(tmp_path)
+
+        assert sorted(p.name for p in files) == ["snap_one.h5", "snap_two.hdf5"], "list_hdf5_snapshots returned a wrong/empty list (the pre-fix except fallback)"
+
+    def test_list_hdf5_snapshots_nonexistent_directory_still_returns_empty(self):
+        """The pinned empty-list contract for a missing directory is preserved."""
+        network = _make_network()
+        assert network.list_hdf5_snapshots("/nonexistent/directory/for/defect2") == []
+
+
+# ---------------------------------------------------------------------------
+# Defect 3: dead None guard removed from calculate_accuracy
+# ---------------------------------------------------------------------------
+class TestCalculateAccuracyValidPath:
+    """Valid-tensor behavior must be unchanged by the dead-guard removal."""
+
+    def test_calculate_accuracy_valid_tensors(self):
+        """calculate_accuracy returns a float in [0, 1] for well-formed input."""
+        network = _make_network()
+        torch.manual_seed(42)
+        x = torch.randn(8, network.input_size)
+        y = torch.zeros(8, network.output_size)
+        y[torch.arange(8), torch.randint(0, network.output_size, (8,))] = 1.0
+
+        accuracy = network.calculate_accuracy(x, y)
+
+        assert isinstance(accuracy, float)
+        assert 0.0 <= accuracy <= 1.0
+
+    def test_calculate_accuracy_mismatched_batch_still_raises(self):
+        """The shape-mismatch ValueError (which also serves the None-x case) is preserved."""
+        network = _make_network()
+        x = torch.randn(10, network.input_size)
+        y = torch.randn(5, network.output_size)
+        with pytest.raises(ValueError):
+            network.calculate_accuracy(x, y)
+
+
+# ---------------------------------------------------------------------------
+# Defect 4: the genuine _init_logging_system body must run under pytest
+# ---------------------------------------------------------------------------
+class TestRealInitLoggingSystem:
+    """Execute the real (un-patched) _init_logging_system against a tmp_path config."""
+
+    def test_real_init_logging_system_builds_logger_from_config(self, real_init_logging_system, tmp_path):
+        """The real body builds a fresh LogConfig from THIS network's config and wires its logger in.
+
+        The suite-wide fast fixture would instead attach the session-cached
+        LogConfig and a no-op logger, so every assertion below distinguishes
+        the genuine body from the patched one.
+        """
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        network = _make_network(log_file_name="latent_defect_d4", log_file_path=str(log_dir), log_level_name="WARNING")
+
+        real_init_logging_system(network)
+
+        assert network.log_file_name == "latent_defect_d4"
+        assert network.log_file_path == str(log_dir)
+        assert network.log_level_name == "WARNING"
+        assert network.log_config is not None
+        assert network.log_config.get_log_file_path() == str(log_dir), "log_config was not built from this network's config (fast-fixture cached LogConfig?)"
+        assert network.logger is network.log_config.get_logger(), "logger was not wired from the freshly built LogConfig (no-op fast-fixture logger?)"
+        assert type(network.logger).__name__ != "_NoOpLogger"
+        assert network.logger.level == network.log_config.get_log_level()


### PR DESCRIPTION
## Summary

Repairs four verified latent defects in `cascade_correlation.py` / `snapshot_utils.py` — dead snapshot restore, dead snapshot listing, a dead `None` guard, and a suite-wide logging-init bypass — and pins the real success behavior with regression tests that demonstrably fail against the pre-fix code. Defects were independently verified on `main` @ `0a44938` (this branch's base).

## Per-defect changes

### 1. `restore_snapshot` could never succeed (dead success path)

`restore_snapshot` is a `@classmethod`; its success path executed `cls.__dict__.update(loaded_network.__dict__)`. A class's `__dict__` is a read-only `mappingproxy` with no `.update`, so every load-then-restore raised `AttributeError`, landed in the `except`, and returned `False`. `cls._load_from_hdf5(...)` already returns a usable network before the broken copy step.

**Fix**: return the loaded network on success (mirrors the sibling classmethod `load_from_hdf5`, which returns network-or-`None`). All existing call sites invoke the method on the class (`CascadeCorrelationNetwork.restore_snapshot(...)`), so an instance-method conversion would have broken 7 existing test call sites. All failure paths keep the pinned `False` contract; return annotation and docstring updated to `Union["CascadeCorrelationNetwork", bool]`.

### 2. `list_hdf5_snapshots` always returned `[]`

Line 5014 called `HDF5Utils.list_hdf5_files(directory)`, which was **not defined anywhere in the codebase**, so every existing-directory call raised `AttributeError` and fell through the `except` to `return []`. (The nearest capability, `list_networks_in_directory`, returns verification dicts — a different contract than the documented "List of HDF5 file paths".)

**Fix**: implement `HDF5Utils.list_hdf5_files(directory) -> List[Path]` in `src/snapshots/snapshot_utils.py` matching the class's static-method idiom: sorted `.h5`/`.hdf5` paths, empty list for a missing directory. `list_hdf5_snapshots` itself is unchanged. Also updated the now-stale "finding" note in `test_serialization_error_paths_coverage.py`'s module docstring, which had documented this exact defect.

### 3. Dead `None` guard in `calculate_accuracy`

Lines 5375–5376 default `x`/`y` via the tuple-index idiom, so the `if x is None or y is None:` guard below could never fire. Removed the dead block; the code now has one real defaulting path plus the live isinstance/shape validation. Behavior for valid tensors is unchanged, and the existing `test_accuracy_none_inputs` semantics (None → `ValueError`) are preserved because that error comes from the live shape-mismatch branch, not the dead guard.

### 4. Real `_init_logging_system` was never executed by the unit suite

The autouse session fixture `_cache_logging_system` monkey-patches `_init_logging_system` away for the entire unit run, so regressions in the real body were invisible.

**Fix**: the session fixture now stashes the genuine method in a module global, exposed via a new function-scoped `real_init_logging_system` fixture; a dedicated test invokes the real body against a `tmp_path` log config. The suite-wide fast-logging speedup is fully preserved (the autouse patching behavior is untouched). Coverage proof below.

## Regression tests (`src/tests/unit/test_latent_defect_repairs.py`)

- **Round-trip restore**: saves a real snapshot to `tmp_path` (no serializer mocking), restores it, and asserts restored state matches the original (`input_size`, `output_size`, hidden-unit count, `torch.equal` on `output_weights`/`output_bias`) — not merely `is not None`.
- **Listing**: creates `.h5`/`.hdf5`/`.txt` files in `tmp_path`, asserts the returned list is exactly the two HDF5 paths (network-level and `HDF5Utils`-level), plus the preserved empty-list contracts.
- **Accuracy**: valid-tensor behavior and the shape-mismatch `ValueError` pinned.
- **Real logging init**: every assertion distinguishes the genuine body from the fast fixture (fresh `LogConfig` built from *this* config's `tmp_path`, `logger is log_config.get_logger()`, not a `_NoOpLogger`).

### Fail-first evidence (new tests vs. pre-fix code)

Run with only the tests + conftest fixture in place, source unfixed:

```text
FAILED tests/unit/test_latent_defect_repairs.py::TestRestoreSnapshotRoundTrip::test_restore_snapshot_round_trip_returns_restored_network
  AssertionError: restore_snapshot returned False for a valid snapshot (the pre-fix dead success path)
FAILED tests/unit/test_latent_defect_repairs.py::TestListHdf5Snapshots::test_list_hdf5_files_returns_hdf5_paths
  AttributeError: type object 'HDF5Utils' has no attribute 'list_hdf5_files'
FAILED tests/unit/test_latent_defect_repairs.py::TestListHdf5Snapshots::test_list_hdf5_files_missing_directory_returns_empty
  AttributeError: type object 'HDF5Utils' has no attribute 'list_hdf5_files'
FAILED tests/unit/test_latent_defect_repairs.py::TestListHdf5Snapshots::test_list_hdf5_snapshots_returns_files_in_existing_directory
  AssertionError: list_hdf5_snapshots returned a wrong/empty list (the pre-fix except fallback)
==================== 4 failed, 5 passed, 1 warning in 1.66s ====================
```

## Acceptance evidence (fixed code, env `JuniperCascor1`)

New tests:

```text
tests/unit/test_latent_defect_repairs.py .........                       [100%]
========================= 9 passed, 1 warning in 1.39s =========================
```

Full unit suite (`cd src && python -m pytest tests/unit/ -v`):

```text
=========== 4132 passed, 15 skipped, 2 warnings in 118.91s (0:01:58) ===========
```

(all 15 skips are pre-existing `need --slow option to run` gates)

Repo harness (`bash src/tests/scripts/run_tests.bash`): exit 0 — `✓ All tests passed!`

`pre-commit run --all-files`: exit 0 — all hooks pass (Black, isort, Flake8 source+tests, MyPy, Bandit, markdownlint, doc links, shellcheck, yamllint).

D4 coverage proof — running only `TestRealInitLoggingSystem` with `--cov=cascade_correlation`:

```text
_init_logging_system body lines 631-658 executed by the D4 test: 8/28 -> [632, 635, 636, 637, 640, 656, 657, 658]
```

Those 8 lines are exactly the 8 executable statements of the body (641–654 are continuation lines of the single `LogConfig(...)` call starting at 640) — 100% of the real body executes under pytest while the autouse fast-logging fixture remains in place for the rest of the suite.

## Notes

- No test was deleted, disabled, or weakened; the previously-pinned failure-path semantics (`False` returns, empty-list returns, `ValueError` raises) are all still asserted, both by the untouched existing tests and by new companion tests.
- Test snapshots are written only to pytest `tmp_path`; nothing under the repo tree (`src/snapshots/` committed `.h5` artifacts untouched).
- One resource correction from execution: the live conda env is `JuniperCascor1` (per AGENTS.md; `JuniperCascor` is now `*-DEPRECATED`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
