### PR TITLE
feat(security): SEC-F01 boot-time auth-posture self-check (service-core 0.5.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,14 @@ dependencies = [
     # of the cascor service (not test-only). Pin matches the [test] conformance
     # kit (OQ-B2, plan §9): >=0.2.0,<0.3.0; model-core has zero deps / no torch.
     "juniper-model-core>=0.2.0,<0.4.0",
+    # SEC-F01 / HO-2 (per-service adoption wave): boot-time auth-posture
+    # self-check. The lifespan calls enforce_auth_posture with the resolved
+    # inbound api_keys right after the bind-attestation guard, so an
+    # empty/placeholder JUNIPER_CASCOR_API_KEYS secret (which silently
+    # disables APIKeyAuth and serves protected routes open behind a healthy
+    # health check) is loud at boot. Stdlib-only import surface; 0.5.0 is the
+    # release that ships the check. Pin mirrors the model-core floor+cap style.
+    "juniper-service-core>=0.5.0,<0.6.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.lock
+++ b/requirements.lock
@@ -4,7 +4,7 @@ annotated-doc==0.0.4
     # via fastapi
 annotated-types==0.7.0
     # via pydantic
-anyio==4.14.1
+anyio==4.14.2
     # via
     #   starlette
     #   watchfiles
@@ -14,7 +14,7 @@ certifi==2026.6.17
     # via
     #   requests
     #   sentry-sdk
-charset-normalizer==3.4.7
+charset-normalizer==3.4.9
     # via requests
 click==8.4.2
     # via uvicorn
@@ -24,13 +24,15 @@ cuda-bindings==13.3.1
     # via torch
 cuda-pathfinder==1.5.6
     # via cuda-bindings
-cuda-toolkit==13.0.2
+cuda-toolkit==13.0.3.0
     # via torch
 cycler==0.12.1
     # via matplotlib
-fastapi==0.139.0
-    # via juniper-cascor (pyproject.toml)
-filelock==3.29.5
+fastapi==0.139.2
+    # via
+    #   juniper-cascor (pyproject.toml)
+    #   juniper-service-core
+filelock==3.31.1
     # via torch
 fonttools==4.63.0
     # via matplotlib
@@ -50,25 +52,29 @@ jinja2==3.1.6
     # via torch
 juniper-cascor-protocol==0.1.0
     # via juniper-cascor (pyproject.toml)
-juniper-data==0.9.0
+juniper-data==0.10.0
     # via juniper-cascor (pyproject.toml)
 juniper-data-client==0.4.2
     # via juniper-cascor (pyproject.toml)
 juniper-model-core==0.3.0
-    # via juniper-cascor (pyproject.toml)
+    # via
+    #   juniper-cascor (pyproject.toml)
+    #   juniper-service-core
 juniper-observability==0.4.0
+    # via juniper-cascor (pyproject.toml)
+juniper-service-core==0.5.0
     # via juniper-cascor (pyproject.toml)
 kiwisolver==1.5.0
     # via matplotlib
 markupsafe==3.0.3
     # via jinja2
-matplotlib==3.11.0
+matplotlib==3.11.1
     # via juniper-cascor (pyproject.toml)
 mpmath==1.3.0
     # via sympy
 networkx==3.6.1
     # via torch
-numpy==2.5.0
+numpy==2.5.1
     # via
     #   juniper-cascor (pyproject.toml)
     #   contourpy
@@ -76,12 +82,13 @@ numpy==2.5.0
     #   juniper-cascor-protocol
     #   juniper-data
     #   juniper-data-client
+    #   juniper-service-core
     #   matplotlib
 nvidia-cublas==13.1.1.3
     # via
+    #   cuda-toolkit
     #   nvidia-cudnn-cu13
     #   nvidia-cusolver
-    #   torch
 nvidia-cuda-cupti==13.0.85
     # via cuda-toolkit
 nvidia-cuda-nvrtc==13.0.88
@@ -108,7 +115,7 @@ nvidia-cusparselt-cu13==0.8.1
     # via torch
 nvidia-nccl-cu13==2.29.7
     # via torch
-nvidia-nvjitlink==13.0.88
+nvidia-nvjitlink==13.3.33
     # via
     #   cuda-toolkit
     #   nvidia-cufft
@@ -131,11 +138,14 @@ pydantic==2.13.4
     #   juniper-cascor-protocol
     #   juniper-data
     #   juniper-observability
+    #   juniper-service-core
     #   pydantic-settings
 pydantic-core==2.46.4
     # via pydantic
 pydantic-settings==2.14.2
-    # via juniper-cascor (pyproject.toml)
+    # via
+    #   juniper-cascor (pyproject.toml)
+    #   juniper-service-core
 pyparsing==3.3.2
     # via matplotlib
 python-dateutil==2.9.0.post0
@@ -152,9 +162,9 @@ pyyaml==6.0.3
     #   uvicorn
 requests==2.34.2
     # via juniper-data-client
-sentry-sdk==2.64.0
+sentry-sdk==2.66.0
     # via juniper-cascor (pyproject.toml)
-setuptools==81.0.0
+setuptools==83.0.0
     # via torch
 six==1.17.0
     # via python-dateutil
@@ -184,13 +194,13 @@ urllib3==2.7.0
     #   juniper-data-client
     #   requests
     #   sentry-sdk
-uvicorn==0.49.0
+uvicorn==0.51.0
     # via juniper-cascor (pyproject.toml)
 uvloop==0.22.1
     # via uvicorn
 watchfiles==1.2.0
     # via uvicorn
-websockets==16.0
+websockets==16.1.1
     # via uvicorn
 
 # The following packages were excluded from the output:

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -13,6 +13,7 @@ import torch
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from juniper_service_core import enforce_auth_posture
 
 from api import provenance
 from api.lifecycle.manager import TrainingLifecycleManager
@@ -312,6 +313,21 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # proxy), before uvicorn binds the socket or any background thread is
     # spawned. Fail-closed and loud.
     enforce_bind_attestation_guard(settings)
+
+    # SEC-F01 (HO-2): boot-time auth-posture self-check. An empty/placeholder
+    # JUNIPER_CASCOR_API_KEYS secret silently disables APIKeyAuth and cascor
+    # serves protected routes OPEN behind a healthy health check; make that
+    # posture loud here, before serving begins. require_auth=False because
+    # cascor has no require-auth flag today — flipping to fail-closed
+    # (CRITICAL + refuse to start) is the owner-approved
+    # JUNIPER_CASCOR_REQUIRE_AUTH follow-up. Bypass with
+    # JUNIPER_SKIP_AUTH_POSTURE_CHECK=1 (logged loudly).
+    enforce_auth_posture(
+        settings.api_keys,
+        require_auth=False,
+        service_name="juniper-cascor",
+        logger=logger,
+    )
 
     configure_sentry(settings.sentry_dsn, "juniper-cascor", _API_VERSION)
     if settings.metrics_enabled:

--- a/src/tests/unit/api/test_auth_posture_boot_check.py
+++ b/src/tests/unit/api/test_auth_posture_boot_check.py
@@ -1,0 +1,102 @@
+"""Tests for the SEC-F01 boot-time auth-posture self-check.
+
+The lifespan calls juniper-service-core's ``enforce_auth_posture(settings.api_keys,
+require_auth=False, service_name="juniper-cascor")`` right after the bind-attestation
+guard — before serving — so an empty/placeholder ``JUNIPER_CASCOR_API_KEYS`` secret
+(which silently disables ``APIKeyAuth`` and serves protected routes open behind a
+healthy health check — the HO-2 incident class) is at least LOUD at boot.
+``require_auth`` stays ``False`` until the owner-approved
+``JUNIPER_CASCOR_REQUIRE_AUTH`` follow-up flips the posture to fail-closed.
+
+The wiring test monkeypatches the module attribute with a recorder that raises a
+sentinel, proving the lifespan invokes the check (with the resolved keys, before
+any background machinery starts) without running the heavy startup tail. The
+behavioural tests exercise the helper directly.
+"""
+
+import asyncio
+
+import pytest
+
+from api.app import create_app, lifespan
+from api.settings import Settings
+
+pytestmark = pytest.mark.unit
+
+
+class _Sentinel(Exception):
+    """Raised by the recorder to stop the lifespan right after the posture check."""
+
+
+class TestAuthPostureLifespanWiring:
+    """The check is actually invoked at application startup (before serving)."""
+
+    def test_lifespan_invokes_posture_check_with_resolved_keys(self, monkeypatch):
+        calls: list[tuple[list[str], bool, str]] = []
+
+        def _recorder(api_keys, *, require_auth, service_name, logger=None, **_kwargs):
+            calls.append((list(api_keys or []), require_auth, service_name))
+            raise _Sentinel
+
+        monkeypatch.setattr("api.app.enforce_auth_posture", _recorder)
+        app = create_app(Settings(api_keys=["k1", "k2"], auto_start=False))
+
+        async def _enter() -> None:
+            async with lifespan(app):
+                pass  # pragma: no cover — the recorder raises before yield
+
+        with pytest.raises(_Sentinel):
+            asyncio.run(_enter())
+        assert calls == [(["k1", "k2"], False, "juniper-cascor")]
+
+    def test_create_app_itself_does_not_invoke_the_check(self, monkeypatch):
+        # Construction must stay check-free — the posture fires at startup
+        # (lifespan), mirroring the bind guard's construction/startup split.
+        monkeypatch.setattr("api.app.enforce_auth_posture", lambda *a, **k: (_ for _ in ()).throw(_Sentinel))
+        app = create_app(Settings(api_keys=None, auto_start=False))
+        assert app.state.settings.api_keys is None
+
+
+class TestAuthPostureBehaviour:
+    """The helper's three outcomes, exercised directly (hermetic)."""
+
+    def test_no_keys_and_not_required_warns_open(self, monkeypatch, caplog):
+        from juniper_service_core import enforce_auth_posture
+
+        monkeypatch.delenv("JUNIPER_SKIP_AUTH_POSTURE_CHECK", raising=False)
+        with caplog.at_level("WARNING"):
+            enforce_auth_posture(None, require_auth=False, service_name="juniper-cascor")
+        assert any("running OPEN" in rec.getMessage() and "juniper-cascor" in rec.getMessage() for rec in caplog.records)
+
+    def test_blank_key_counts_as_unset(self, monkeypatch, caplog):
+        # Exactly what an empty secret file resolves to (the HO-2 class).
+        from juniper_service_core import auth_is_configured, enforce_auth_posture
+
+        assert not auth_is_configured([""])
+        assert not auth_is_configured(["   "])
+        monkeypatch.delenv("JUNIPER_SKIP_AUTH_POSTURE_CHECK", raising=False)
+        with caplog.at_level("WARNING"):
+            enforce_auth_posture(["   "], require_auth=False, service_name="juniper-cascor")
+        assert any("running OPEN" in rec.getMessage() for rec in caplog.records)
+
+    def test_real_key_passes_quietly(self, monkeypatch, caplog):
+        from juniper_service_core import enforce_auth_posture
+
+        monkeypatch.delenv("JUNIPER_SKIP_AUTH_POSTURE_CHECK", raising=False)
+        with caplog.at_level("INFO"):
+            enforce_auth_posture(["a-real-cascor-key"], require_auth=True, service_name="juniper-cascor")
+        assert not any(rec.levelname in ("WARNING", "CRITICAL") for rec in caplog.records)
+
+    def test_required_with_no_key_raises(self, monkeypatch):
+        # The fail-closed posture the follow-up flag will enable.
+        from juniper_service_core import AuthPostureError, enforce_auth_posture
+
+        monkeypatch.delenv("JUNIPER_SKIP_AUTH_POSTURE_CHECK", raising=False)
+        with pytest.raises(AuthPostureError):
+            enforce_auth_posture([], require_auth=True, service_name="juniper-cascor")
+
+    def test_escape_hatch_bypasses_the_check(self, monkeypatch):
+        from juniper_service_core import enforce_auth_posture
+
+        monkeypatch.setenv("JUNIPER_SKIP_AUTH_POSTURE_CHECK", "1")
+        enforce_auth_posture([], require_auth=True, service_name="juniper-cascor")


### PR DESCRIPTION
## Summary

Implements the owner-approved SEC-F01 adoption for juniper-cascor (per the 2026-07-19 proposal, approved as-is): a boot-time auth-posture self-check from the **new** `juniper-service-core>=0.5.0,<0.6.0` core dependency. An empty/placeholder `JUNIPER_CASCOR_API_KEYS` secret silently disables `APIKeyAuth` and cascor serves protected routes **open** behind a healthy health check — the HO-2 incident class. With this change that posture is loudly visible at startup.

## Changes

- `pyproject.toml`: adds `juniper-service-core>=0.5.0,<0.6.0` to core `[project].dependencies` (boot-path always-on helper → core, not an extra), pin mirroring the `juniper-model-core>=0.2.0,<0.4.0` floor+cap style. Stdlib-only import surface — no transitive weight.
- `src/api/app.py` (lifespan): `enforce_auth_posture(settings.api_keys, require_auth=False, service_name="juniper-cascor", logger=logger)` immediately after `enforce_bind_attestation_guard` — its fail-loud sibling — before serving. Keys are the same `JUNIPER_CASCOR_API_KEYS`/`_FILE`-resolved `settings.api_keys` the `APIKeyAuth` middleware consumes. Real key → INFO; no/blank key → **loud WARNING (running OPEN)**. Never blocks startup in this wave.
- `src/tests/unit/api/test_auth_posture_boot_check.py` (new, 7 tests, modeled on `test_bind_guard.py`): lifespan wiring via a sentinel-raising recorder (asserts resolved keys + `require_auth=False` + service name without running the heavy startup tail), construction-stays-check-free, open-posture WARNING, blank-key-counts-as-unset, real-key-quiet, fail-closed raise, escape hatch.

## Proposed follow-up (owner approval requested — not in this PR)

A `JUNIPER_CASCOR_REQUIRE_AUTH` settings flag passed through as `require_auth=settings.require_auth` — suggested **False** bare/dev, **True** in the composed juniper-deploy stack, flipping the posture there to CRITICAL + refuse-to-start on a missing key.

**Escape hatch**: `JUNIPER_SKIP_AUTH_POSTURE_CHECK=1` (logged loudly).

## Testing (local, JuniperCascor1 + service-core 0.5.0 from PyPI)

- Full `tests/unit/api/` lane: **1760 passed** (7 new), exit 0.
- `pre-commit` over the changed files: all hooks pass.
- Note: an initial 3-test red herring (`0.5.0 != 0.6.0` version asserts) was the env's stale installed cascor metadata, fixed by `--force-reinstall --no-deps -e` from the canonical checkout — not this change; the posture WARNING fires cleanly in those tests' own captured startup logs.
- Lockfile: the dep-add makes `requirements.lock` stale by design — cascor's lockfile-update workflow auto-regenerates on `pull_request` (the canopy-#250-class hardening); expecting the freshness gate to go green after its regen commit.

*Owner merges — no auto-merge. Sibling PRs: canopy#452 (merged), recurrence#86, data#232.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017g8Qcd5PYX2pu4eWb5jwnu