### PR TITLE
fix(api): C2a — parameter apply reports applied/skipped per key (no silent hasattr drops)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **C2a (I-4 / T3) — parameter apply reports `applied`/`skipped` per key; the silent `hasattr` drop is gone.**
+  `_apply_params_unlocked` (`src/api/lifecycle/manager.py`) silently dropped requested keys that failed `hasattr(self.network, k)` — and non-whitelisted keys — while returning 200 with the full params echo,
+  the latent generator behind canopy's applied-yet-error verification divergence (juniper-ml [`notes/JUNIPER_2026-07-11_JUNIPER-CANOPY_TRAINING-RUNTIME-DEFECTS-PLAN.md`](https://github.com/pcalnon/juniper-ml/blob/main/notes/JUNIPER_2026-07-11_JUNIPER-CANOPY_TRAINING-RUNTIME-DEFECTS-PLAN.md) §4 I-4 / §7 C2a).
+  The success response now accounts for EVERY requested key with two additive fields alongside the unchanged params echo: `applied: [key, ...]` (keys that landed, in application order) and `skipped: [{"key", "reason"}, ...]`
+  with reasons `not-updatable` (outside the whitelist), `no-such-attribute` (whitelisted but absent on the live network object — the silent-drop case), and `null-value` (None nested/lifecycle value from an internal caller; the REST/WS boundaries strip None via `exclude_none=True`).
+  Carried additively through `PATCH /v1/training/params` (`data`) and the WS `set_params` ack (`result`) — no schema change; existing consumers (canopy adapter, cascor-client pass-through) are unaffected, and `FakeCascorClient` parity lands in roadmap unit CL2.
+  Pydantic request-model validation is untouched: a bound violation still rejects the whole body 422 atomically (deliberate — reporting, not partial apply), and the GAP-WS-28 atomic-rollback contract is unchanged.
+  Tests: `TestAppliedSkippedReporting` (`src/tests/unit/api/test_api_runtime_params.py`), `TestUpdateParamsAtomicity` additions (`src/tests/unit/api/test_lifecycle_manager.py`), `test_set_params_ack_result_carries_applied_skipped` (`src/tests/unit/api/test_websocket_control.py`).
+
 - **Docker image default now stays compatible with the SEC-F22 bind guard.** The runtime image no longer bakes in `JUNIPER_CASCOR_HOST=0.0.0.0` without a bind attestation (`JUNIPER_CASCOR_LOOPBACK_PUBLISH_ATTESTED=true`), which would make a bare image crash-loop at lifespan startup. Published-container examples now show the explicit loopback host-publish plus attestation opt-in.
 
 - **SEC-F22 bind guard now covers the documented uvicorn factory bind path.** `uvicorn api.app:create_app --factory --host 0.0.0.0` passes the public bind host to uvicorn rather than `Settings.host`; the app factory now mirrors those CLI bind args into the transient settings copy before lifespan startup so the guard cannot be bypassed by that documented production command.

--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -3086,7 +3086,10 @@ class TrainingLifecycleManager:
             params: Dict of parameter names and new values (None values excluded).
 
         Returns:
-            Updated training parameters dict.
+            Updated training parameters dict, plus additive per-key reporting
+            (C2a / I-4): ``applied`` — the keys that landed — and ``skipped`` —
+            ``{"key", "reason"}`` rows for every requested key that did not.
+            See ``_apply_params_unlocked`` for the reason taxonomy.
 
         Raises:
             ValueError: If no network exists.
@@ -3196,6 +3199,18 @@ class TrainingLifecycleManager:
         All three flavors share the same GAP-WS-28 atomic-rollback contract:
         if any setter raises, every previously-applied key is reverted to
         its pre-call value before re-raising.
