### PR TITLE
fix(tests): derive API version assertions from _API_VERSION — unbreak main after v0.7.0 bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Unit tests no longer pin the service version as a literal: the four `0.6.0` assertions in `test_api_app.py`, `test_api_app_coverage_deep.py`, and `test_api_health.py` (red on `main` since the v0.7.0 bump merged in #429 without CI running) now assert against `api.app._API_VERSION` — the BUG-CC-04 canonical runtime read — so a release version bump can no longer break the suite.
+
 ## [0.7.0] - 2026-07-28
 
 ### Added

--- a/src/tests/unit/api/test_api_app.py
+++ b/src/tests/unit/api/test_api_app.py
@@ -3,7 +3,7 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from api.app import create_app
+from api.app import _API_VERSION, create_app
 from api.settings import Settings
 
 
@@ -28,7 +28,9 @@ class TestAppFactory:
         """Test app metadata."""
         app = create_app(Settings(auto_start=False))
         assert app.title == "JuniperCascor API"
-        assert app.version == "0.6.0"
+        # Assert against the BUG-CC-04 canonical runtime read, never a pinned
+        # literal — a release version bump must not break this wiring test.
+        assert app.version == _API_VERSION
 
     def test_cors_middleware_skipped_with_empty_origins(self):
         """Test that CORS middleware is not applied when origins is empty."""

--- a/src/tests/unit/api/test_api_app_coverage_deep.py
+++ b/src/tests/unit/api/test_api_app_coverage_deep.py
@@ -18,7 +18,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-from api.app import _auto_start_canopy, _auto_start_training, _unregister_worker_metrics_collector, create_app
+from api.app import _API_VERSION, _auto_start_canopy, _auto_start_training, _unregister_worker_metrics_collector, create_app
 from api.settings import Settings
 
 pytestmark = pytest.mark.unit
@@ -66,7 +66,7 @@ class TestLifespanMetricsEnabled:
                 # set_build_info now also receives git_sha/build_date from the
                 # api.provenance accessor — both None outside a provenance-stamped
                 # image (no env vars in the unit-test context).
-                mock_build_info.assert_called_once_with("juniper_cascor", "0.6.0", git_sha=None, build_date=None)
+                mock_build_info.assert_called_once_with("juniper_cascor", _API_VERSION, git_sha=None, build_date=None)
 
     def test_metrics_not_called_when_disabled(self):
         """When metrics_enabled=False (default), set_build_info is NOT called."""

--- a/src/tests/unit/api/test_api_health.py
+++ b/src/tests/unit/api/test_api_health.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 from fastapi.testclient import TestClient
 
-from api.app import create_app
+from api.app import _API_VERSION, create_app
 from api.models.health import DependencyStatus, ReadinessResponse, probe_dependency
 from api.settings import Settings
 
@@ -29,7 +29,7 @@ class TestHealthEndpoints:
         assert response.status_code == 200
         body = response.json()
         assert body["status"] == "ok"
-        assert body["version"] == "0.6.0"
+        assert body["version"] == _API_VERSION
 
     def test_health_includes_service_identifier(self, client):
         """API-02: /v1/health includes the ``service`` field naming this service.
@@ -92,7 +92,7 @@ class TestHealthEndpoints:
         assert response.headers.get("X-Juniper-Readiness") == "ready"
         body = response.json()
         assert body["status"] == "ready"
-        assert body["version"] == "0.6.0"
+        assert body["version"] == _API_VERSION
         assert body["service"] == "juniper-cascor"
         assert "timestamp" in body
         assert body["details"]["network_loaded"] is False


### PR DESCRIPTION
## Summary

`main` has been red on all four Unit Tests + Coverage matrix legs since 2026-07-28 21:29 UTC, when the v0.7.0 release proposal (#429) merged. Four unit tests pin the service version as the literal `0.6.0` and have failed on every run since (`assert '0.7.0' == '0.6.0'`). Every open PR (#432–#435) inherits the failure through the merge-ref.

## Root cause

#429 was opened on the release train's degraded no-App path: a PR opened with the built-in `GITHUB_TOKEN` does not trigger CI (GitHub's recursion guard), so it showed **zero checks** and merged without the runbook's re-trigger step. Had CI run, these four tests would have blocked it.

## Fix

The four assertions now derive their expected value from `api.app._API_VERSION` — the BUG-CC-04 canonical runtime read (`importlib.metadata.version("juniper-cascor")`, `src/api/app.py:37`) that the app factory, health endpoints, and `set_build_info` all serve — instead of a pinned literal. A release version bump can no longer re-break the suite; the tests still catch real wiring regressions (factory not passing the canonical version, endpoints dropping the field, lifespan passing wrong args).

- `src/tests/unit/api/test_api_app.py::test_app_title_and_version`
- `src/tests/unit/api/test_api_app_coverage_deep.py::test_set_build_info_called_when_metrics_enabled`
- `src/tests/unit/api/test_api_health.py::test_health_check`
- `src/tests/unit/api/test_api_health.py::test_readiness_probe_default`

The remaining `0.6.0` literals in tests (`test_api_observability.py:310/314/561`, `test_api_health.py:210`) are synthetic model-construction fixtures unrelated to the app's version — deliberately untouched.

## Testing

- `cd src && python -m pytest tests/unit/api/test_api_app.py tests/unit/api/test_api_health.py tests/unit/api/test_api_app_coverage_deep.py` — 68 passed (JuniperCascor1 env)
- `pre-commit run --files <changed>` — all hooks pass

## Follow-up (not in this PR)

The four red dependabot PRs (#432–#435) just need their checks re-run once this merges. Longer-term, the proposal generator doesn't know about consumer-repo test literals — deriving from the canonical source (this PR) is the durable cure for this class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTFePqmkdq7fvsQWTiuRFf