### PR TITLE
feat(security): JUNIPER_CASCOR_REQUIRE_AUTH fail-closed posture flag (SEC-F01 tail)

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -317,14 +317,15 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # SEC-F01 (HO-2): boot-time auth-posture self-check. An empty/placeholder
     # JUNIPER_CASCOR_API_KEYS secret silently disables APIKeyAuth and cascor
     # serves protected routes OPEN behind a healthy health check; make that
-    # posture loud here, before serving begins. require_auth=False because
-    # cascor has no require-auth flag today — flipping to fail-closed
-    # (CRITICAL + refuse to start) is the owner-approved
-    # JUNIPER_CASCOR_REQUIRE_AUTH follow-up. Bypass with
-    # JUNIPER_SKIP_AUTH_POSTURE_CHECK=1 (logged loudly).
+    # posture loud here, before serving begins. The intended posture comes
+    # from JUNIPER_CASCOR_REQUIRE_AUTH (settings.require_auth; default
+    # false): false = loud WARNING only (bare/dev profile), true = a
+    # missing/blank key is a boot FAILURE (CRITICAL + AuthPostureError) —
+    # set true wherever secrets are provisioned (the composed juniper-deploy
+    # stack). Bypass with JUNIPER_SKIP_AUTH_POSTURE_CHECK=1 (logged loudly).
     enforce_auth_posture(
         settings.api_keys,
-        require_auth=False,
+        require_auth=settings.require_auth,
         service_name="juniper-cascor",
         logger=logger,
     )

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -159,6 +159,14 @@ class Settings(BaseSettings):
     loopback_publish_attested: bool = False
     auth_proxy_attested: bool = False
 
+    # SEC-F01: the INTENDED auth posture, fed to enforce_auth_posture in the
+    # lifespan (env ``JUNIPER_CASCOR_REQUIRE_AUTH``). False (default) = an
+    # unset/blank JUNIPER_CASCOR_API_KEYS only WARNs at boot (service runs
+    # open — bare/dev profile); True = boot REFUSES (CRITICAL +
+    # AuthPostureError) when no real key is configured. Set true wherever
+    # secrets are provisioned (the composed juniper-deploy stack).
+    require_auth: bool = False
+
     log_level: str = _JUNIPER_CASCOR_API_LOGLEVEL_DEFAULT
     cors_origins: list[str] = _JUNIPER_CASCOR_API_CORS_ORIGINS_DEFAULT
 

