### PR TITLE
fix(lifecycle): create network on start from dataset dims + translate staged configs to juniper-data schema — PR-B1

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -1422,37 +1422,47 @@ class TrainingLifecycleManager:
         Returns:
             Network info dictionary
         """
+        with self._lock:
+            return self._create_network_locked(**kwargs)
+
+    def _create_network_locked(self, **kwargs) -> Dict[str, Any]:
+        """``create_network`` body for callers that already hold ``self._lock``.
+
+        ``self._lock`` is a non-reentrant ``threading.Lock``, so ``start_training``'s
+        create-on-start path (training-start diagnosis 2026-07-09 PR-B) cannot call
+        the public ``create_network`` from inside its locked section — it calls this
+        instead. Behavior is identical to the public method.
+        """
         from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
         from cascade_correlation.cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
 
-        with self._lock:
-            if self.state_machine.is_started():
-                raise RuntimeError("Cannot create network while training is active")
+        if self.state_machine.is_started():
+            raise RuntimeError("Cannot create network while training is active")
 
-            self._params = kwargs.copy()
-            config = CascadeCorrelationConfig.create_simple_config(**kwargs)
-            # WS-6 B-phase: wrap the freshly built CCN in the model-core CascorModel.
-            # PR-B3.3: no monitoring hooks to install — live monitoring rides
-            # CascorModel.fit's on_event sink (_handle_event), wired per-fit in _run_training.
-            self.model = CascorModel(network=CascadeCorrelationNetwork(config=config))
+        self._params = kwargs.copy()
+        config = CascadeCorrelationConfig.create_simple_config(**kwargs)
+        # WS-6 B-phase: wrap the freshly built CCN in the model-core CascorModel.
+        # PR-B3.3: no monitoring hooks to install — live monitoring rides
+        # CascorModel.fit's on_event sink (_handle_event), wired per-fit in _run_training.
+        self.model = CascorModel(network=CascadeCorrelationNetwork(config=config))
 
-            # Inject worker coordinator for remote dispatch if available
-            if self._worker_coordinator is not None and hasattr(self.network, "set_worker_coordinator"):
-                self.network.set_worker_coordinator(self._worker_coordinator)
+        # Inject worker coordinator for remote dispatch if available
+        if self._worker_coordinator is not None and hasattr(self.network, "set_worker_coordinator"):
+            self.network.set_worker_coordinator(self._worker_coordinator)
 
-            self.training_state.update_state(
-                status="Stopped",
-                phase="Idle",
-                learning_rate=kwargs.get("learning_rate", _PROJECT_API_NETWORK_LEARNING_RATE_DEFAULT),
-                max_hidden_units=kwargs.get("max_hidden_units", _PROJECT_API_LIFECYCLE_DEFAULT_MAX_HIDDEN_UNITS),
-                max_epochs=kwargs.get("epochs_max", _PROJECT_API_LIFECYCLE_DEFAULT_EPOCHS_MAX),
-                max_iterations=kwargs.get("max_iterations", _PROJECT_API_LIFECYCLE_DEFAULT_MAX_ITERATIONS),
-                network_name=f"CasCor-{kwargs.get('input_size', _PROJECT_API_NETWORK_INPUT_SIZE_DEFAULT)}x{kwargs.get('output_size', _PROJECT_API_NETWORK_OUTPUT_SIZE_DEFAULT)}",
-            )
+        self.training_state.update_state(
+            status="Stopped",
+            phase="Idle",
+            learning_rate=kwargs.get("learning_rate", _PROJECT_API_NETWORK_LEARNING_RATE_DEFAULT),
+            max_hidden_units=kwargs.get("max_hidden_units", _PROJECT_API_LIFECYCLE_DEFAULT_MAX_HIDDEN_UNITS),
+            max_epochs=kwargs.get("epochs_max", _PROJECT_API_LIFECYCLE_DEFAULT_EPOCHS_MAX),
+            max_iterations=kwargs.get("max_iterations", _PROJECT_API_LIFECYCLE_DEFAULT_MAX_ITERATIONS),
+            network_name=f"CasCor-{kwargs.get('input_size', _PROJECT_API_NETWORK_INPUT_SIZE_DEFAULT)}x{kwargs.get('output_size', _PROJECT_API_NETWORK_OUTPUT_SIZE_DEFAULT)}",
+        )
 
-            info = self.get_network_info()
-            self.logger.info(f"Network created: {info['input_size']}x{info['output_size']}")
-            return info
+        info = self.get_network_info()
+        self.logger.info(f"Network created: {info['input_size']}x{info['output_size']}")
+        return info
 
     def delete_network(self) -> None:
         """Delete the current network."""
@@ -1859,9 +1869,6 @@ class TrainingLifecycleManager:
         Returns:
             Status dictionary
         """
