### PR TITLE
ci(codeql): align analyze to v4.36.3 (fix init/analyze version mismatch)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,6 +55,6 @@ jobs:
         uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Fixes the **CodeQL "Analyze (python)" failure on `main`**. Dependabot split the `github/codeql-action` bump into per-subaction PRs; `init` and `autobuild` merged to **v4.36.3** but `analyze` was left at **v4.36.2**. CodeQL requires the same version across steps, so every run failed at the analyze step:

```
##[error]Loaded a configuration file for version '4.36.3', but running version '4.36.2'
```

This one-line change bumps `analyze` to **v4.36.3** (SHA `54f647b7…` — the same release SHA `init`/`autobuild` already use, since all three are subdirs of one repo), so init/autobuild/analyze match.

## Scope note

This split-bump mismatch is fleet-wide (same class in juniper-cascor-worker, and the inverse — init lagging — in juniper-data + juniper-cascor-client). Those are separate follow-ups.

## Testing

- `codeql.yml` is valid YAML; all three subactions now pinned to `54f647b7…` (v4.36.3).
- The fix will be confirmed by the "Analyze (python)" check going green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX5ToumBaABH3QutQC86sM