### PR TITLE
fix(api): C1 — snapshot create tolerates null description; save failures carry reason (not 404); history serialized from a consistent copy

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -3851,10 +3851,18 @@ class TrainingLifecycleManager:
         slot. The no-collision path is byte-identical to the prior
         behaviour, so the ``snapshot_YYYYMMDDTHHMMSSZ`` format remains the
         common case for canopy / REST consumers that parse it.
+
+        C1 (I-3): ``None`` is returned only for the no-network case. A
+        failed write raises ``SnapshotSaveError`` carrying the serializer's
+        reason — pre-C1 both collapsed to ``None`` and the API route mapped
+        a disk/HDF5 failure to the same 404 as a missing network. The
+        failure-tolerant callers (``auto_snap_best``, the swap pre/post
+        snaps) already wrap this call in ``try/except Exception``.
         """
         if self.network is None:
             return None
 
+        from snapshots.snapshot_errors import SnapshotSaveError
         from snapshots.snapshot_serializer import CascadeHDF5Serializer
 
         serializer = CascadeHDF5Serializer()
@@ -3874,10 +3882,17 @@ class TrainingLifecycleManager:
             filepath = snapshots_dir / f"{snapshot_id}.h5"
             suffix += 1
 
-        success = serializer.save_network(self.network, filepath, include_training_state=True)
+        try:
+            success = serializer.save_network(self.network, filepath, include_training_state=True)
+        except SnapshotSaveError as exc:
+            self.logger.error(f"Failed to save snapshot to {filepath}: {exc}")
+            raise
         if not success:
+            # Defensive: ``save_network``'s contract is raise-on-failure, but a
+            # stubbed / legacy serializer returning falsy must not turn into a
+            # phantom "no network" 404 downstream (C1 / I-3).
             self.logger.error(f"Failed to save snapshot to {filepath}")
-            return None
+            raise SnapshotSaveError(f"Snapshot save to {filepath} failed (serializer returned {success!r})")
 
         self.logger.info(f"Snapshot saved: {snapshot_id}")
         return {

--- a/src/api/routes/snapshots.py
+++ b/src/api/routes/snapshots.py
@@ -5,9 +5,10 @@ import logging
 import re
 
 from fastapi import APIRouter, HTTPException, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from api.models.common import success_response
+from snapshots.snapshot_errors import SnapshotSaveError
 
 logger = logging.getLogger("juniper_cascor.api.routes.snapshots")
 
@@ -40,9 +41,23 @@ def _validate_snapshot_id(snapshot_id: str, client: str | None = None) -> None:
 
 
 class SnapshotCreateRequest(BaseModel):
-    """Request body for creating a snapshot."""
+    """Request body for creating a snapshot.
 
-    description: str = ""
+    C1 (I-3): ``description`` tolerates an explicit JSON ``null`` in
+    addition to omission and a plain string. Canopy's route seam posts
+    ``{"description": null}`` for a blank description (live incident
+    2026-07-11: the resulting 422 ``string_type`` rejection masqueraded
+    as a failed snapshot); a ``null`` is normalized to ``""`` so all
+    three shapes are equivalent downstream.
+    """
+
+    description: str | None = ""
+
+    @field_validator("description", mode="before")
+    @classmethod
+    def _null_description_is_empty(cls, value):
+        """Normalize an explicit ``null`` to the empty description."""
+        return "" if value is None else value
 
 
 def _get_lifecycle(request: Request):
@@ -136,7 +151,15 @@ async def save_snapshot(request: Request, body: SnapshotCreateRequest = None) ->
     # PERF-CC-01: serializer.save_network is synchronous HDF5 I/O. Run it
     # off the event loop so concurrent requests aren't blocked while the
     # snapshot is being written.
-    result = await asyncio.to_thread(lifecycle.save_snapshot, description=description)
+    #
+    # C1 (I-3): a FAILED WRITE surfaces as 500 with the serializer's reason
+    # in the detail, distinct from the 404 no-network case below — pre-C1
+    # both collapsed to the 404 and a disk/HDF5 failure masqueraded as a
+    # missing network.
+    try:
+        result = await asyncio.to_thread(lifecycle.save_snapshot, description=description)
+    except SnapshotSaveError as exc:
+        raise HTTPException(status_code=500, detail=f"Snapshot save failed: {exc}") from exc
     if result is None:
         raise HTTPException(status_code=404, detail="No network available to snapshot")
     return success_response(result)

--- a/src/snapshots/snapshot_errors.py
+++ b/src/snapshots/snapshot_errors.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+"""
+Typed exceptions for the snapshot subsystem.
+
+Kept in a dedicated stdlib-only module so API route modules can import the
+exception types at module scope without pulling the heavy serializer stack
+(h5py / numpy / torch) into their import graph — the serializer itself is
+deliberately imported lazily by the lifecycle manager.
+"""
+
+
+class SnapshotSaveError(RuntimeError):
+    """A snapshot write failed after the save was attempted.
+
+    C1 (I-3 upstream half — see juniper-ml
+    ``notes/JUNIPER_2026-07-11_JUNIPER-CANOPY_TRAINING-RUNTIME-DEFECTS-PLAN.md``):
+    ``CascadeHDF5Serializer.save_network`` used to swallow every exception
+    into ``False``, which the lifecycle collapsed to ``None`` and the API
+    route mapped to a 404 "No network available to snapshot" — a failed
+    save masquerading as a missing network. The serializer now raises this
+    exception (chaining the underlying cause) so the lifecycle and route
+    can propagate the real reason with a correct 500 status, while the
+    no-network case keeps its 404.
+    """

--- a/src/snapshots/snapshot_serializer.py
+++ b/src/snapshots/snapshot_serializer.py
@@ -91,6 +91,7 @@ from log_config.logger.logger import Logger
 from utils.activation import ActivationWithDerivative
 
 from .snapshot_common import calculate_tensor_checksum, load_numpy_array, load_tensor, read_str_attr, read_str_dataset, save_numpy_array, save_tensor, verify_tensor_checksum, write_str_attr, write_str_dataset
+from .snapshot_errors import SnapshotSaveError
 
 
 class CascadeHDF5Serializer:
@@ -135,7 +136,14 @@ class CascadeHDF5Serializer:
             compression_opts: Compression level (0-9)
 
         Returns:
-            bool: Success status
+            bool: True on success.
+
+        Raises:
+            SnapshotSaveError: when the write fails, chaining the underlying
+                exception so callers can surface the real reason (C1 / I-3 —
+                pre-C1 every failure was swallowed into ``False`` and a failed
+                save was indistinguishable from a missing network at the API
+                route). Callers that want bool semantics catch it.
         """
         try:
             self.logger.info(f"CascadeHDF5Serializer: Saving network to {filepath}")
