### PR TITLE
ci(dependabot): group github/codeql-action bumps atomically (split-subaction prevention)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,3 +49,7 @@ updates:
       - "ci"
     commit-message:
       prefix: "ci"
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"


### PR DESCRIPTION
## Summary

**Scope reduced**: the align-to-v4.37.1 half of this branch was independently shipped and merged by a concurrent session's PR before this one — what remains here is the **prevention** that three recurrences in three weeks proved necessary.

## Change

`.github/dependabot.yml` github-actions block: new `codeql-action` group (`github/codeql-action*`) so every future codeql-action bump moves `init`/`autobuild`/`analyze`/`upload-sarif` together in one PR — making the `Loaded a configuration file for version X, but running version Y` split class structurally impossible.

## Verification

yamllint/pre-commit green; one-file diff.

*Owner merges. Part of the fleet-wide CodeQL item in the approved plan (juniper-ml#683); the same group lands in all 7 codeql-bearing repos.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017g8Qcd5PYX2pu4eWb5jwnu