-        if self.network is None:
-            raise RuntimeError("No network created")
-
         with self._lock:
             if self.state_machine.is_started():
                 raise RuntimeError("Training already in progress")
@@ -1898,6 +1905,27 @@ class TrainingLifecycleManager:
 
             if self._train_x is None or self._train_y is None:
                 raise ValueError("Training data not provided")
+
+            # Training-start diagnosis 2026-07-09 (PR-B): with ``auto_start``
+            # defaulting off, nothing creates a network before the first
+            # user-initiated start — every UI start on a fresh cascor died on
+            # the old pre-lock "No network created" guard. Mirror
+            # ``_auto_start_training``'s inference instead: size the network
+            # from the actual training arrays (the staged/pending dataset was
+            # consumed above, so the dims are authoritative). A bare start with
+            # neither data nor a staged dataset still fails loud on the
+            # "Training data not provided" check above.
+            if self.network is None:
+                create_cfg = {
+                    "input_size": self._train_x.shape[1],
+                    "output_size": self._train_y.shape[1] if self._train_y.dim() > 1 else 1,
+                }
+                self.logger.info(
+                    "start_training: no network — creating %sx%s from dataset dims",
+                    create_cfg["input_size"],
+                    create_cfg["output_size"],
+                )
+                self._create_network_locked(**create_cfg)
 
             # P2-1d: cold-swap parity with swap_dataset_live. If the dataset
             # is smaller than the network's input/output dims (e.g., after a
@@ -2815,6 +2843,53 @@ class TrainingLifecycleManager:
                 self.logger.exception("swap_dataset_live rollback: load_state_dict failed; weights may be inconsistent")
         self._current_dataset_config = dict(pre.dataset_config) if pre.dataset_config else None
 
