### PR TITLE
ci(publish): strict --no-deps TestPyPI verify for cascor + protocol (release-train Phase 0.2, F-5)

### DIFF
--- a/.github/workflows/publish-protocol.yml
+++ b/.github/workflows/publish-protocol.yml
@@ -138,17 +138,25 @@ jobs:
         run: |
           set -euo pipefail
           version=$(grep '^version' juniper-cascor-protocol/pyproject.toml | head -1 | sed -E 's/version = "(.+)"/\1/')
+          # Release-train Phase 0.2 (finding F-5, policy juniper-ml#384): install
+          # juniper-cascor-protocol from TestPyPI ONLY, with --no-deps and no
+          # `--extra-index-url https://pypi.org/simple/` fallback. Anti-target-squatting: under
+          # --no-deps pip fetches no dependencies, so a pypi.org fallback index could only serve
+          # to resolve a squatted same-name TARGET package.
           for attempt in 1 2 3 4 5; do
             if pip install \
+              --no-deps \
               --index-url https://test.pypi.org/simple/ \
-              --extra-index-url https://pypi.org/simple/ \
               "juniper-cascor-protocol==${version}"; then
               break
             fi
             echo "TestPyPI index lag — retrying in 10s (attempt ${attempt}/5)"
             sleep 10
           done
-          python -c "import juniper_cascor_protocol; print('TestPyPI install OK', juniper_cascor_protocol.__version__)"
+          # `import juniper_cascor_protocol` eagerly loads the numpy BinaryFrame codec (worker
+          # subpackage), which is absent under --no-deps; assert the installed distribution and
+          # version via importlib.metadata instead of importing the package.
+          python -c "import importlib.metadata as m; print('TestPyPI install OK', m.version('juniper-cascor-protocol'))"
 
   publish-pypi:
     name: Publish to PyPI

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,8 +41,13 @@ jobs:
           VERSION="${{ github.event.release.tag_name }}"
           VERSION="${VERSION#v}"
           sleep 30
-          pip install torch --index-url https://download.pytorch.org/whl/cpu
-          pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ juniper-cascor==${VERSION}
+          # Release-train Phase 0.2 (finding F-5, policy juniper-ml#384): install juniper-cascor from
+          # TestPyPI ONLY, with --no-deps and no `--extra-index-url https://pypi.org/simple/` fallback.
+          # Anti-target-squatting: under --no-deps pip fetches no dependencies, so a pypi.org fallback
+          # index could only serve to resolve a squatted same-name TARGET package. The top-level
+          # `juniper_cascor` package is torch-free (it only exposes __version__), so this validates that
+          # the published artifact installs and imports without pulling the multi-GB torch stack into CI.
+          pip install --no-deps --index-url https://test.pypi.org/simple/ juniper-cascor==${VERSION}
           python -c "from juniper_cascor import __version__; print(f'TestPyPI OK: v{__version__}')"
 
   pypi:


### PR DESCRIPTION
## Summary

Standardize the **TestPyPI install-verify** step in juniper-cascor's two leaf publish
workflows to the strict pattern ratified in **juniper-ml#384**: resolve the target
package from **TestPyPI only** — `pip install --no-deps --index-url https://test.pypi.org/simple/ "<pkg>==<version>"` —
with **no** production-PyPI `--extra-index-url https://pypi.org/simple/` fallback.

**Why (anti-target-squatting):** with `--no-deps` no dependencies are fetched, so a
pypi.org fallback index cannot help resolve any legitimate dependency — it can only
serve to resolve a **squatted same-name TARGET package**. Removing the fallback closes
that hole while still tolerating TestPyPI index lag via each file's existing retry/sleep.

Release-train plan §12 **step 0.2**, audit finding **F-5**
(`notes/JUNIPER_2026-07-11_JUNIPER-ECOSYSTEM_PYPI-RELEASE-SURFACE-AUDIT.md` §3.4 in
juniper-ml). In-repo strict model followed: `.github/workflows/publish-cascor-model.yml`.

## Changes

