### PR TITLE
chore(ci): bump juniper-ci-tools pin ceiling to <0.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
       - name: Install juniper-ci-tools (workflow-path + agents-md lints)
         run: |
           python -m pip install --upgrade "pip>=26.1.1"
-          pip install "juniper-ci-tools>=0.2.0,<0.5.0"
+          pip install "juniper-ci-tools>=0.2.0,<0.7.0"
 
       - name: Lint .github/workflows/ script paths
         run: |
@@ -550,7 +550,7 @@ jobs:
         shell: bash -l {0}
         run: |
           python -m pip install --upgrade "pip>=26.1.1"
-          pip install "juniper-ci-tools>=0.2.0,<0.5.0"
+          pip install "juniper-ci-tools>=0.2.0,<0.7.0"
 
       - name: Generate Dependency Documentation
         shell: bash -l {0}


### PR DESCRIPTION
juniper-ci-tools 0.6.0 shipped 2026-07-01; the legacy dep-docs/doc-links jobs here still pinned `<0.5.0`, which pcalnon/juniper-ml's cross-repo drift lint hard-fails (weekly Docs Full Check red since 2026-07-06). Ceiling-only bump `<0.5.0` → `<0.7.0` — documented floors (`>=0.2.0`/`>=0.4.0`) preserved, newer `>=0.6.0,<0.7.0` sites untouched. One-line class; safe alongside in-flight coverage work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011WK935A7y71buYsuZwR2L4