### PR TITLE
ci(publish): migrate 2 tag-push publish triggers to release:published (release-train Phase 0.1, F-4)

### DIFF
--- a/.github/workflows/publish-cascor-model.yml
+++ b/.github/workflows/publish-cascor-model.yml
@@ -31,18 +31,36 @@
 name: Publish juniper-cascor-model to PyPI
 
 on:
-  push:
-    tags:
-      - "juniper-cascor-model-v*"
+  # Publish ONLY on a cut GitHub Release (the ratified convention — never a bare `git push <tag>`).
+  # We deliberately do NOT subscribe to `push: tags`: cutting a Release also creates the tag, which
+  # emits a `push: tags` event — subscribing to both fired TWO concurrent publish runs that raced the
+  # immutable TestPyPI upload (one uploaded, the other 400'd "file already exists"; see juniper-ml#555).
+  # The build job is tag-prefix-guarded below; `release: published` is the single publish path.
+  release:
+    types: [published]
+  # Manual dispatch so operators can re-fire a publish (e.g. after a transient failure).
   workflow_dispatch:
 
 permissions:
   id-token: write
   contents: read
 
+concurrency:
+  # Belt-and-suspenders serialization keyed on the ref. The primary dedupe is the single
+  # `release: published` trigger above (dropping `push: tags` removes the juniper-ml#555 double-fire
+  # at the source); this group additionally serializes any residual overlap (e.g. a manual dispatch
+  # during a release) so two runs never race the immutable TestPyPI upload concurrently.
+  group: publish-cascor-model-${{ github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   build:
     name: Build and Validate
+    # For a `release` event, run only when the release is THIS package's tag. A release for another
+    # package in this repo (the cascor app `v*` release, or the sibling `juniper-cascor-protocol-v*`)
+    # also fires this workflow and must be skipped. workflow_dispatch always runs. Downstream jobs
+    # `needs: build`, so this one guard gates the whole pipeline.
+    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'juniper-cascor-model-v')
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/publish-protocol.yml
+++ b/.github/workflows/publish-protocol.yml
@@ -24,15 +24,27 @@
 name: Publish juniper-cascor-protocol to PyPI
 
 on:
-  push:
-    tags:
-      - "juniper-cascor-protocol-v*"
-  # Manual dispatch so operators can re-fire a publish against any tag.
+  # Publish ONLY on a cut GitHub Release (the ratified convention — never a bare `git push <tag>`).
+  # We deliberately do NOT subscribe to `push: tags`: cutting a Release also creates the tag, which
+  # emits a `push: tags` event — subscribing to both fired TWO concurrent publish runs that raced the
+  # immutable TestPyPI upload (one uploaded, the other 400'd "file already exists"; see juniper-ml#555).
+  # The build job is tag-prefix-guarded below; `release: published` is the single publish path.
+  release:
+    types: [published]
+  # Manual dispatch so operators can re-fire a publish (e.g. after a transient failure).
   workflow_dispatch:
 
 permissions:
   id-token: write
   contents: read
+
+concurrency:
+  # Belt-and-suspenders serialization keyed on the ref. The primary dedupe is the single
+  # `release: published` trigger above (dropping `push: tags` removes the juniper-ml#555 double-fire
+  # at the source); this group additionally serializes any residual overlap (e.g. a manual dispatch
+  # during a release) so two runs never race the immutable TestPyPI upload concurrently.
+  group: publish-protocol-${{ github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
   # ═══════════════════════════════════════════════════════════════════════════════════════════════
@@ -40,6 +52,11 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════════════════════════════
   build:
     name: Build and Validate
+    # For a `release` event, run only when the release is THIS package's tag. A release for another
+    # package in this repo (the cascor app `v*` release, or the sibling `juniper-cascor-model-v*`)
+    # also fires this workflow and must be skipped. workflow_dispatch always runs. Downstream jobs
+    # `needs: build`, so this one guard gates the whole pipeline.
+    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'juniper-cascor-protocol-v')
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## Summary

Phase 0 step **0.1** of the ratified PyPI release-train plan (drift finding **F-4**):
migrate this repo's two `push: tags`-triggered publish workflows to the single
`release: published` trigger model, so the "cut a GitHub Release, never a bare
`git push <tag>`" convention is enforced *structurally* (no Release ⇒ no publish) and
the `push: tags` + `release` double-fire loophole is closed.

| Workflow | Before | After |
|---|---|---|
| `.github/workflows/publish-cascor-model.yml` | `push: tags: [juniper-cascor-model-v*]` | `release: [published]` + tag-prefix guard |
| `.github/workflows/publish-protocol.yml` | `push: tags: [juniper-cascor-protocol-v*]` | `release: [published]` + tag-prefix guard |

Each workflow additionally gains a ref-keyed **`concurrency` group** and a tag-prefix
**build-job `if:` guard**, and preserves its existing `workflow_dispatch` escape hatch.

## Canonical model replicated

`pcalnon/juniper-ml` `.github/workflows/publish-service-core.yml:34-53,65`
(and its siblings `publish-model-core.yml` / `publish-config-tools.yml` /
`publish-doc-tools.yml`, which carry the `#555` phrasing used here). That is the
already-migrated shape: single `release: published` trigger + `#555` double-fire
rationale comment + ref-keyed `concurrency` group + a tag-prefix `if:` guard on
`github.event.release.tag_name`. Reference: audit §3.1 and plan §12 step 0.1.

**Comment attribution note:** the juniper-ml sub-package workflows cite the incident as
a bare `#555`; inside a *cascor* file a bare `#555` would ambiguously resolve to
cascor#555, so the comment cites **`juniper-ml#555`** (the repo where the double-fire
was diagnosed and fixed). The rationale is otherwise verbatim.

## `github.ref` → release-event adaptations

**None were required.** I searched both workflows for every `github.ref` /
`github.ref_name` / `GITHUB_REF*` usage:

- Neither workflow derives the package version from the tag — both TestPyPI
  verify steps read the version from `pyproject.toml`
  (`grep '^version' <pkg>/pyproject.toml`), so there is **no** tag-derived version
  logic to adapt.
- The only remaining `GITHUB_REF_NAME` is inside the pre-existing
  **"Require a GitHub Release for this tag"** step, which is guarded
  `if: github.event_name == 'push'`. With `push:` gone that step never executes — it
  is retained verbatim exactly as the canonical `publish-service-core.yml` retains it
  (inert/defensive, minimal-diff).
- `github.ref_name` is used in the new `concurrency.group` (the fleet convention:
  `group: <workflow-filename-stem>-${{ github.ref_name }}`), which resolves to the
  release tag on a `release` event and to the branch on `workflow_dispatch`.

## Prefix-overlap analysis (three mutually-exclusive release guards in this repo)

After this change, **three** publish workflows in this repo subscribe to
`release: published`; each has a mutually-exclusive tag-prefix guard, so one Release
fires all three but only the matching one proceeds (the others skip at `build`, which
gates the whole pipeline via `needs:`):

| Workflow | Guard prefix | Matching tags |
|---|---|---|
| `publish.yml` (cascor app) | `startsWith(tag, 'v')` | `v0.5.0`, … (app only) |
| `publish-cascor-model.yml` | `startsWith(tag, 'juniper-cascor-model-v')` | `juniper-cascor-model-v*` |
| `publish-protocol.yml` | `startsWith(tag, 'juniper-cascor-protocol-v')` | `juniper-cascor-protocol-v*` |

These are disjoint: the `juniper-cascor-*` tags do not start with `v` (they start with
`j`), so the app guard never matches a sub-package release; and `model` vs `protocol`
diverge at the first character after `juniper-cascor-` (`m` vs `p`), so neither
sub-package guard matches the other. Verified against the live tag set
(`git ls-remote --tags`): `juniper-cascor-model-v0.1.0`,
`juniper-cascor-protocol-v0.1.0`, `juniper-cascor-protocol-v0.1.0a0`.

**How the current `push: tags` globs handled this overlap:** they already handled it
correctly, by the same discriminator — the glob `juniper-cascor-model-v*` requires the
literal prefix `juniper-cascor-model-v`, which a `juniper-cascor-protocol-v*` tag does
not have. This migration preserves exactly that matching semantics: a GitHub Actions
`push.tags` glob `<prefix>*` and `startsWith(tag, '<prefix>')` are both prefix matches
on the same `<prefix>`.

## Testing / verification evidence (local)

- **Grep-proof — triggers removed:** `grep -nE '^\s*(push:|tags:)'` over both files ⇒
  **no matches** (no `push:`/`tags:` trigger remains).
- **Grep-proof — no stale tag logic:** the only `github.ref`/`GITHUB_REF` usages are
  the intended `concurrency` `github.ref_name` and the inert push-gated
  `GITHUB_REF_NAME` Release-check (identical to the model file).
- **yamllint** (`.yamllint.yaml`, `--strict`): **PASS** (clean) on both files.
- **actionlint** 1.7.12: **PASS** on both files.
- **pre-commit** (`pre-commit run --files …`): all matching hooks **Passed**
  (Check YAML syntax, Lint YAML files/yamllint, trailing-whitespace, end-of-file,
  merge-conflict, large-files).

## Post-merge watch item (real acceptance proof)

Per plan §12 step 0.1's verify clause, the real proof is that the **next actual
GitHub Release per package fires exactly one publish run** (no double-fire). The
release ceremony is owner-gated — this PR intentionally creates **no** Release and
**no** tag. Recommended watch on the next `juniper-cascor-model-v*` /
`juniper-cascor-protocol-v*` Release: confirm a single `Publish … to PyPI` run
starts, the tag-prefix guard skips the two non-matching sibling publish workflows,
and TestPyPI publishes once. `workflow_dispatch` remains available for an
operator dry-run before the first real Release.

## Scope (explicitly untouched)

Environments (`pypi` / `testpypi`), OIDC `permissions` blocks, build/publish/verify
steps, and version files are **unchanged**. The TestPyPI `--no-deps` strict-verify
standardization (finding F-5) is a separate work unit (plan step 0.2) and is **not**
in this PR — `publish-protocol.yml` deliberately keeps its existing verify step.

## Requirements

No tracked `JR-*` requirement applies. This PR implements Phase 0.1 of the release-train
plan (`juniper-ml/notes/JUNIPER_2026-07-11_JUNIPER-ECOSYSTEM_PYPI-RELEASE-TRAIN-WORKFLOW-PLAN.md`
§12), addressing audit finding **F-4**
(`juniper-ml/notes/JUNIPER_2026-07-11_JUNIPER-ECOSYSTEM_PYPI-RELEASE-SURFACE-AUDIT.md` §5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011QJRyKLvHu5Pef5TQbvk8z