Two files, verify step only. Triggers/concurrency (just migrated by **#399**) and all
build / publish / OIDC steps are untouched.

### `.github/workflows/publish.yml` (juniper-cascor app)
- Add `--no-deps`; drop `--extra-index-url https://pypi.org/simple/`; add the security NOTE.
- **Removed the now-vestigial `pip install torch --index-url .../whl/cpu` pre-install.**
  The top-level `juniper_cascor` package is torch-free — `juniper_cascor/__init__.py`
  only assigns `__version__`/`__author__` string literals, no imports — so
  `from juniper_cascor import __version__` verifies under **pure `--no-deps`** with no
  torch/numpy present (rehearsal below). torch is not even a core dependency (it lives in
  the `[ml]` extra), so the pre-install served no purpose for this check. This also matches
  the strict model's stated goal of verifying "without pulling the multi-GB torch stack
  into CI." Kept the existing bare `sleep 30` + single-attempt shape (no retry loop added).
  *If you'd prefer to retain the `pip install torch` line, it's a one-line restore — the
  verify passes with or without it.*
- Post-install command kept as-is (`from juniper_cascor import __version__`); it passes
  under `--no-deps` (does not fail on missing deps), so per the task rule it was not swapped.

### `.github/workflows/publish-protocol.yml` (juniper-cascor-protocol)
- Add `--no-deps`; drop `--extra-index-url https://pypi.org/simple/`; add the security NOTE.
  Kept the existing **5-attempt retry loop**.
- **Substituted the post-install command.** `import juniper_cascor_protocol` eagerly loads
  the numpy `BinaryFrame` codec (`__init__.py` → `worker/__init__.py` → `worker/binary_frame.py: import numpy`),
  which is absent under `--no-deps`. The version check now uses `importlib.metadata` (no
  package import): `python -c "import importlib.metadata as m; print('TestPyPI install OK', m.version('juniper-cascor-protocol'))"`.
  This is the version-only alternative called out in the task (the strict model's own
  `import juniper_cascor_model` works only because that package is intentionally torch-/numpy-free).

## Rehearsal (local, `--no-deps`, python 3.12.11 to match CI)

Each package's wheel built from this branch (app: repo-root pyproject; protocol: its
subdirectory, matching where each workflow builds), installed into a fresh venv with
`pip install --no-deps <wheel>`, then the **exact shipped post-install command** run:

| Package | venv contents (`--no-deps`) | Shipped command | Result |
|---|---|---|---|
| juniper-cascor (app) | only `juniper-cascor==0.5.0` (no torch, no numpy) | `from juniper_cascor import __version__` | **exit 0** → `TestPyPI OK: v0.3.17` |
| juniper-cascor-protocol | only `juniper-cascor-protocol==0.1.0` (no numpy, no pydantic) | `importlib.metadata ... version('juniper-cascor-protocol')` | **exit 0** → `TestPyPI install OK 0.1.0` |
| protocol (control — OLD command) | same | `import juniper_cascor_protocol` | **exit 1** → `ModuleNotFoundError: No module named 'numpy'` |

The control row confirms the protocol substitution was necessary; the app row confirms
dropping the torch pre-install is safe.

## Out-of-scope observation (not fixed here)

The app rehearsal prints `v0.3.17`, but the packaged version is `0.5.0` — `juniper_cascor/__init__.py`
carries a stale hardcoded `__version__ = "0.3.17"` while `pyproject.toml` is at `0.5.0`.
The verify step only prints this string (it does not assert equality with the release
tag), so it does not affect this change. Flagging it as a separate, pre-existing defect —
not touched here to keep this PR to the F-5 CI-hygiene scope.

## Verification

- `pre-commit run --files .github/workflows/publish.yml .github/workflows/publish-protocol.yml` → **all Passed/Skipped, exit 0** (Check YAML, yamllint, EOF, trailing-whitespace, merge-conflicts).
- `yamllint -c .yamllint.yaml` on both files → **exit 0**.
- `juniper-lint-workflow-paths` (the CI workflow-path lint, `juniper-ci-tools` 0.6.0) → **exit 0** ("14 workflow file(s) checked, no missing script paths"). No `python <path.py>`/`bash <path.bash>` references were added (only `python -c` inline + `pip install`).
- **Runtime proof lands at the next release** of each package (these steps only run on a cut Release / matching tag); the local rehearsal above stands in for that until then.

## Note on pre-existing main CI status

At branch time, main's **CI/CD Pipeline** is already red on the latest push (#405): the
failures are in **integration tests** ("Run Integration Tests (Fast Only)", "Run Quick
Integration Tests") → Quality Gate — the known 'spiral' vs 'spirals' training-runtime
breakage, unrelated to publishing. This PR touches only the release-triggered publish
workflows (not part of `ci.yml`), so any identical integration-test red here is inherited
from main, not introduced by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RH3FKUsAfr9WnMKJhhoy5s