@@ -157,7 +165,11 @@ class CascadeHDF5Serializer:
             return True
 
         except Exception as e:
-            return self._log_exception_stacktrace("CascadeHDF5Serializer: Error saving network: ", e, False)
+            # C1 (I-3): keep the ERROR + stacktrace logging, then raise a typed
+            # error carrying the reason instead of collapsing to ``False`` — a
+            # failed save must not be indistinguishable from "no network".
+            self._log_exception_stacktrace("CascadeHDF5Serializer: Error saving network: ", e, False)
+            raise SnapshotSaveError(f"{type(e).__name__}: {e}") from e
 
     def save_object(
         self,
@@ -613,9 +625,41 @@ class CascadeHDF5Serializer:
         # Save policy flags
         mp_group.attrs["autostart"] = True  # Default to autostart on restore
 
+    @staticmethod
+    def _snapshot_history_view(network) -> Dict[str, Any]:
+        """Return a shallow, point-in-time copy of the network's history dict.
+
+        C1 (I-3 write-isolation hardening): ``save_network`` can run
+        concurrently with the training thread, which appends per-epoch
+        entries to the history lists (``cascade_correlation.py`` — no lock is
+        shared with the serializer, so no manager-side lock can exclude those
+        appends). The HDF5 writes below are slow; iterating the live lists
+        risks mid-iteration mutation. Copying the top-level dict and each
+        list value is a handful of GIL-atomic operations taken up front,
+        giving every subsequent write a stable iteration target. Per-element
+        objects (floats, unit-metadata dicts, swap events) are appended
+        fully built and at most attr-backfilled afterwards, so a shallow
+        copy is sufficient to prevent crashes; deep consistency of element
+        internals is not claimed.
+        """
+        history = getattr(network, "history", None)
+        if not history:
+            return {}
+        view: Dict[str, Any] = {}
+        for key in list(history.keys()):
+            value = history.get(key)
+            view[key] = list(value) if isinstance(value, list) else value
+        return view
+
     def _save_training_history(self, hdf5_file: h5py.File, network, compression: str, compression_opts: int) -> None:  # noqa: C901
-        """Save training history."""
-        if not hasattr(network, "history") or not network.history:
+        """Save training history.
+
+        C1 (I-3): serializes from ``_snapshot_history_view``'s point-in-time
+        copy rather than the live history dict, so a mid-training snapshot
+        cannot crash on concurrent list mutation by the training thread.
+        """
+        history = self._snapshot_history_view(network)
+        if not history:
             return
 
         history_group = hdf5_file.create_group("history")
@@ -623,21 +667,21 @@ class CascadeHDF5Serializer:
         # Save numeric arrays - use network's actual keys (value_* not val_*)
         key_mapping = {
             "train_loss": "train_loss",
-            "value_loss": "value_loss",  # Match network.history keys
+            "value_loss": "value_loss",  # Match network history keys
             "train_accuracy": "train_accuracy",
-            "value_accuracy": "value_accuracy",  # Match network.history keys
+            "value_accuracy": "value_accuracy",  # Match network history keys
         }
 
         for network_key, save_key in key_mapping.items():
-            if network_key in network.history and network.history[network_key]:
-                data = np.array(network.history[network_key])
+            if network_key in history and history[network_key]:
+                data = np.array(history[network_key])
                 save_numpy_array(history_group, save_key, data, compression, compression_opts)
 
         # Save hidden units added history (metadata-only since CR-063;
         # legacy weight/bias arrays are still handled for backward compat)
-        if "hidden_units_added" in network.history:
+        if "hidden_units_added" in history:
             units_group = history_group.create_group("hidden_units_added")
-            for i, unit_data in enumerate(network.history["hidden_units_added"]):
+            for i, unit_data in enumerate(history["hidden_units_added"]):
                 unit_group = units_group.create_group(f"unit_{i}")
                 if isinstance(unit_data, dict):
                     if "correlation" in unit_data:
@@ -678,9 +722,9 @@ class CascadeHDF5Serializer:
         # ``arch_changes`` block has variable shape (``appended_nodes`` is
         # itself a dict). Missing snapshot-ID attrs decode back to None on
         # load so the §3.9 schema is faithfully reproduced.
-        if "dataset_swaps" in network.history and network.history["dataset_swaps"]:
+        if "dataset_swaps" in history and history["dataset_swaps"]:
             swaps_group = history_group.create_group("dataset_swaps")
-            for i, swap_event in enumerate(network.history["dataset_swaps"]):
+            for i, swap_event in enumerate(history["dataset_swaps"]):
                 if not isinstance(swap_event, dict):
                     continue
                 ev_group = swaps_group.create_group(f"event_{i}")

--- a/src/tests/unit/api/test_lifecycle_manager_coverage_ext.py
+++ b/src/tests/unit/api/test_lifecycle_manager_coverage_ext.py
@@ -290,12 +290,18 @@ class TestSnapshotSaveLoad:
     def test_save_snapshot_no_network_returns_none(self, mgr):
         assert mgr.save_snapshot() is None
 
-    def test_save_snapshot_serializer_failure_returns_none(self, mgr, tmp_path):
+    def test_save_snapshot_serializer_failure_raises(self, mgr, tmp_path):
+        """C1 (I-3): a falsy serializer result raises SnapshotSaveError instead
+        of collapsing to ``None`` — pre-C1 the API route mapped that ``None``
+        to the same 404 as a missing network."""
+        from snapshots.snapshot_errors import SnapshotSaveError
+
         mgr.create_network(input_size=2, output_size=2)
         fake_serializer = MagicMock()
         fake_serializer.save_network.return_value = False
         with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer", return_value=fake_serializer):
-            assert mgr.save_snapshot(description="x") is None
+            with pytest.raises(SnapshotSaveError):
+                mgr.save_snapshot(description="x")
 
     def test_load_snapshot_injects_worker_coordinator(self, mgr, tmp_path):
         (tmp_path / "snap_wc.h5").write_bytes(b"stub")

--- a/src/tests/unit/api/test_snapshot_create_error_paths.py
+++ b/src/tests/unit/api/test_snapshot_create_error_paths.py
@@ -1,0 +1,233 @@
+"""C1 (I-3 upstream half) — snapshot-create correctness + error propagation.
+
+Plan of record: juniper-ml
+``notes/JUNIPER_2026-07-11_JUNIPER-CANOPY_TRAINING-RUNTIME-DEFECTS-PLAN.md``
+§4 I-3 / §7 C1.
+
+Pins the corrected route/lifecycle contracts:
+
+* ``SnapshotCreateRequest.description`` tolerates an explicit JSON ``null``
+  (live incident 2026-07-11: canopy's route seam posts ``{"description": null}``
+  for a blank description and cascor 422'd it with a ``string_type``
+  rejection). Omission, ``null``, and a plain string are all accepted;
+  ``null`` normalizes to ``""``.
+* A FAILED SAVE surfaces as 500 with the serializer's reason in the detail —
+  no longer collapsed into the 404 "No network available to snapshot" that
+  made a disk/HDF5 failure masquerade as a missing network.
+* The no-network cases remain 404 (both the ``has_model`` pre-check and a
+  ``None`` result from the lifecycle).
+* Lifecycle level: ``save_snapshot`` raises ``SnapshotSaveError`` (reason
+  attached) on write failure and returns ``None`` only when there is no
+  network.
+
+All snapshot writes in this module go to pytest ``tmp_path`` —
+``src/snapshots/`` holds committed .h5 artifacts and must never be written
+by tests.
+"""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
+
+from api.app import create_app
+from api.lifecycle.manager import TrainingLifecycleManager
+from api.settings import Settings
+from snapshots.snapshot_errors import SnapshotSaveError
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def client():
+    """Create a test client with lifecycle manager (lifespan runs)."""
+    settings = Settings(auto_start=False)
+    app = create_app(settings)
+    with TestClient(app) as c:
+        yield c
+
+
+SNAPSHOT_OK = {"id": "snap-c1", "path": "snap-c1.h5", "timestamp": "20260711T000000Z", "description": ""}
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/snapshots — description shapes (explicit null / omission / string)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateDescriptionShapes:
+    """Explicit ``null``, omission, and a plain string must all be accepted."""
+
+    def test_explicit_null_description_is_accepted(self, client):
+        """Regression for the live 2026-07-11 incident: ``{"description": null}``
+        must not 422 — it normalizes to the empty description."""
+        captured = {}
+
+        def fake_save(description: str = ""):
+            captured["description"] = description
+            return dict(SNAPSHOT_OK)
+
+        with patch.object(client.app.state.lifecycle, "has_model", return_value=True), patch.object(client.app.state.lifecycle, "save_snapshot", side_effect=fake_save):
+            response = client.post("/v1/snapshots", json={"description": None})
+            assert response.status_code == 200, f"explicit-null description rejected: {response.text}"
+            assert captured["description"] == "", "explicit null must normalize to the empty description"
+
+    def test_omitted_description_still_works(self, client):
+        captured = {}
+
+        def fake_save(description: str = ""):
+            captured["description"] = description
+            return dict(SNAPSHOT_OK)
+
+        with patch.object(client.app.state.lifecycle, "has_model", return_value=True), patch.object(client.app.state.lifecycle, "save_snapshot", side_effect=fake_save):
+            response = client.post("/v1/snapshots", json={})
+            assert response.status_code == 200, response.text
+            assert captured["description"] == ""
+
+    def test_string_description_still_works(self, client):
+        captured = {}
+
+        def fake_save(description: str = ""):
+            captured["description"] = description
+            return dict(SNAPSHOT_OK)
+
+        with patch.object(client.app.state.lifecycle, "has_model", return_value=True), patch.object(client.app.state.lifecycle, "save_snapshot", side_effect=fake_save):
+            response = client.post("/v1/snapshots", json={"description": "before the big change"})
+            assert response.status_code == 200, response.text
+            assert captured["description"] == "before the big change"
+
+    def test_no_body_still_works(self, client):
+        with patch.object(client.app.state.lifecycle, "has_model", return_value=True), patch.object(client.app.state.lifecycle, "save_snapshot", return_value=dict(SNAPSHOT_OK)):
+            response = client.post("/v1/snapshots")
+            assert response.status_code == 200, response.text
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/snapshots — failure-status separation (500 with reason vs 404)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateFailureStatusSeparation:
+    """A failed WRITE is a 500 carrying the reason; no-network stays 404."""
+
+    def test_failed_save_returns_500_with_reason(self, client):
+        with patch.object(client.app.state.lifecycle, "has_model", return_value=True), patch.object(client.app.state.lifecycle, "save_snapshot", side_effect=SnapshotSaveError("OSError: [Errno 28] No space left on device")):
+            response = client.post("/v1/snapshots", json={"description": "will fail"})
+            assert response.status_code == 500, f"failed save must be 500, got {response.status_code}: {response.text}"
+            message = response.json()["error"]["message"]
+            assert "Snapshot save failed" in message
+            assert "No space left on device" in message, f"detail must carry the underlying reason, got: {message!r}"
+
+    def test_failed_save_is_not_the_no_network_404(self, client):
+        """The pre-C1 defect: a failed save masqueraded as a missing network."""
+        with patch.object(client.app.state.lifecycle, "has_model", return_value=True), patch.object(client.app.state.lifecycle, "save_snapshot", side_effect=SnapshotSaveError("boom")):
+            response = client.post("/v1/snapshots", json={"description": "x"})
+            assert response.status_code != 404
+            assert "No network available to snapshot" not in response.text
+
+    def test_no_network_precheck_stays_404(self, client):
+        with patch.object(client.app.state.lifecycle, "has_model", return_value=False):
+            response = client.post("/v1/snapshots", json={"description": "no net"})
+            assert response.status_code == 404
+            assert "No network created" in response.json()["error"]["message"]
+
+    def test_lifecycle_none_result_stays_404(self, client):
+        """``None`` now strictly means "no network at save time" — still 404."""
+        with patch.object(client.app.state.lifecycle, "has_model", return_value=True), patch.object(client.app.state.lifecycle, "save_snapshot", return_value=None):
+            response = client.post("/v1/snapshots", json={"description": "raced away"})
+            assert response.status_code == 404
+            assert "No network available to snapshot" in response.json()["error"]["message"]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through the real lifecycle + serializer (writes to tmp_path)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateEndToEnd:
+    """Full route → lifecycle → serializer path with a real tiny network."""
+
+    def test_null_description_creates_real_snapshot_in_tmp_path(self, client, tmp_path):
+        lifecycle = client.app.state.lifecycle
+        lifecycle.create_network(input_size=2, output_size=2)
+        original_dir = lifecycle._get_snapshots_dir
+        lifecycle._get_snapshots_dir = lambda: tmp_path  # type: ignore[method-assign]
+        try:
+            response = client.post("/v1/snapshots", json={"description": None})
+            assert response.status_code == 200, response.text
+            data = response.json()["data"]
+            assert data["description"] == ""
+            written = Path(data["path"])
+            assert written.parent == tmp_path, f"snapshot must be written to tmp_path, not {written.parent}"
+            assert written.exists()
+        finally:
+            lifecycle._get_snapshots_dir = original_dir  # type: ignore[method-assign]
+
+    def test_real_write_failure_surfaces_500_with_reason(self, client, tmp_path):
+        """An uncreatable snapshots dir (parent is a file) drives the real
+        serializer failure path end-to-end: 500 + reason, not 404."""
+        lifecycle = client.app.state.lifecycle
+        lifecycle.create_network(input_size=2, output_size=2)
+        blocker = tmp_path / "blocker"
+        blocker.write_text("a file where a directory must go")
+        original_dir = lifecycle._get_snapshots_dir
+        lifecycle._get_snapshots_dir = lambda: blocker / "nested"  # type: ignore[method-assign]
+        try:
+            response = client.post("/v1/snapshots", json={"description": "doomed"})
+            assert response.status_code == 500, f"expected 500 for a real write failure, got {response.status_code}: {response.text}"
+            message = response.json()["error"]["message"]
+            assert "Snapshot save failed" in message
+        finally:
+            lifecycle._get_snapshots_dir = original_dir  # type: ignore[method-assign]
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle-level contract (save_snapshot)
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycleSaveSnapshotErrorContract:
+    """``save_snapshot``: ``None`` only for no-network; failures raise with reason."""
+
+    @pytest.fixture
+    def mgr(self, tmp_path):
+        m = TrainingLifecycleManager()
+        m.create_network(input_size=2, output_size=2)
+        m._get_snapshots_dir = lambda: tmp_path  # type: ignore[method-assign]
+        try:
+            yield m
+        finally:
+            m.shutdown()
+
+    def test_no_network_returns_none(self):
+        m = TrainingLifecycleManager()
+        try:
+            assert m.network is None
+            assert m.save_snapshot(description="x") is None
+        finally:
+            m.shutdown()
+
+    def test_serializer_exception_propagates_with_reason(self, mgr):
+        with patch("snapshots.snapshot_serializer.CascadeHDF5Serializer.save_network", side_effect=SnapshotSaveError("ValueError: boom")):
+            with pytest.raises(SnapshotSaveError, match="boom"):
+                mgr.save_snapshot(description="x")
+
+    def test_real_write_failure_raises_with_underlying_cause(self, mgr, tmp_path):
+        blocker = tmp_path / "blocker"
+        blocker.write_text("not a directory")
+        mgr._get_snapshots_dir = lambda: blocker / "nested"  # type: ignore[method-assign]
+        with pytest.raises(SnapshotSaveError) as excinfo:
+            mgr.save_snapshot(description="x")
+        assert excinfo.value.__cause__ is not None, "the underlying OS error must be chained"
+
+    def test_success_path_unchanged(self, mgr, tmp_path):
+        result = mgr.save_snapshot(description="all good")
+        assert result is not None
+        assert result["description"] == "all good"
+        assert Path(result["path"]).parent == tmp_path
+        assert Path(result["path"]).exists()

--- a/src/tests/unit/test_snapshot_serializer.py
+++ b/src/tests/unit/test_snapshot_serializer.py
@@ -184,9 +184,15 @@ class TestEdgeCases:
     """Tests for edge cases and error handling."""
 
     def test_save_to_invalid_path(self, serializer, simple_network):
-        """Test saving to an invalid path returns False."""
-        result = serializer.save_network(simple_network, "/nonexistent/readonly/path.h5")
-        assert result is False
+        """Saving to an invalid path raises SnapshotSaveError (C1 / I-3).
+
+        Pre-C1 the failure was swallowed into ``False`` and a failed save was
+        indistinguishable from a missing network at the API route."""
+        from snapshots.snapshot_errors import SnapshotSaveError
+
+        with pytest.raises(SnapshotSaveError) as excinfo:
+            serializer.save_network(simple_network, "/nonexistent/readonly/path.h5")
+        assert excinfo.value.__cause__ is not None
 
     def test_load_from_invalid_path(self, serializer):
         """Test loading from invalid path returns None."""

--- a/src/tests/unit/test_snapshot_serializer_coverage_deep.py
+++ b/src/tests/unit/test_snapshot_serializer_coverage_deep.py
@@ -813,10 +813,20 @@ class TestSerializerEdgeCases:
 
     @pytest.mark.unit
     def test_save_network_exception_handling(self, serializer, simple_network):
-        """Lines 93-94: save_network exception returns False."""
+        """save_network raises SnapshotSaveError on write failure (C1 / I-3).
+
+        Pre-C1 this path swallowed the exception into ``False``, which the
+        lifecycle collapsed to ``None`` and the API route mapped to the same
+        404 as a missing network. The typed error carries the reason and
+        chains the underlying exception.
+        """
+        from snapshots.snapshot_errors import SnapshotSaveError
+
         # Try to save to an invalid path
-        result = serializer.save_network(simple_network, "/proc/impossible/path/file.h5")
-        assert result is False
+        with pytest.raises(SnapshotSaveError) as excinfo:
+            serializer.save_network(simple_network, "/proc/impossible/path/file.h5")
+        assert excinfo.value.__cause__ is not None
+        assert str(excinfo.value)
 
     @pytest.mark.unit
     def test_create_network_from_file_no_config(self, serializer, temp_hdf5_path):

--- a/src/tests/unit/test_snapshot_serializer_error_and_isolation.py
+++ b/src/tests/unit/test_snapshot_serializer_error_and_isolation.py
@@ -1,0 +1,163 @@
+"""C1 (I-3) — serializer failure typing + training-history write isolation.
+
+Plan of record: juniper-ml
+``notes/JUNIPER_2026-07-11_JUNIPER-CANOPY_TRAINING-RUNTIME-DEFECTS-PLAN.md``
+§4 I-3 / §7 C1.
+
+* ``save_network`` raises ``SnapshotSaveError`` (underlying cause chained)
+  instead of swallowing every exception into ``False``.
+* ``_save_training_history`` serializes from ``_snapshot_history_view``'s
+  point-in-time copy, so a mid-training save cannot crash on concurrent
+  history mutation by the training thread. The helper's copy contract is
+  pinned deterministically; a threaded append loop exercises the real save
+  path as behavioral evidence; a source pin (same style as the route
+  coverage suite's PERF-CC-01 invariant) keeps the writer on the view.
+
+All writes go to pytest ``tmp_path`` — ``src/snapshots/`` holds committed
+.h5 artifacts and must never be written by tests.
+"""
+
+import inspect
+import os
+import sys
+import threading
+
+import h5py
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
+from cascade_correlation.cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
+from snapshots.snapshot_errors import SnapshotSaveError
+from snapshots.snapshot_serializer import CascadeHDF5Serializer
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def serializer():
+    return CascadeHDF5Serializer()
+
+
+@pytest.fixture
+def tiny_network():
+    config = CascadeCorrelationConfig(input_size=2, output_size=1)
+    return CascadeCorrelationNetwork(config=config)
+
+
+# ---------------------------------------------------------------------------
+# Failure typing
+# ---------------------------------------------------------------------------
+
+
+class TestSaveNetworkFailureTyping:
+    """save_network raises SnapshotSaveError with the underlying reason."""
+
+    def test_write_failure_raises_snapshot_save_error(self, serializer, tiny_network, tmp_path):
+        blocker = tmp_path / "blocker"
+        blocker.write_text("a file where a directory must go")
+        target = blocker / "sub" / "snap.h5"  # parent mkdir must fail
+        with pytest.raises(SnapshotSaveError) as excinfo:
+            serializer.save_network(tiny_network, target, include_training_state=True)
+        assert excinfo.value.__cause__ is not None, "the underlying exception must be chained for diagnosis"
+        assert str(excinfo.value), "the error must carry a human-readable reason"
+
+    def test_success_still_returns_true(self, serializer, tiny_network, tmp_path):
+        target = tmp_path / "snap.h5"
+        assert serializer.save_network(tiny_network, target, include_training_state=True) is True
+        assert target.exists()
+
+
+# ---------------------------------------------------------------------------
+# History view contract (write isolation)
+# ---------------------------------------------------------------------------
+
+
+class TestHistoryViewContract:
+    """_snapshot_history_view returns an independent, point-in-time copy."""
+
+    def test_view_lists_are_independent_copies(self, tiny_network):
+        tiny_network.history["train_loss"].extend([0.5, 0.4])
+        view = CascadeHDF5Serializer._snapshot_history_view(tiny_network)
+        assert view["train_loss"] == [0.5, 0.4]
+        assert view["train_loss"] is not tiny_network.history["train_loss"]
+        tiny_network.history["train_loss"].append(0.3)
+        assert view["train_loss"] == [0.5, 0.4], "appends after the view is taken must not be visible in the view"
+
+    def test_view_covers_every_history_key(self, tiny_network):
+        view = CascadeHDF5Serializer._snapshot_history_view(tiny_network)
+        assert set(view.keys()) == set(tiny_network.history.keys())
+        for key, value in tiny_network.history.items():
+            if isinstance(value, list):
+                assert view[key] is not value, f"list under {key!r} must be copied, not aliased"
+
+    def test_view_handles_missing_or_empty_history(self):
+        class NoHistory:
+            pass
+
+        class EmptyHistory:
+            history = {}
+
+        assert CascadeHDF5Serializer._snapshot_history_view(NoHistory()) == {}
+        assert CascadeHDF5Serializer._snapshot_history_view(EmptyHistory()) == {}
+
+    def test_view_passes_non_list_values_through(self):
+        class Weird:
+            history = {"train_loss": [1.0], "note": "not-a-list"}
+
+        view = CascadeHDF5Serializer._snapshot_history_view(Weird())
+        assert view["note"] == "not-a-list"
+        assert view["train_loss"] == [1.0]
+
+    def test_save_training_history_reads_from_view(self):
+        """Source pin (same style as the route suite's PERF-CC-01 invariant):
+        the history writer must serialize from the point-in-time view, never
+        index into the live history dict on the network."""
+        source = inspect.getsource(CascadeHDF5Serializer._save_training_history)
+        assert "_snapshot_history_view(" in source
+        assert "network.history[" not in source
+
+
+# ---------------------------------------------------------------------------
+# Concurrent-append behavioral evidence
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentAppendDuringSave:
+    """A training-thread-shaped writer appending per-epoch entries while
+    save_network runs must not crash the save (the I-3 latent hazard:
+    ``save_snapshot`` takes no lock and pre-C1 the serializer iterated the
+    live lists during slow HDF5 writes)."""
+
+    def test_history_appends_during_save_do_not_crash(self, serializer, tiny_network, tmp_path):
+        stop = threading.Event()
+        error: list = []
+
+        def churn():
+            i = 0
+            try:
+                while not stop.is_set() and i < 200_000:
+                    tiny_network.history["train_loss"].append(0.1 * i)
+                    tiny_network.history["value_loss"].append(0.2 * i)
+                    tiny_network.history["train_accuracy"].append(0.3)
+                    tiny_network.history["value_accuracy"].append(0.4)
+                    if i % 500 == 0:
+                        tiny_network.history["hidden_units_added"].append({"correlation": 0.0, "weight_shape": (2,), "unit_index": i})
+                    i += 1
+            except Exception as exc:  # pragma: no cover - diagnostic aid
+                error.append(exc)
+
+        writer = threading.Thread(target=churn, name="history-churn", daemon=True)
+        writer.start()
+        try:
+            for n in range(5):
+                target = tmp_path / f"snap_{n}.h5"
+                assert serializer.save_network(tiny_network, target, include_training_state=True) is True, f"save {n} failed under concurrent history appends"
+                with h5py.File(target, "r") as f:
+                    assert "history" in f, f"save {n} produced no history group"
+        finally:
+            stop.set()
+            writer.join(timeout=10)
+        assert not writer.is_alive(), "churn thread failed to stop"
+        assert not error, f"churn thread raised: {error}"

--- a/src/tests/unit/test_snapshot_weight_history.py
+++ b/src/tests/unit/test_snapshot_weight_history.py
@@ -224,19 +224,26 @@ class TestV1BackwardCompat:
 
 class TestWeightHistoryValidation:
     def test_length_mismatch_output_weights_rejected(self, serializer, simple_network, temp_file):
+        from snapshots.snapshot_errors import SnapshotSaveError
+
         wh = _make_weight_history(num_samples=3)
         wh["output_weights"] = wh["output_weights"][:2]  # mismatch with sample_indices length
         simple_network.history = {"train_loss": [], "value_loss": [], "train_accuracy": [], "value_accuracy": [], "hidden_units_added": []}
         simple_network.weight_history = wh
-        # save_network catches and logs but returns False; assert that.
-        assert serializer.save_network(simple_network, temp_file, include_training_state=True) is False
+        # C1 (I-3): save_network logs and raises SnapshotSaveError carrying the
+        # validation reason (pre-C1 it swallowed the ValueError into ``False``).
+        with pytest.raises(SnapshotSaveError, match="length mismatch"):
+            serializer.save_network(simple_network, temp_file, include_training_state=True)
 
     def test_length_mismatch_hidden_unit_rejected(self, serializer, simple_network, temp_file):
+        from snapshots.snapshot_errors import SnapshotSaveError
+
         wh = _make_weight_history(num_samples=4, num_hidden=2)
         wh["hidden_units"][0]["bias"] = wh["hidden_units"][0]["bias"][:1]
         simple_network.history = {"train_loss": [], "value_loss": [], "train_accuracy": [], "value_accuracy": [], "hidden_units_added": []}
         simple_network.weight_history = wh
-        assert serializer.save_network(simple_network, temp_file, include_training_state=True) is False
+        with pytest.raises(SnapshotSaveError, match="length mismatch"):
+            serializer.save_network(simple_network, temp_file, include_training_state=True)
 
     def test_unsupported_schema_version_degrades_gracefully(self, serializer, simple_network, temp_file):
         # Write a V1 snapshot, then synthesize a forward-incompatible


### PR DESCRIPTION
## Summary

Roadmap unit **C1** (I-3 upstream half) of the plan of record
`juniper-ml/notes/JUNIPER_2026-07-11_JUNIPER-CANOPY_TRAINING-RUNTIME-DEFECTS-PLAN.md` (§4 I-3, §7 C1 row). Anchors verified against `2926245c` (origin/main at branch time). Sibling unit C2a (params apply reporting) is being implemented in parallel; this PR touches only the snapshot surfaces.

### 1. Explicit-null `description` accepted (the live 2026-07-11 incident)

`SnapshotCreateRequest.description: str = ""` 422'd on explicit `null` — canopy's route seam posts `{"description": null}` for a blank description, producing `{'type': 'string_type', 'loc': ['body','description'], 'input': None}` and the doubled "Failed to create snapshot" toast. The field is now `str | None = ""` with a `mode="before"` validator normalizing `null` → `""`, so omission, explicit null, and a plain string are all equivalent (`src/api/routes/snapshots.py`).

### 2. Failed saves carry their reason with the correct status

Pre-C1 chain: serializer swallowed ANY exception into `False` (`snapshot_serializer.py` `save_network` except-arm) → lifecycle `save_snapshot` returned `None` → route 404 **"No network available to snapshot"** — a disk/HDF5 failure masqueraded as a missing network.

Mechanism (typed exception):

- New stdlib-only `src/snapshots/snapshot_errors.py` defines `SnapshotSaveError` (kept out of the heavy h5py/numpy/torch serializer module so the route imports it at module scope for free).
- `CascadeHDF5Serializer.save_network` keeps its ERROR + stacktrace logging, then raises `SnapshotSaveError(f"{type(e).__name__}: {e}") from e`.
- `TrainingLifecycleManager.save_snapshot` propagates it (logging the filepath); a falsy serializer result also raises (defensive belt). `None` now strictly means **no network**.
- `POST /v1/snapshots` maps `SnapshotSaveError` → **500** with the reason in the detail; both no-network cases keep their **404**; the success path is byte-identical. 500 (not 409) because a write failure is a server-side fault, not a state conflict.

Bool-contract callers audited and unchanged in behavior: `cascade_correlation.save_to_hdf5` (method-level `except Exception` → `False`), `auto_snap_best` (`manager.py:1242-1247`), and the swap pre/post snaps (`manager.py:2474-2480`, `:2584-2590`) already wrap in `try/except Exception` and stay failure-tolerant.

### 3. Write-isolation hardening (shipped scope + documented remainder)

`_save_training_history` iterated the live `network.history` lists while the training thread appends per-epoch entries, and `save_snapshot` takes no lock. A manager-side lock cannot help: the appends happen inside `cascade_correlation.py`'s training loop, which shares no lock with the serializer (the manager's `_topology_lock` is only used by its own boundary/topology readers). Shipped: `_snapshot_history_view` takes a shallow point-in-time copy (top-level dict + each list value, a handful of GIL-atomic ops) up front, and the whole history writer serializes from that view — a mid-training save can no longer crash on concurrent list mutation. A source pin plus a threaded-append regression keep the writer on the view. `_save_weight_history` already `list()`-copies the containers it iterates.

