### PR TITLE
fix(golden): re-capture metrics_post_train for C7 scalar eval metrics

### DIFF
--- a/src/tests/fixtures/golden/api_snapshots/metrics_post_train.json
+++ b/src/tests/fixtures/golden/api_snapshots/metrics_post_train.json
@@ -1,7 +1,19 @@
 {
   "data": {
     "epoch": 3,
+    "eval_metrics": {
+      "average": "macro",
+      "enabled": true,
+      "n_classes": 2,
+      "n_samples": 60,
+      "split": "training",
+      "undefined": {}
+    },
+    "f1": 0.42574868786662556,
     "hidden_units": 2,
+    "precision": 0.4721706864564007,
+    "recall": 0.48333333333333334,
+    "roc_auc": 0.43444444444444447,
     "train_accuracy": 0.48333333333333334,
     "train_loss": 0.40217360854148865,
     "val_accuracy": null,


### PR DESCRIPTION
## Summary

The Golden / Snapshot Regression lane fails on every PR (first surfaced on the innocent dependabot workflow bump #424) because `dfb408c` (C7 phase 1 — scalar evaluation metrics) added `f1` / `precision` / `recall` / `roc_auc` + the `eval_metrics` metadata block to the `/v1/metrics` payload without re-capturing the golden:

```
$.data: unexpected keys ['eval_metrics', 'f1', 'precision', 'recall', 'roc_auc']
```

Re-captured per `src/tests/fixtures/golden/README.md` on `JuniperCascor1` (single-thread BLAS pins, `CASCOR_NUM_PROCESSES=1`, `GOLDEN_CAPTURE=1`). The diff is **purely additive** — exactly the five intended C7 keys with deterministic fixed-seed values; no other golden artifact moved (trajectory/predict/other snapshots untouched, confirming the fixed-seed train is still bit-stable vs the 2026-06-17 calibration).

## Test plan

- [x] Capture run: `GOLDEN_CAPTURE=1 python -m pytest -m golden --golden --slow --integration src/tests/integration` — 5 passed
- [x] Assert-mode lock-in (no `GOLDEN_CAPTURE`) — 5 passed
- [x] Diff review: single file, additive keys only

After merge, re-running #424's golden check should go green (its own delta is workflow-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019fV7aJw26F7YVkRvcSTH1G