+    # Canopy-facing staged ``dataset_type`` values (``StageDatasetRequest``'s
+    # Literal) → juniper-data ``GENERATOR_REGISTRY`` keys. Types not listed pass
+    # through unchanged (their registry key already matches).
+    _STAGED_GENERATOR_ALIASES: Dict[str, str] = {"spirals": "spiral", "moons": "moon"}
+
+    @staticmethod
+    def _translate_staged_config(dataset_type: str, cfg: Dict[str, Any]) -> "tuple[str, Dict[str, Any]]":
+        """Translate a canopy-facing staged dataset config into juniper-data's schema.
+
+        ``StageDatasetRequest`` speaks canopy's dialect — ``dataset_type``
+        ``"spirals"``/``"moons"``, a *total* ``n_samples``, ``rotations`` — while
+        juniper-data's registry keys are ``"spiral"``/``"moon"`` and its spiral/xor
+        generators take per-arm / per-quadrant counts (``n_points_per_spiral``,
+        ``n_points_per_quadrant``) and ``n_rotations``. Nothing translated between
+        the two dialects before this helper, so every canopy-staged reload died
+        with "Unknown generator 'spirals'" at juniper-data (training-start
+        diagnosis 2026-07-09 — the unit stubs exercised this path with
+        juniper-data names directly, masking the seam).
+
+        Returns ``(generator, params)`` ready for ``create_dataset``. Translated
+        keys are written with ``setdefault`` so caller-supplied generic ``params``
+        (which won their merge upstream) keep winning on conflict.
+        """
+        generator = TrainingLifecycleManager._STAGED_GENERATOR_ALIASES.get(dataset_type, dataset_type)
+        params = dict(cfg)
+        if generator == "spiral":
+            n_spirals = int(params.get("n_spirals") or 2)  # juniper-data SPIRAL_DEFAULT_N_SPIRALS
+            n_samples = params.pop("n_samples", None)
+            if n_samples is not None:
+                params.setdefault("n_points_per_spiral", max(1, int(n_samples) // max(1, n_spirals)))
+            rotations = params.pop("rotations", None)
+            if rotations is not None:
+                params.setdefault("n_rotations", rotations)
+        elif generator == "xor":
+            n_samples = params.pop("n_samples", None)
+            if n_samples is not None:
+                params.setdefault("n_points_per_quadrant", max(1, int(n_samples) // 4))
+            params.pop("rotations", None)
+            params.pop("n_spirals", None)
+        else:
+            # circles / moon / mnist / gaussian take ``n_samples`` directly; drop
+            # the spiral-only typed fields so they never reach generators that do
+            # not declare them.
+            params.pop("rotations", None)
+            params.pop("n_spirals", None)
+        return generator, params
+
     def _reload_dataset(self, **cfg: Any) -> None:
         """Fetch a fresh dataset from juniper-data and replace the live tensors.
 
@@ -2823,6 +2898,11 @@ class TrainingLifecycleManager:
         staged generator + params, ``download_artifact_npz``, convert to
         ``torch.float32`` tensors, swap ``_train_x/_train_y`` (and val if
         the artifact carries them).
+
+        The staged config is kept in canopy's dialect everywhere it is stored
+        (``_pending_dataset_config`` / ``_current_dataset_config``); it is
+        translated to juniper-data's generator key + params schema via
+        ``_translate_staged_config`` at the fetch boundary only.
 
         Held under ``_lock`` by the caller (``start_training``);
         any I/O failure surfaces as ``RuntimeError`` so the caller can leave
@@ -2873,8 +2953,9 @@ class TrainingLifecycleManager:
         api_key = get_secret("JUNIPER_DATA_API_KEY")
         client = JuniperDataClient(base_url=data_url, api_key=api_key)
 
+        generator, jd_params = self._translate_staged_config(dataset_type, cfg)
         try:
-            result = client.create_dataset(generator=dataset_type, params=cfg, persist=True)
+            result = client.create_dataset(generator=generator, params=jd_params, persist=True)
             dataset_id = result["dataset_id"]
             arrays = client.download_artifact_npz(dataset_id)
         except Exception as exc:

--- a/src/api/routes/training.py
+++ b/src/api/routes/training.py
@@ -35,6 +35,12 @@ async def start_training(request: Request, body: TrainingStartRequest = None) ->
     - dataset: Dataset source specification (juniper-data or generator)
     - params: Training parameter overrides
     - epochs: Max epochs override (shorthand)
+
+    If no network exists yet, one is created automatically from the training
+    data's dims (inline/staged/pending dataset) — ``_auto_start_training``
+    parity, so the first user-initiated start works on a fresh service
+    (training-start diagnosis 2026-07-09, PR-B). A start with neither data nor
+    a staged dataset still 409s with "Training data not provided".
     """
     lifecycle = _get_lifecycle(request)
 
@@ -74,12 +80,14 @@ async def start_training(request: Request, body: TrainingStartRequest = None) ->
         result = lifecycle.start_training(X=x, y=y, X_val=x_val, y_val=y_val, **kwargs)
         return success_response(result)
     except (RuntimeError, ValueError) as e:
-        # Surface the specific reason (no network created / training already in progress /
-        # no dataset staged ("Training data not provided") / juniper-data fetch failed /
+        # Surface the specific reason (training already in progress / no dataset
+        # staged ("Training data not provided") / juniper-data fetch failed /
         # investigating|replaying a snapshot) rather than a generic message, so API and
         # Canopy callers can tell *why* the start was rejected and act on it. The generic
         # string previously masked a juniper-data fetch failure as a bogus "state" error.
         # See notes/CASCOR_STARTUP_SECRET_INDIRECTION_INVESTIGATION_2026-06-14.md (3.4).
+        # ("No network created" left this list in PR-B — start now creates the
+        # network from the dataset dims when one is missing.)
         logger.debug("Start training failed: %s", e)
         raise HTTPException(status_code=409, detail=f"Training cannot be started: {e}") from e
 

--- a/src/tests/unit/api/test_lifecycle_manager.py
+++ b/src/tests/unit/api/test_lifecycle_manager.py
@@ -201,11 +201,40 @@ class TestLifecycleHeartbeat:
 class TestLifecycleManagerTrainingControl:
     """Test training start/stop/pause/resume/reset."""
 
-    def test_start_training_without_network(self):
-        """Start fails without network."""
+    def test_start_training_without_network_creates_from_data(self):
+        """PR-B (training-start diagnosis 2026-07-09): a start with data but no
+        network creates the network from the training-array dims instead of
+        raising 'No network created' (``_auto_start_training`` parity — with
+        ``auto_start`` defaulting off, the first user-initiated start owns
+        network creation)."""
+        from unittest.mock import patch
+
         mgr = TrainingLifecycleManager()
-        with pytest.raises(RuntimeError, match="No network created"):
-            mgr.start_training(X=torch.randn(10, 2), y=torch.randn(10, 2))
+        with patch.object(mgr, "_run_training"):
+            result = mgr.start_training(X=torch.randn(10, 2), y=torch.randn(10, 2))
+            assert result["status"] == "training_started"
+            if mgr._training_future is not None:
+                mgr._training_future.result(timeout=10)
+        assert mgr.network is not None
+        assert mgr.network.input_size == 2
+        assert mgr.network.output_size == 2
+        mgr.shutdown()
+
+    def test_start_training_without_network_infers_single_column_target_width(self):
+        """Single-column targets infer ``output_size=1`` (the ``y.shape[1]`` arm of
+        ``_auto_start_training``'s inference; truly 1-D ``y`` is unsupported further
+        down in ``_pad_dataset_for_network`` regardless of network creation)."""
+        from unittest.mock import patch
+
+        mgr = TrainingLifecycleManager()
+        with patch.object(mgr, "_run_training"):
+            mgr.start_training(X=torch.randn(10, 3), y=torch.randn(10, 1))
+            if mgr._training_future is not None:
+                mgr._training_future.result(timeout=10)
+        assert mgr.network is not None
+        assert mgr.network.input_size == 3
+        assert mgr.network.output_size == 1
+        mgr.shutdown()
 
     def test_start_training_without_data(self):
         """Start fails without training data."""

--- a/src/tests/unit/api/test_lifecycle_manager_swap.py
+++ b/src/tests/unit/api/test_lifecycle_manager_swap.py
@@ -222,6 +222,60 @@ class TestReloadDataset:
             with pytest.raises(RuntimeError, match="artifact missing required key"):
                 mgr._reload_dataset(dataset_type="spiral")
 
+    def test_canopy_staged_spirals_config_is_translated(self, mgr):
+        """The canopy-facing staged dialect (``dataset_type='spirals'``, total
+        ``n_samples``, ``rotations``) is translated to juniper-data's registry
+        key + spiral params at the fetch boundary; the stored config keeps the
+        canopy dialect (PR-B, training-start diagnosis 2026-07-09 — previously
+        this reload died at juniper-data with "Unknown generator 'spirals'")."""
+        mod, client = _fake_data_client_module()
+        with patch.dict(sys.modules, {"juniper_data_client": mod}), patch("api.secrets.get_secret", return_value=None), patch("api.settings.Settings"):
+            mgr._reload_dataset(dataset_type="spirals", n_samples=1000, noise=0.1, rotations=1.5, n_spirals=2)
+        _, kwargs = client.create_dataset.call_args
+        assert kwargs["generator"] == "spiral"
+        assert kwargs["params"] == {"n_points_per_spiral": 500, "n_rotations": 1.5, "noise": 0.1, "n_spirals": 2}
+        assert mgr._current_dataset_config["dataset_type"] == "spirals"
+        assert mgr._current_dataset_config["n_samples"] == 1000
+
+    def test_canopy_staged_xor_config_is_translated(self, mgr):
+        """XOR: total ``n_samples`` becomes per-quadrant; spiral-only typed
+        fields are dropped rather than leaking to a generator that never
+        declared them."""
+        mod, client = _fake_data_client_module()
+        with patch.dict(sys.modules, {"juniper_data_client": mod}), patch("api.secrets.get_secret", return_value=None), patch("api.settings.Settings"):
+            mgr._reload_dataset(dataset_type="xor", n_samples=1000, noise=0.2, rotations=1.5, n_spirals=2)
+        _, kwargs = client.create_dataset.call_args
+        assert kwargs["generator"] == "xor"
+        assert kwargs["params"] == {"n_points_per_quadrant": 250, "noise": 0.2}
+
+    def test_generic_params_win_over_translated_typed_fields(self, mgr):
+        """Caller-supplied generic ``params`` keep winning over the translated
+        typed fields (the pre-existing merge contract, preserved via setdefault)."""
+        mod, client = _fake_data_client_module()
+        with patch.dict(sys.modules, {"juniper_data_client": mod}), patch("api.secrets.get_secret", return_value=None), patch("api.settings.Settings"):
+            mgr._reload_dataset(dataset_type="spirals", n_samples=1000, params={"n_points_per_spiral": 7})
+        _, kwargs = client.create_dataset.call_args
+        assert kwargs["params"]["n_points_per_spiral"] == 7
+
+    def test_start_training_consumes_pending_and_creates_network(self, mgr):
+        """End-to-end through ``start_training``: a pending canopy-staged dataset
+        is consumed and the network is created from the fetched array dims
+        (PR-B create-on-start; the fresh-boot UI flow)."""
+        mod, client = _fake_data_client_module()
+        mgr._pending_dataset_config = {"dataset_type": "spirals", "n_samples": 6, "n_spirals": 2}
+        with patch.dict(sys.modules, {"juniper_data_client": mod}), patch("api.secrets.get_secret", return_value=None), patch("api.settings.Settings"), patch.object(mgr, "_run_training"):
+            result = mgr.start_training()
+            assert result["status"] == "training_started"
+            if mgr._training_future is not None:
+                mgr._training_future.result(timeout=10)
+        assert mgr._pending_dataset_config is None
+        assert mgr.network is not None
+        assert mgr.network.input_size == 2
+        assert mgr.network.output_size == 2
+        _, kwargs = client.create_dataset.call_args
+        assert kwargs["generator"] == "spiral"
+        assert kwargs["params"]["n_points_per_spiral"] == 3
+
 
 class TestSwapConcurrencyAndCancel:
     """``swap_dataset_live`` concurrent guard + cancel signalling."""

--- a/src/tests/unit/api/test_training_route_coverage.py
+++ b/src/tests/unit/api/test_training_route_coverage.py
@@ -151,18 +151,28 @@ class TestStartTraining:
         )
         assert response.status_code == 200
 
-    def test_start_training_without_network_returns_error(self, client):
-        """start_training should return 409 when no network exists."""
+    def test_start_training_without_network_creates_it_from_inline_data(self, client):
+        """PR-B (training-start diagnosis 2026-07-09): a start with data but no
+        network creates the network from the data dims (``_auto_start_training``
+        parity) instead of returning 409 'No network created'."""
         response = client.post(
             "/v1/training/start",
             json={
                 "inline_data": {
-                    "train_x": [[0.1, 0.2]],
-                    "train_y": [[1.0, 0.0]],
-                }
+                    "train_x": [[0.1, 0.2], [0.3, 0.4]],
+                    "train_y": [[1.0, 0.0], [0.0, 1.0]],
+                },
+                "epochs": 2,
             },
         )
-        assert response.status_code == 409
+        assert response.status_code == 200
+        net = client.get("/v1/network")
+        assert net.status_code == 200
+        info = net.json()["data"]
+        assert info["input_size"] == 2
+        assert info["output_size"] == 2
+        # Stop the background run before client teardown triggers lifespan shutdown.
+        client.post("/v1/training/stop")
 
     def test_start_training_no_body(self, client_with_network):
         """start_training without body should fail with state error."""


### PR DESCRIPTION
## Summary

**PR-B1 of the 2026-07-09 training-start fix plan** (defect 1 — no network-creation path; diagnosis: juniper-ml `notes/JUNIPER_2026-07-09_JUNIPER-ECOSYSTEM_TRAINING-START-FAILURE-DIAGNOSIS-AND-FIX-PLAN.md` §4.1, lands via juniper-ml#633). Two coupled fixes, both in the lifecycle manager:

### 1. Create-on-start

With `auto_start` now defaulting off (only the deploy demo profile re-enables it), nothing created a network before the first user-initiated start — every `POST /v1/training/start` on a fresh service 409'd on the pre-lock "No network created" guard, **before the staged/pending dataset was even consumed** (verified live). `start_training` now consumes the pending dataset first and, when no network exists, creates one sized from the actual training arrays (`input=X.shape[1]`, `output=y.shape[1] if 2-D else 1`) — exact `_auto_start_training` parity. A bare start with neither data nor a staged dataset still fails loud with "Training data not provided". `create_network`'s body moves to `_create_network_locked` so the non-reentrant lifecycle lock is held across consume→create→start (public behavior unchanged).

### 2. Staged-config dialect translation

`StageDatasetRequest` speaks canopy's dialect — `dataset_type` Literal `'spirals'`/`'moons'`, **total** `n_samples`, `rotations` — while juniper-data's registry keys are `'spiral'`/`'moon'` with per-arm/per-quadrant counts (`n_points_per_spiral`, `n_points_per_quadrant`) and `n_rotations`. `_reload_dataset` forwarded the canopy dialect verbatim, so every canopy-staged reload — the cold-swap **and** live-swap flows share this path — would die at juniper-data with `Unknown generator 'spirals'`. The seam was masked because the unit stubs called `_reload_dataset` with juniper-data names directly. `_translate_staged_config` now maps the dialect at the fetch boundary only; stored configs (pending/current/rollback) stay canopy-facing, and generic `params` keep winning on conflict (`setdefault`).

## Requirements

References JR-CAN-TRAIN-003 (external-cascor phases: backend sync / dataset adapters — this makes the canopy-facing staged-dataset and first-start contracts actually executable).

## Testing

- New: create-on-start via inline data and via pending staged dataset (network dims asserted from fetched arrays), single-column output-size inference, spirals/xor translation (`generator`/params asserted at the `create_dataset` boundary), generic-params precedence, canopy-dialect preservation in `_current_dataset_config`.
- Updated the two tests that had pinned the old contract (`test_start_training_without_network` 409, route-level inline-data 409).
- `tests/unit/api/` full suite green (exit 0); lifecycle suites 168 passed. Pre-commit clean (black/isort/flake8/mypy/bandit/async-audit).

Companions: canopy#437 (PR-A failure propagation, merged-independent), canopy PR-B2 (default-dataset staging for the trivial case) to follow, juniper-ml#634 (PR-C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0192fCcLFN9EaZmstwK5Yjax