**Documented remainder (explicitly out of this unit's scope):** (a) per-element deep consistency — unit-metadata dicts and swap events are appended fully built and at most attr-backfilled, so the shallow copy prevents crashes but does not freeze element internals; (b) `_save_network_objects_helper` still reads the live weight/topology tensors, so a snapshot taken mid-cascade-add may capture a torn architecture view — full isolation there needs a pause-or-deep-copy design at the manager level (candidate for a follow-up unit alongside C3's Path-B work).

## Testing

Env `JuniperCascor1`, all from `src/`:

- New `tests/unit/api/test_snapshot_create_error_paths.py` (14 tests): explicit-null / omission / string / no-body accepted with `""` normalization; failed save → 500 + reason (and explicitly not the no-network 404); both 404 cases pinned; end-to-end null-description create writing a real snapshot to `tmp_path`; real write-failure → 500; lifecycle contract (None only for no-network, raise with chained cause, success unchanged).
- New `tests/unit/test_snapshot_serializer_error_and_isolation.py` (8 tests): `SnapshotSaveError` typing with chained cause; success returns `True`; history-view copy contract (independent lists, all keys, empty/missing, non-list passthrough); source pin; 5 saves under a concurrent history-churn thread all succeed.
- Updated 5 tests that pinned the defective swallow-to-`False` contract to the typed-error contract (same code paths, corrected expectation): `test_snapshot_serializer.py::test_save_to_invalid_path`, `test_snapshot_serializer_coverage_deep.py::test_save_network_exception_handling`, `test_snapshot_weight_history.py` length-mismatch pair (now also assert the reason text), `test_lifecycle_manager_coverage_ext.py::test_save_snapshot_serializer_failure_raises`.
- All test snapshot writes go to pytest `tmp_path` (never `src/snapshots/`, which holds committed .h5 artifacts).

Results:

- `python -m pytest tests/unit/api/` → **1687 passed**
- Snapshot surface (15 files incl. both new) → **345+22 passed**
- Serialization/swap integration (`--integration`, `--slow`, `--golden` incl. the golden roundtrip against the committed .h5 artifacts) → **68+5+1 passed** (on-disk format unchanged)
- `bash src/tests/scripts/run_tests.bash` → **4077 passed / 0 failed / 0 errors / 10 skipped (slow-gated)** in 182 s
- `pre-commit run --all-files` → all hooks green (black, isort, flake8, mypy, bandit, shellcheck, markdownlint, doc links)

Note: `src/snapshots/snapshot_errors.py` required `git add -f` — `.gitignore`'s blanket `**/snapshots` rule (line 65) ignores new files there; the module is force-tracked exactly like the directory's existing .py sources.

## Requirements

References JR-CASCOR-API-* (snapshot management surface) — plan-driven fix; see plan §4 I-3 for the incident evidence chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pe5UkXcNAHTniWVTYh4GSN