--- a/src/tests/unit/api/test_auth_posture_boot_check.py
+++ b/src/tests/unit/api/test_auth_posture_boot_check.py
@@ -1,12 +1,13 @@
 """Tests for the SEC-F01 boot-time auth-posture self-check.
 
 The lifespan calls juniper-service-core's ``enforce_auth_posture(settings.api_keys,
-require_auth=False, service_name="juniper-cascor")`` right after the bind-attestation
-guard — before serving — so an empty/placeholder ``JUNIPER_CASCOR_API_KEYS`` secret
-(which silently disables ``APIKeyAuth`` and serves protected routes open behind a
-healthy health check — the HO-2 incident class) is at least LOUD at boot.
-``require_auth`` stays ``False`` until the owner-approved
-``JUNIPER_CASCOR_REQUIRE_AUTH`` follow-up flips the posture to fail-closed.
+require_auth=settings.require_auth, service_name="juniper-cascor")`` right after the
+bind-attestation guard — before serving — so an empty/placeholder
+``JUNIPER_CASCOR_API_KEYS`` secret (which silently disables ``APIKeyAuth`` and serves
+protected routes open behind a healthy health check — the HO-2 incident class) is
+LOUD at boot, and — with ``JUNIPER_CASCOR_REQUIRE_AUTH=true`` (default false) — a
+boot FAILURE instead (the fail-closed posture for deployments where secrets are
+provisioned).
 
 The wiring test monkeypatches the module attribute with a recorder that raises a
 sentinel, proving the lifespan invokes the check (with the resolved keys, before
@@ -31,7 +32,8 @@ class _Sentinel(Exception):
 class TestAuthPostureLifespanWiring:
     """The check is actually invoked at application startup (before serving)."""
 
-    def test_lifespan_invokes_posture_check_with_resolved_keys(self, monkeypatch):
+    @pytest.mark.parametrize("require_auth", [False, True])
+    def test_lifespan_invokes_posture_check_with_resolved_keys(self, monkeypatch, require_auth):
         calls: list[tuple[list[str], bool, str]] = []
 
         def _recorder(api_keys, *, require_auth, service_name, logger=None, **_kwargs):
@@ -39,7 +41,7 @@ class TestAuthPostureLifespanWiring:
             raise _Sentinel
 
         monkeypatch.setattr("api.app.enforce_auth_posture", _recorder)
-        app = create_app(Settings(api_keys=["k1", "k2"], auto_start=False))
+        app = create_app(Settings(api_keys=["k1", "k2"], auto_start=False, require_auth=require_auth))
 
         async def _enter() -> None:
             async with lifespan(app):
@@ -47,7 +49,32 @@ class TestAuthPostureLifespanWiring:
 
         with pytest.raises(_Sentinel):
             asyncio.run(_enter())
-        assert calls == [(["k1", "k2"], False, "juniper-cascor")]
+        assert calls == [(["k1", "k2"], require_auth, "juniper-cascor")]
+
+    def test_require_auth_defaults_to_false(self):
+        # Default keeps today's loud-WARNING posture; deployments opt in to
+        # fail-closed explicitly (the composed stack sets the env flag).
+        assert Settings.model_fields["require_auth"].default is False
+
+    def test_env_flag_flips_posture(self, monkeypatch):
+        monkeypatch.setenv("JUNIPER_CASCOR_REQUIRE_AUTH", "true")
+        assert Settings().require_auth is True
+
+    def test_required_with_no_keys_refuses_startup(self, monkeypatch):
+        # The fail-closed posture end-to-end: the REAL lifespan raises
+        # AuthPostureError right after the bind guard, before any background
+        # machinery starts, so uvicorn startup fails instead of serving open.
+        from juniper_service_core import AuthPostureError
+
+        monkeypatch.delenv("JUNIPER_SKIP_AUTH_POSTURE_CHECK", raising=False)
+        app = create_app(Settings(api_keys=None, auto_start=False, require_auth=True))
+
+        async def _enter() -> None:
+            async with lifespan(app):
+                pass  # pragma: no cover — the posture check raises before yield
+
+        with pytest.raises(AuthPostureError):
+            asyncio.run(_enter())
 
     def test_create_app_itself_does_not_invoke_the_check(self, monkeypatch):
         # Construction must stay check-free — the posture fires at startup


### PR DESCRIPTION
## Summary

The owner-approved follow-up from #415: a `require_auth` settings flag (env `JUNIPER_CASCOR_REQUIRE_AUTH`, **default false**) passed through the lifespan's `enforce_auth_posture` call. False = today's loud-WARNING posture (bare/dev); true = a missing/blank `JUNIPER_CASCOR_API_KEYS` refuses startup (`CRITICAL` + `AuthPostureError`) right after the bind-attestation guard, before any background machinery starts.

## Changes

- `src/api/settings.py`: `require_auth: bool = False` beside the attestation pair (standard `JUNIPER_CASCOR_` env wiring).
- `src/api/app.py` (lifespan): `require_auth=settings.require_auth` (was the literal `False`), comment updated.
- `src/tests/unit/api/test_auth_posture_boot_check.py`: wiring test parametrized over both postures; new tests — default-is-false (model_fields), env flag flips via prefix, and the fail-closed path **through the real lifespan** (raises before the heavy startup tail).

## Deploy note

juniper-deploy#158 sets `JUNIPER_CASCOR_REQUIRE_AUTH=true` on the main cascor service (its key secret is provisioned there); `juniper-cascor-demo` stays intentionally keyless/open and does not set it.

## Testing (local, JuniperCascor1)

Full `tests/unit/api/` lane: **exit 0** (the posture file now 12 tests incl. parametrization). `pre-commit`: all hooks pass. Lockfile untouched (no dependency change).

*Owner merges — no auto-merge. Siblings: canopy/recurrence/data flag PRs + juniper-deploy#158.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017g8Qcd5PYX2pu4eWb5jwnu