+
+        C2a (I-4 / T3): the success return is ``get_training_params()`` plus two
+        additive reporting keys that account for EVERY requested key:
+        ``applied`` (keys that landed, in application order) and ``skipped``
+        (``{"key", "reason"}`` rows for keys that did not). Reasons:
+        ``not-updatable`` (key outside ``updatable_keys``), ``no-such-attribute``
+        (whitelisted key the live network object lacks — previously a silent
+        drop), and ``null-value`` (None nested/lifecycle value from an internal
+        caller; boundary callers strip None via ``exclude_none=True``). Bound
+        violations never reach this path — pydantic request-model validation
+        rejects the whole body 422 upstream (deliberately atomic; no partial
+        apply on validation failure).
         """
         if self.network is None:
             raise ValueError("No network exists — create a network first")
@@ -3240,6 +3255,23 @@ class TrainingLifecycleManager:
             raise InvalidCandidatePoolError(triple_violation)
         applicable = {k: v for k, v in params.items() if k in simple_keys and hasattr(self.network, k)}
         old_values = {k: getattr(self.network, k) for k in applicable}
+
+        # C2a (I-4 / T3): account for every requested key. ``skipped`` pairs each
+        # non-landing key with a reason so the ``hasattr`` filter above can never
+        # again silently drop a whitelisted-but-absent attribute (the latent
+        # generator behind canopy's applied-yet-error verification divergence).
+        # Computed against the same pre-apply view of the network as ``applicable``.
+        skipped: list[dict[str, str]] = []
+        for key in params:
+            if key not in updatable_keys:
+                skipped.append({"key": key, "reason": "not-updatable"})
+            elif key in simple_keys and not hasattr(self.network, key):
+                skipped.append({"key": key, "reason": "no-such-attribute"})
+            elif key in nested_keys | lifecycle_keys and params[key] is None:
+                # Boundary callers strip None via ``exclude_none=True``; internal
+                # callers can pass raw dicts. A None nested/lifecycle value is
+                # deliberately not applied (the ``*_pending`` guards below).
+                skipped.append({"key": key, "reason": "null-value"})
 
         # CAN-010 / ENH-006 (A-2): ``optimizer_type`` lives at
         # ``self.network.config.optimizer_config.optimizer_type``.
@@ -3306,7 +3338,13 @@ class TrainingLifecycleManager:
                     # back the rest — best-effort consistency.
                     self.logger.exception("update_params rollback: revert of %s failed", key)
             raise
-        return self.get_training_params()
+        # C2a: additive per-key reporting — the params-echo keys are unchanged;
+        # ``applied``/``skipped`` ride alongside them in the same dict (the REST
+        # route's ``data`` and the WS ack's ``result`` carry them through untouched).
+        result = self.get_training_params()
+        result["applied"] = applied
+        result["skipped"] = skipped
+        return result
 
     def _validate_candidate_pool_post_merge(self, params: Dict[str, Any]) -> Optional[str]:
         """Validate the §1.5 C2.1 candidate-pool invariant against the *post-merge*

