### PR TITLE
ci(codeql): align codeql-action subactions to v4.37.1 (split-bump mismatch)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,13 +46,13 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a  # v4.37.1
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
+        uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a  # v4.37.1
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a  # v4.37.1


### PR DESCRIPTION
## Summary

Third recurrence of the CodeQL split-bump class (prior: 2026-07-07, 2026-07-14): Dependabot's per-subaction 4.37.1 bumps merged piecemeal, leaving this repo's `codeql-action` pins on mixed 4.37.0/4.37.1 — the `Loaded a configuration file for version 'X', but running version 'Y'` failure (already red on cascor/data main; the rest one run away). Aligns **every** `codeql-action` subaction pin in this repo to **v4.37.1** (`7188fc363630916deb702c7fdcf4e481b751f97a`), same playbook both prior cycles.

1 file(s) changed, YAML pin alignment only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RH3FKUsAfr9WnMKJhhoy5s