### PR TITLE
fix(ci): gate lockfile-update on PAT availability — unbreak Dependabot runs

### DIFF
--- a/.github/workflows/lockfile-update.yml
+++ b/.github/workflows/lockfile-update.yml
@@ -8,7 +8,7 @@
 # Version:       0.1.0
 #
 # Date Created:  2026-03-02
-# Last Modified: 2026-03-02
+# Last Modified: 2026-07-28
 #
 # License:       MIT License
 # Copyright:     Copyright (c) 2024-2026 Paul Calnon
@@ -19,6 +19,16 @@
 #    the lockfile and commits the result so Docker builds stay in sync.
 #
 #    Uses CROSS_REPO_DISPATCH_TOKEN (not GITHUB_TOKEN) so the push re-triggers CI.
+#
+#    Dependabot caveat (2026-07-28): Dependabot-triggered runs use the
+#    Dependabot secret store ("Secret source: Dependabot"), so the repo-scoped
+#    CROSS_REPO_DISPATCH_TOKEN is EMPTY there and the checkout hard-failed on
+#    every dependabot/pip/** push (e.g. run 30346680261 on #426). The
+#    token-availability gate below turns that arm into a loud green no-op
+#    until the owner registers the same PAT under Settings -> Secrets ->
+#    Dependabot, which re-enables full auto-regen with no workflow change.
+#    A missing PAT on a NON-Dependabot run still fails loudly. Mirrors
+#    juniper-canopy #476.
 #
 # References:
 #    - Step 7.5.2: Dependency Update Workflow (POLYREPO_MIGRATION_PLAN.md)
@@ -53,7 +63,25 @@ jobs:
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
 
     steps:
+      - name: Gate on CROSS_REPO_DISPATCH_TOKEN availability
+        id: gate
+        env:
+          # Secrets are not readable in job/step `if:` expressions, so surface
+          # presence (never the value) through env for the shell to branch on.
+          HAVE_PAT: ${{ secrets.CROSS_REPO_DISPATCH_TOKEN != '' }}
+        run: |
+          if [[ "${HAVE_PAT}" == "true" ]]; then
+            echo "proceed=true" >> "${GITHUB_OUTPUT}"
+          elif [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
+            echo "::notice::CROSS_REPO_DISPATCH_TOKEN is not available to Dependabot-triggered runs (Dependabot secret store). Skipping auto-regen; the Lockfile Freshness CI gate still enforces staleness. Register the PAT under Settings -> Secrets -> Dependabot to re-enable."
+            echo "proceed=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "::error::CROSS_REPO_DISPATCH_TOKEN is missing for a non-Dependabot run — secret misconfiguration."
+            exit 1
+          fi
+
       - name: Checkout Code
+        if: steps.gate.outputs.proceed == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           token: ${{ secrets.CROSS_REPO_DISPATCH_TOKEN }}
@@ -63,14 +91,17 @@ jobs:
           ref: ${{ github.head_ref || github.ref }}
 
       - name: Set up Python
+        if: steps.gate.outputs.proceed == 'true'
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.14"
 
       - name: Install uv
+        if: steps.gate.outputs.proceed == 'true'
         run: pip install uv==0.11.8
 
       - name: Regenerate requirements.lock
+        if: steps.gate.outputs.proceed == 'true'
         run: |
           echo "╔════════════════════════════════════════════════════════════╗"
           echo "║       Juniper Cascor - Regenerate Lockfile                 ║"
@@ -88,6 +119,7 @@ jobs:
           mv /tmp/requirements.lock.check requirements.lock
 
       - name: Commit updated lockfile
+        if: steps.gate.outputs.proceed == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary

Port of juniper-canopy #476 — same workflow, same bug: Dependabot-triggered runs draw from the Dependabot secret store, where the repo-scoped `CROSS_REPO_DISPATCH_TOKEN` doesn't exist, so `Update requirements.lock` hard-fails (`Input required and not supplied: token`) on every `dependabot/pip/**` push. Run 30346680261 is the remaining red check on #426 (its golden lane went green after the rebase).

Gate behavior: PAT present → unchanged full regen + PAT push; PAT absent under `dependabot[bot]` → loud green no-op (Lockfile Freshness still enforces staleness); PAT absent otherwise → hard fail.

**Owner follow-up (optional):** register the PAT under **Settings → Secrets → Dependabot** to restore full auto-regen on Dependabot pushes. juniper-data has the identical workflow + failure history (runs 30269393178, 29860739774) — companion PR incoming.

## Test plan

- [x] `actionlint -shellcheck=` clean; YAML parses
- [x] Traced against run 30346680261's log (`Secret source: Dependabot` + empty token)

After merge: `@dependabot rebase` on #426 clears its last red check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019fV7aJw26F7YVkRvcSTH1G