--- a/src/api/routes/training.py
+++ b/src/api/routes/training.py
@@ -162,6 +162,13 @@ async def update_training_params(request: Request, body: TrainingParamUpdateRequ
 
     Modifies parameters on the running network without requiring a restart.
     All fields are optional — only provided fields are updated (PATCH semantics).
+
+    C2a (I-4 / T3): the success ``data`` accounts for every requested key — the
+    full params echo plus additive ``applied: [key, ...]`` and
+    ``skipped: [{"key", "reason"}, ...]`` fields, so a whitelisted key the live
+    network object lacks is reported (``no-such-attribute``) instead of being
+    silently dropped. Bound violations remain atomic 422 rejections at
+    request-model validation (no partial apply).
     """
     lifecycle = _get_lifecycle(request)
     if not lifecycle.has_model():

--- a/src/api/websocket/control_stream.py
+++ b/src/api/websocket/control_stream.py
@@ -421,6 +421,9 @@ def _execute_command(lifecycle, command: str, params: dict = None) -> dict:
         # ``ValidationError`` propagates to ``_handle_command_message``, which
         # returns a clean error ack (the WS analogue of the REST 422) without crashing.
         validated = TrainingParamUpdateRequest(**params)
+        # C2a (I-4 / T3): the returned dict carries additive ``applied``/``skipped``
+        # per-key reporting alongside the params echo; it rides the success ack's
+        # free-form ``result`` field untouched, so the ack schema is unchanged.
         return lifecycle.update_params(validated.model_dump(exclude_none=True))
     else:
         raise ValueError(f"Unhandled command: {command}")

--- a/src/tests/unit/api/test_api_runtime_params.py
+++ b/src/tests/unit/api/test_api_runtime_params.py
@@ -439,6 +439,75 @@ class TestUpdateTrainingParams:
 
 
 @pytest.mark.unit
+class TestAppliedSkippedReporting:
+    """C2a (I-4 / T3): PATCH /v1/training/params accounts for EVERY requested key.
+
+    The success ``data`` carries the full params echo plus additive
+    ``applied: [key, ...]`` and ``skipped: [{"key", "reason"}, ...]`` fields.
+    Before C2a, ``_apply_params_unlocked`` silently dropped whitelisted keys
+    failing ``hasattr(self.network, k)`` while returning 200 — the latent
+    generator behind canopy's applied-yet-error verification divergence
+    (training-runtime-defects plan §4 I-4).
+    """
+
+    def test_all_valid_keys_reported_applied(self, test_client_with_network):
+        """Every valid requested key lands in ``applied``; ``skipped`` is empty; the full params echo is intact."""
+        response = test_client_with_network.patch(
+            "/v1/training/params",
+            json={"learning_rate": 0.004, "patience": 12},
+        )
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert set(data["applied"]) == {"learning_rate", "patience"}
+        assert data["skipped"] == []
+        # The pre-C2a params echo is unchanged (additive contract): the PATCHed
+        # values round-trip and untouched surface keys are still present.
+        assert data["learning_rate"] == pytest.approx(0.004)
+        assert data["patience"] == 12
+        assert "epochs_max" in data
+        assert "optimizer_type" in data
+
+    def test_whitelisted_but_absent_attribute_reported_skipped(self, test_client_with_network):
+        """A whitelisted key the live network object lacks is reported as
+        ``skipped(no-such-attribute)`` while the rest of the PATCH applies with
+        200 semantics — the exact silent-drop case C2a kills."""
+        lifecycle = test_client_with_network.app.state.lifecycle
+        delattr(lifecycle.network, "multi_candidate")
+        response = test_client_with_network.patch(
+            "/v1/training/params",
+            json={"multi_candidate": True, "learning_rate": 0.006},
+        )
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert data["applied"] == ["learning_rate"]
+        assert data["skipped"] == [{"key": "multi_candidate", "reason": "no-such-attribute"}]
+        assert lifecycle.network.learning_rate == pytest.approx(0.006)
+        # The absent attribute was never materialized by the PATCH.
+        assert not hasattr(lifecycle.network, "multi_candidate")
+
+    def test_empty_body_reports_empty_applied_and_skipped(self, test_client_with_network):
+        """PATCH {} — nothing requested, nothing applied, nothing skipped."""
+        response = test_client_with_network.patch("/v1/training/params", json={})
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert data["applied"] == []
+        assert data["skipped"] == []
+
+    def test_bound_violation_remains_atomic_422(self, test_client_with_network):
+        """A single out-of-bound key still rejects the WHOLE body at request-model
+        validation (deliberate — C2a adds reporting, not partial apply): the
+        in-range sibling key must NOT land."""
+        lifecycle = test_client_with_network.app.state.lifecycle
+        before = lifecycle.network.learning_rate
+        response = test_client_with_network.patch(
+            "/v1/training/params",
+            json={"learning_rate": 0.008, "epochs_max": 1_000_001},  # epochs_max le=1_000_000
+        )
+        assert response.status_code == 422
+        assert lifecycle.network.learning_rate == pytest.approx(before)
+
+
+@pytest.mark.unit
 class TestAutoSnapBestCallback:
     """Functional tests for the CAS-006 epoch_end callback.
 

--- a/src/tests/unit/api/test_lifecycle_manager.py
+++ b/src/tests/unit/api/test_lifecycle_manager.py
@@ -662,13 +662,51 @@ class TestUpdateParamsAtomicity:
         assert net.correlation_threshold == pytest.approx(0.2)
         assert net.patience == 10
 
-    def test_unrecognized_keys_silently_skipped(self):
-        """Unknown keys don't raise and don't change state."""
+    def test_unrecognized_keys_skipped_and_reported(self):
+        """Unknown keys don't raise and don't change state — and since C2a (I-4)
+        they are reported as ``skipped(not-updatable)`` instead of vanishing."""
         net = self._FakeNetwork()
         mgr = self._mgr_with_network(net)
         before = net.learning_rate
-        mgr.update_params({"this_is_not_a_real_key": 99, "learning_rate": before + 0.1})
+        result = mgr.update_params({"this_is_not_a_real_key": 99, "learning_rate": before + 0.1})
         assert net.learning_rate == pytest.approx(before + 0.1)
+        assert {"key": "this_is_not_a_real_key", "reason": "not-updatable"} in result["skipped"]
+        assert "learning_rate" in result["applied"]
+
+    def test_whitelisted_but_absent_attribute_reported_not_dropped(self):
+        """C2a (I-4): a whitelisted key the network object lacks used to be
+        silently dropped by the ``hasattr`` filter in ``_apply_params_unlocked``
+        while the call returned success — the response now accounts for it as
+        ``skipped(no-such-attribute)`` and never materializes the attribute."""
+        net = self._FakeNetwork()  # deliberately has no ``output_epochs`` attribute
+        assert not hasattr(net, "output_epochs")
+        mgr = self._mgr_with_network(net)
+        result = mgr.update_params({"output_epochs": 250, "learning_rate": 0.004})
+        assert result["applied"] == ["learning_rate"]
+        assert result["skipped"] == [{"key": "output_epochs", "reason": "no-such-attribute"}]
+        assert net.learning_rate == pytest.approx(0.004)
+        assert not hasattr(net, "output_epochs")
+
+    def test_null_nested_value_reported_skipped(self):
+        """Internal callers may pass raw dicts (the REST/WS boundaries strip None
+        via ``exclude_none=True``): a None nested-setter value is not applied and
+        is reported as ``skipped(null-value)``."""
+        net = self._FakeNetwork()
+        mgr = self._mgr_with_network(net)
+        result = mgr.update_params({"optimizer_type": None})
+        assert result["applied"] == []
+        assert result["skipped"] == [{"key": "optimizer_type", "reason": "null-value"}]
+
+    def test_report_partitions_every_requested_key(self):
+        """C2a contract: ``applied`` and ``skipped`` exactly partition the
+        requested key set — no silent drops, no double counting."""
+        net = self._FakeNetwork()
+        mgr = self._mgr_with_network(net)
+        requested = {"learning_rate": 0.005, "patience": 7, "output_epochs": 9, "bogus": 1}
+        result = mgr.update_params(requested)
+        skipped_keys = {row["key"] for row in result["skipped"]}
+        assert set(result["applied"]) | skipped_keys == set(requested)
+        assert set(result["applied"]).isdisjoint(skipped_keys)
 
     def test_setter_failure_rolls_back_earlier_keys(self):
         """If patience setter raises, learning_rate and correlation_threshold

--- a/src/tests/unit/api/test_websocket_control.py
+++ b/src/tests/unit/api/test_websocket_control.py
@@ -138,6 +138,30 @@ class TestControlStreamHandler:
         assert lifecycle.network.learning_rate == pytest.approx(0.007)
         assert lifecycle.network.max_iterations == 23
 
+    def test_set_params_ack_result_carries_applied_skipped(self, client_with_network):
+        """C2a (I-4 / T3): the WS ``set_params`` success ack's ``result`` carries
+        the additive ``applied``/``skipped`` per-key reporting fields (the same
+        dict the REST PATCH returns) without changing the ack schema."""
+        with client_with_network.websocket_connect("/ws/control") as ws:
+            ws.receive_json()  # connection_established
+            ws.send_text(
+                json.dumps(
+                    {
+                        "command": "set_params",
+                        "params": {"learning_rate": 0.009},
+                    }
+                )
+            )
+            response = ws.receive_json()
+            assert response["type"] == "command_response"
+            assert response["data"]["command"] == "set_params"
+            assert response["data"]["status"] == "success"
+            result = response["data"]["result"]
+            assert result["applied"] == ["learning_rate"]
+            assert result["skipped"] == []
+            # The params echo rides alongside the report, unchanged.
+            assert result["learning_rate"] == pytest.approx(0.009)
+
     def test_set_params_without_params_dict_errors(self, client_with_network):
         """set_params without a 'params' dict returns error."""
         with client_with_network.websocket_connect("/ws/control") as ws:


### PR DESCRIPTION
## Summary

Executes roadmap unit **C2a** of the training-runtime-defects plan (juniper-ml [`notes/JUNIPER_2026-07-11_JUNIPER-CANOPY_TRAINING-RUNTIME-DEFECTS-PLAN.md`](https://github.com/pcalnon/juniper-ml/blob/main/notes/JUNIPER_2026-07-11_JUNIPER-CANOPY_TRAINING-RUNTIME-DEFECTS-PLAN.md) §4 I-4 / §7 C2a, cross-cutting theme T3): the parameter-apply response now accounts for **every** requested key, killing the silent `hasattr` drop.

**Before**: `_apply_params_unlocked` (`src/api/lifecycle/manager.py`) silently dropped requested keys that failed `hasattr(self.network, k)` — and non-whitelisted keys — while returning 200 with the full params echo. Canopy's post-apply verification then read getattr-defaults and diverged: the latent applied-yet-error generator diagnosed under I-4.

**After**: the success return is the unchanged params echo plus two **additive** fields:

- `applied: [key, ...]` — keys that landed, in application order
- `skipped: [{"key": ..., "reason": ...}, ...]` — reasons:
  - `not-updatable` — key outside `updatable_keys`
  - `no-such-attribute` — whitelisted key the live network object lacks (the silent-drop case)
  - `null-value` — None nested/lifecycle value from an internal caller (REST/WS boundaries strip None via `exclude_none=True`)

`applied` and `skipped` exactly partition the requested key set (regression-pinned).

## Surfaces

- **REST** `PATCH /v1/training/params` — fields ride the `data` envelope (route mechanics unchanged; 404 no-model and 422 candidate-pool paths untouched).
- **WS** `set_params` — the same dict rides the success ack's free-form `result` field; ack schema unchanged (verified against the installed `juniper_cascor_protocol` `CommandResponseEnvelope`). Comment added at the `_execute_command` branch.

## Deliberately unchanged

- Pydantic request-model validation: a bound violation still rejects the **whole body** 422 atomically — reporting, not partial-apply-on-validation-failure (plan §4 I-4 "Options & trade-offs"; partial apply was explicitly deferred in validation).
- GAP-WS-28 atomic rollback: on a setter failure the exception still propagates after full revert (no report on failure by construction).
- `start_training`'s internal `_apply_params_unlocked` call discards the return — unaffected.
- Consumers verified compatible: canopy adapter (`apply_params` / `_verify_apply_roundtrip` iterate requested keys only), cascor-client (`update_params` is a raw pass-through). `FakeCascorClient` parity lands in roadmap unit CL2.
- No existing cascor test pinned the exact response key-set; tests were updated additively only (original assertions all retained).

## Testing (conda env `JuniperCascor1`)

| Suite | Result |
|---|---|
| `src/tests/unit/api/` (`python -m pytest tests/unit/api/`) | **1681 passed**, 0 failed (junitxml-verified; stdout summary truncation is the known pre-existing display quirk) |
| `bash src/tests/scripts/run_tests.bash` (full unit suite) | **4060 passed**, 0 failed, 10 skipped (pre-existing GPU/optional skips), 182.6s |
| `tests/integration/api/test_candidate_pool_invariants.py --integration` | **18 passed** |
| `pre-commit run --all-files` | all hooks passed (black, isort, flake8, mypy, bandit, markdownlint, doc-links, shellcheck, yamllint) |

New regression coverage:

- Route (`TestAppliedSkippedReporting`, `src/tests/unit/api/test_api_runtime_params.py`): all-valid keys → all in `applied` + `skipped == []` + full params echo intact; whitelisted-but-absent attribute (delattr'd live network) → `skipped(no-such-attribute)` with the sibling key applied under 200; empty body → both empty; one out-of-bound key → atomic 422 with the in-range sibling NOT landing.
- Manager (`TestUpdateParamsAtomicity` additions, `src/tests/unit/api/test_lifecycle_manager.py`): non-whitelisted key → `skipped(not-updatable)` (assertions added to the existing test, none removed); absent-attribute reporting never materializes the attribute; None nested value → `skipped(null-value)`; applied/skipped partition every requested key.
- WS (`test_set_params_ack_result_carries_applied_skipped`, `src/tests/unit/api/test_websocket_control.py`): success ack `result` carries `applied`/`skipped` alongside the params echo.

## Requirements

References JR-CASCOR-API-* (runtime parameter-update surface); this PR implements plan unit C2a (I-4 contract half). Sibling unit C2b (bound/surface coherence) and canopy N5 (render applied/skipped, toast detail) follow separately per the roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pe5UkXcNAHTniWVTYh4GSN