### PR TITLE
ci(sequence-safety): advisory symbol-loss + docs-additions net (per-PR + post-merge)

### DIFF
--- a/.github/workflows/main-verify.yml
+++ b/.github/workflows/main-verify.yml
@@ -1,0 +1,296 @@
+---
+#####################################################################################################################################################################################################
+# Project:       Juniper
+# Sub-Project:   JuniperCascor
+# Application:   juniper_cascor
+# File Name:     main-verify.yml
+# Author:        Paul Calnon
+# Version:       0.1.0
+#
+# Date Created:  2026-08-07
+# Last Modified: 2026-08-07
+#
+# License:       MIT License
+# Copyright:     Copyright (c) 2024-2026 Paul Calnon
+#
+# Description:
+#    Post-merge main-verification net (ported from juniper-ml; ml#873 / #880 / #928,
+#    flood-remediation analysis §4 item 8). Runs AFTER a merge lands on main, so it fires
+#    no matter who merged or what they bypassed -- the bypass-proof compositional-loss net
+#    the per-PR advisory screen (sequence-safety.yml) cannot guarantee. The flood damage
+#    class was every-PR-green but serial same-file merges fused / silently deleted sibling
+#    content, and a deleted test cannot fail, so nothing per-PR saw it.
+#
+#    Jobs:
+#      * symbol-screen -- ALWAYS runs. AST symbol-loss screen + docs deletion-magnitude
+#        screen of BASE .. <merge>, both via util/sequence_safety/. Uploads the JSON
+#        reports as an artifact. FAILs the job on a compositional-loss finding. Seconds to
+#        run (AST + git).
+#          CATCH-UP BASE (ml#880 G3.1): a quoted `[skip ci]` in a merge-commit body skips
+#          this workflow entirely, so a window of merges can land un-screened. BASE is
+#          therefore resolved to the head_sha of the most recent SUCCESSFUL main-verify run
+#          on main WHEN it is an ancestor of HEAD, so the NEXT run sweeps every skipped
+#          merge in between; it falls back to github.event.before (the push's first parent),
+#          then HEAD^1. The chosen base + reason are echoed to the step summary.
+#      * notify -- on failure only. Upserts a STABLE-TITLE dedup tracking issue (ml#928):
+#        ONE open issue per red streak; each subsequent failing SHA COMMENTS on it. Dedup
+#        binds to the workflow's OWN authorship (creator=github-actions[bot] + exact title
+#        + .pull_request == null), never title alone -- a forgeable public title is not a
+#        trust boundary. NOT auto-closed on green (the owner closes it after adjudication).
+#
+#    v1 DEFERRALS (adaptation notes, distinct from the juniper-ml original):
+#      * Battery job DEFERRED: juniper-ml re-runs its full unittest battery post-merge, but
+#        cascor's suite is heavy (pytest + coverage, minutes not seconds). v1 ships the
+#        screens-only net; a post-merge regression battery is a follow-up once the screens
+#        have soaked. The per-branch CI (ci.yml) still runs the full suite pre-merge.
+#      * Slack DEFERRED: cascor has no SLACK_WEBHOOK_URL workflow pattern, so v1 notifies
+#        via the tracking issue only (add a non-blocking Slack step later if a webhook
+#        secret is provisioned, mirroring juniper-ml's release-train pattern).
+#
+# Concurrency (grounded design requirement):
+#    ci.yml uses group: ci-${{ github.ref }} + cancel-in-progress: true, and for main
+#    pushes github.ref is constant (refs/heads/main), so rapid serial merges CANCEL each
+#    other and only the last merge is verified. This net MUST use a per-SHA group with
+#    cancel-in-progress: false so EVERY merge is verified during a storm (delayed by the
+#    runner cap, never dropped).
+#
+# Security Notes:
+#    - Runs on push:main + manual dispatch only (never on forks / PRs).
+#    - Workflow-level permissions are 'contents: read'; the symbol-screen job adds
+#      'actions: read' (gh api reads the last successful run for the catch-up base) and
+#      only the notify job elevates ('issues: write') to upsert the tracking issue.
+#
+# References:
+#    - util/sequence_safety/{symbol_loss_check,docs_additions_check}.py
+#    - juniper-ml .github/workflows/main-verify.yml (the #928 stable-title / catch-up-base version this ports)
+#    - juniper-ml notes/JUNIPER_2026-07-28_JUNIPER-ML_CURSOR-PR-FLOOD-REMEDIATION-ANALYSIS.md
+#####################################################################################################################################################################################################
+
+name: Post-Merge Main Verification
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+# Per-SHA, no-cancel: EVERY merge to main is verified even during a merge storm. Contrast
+# ci.yml (group: ci-${{ github.ref }} + cancel-in-progress: true), where serial main pushes
+# cancel each other so only the last merge's run survives.
+concurrency:
+  group: main-verify-${{ github.sha }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  PYTHON_TEST_VERSION: "3.14"
+
+jobs:
+  # ═══════════════════════════════════════════════════════════════════════════════════════════════
+  # symbol-screen (ALWAYS runs): the bypass-proof compositional-loss net -- AST symbol-loss screen +
+  # docs deletion-magnitude screen of the catch-up BASE .. <merge>. Seconds to run (AST + git).
+  # ═══════════════════════════════════════════════════════════════════════════════════════════════
+  symbol-screen:
+    name: Symbol & Docs Screen
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read # gh api reads the last successful main-verify run for the catch-up base
+    steps:
+      - name: Checkout Code (full history)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Need the catch-up base / github.event.before AND the new tip -> full history.
+          fetch-depth: 0
+
+      - name: Set up Python ${{ env.PYTHON_TEST_VERSION }}
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ env.PYTHON_TEST_VERSION }}
+
+      - name: Resolve catch-up base
+        id: base
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BEFORE: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -uo pipefail
+          # CATCH-UP BASE (ml#880 G3.1): a quoted `[skip ci]` in a merge-commit body skips THIS
+          # workflow entirely, so a window of merges can land un-screened. Resolve BASE to the
+          # head_sha of the most recent SUCCESSFUL main-verify run on main WHEN it is an ancestor
+          # of HEAD, so the next run sweeps every merge skipped in between. Fall back to
+          # github.event.before (the push's first parent), then HEAD^1 (force-push / dispatch).
+          last_ok="$(gh api "repos/${REPO}/actions/workflows/main-verify.yml/runs?status=success&branch=main&per_page=1" --jq '.workflow_runs[0].head_sha' 2>/dev/null || true)"
+          base=""
+          reason=""
+          if [ -n "$last_ok" ] && [ "$last_ok" != "null" ] \
+              && git rev-parse --verify -q "${last_ok}^{commit}" >/dev/null 2>&1 \
+              && [ "$last_ok" != "$HEAD_SHA" ] \
+              && git merge-base --is-ancestor "$last_ok" "$HEAD_SHA" 2>/dev/null; then
+            n="$(git rev-list --count "${last_ok}..${HEAD_SHA}" 2>/dev/null || echo '?')"
+            base="$last_ok"
+            reason="catch-up from ${last_ok} (${n} commits)"
+          elif [ -n "$BEFORE" ] && [ "$BEFORE" != "0000000000000000000000000000000000000000" ] \
+              && git rev-parse --verify -q "${BEFORE}^{commit}" >/dev/null 2>&1; then
+            base="$BEFORE"
+            reason="event.before (${BEFORE})"
+          else
+            base="$(git rev-parse --verify -q 'HEAD^1' || git rev-parse HEAD)"
+            reason="HEAD^1 fallback (force-push / initial / dispatch)"
+          fi
+          echo "base=${base}" >> "$GITHUB_OUTPUT"
+          echo "Post-merge screen base: ${reason}"
+          {
+            echo "### Post-merge sequence-safety base (catch-up)"
+            echo ""
+            echo "- HEAD: \`${HEAD_SHA}\`"
+            echo "- BASE: \`${base}\`"
+            echo "- reason: ${reason}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run sequence-safety screens (symbol + docs)
+        env:
+          BASE_REF: ${{ steps.base.outputs.base }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -uo pipefail
+          set +e # this step handles screen exit codes manually
+          echo "╔════════════════════════════════════════════════════════════╗"
+          echo "║       juniper-cascor - Post-Merge Sequence-Safety Screens ║"
+          echo "╚════════════════════════════════════════════════════════════╝"
+          # BASE is resolved by the preceding "Resolve catch-up base" step: the last SUCCESSFUL
+          # main-verify tip when it is an ancestor of HEAD (sweeping any [skip ci]-skipped window),
+          # else github.event.before, else HEAD^1. Defensive re-fallback here if it is empty.
+          base="$BASE_REF"
+          if [ -z "$base" ] || ! git rev-parse --verify -q "${base}^{commit}" >/dev/null 2>&1; then
+            base="$(git rev-parse --verify -q 'HEAD^1' || git rev-parse HEAD)"
+            echo "BASE output empty/unresolvable -> fallback = ${base}"
+          fi
+          echo "Screening ${base} .. ${HEAD_SHA}"
+          echo ""
+          echo "--- symbol-loss screen ---"
+          # Human run to the log carries the authoritative exit code; the guarded --json run
+          # then writes the artifact (same verdicts, machine-readable).
+          python3 util/sequence_safety/symbol_loss_check.py --base "$base" --head "$HEAD_SHA"
+          src=$?
+          python3 util/sequence_safety/symbol_loss_check.py --base "$base" --head "$HEAD_SHA" --json > symbol-report.json || true
+          echo ""
+          echo "--- docs deletion-magnitude screen ---"
+          python3 util/sequence_safety/docs_additions_check.py --base "$base" --head "$HEAD_SHA"
+          drc=$?
+          python3 util/sequence_safety/docs_additions_check.py --base "$base" --head "$HEAD_SHA" --json > docs-report.json || true
+          echo ""
+          echo "symbol screen exit=${src} ; docs screen exit=${drc}"
+          if [ "${src}" -ge 2 ] || [ "${drc}" -ge 2 ]; then
+            echo "::error::sequence-safety screen invocation error (see log)"
+            exit 2
+          fi
+          if [ "${src}" -ge 1 ] || [ "${drc}" -ge 1 ]; then
+            echo "::error::post-merge compositional-loss finding(s) at ${HEAD_SHA} -- see the screens above and the sequence-safety-report artifact"
+            exit 1
+          fi
+          echo "::notice::sequence-safety screens clean at ${HEAD_SHA}"
+
+      - name: Upload sequence-safety report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sequence-safety-report
+          path: |
+            symbol-report.json
+            docs-report.json
+          if-no-files-found: warn
+          retention-days: 30
+
+  # ═══════════════════════════════════════════════════════════════════════════════════════════════
+  # notify (on failure only): a red main-verify must be LOUD. Upserts a STABLE-TITLE dedup tracking
+  # issue -- ONE open issue titled "main-verify: post-merge verification failing" per red streak; each
+  # subsequent failing SHA COMMENTS on it instead of opening a new issue. NOT auto-closed on green (the
+  # owner closes it after adjudication). Dedup binds to the workflow's own AUTHORSHIP
+  # (creator=github-actions[bot] + exact title + .pull_request == null), never title alone -- a
+  # forgeable public title is not a trust boundary (ml#928 review). v1 has no Slack step (cascor has no
+  # webhook secret pattern); add one later, mirroring release-train's non-blocking pattern.
+  # ═══════════════════════════════════════════════════════════════════════════════════════════════
+  notify:
+    name: Notify on Failure
+    runs-on: ubuntu-latest
+    needs: [symbol-screen]
+    if: failure()
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Upsert tracking issue (stable title, one per red streak)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TITLE: "main-verify: post-merge verification failing"
+          SHA: ${{ github.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SYMBOL_RESULT: ${{ needs.symbol-screen.result }}
+        run: |
+          set -uo pipefail
+          # STABLE-TITLE dedup (ml#928): a single OPEN issue tracks a whole red streak. The first
+          # failure opens it; every subsequent failing SHA COMMENTS on it, so one streak == one issue.
+          #
+          # TRUST BOUNDARY (ml#928 review): a stable title is a public, forgeable string -- anyone can
+          # pre-create an OPEN issue with the exact title and capture the tracker. The match therefore
+          # binds to the workflow's own identity: REST creator=github-actions[bot] (unforgeable
+          # authorship) + exact-title narrow + .pull_request == null (the /issues surface includes PRs).
+          # The bot-applied `main-verify` label below is defense-in-depth for operator filtering only --
+          # deliberately NOT part of this match, so a failed label application can never fork a streak.
+          existing="$(gh api "repos/${REPO}/issues?state=open&creator=github-actions%5Bbot%5D&per_page=100" --jq 'map(select(.pull_request == null) | select(.title == env.TITLE)) | .[0].number // empty' 2>/dev/null || true)"
+          if [ -n "$existing" ]; then
+            {
+              echo "Still failing at \`${SHA}\`."
+              echo ""
+              echo "| job | result |"
+              echo "|---|---|"
+              echo "| symbol-screen (symbol + docs loss) | ${SYMBOL_RESULT} |"
+              echo ""
+              echo "- Run: ${RUN_URL}"
+            } > issue-comment.md
+            echo "Commenting new failing SHA on existing tracking issue #${existing}"
+            gh issue comment "$existing" --repo "$REPO" --body-file issue-comment.md
+          else
+            {
+              echo "Post-merge **main-verify** is failing on \`main\`."
+              echo ""
+              echo "First observed failing at \`${SHA}\`."
+              echo ""
+              echo "| job | result |"
+              echo "|---|---|"
+              echo "| symbol-screen (symbol + docs loss) | ${SYMBOL_RESULT} |"
+              echo ""
+              echo "This is the bypass-proof post-merge net: a compositional loss (a silently deleted"
+              echo "def/class/method, a gutted body, or a net docs-section deletion) landed on main."
+              echo "Inspect the **sequence-safety-report** artifact (symbol-report.json /"
+              echo "docs-report.json). Subsequent failures in this streak are appended here as comments:"
+              echo ""
+              echo "- First run: ${RUN_URL}"
+              echo ""
+              echo "**Remediation:** adjudicate each finding; waive a genuinely intentional symbol"
+              echo "removal with an \`Allow-Symbol-Loss: <qualified.symbol>\` commit trailer (an"
+              echo "intentional docs rewrite with \`Allow-Docs-Rewrite: <path>\`), which travels in git"
+              echo "history so it also clears this post-merge net."
+              echo ""
+              echo "_Auto-filed by .github/workflows/main-verify.yml. One issue per red streak; the"
+              echo "owner closes it after adjudication (NOT auto-closed on green)._"
+            } > issue-body.md
+            echo "Opening the stable-title tracking issue"
+            # Bot-applied `main-verify` label: ensure it exists (idempotent, never clobbers owner
+            # customization -- no --force), open the issue, then best-effort apply. The label is
+            # operator filtering / defense-in-depth, never part of the dedup match above -- but a
+            # failed CREATE must still fail this step loudly (the tracker is the point of notify).
+            gh label create main-verify --repo "$REPO" --description "Auto-filed by the main-verify post-merge net" --color B60205 2>/dev/null || true
+            if new_url="$(gh issue create --repo "$REPO" --title "$TITLE" --body-file issue-body.md)"; then
+              gh issue edit "${new_url##*/}" --repo "$REPO" --add-label main-verify 2>/dev/null || true
+            else
+              echo "::error::failed to open the stable-title tracking issue"
+              exit 1
+            fi
+          fi

--- a/.github/workflows/sequence-safety.yml
+++ b/.github/workflows/sequence-safety.yml
@@ -1,0 +1,156 @@
+---
+#####################################################################################################################################################################################################
+# Project:       Juniper
+# Sub-Project:   JuniperCascor
+# Application:   juniper_cascor
+# File Name:     sequence-safety.yml
+# Author:        Paul Calnon
+# Version:       0.1.0
+#
+# Date Created:  2026-08-07
+# Last Modified: 2026-08-07
+#
+# License:       MIT License
+# Copyright:     Copyright (c) 2024-2026 Paul Calnon
+#
+# Description:
+#    Per-PR sequence-safety net (ADVISORY, standalone) -- the compositional-loss screen
+#    ported from juniper-ml (ml#873 / #880 / #928; flood-remediation analysis §4 item 8).
+#    Runs the AST symbol-loss screen + the docs deletion-magnitude screen over the PR's
+#    base..HEAD, so the silent-deletion / net-docs-deletion classes that a green-per-PR
+#    merge storm can ship are visible AT REVIEW. Uploads both JSON reports as the
+#    `sequence-safety-report` artifact a reviewer / supervisor can consume.
+#
+#    ADVISORY, NOT a required check (the codeql soak convention). This is a STANDALONE
+#    workflow, deliberately separate from ci.yml, so it is never wired into the CI Quality
+#    Gate and never blocks a merge. It informs the owner's review; enforcement is the
+#    post-merge net (main-verify.yml). Promotion to a required context, if ever desired,
+#    is an owner-only branch-ruleset decision -- this PR makes NO ruleset change.
+#
+#    Label hatch (WARN-only): the owner-applied `allow-symbol-loss` / `docs-rewrite` PR
+#    labels demote THAT screen's FAIL to WARN-only for this run (`--advisory`: exit 0 with
+#    findings still printed). A bare label is a blanket per-PR override, intentionally
+#    demoted to WARN-only; the auditable enumerated `Allow-Symbol-Loss:` /
+#    `Allow-Docs-Rewrite:` commit trailer (parsed inside the modules, travels in git
+#    history so it also covers the post-merge net) stays the PRIMARY waiver. Labels are
+#    read live via `gh pr view`, so applying one + re-running the job takes effect with no
+#    re-push.
+#
+# Security Notes:
+#    - pull_request-triggered only; workflow permissions are least-privilege
+#      (contents: read + pull-requests: read for the label hatch).
+#    - The screens are pure git + stdlib (no network, no pip, no third-party actions
+#      beyond the SHA-pinned checkout / setup-python / upload-artifact).
+#
+# References:
+#    - util/sequence_safety/{symbol_loss_check,docs_additions_check}.py
+#    - juniper-ml .github/workflows/ci.yml (the per-PR "Sequence Safety" advisory job this ports)
+#    - juniper-ml notes/JUNIPER_2026-07-28_JUNIPER-ML_CURSOR-PR-FLOOD-REMEDIATION-ANALYSIS.md
+#####################################################################################################################################################################################################
+
+name: Sequence Safety (Advisory)
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+
+# Per-PR ref, cancel superseded runs: an advisory review signal only needs the latest push.
+concurrency:
+  group: sequence-safety-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  PYTHON_TEST_VERSION: "3.14"
+
+jobs:
+  # ═══════════════════════════════════════════════════════════════════════════════════════════════
+  # sequence-safety (ADVISORY): AST symbol-loss screen + docs deletion-magnitude screen over the PR's
+  # base..HEAD. Standalone + advisory -- never a required context, never wired into the CI gate.
+  # ═══════════════════════════════════════════════════════════════════════════════════════════════
+  sequence-safety:
+    name: Sequence Safety (Advisory)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read # gh pr view --json labels for the WARN-only label hatch
+    steps:
+      - name: Checkout Code (full history)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0 # need base + head for the three-dot merge-base screens
+
+      - name: Set up Python ${{ env.PYTHON_TEST_VERSION }}
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ env.PYTHON_TEST_VERSION }}
+
+      - name: Run sequence-safety screens (symbol + docs)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -uo pipefail
+          set +e # this step handles the screen exit codes manually
+          echo "╔════════════════════════════════════════════════════════════╗"
+          echo "║       juniper-cascor - Per-PR Sequence-Safety Screens     ║"
+          echo "╚════════════════════════════════════════════════════════════╝"
+          base="$PR_BASE_SHA"
+          if [ -z "$base" ]; then
+            echo "::error::could not resolve a base sha for this pull_request"
+            exit 2
+          fi
+          if ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+            git fetch --no-tags --depth=1 origin "$base" || true
+          fi
+          # Label hatch: read the PR's CURRENT labels (live via gh, so apply-label + re-run
+          # works with no push).
+          sym_adv=""
+          docs_adv=""
+          if [ -n "$PR_NUMBER" ]; then
+            labels="$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' 2>/dev/null || true)"
+            if printf '%s\n' "$labels" | grep -qx 'allow-symbol-loss'; then sym_adv="--advisory"; echo "label allow-symbol-loss -> symbol screen ADVISORY (WARN-only)"; fi
+            if printf '%s\n' "$labels" | grep -qx 'docs-rewrite'; then docs_adv="--advisory"; echo "label docs-rewrite -> docs screen ADVISORY (WARN-only)"; fi
+          fi
+          echo "Screening ${base} .. HEAD"
+          echo ""
+          echo "--- symbol-loss screen ---"
+          # shellcheck disable=SC2086  # $sym_adv is an intentional empty-or---advisory token
+          python3 util/sequence_safety/symbol_loss_check.py --base "$base" --head HEAD $sym_adv
+          src=$?
+          # shellcheck disable=SC2086
+          python3 util/sequence_safety/symbol_loss_check.py --base "$base" --head HEAD $sym_adv --json > symbol-report.json || true
+          echo ""
+          echo "--- docs deletion-magnitude screen ---"
+          # shellcheck disable=SC2086
+          python3 util/sequence_safety/docs_additions_check.py --base "$base" --head HEAD $docs_adv
+          drc=$?
+          # shellcheck disable=SC2086
+          python3 util/sequence_safety/docs_additions_check.py --base "$base" --head HEAD $docs_adv --json > docs-report.json || true
+          echo ""
+          echo "symbol screen exit=${src} ; docs screen exit=${drc}"
+          if [ "${src}" -ge 2 ] || [ "${drc}" -ge 2 ]; then
+            echo "::error::sequence-safety screen invocation error (see log)"
+            exit 2
+          fi
+          if [ "${src}" -ge 1 ] || [ "${drc}" -ge 1 ]; then
+            echo "::error::per-PR compositional-loss finding(s) -- see the screens above and the sequence-safety-report artifact. Waive an intended removal with an Allow-Symbol-Loss / Allow-Docs-Rewrite commit trailer, or (owner) apply the allow-symbol-loss / docs-rewrite label for a WARN-only downgrade."
+            exit 1
+          fi
+          echo "::notice::sequence-safety screens clean (or waived) for this PR"
+
+      - name: Upload sequence-safety report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sequence-safety-report
+          path: |
+            symbol-report.json
+            docs-report.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 **Author**: Paul Calnon
 **License**: MIT License
 **Version**: 0.7.0
-**Last Updated**: 2026-08-06
+**Last Updated**: 2026-08-07
 
 ---
 
@@ -278,6 +278,7 @@ juniper-cascor/
 │   ├── run_all_tests.bash            #   Test runner
 │   ├── profile_training.bash         #   py-spy profiler
 │   ├── get_code_stats.bash           #   Code statistics
+│   ├── sequence_safety/              #   Compositional-loss screens (symbol-loss + docs-additions)
 │   └── (30+ additional utility scripts)
 ├── data/                             # Spiral datasets (.pt files)
 ├── dist/                             # Build artifacts
@@ -293,7 +294,9 @@ juniper-cascor/
 │   │   ├── publish-protocol.yml      #   PyPI publish (juniper-cascor-protocol)
 │   │   ├── publish-cascor-model.yml  #   PyPI publish (juniper-cascor-model)
 │   │   ├── lockfile-update.yml       #   Dependency lockfile updates
-│   │   └── security-scan.yml         #   Security scanning
+│   │   ├── security-scan.yml         #   Security scanning
+│   │   ├── sequence-safety.yml       #   Per-PR compositional-loss screens (ADVISORY, standalone)
+│   │   └── main-verify.yml           #   Post-merge compositional-loss net (catch-up base + stable-title issue)
 │   ├── CODEOWNERS                    #   Code ownership rules
 │   └── dependabot.yml                #   Dependency update automation
 ├── .serena/memories/                 # Serena MCP server context
@@ -816,6 +819,8 @@ Gate: 80% aggregate (override with `COVERAGE_FAIL_UNDER=<n>`). Coverage runs in 
 | Publish model | `.github/workflows/publish-cascor-model.yml` | Release (`juniper-cascor-model-v*`) + `workflow_dispatch` | PyPI publish for `juniper-cascor-model` |
 | Lockfile Update | `.github/workflows/lockfile-update.yml` | Push to dependabot/** branches | Dependency lockfile refresh |
 | Security Scan | `.github/workflows/security-scan.yml` | Schedule/dispatch | Gitleaks, Bandit, pip-audit |
+| Sequence Safety (Advisory) | `.github/workflows/sequence-safety.yml` | PR (`main`/`develop`) | Per-PR symbol-loss + docs-deletion screens over base..HEAD (ADVISORY, standalone, never a required check) |
+| Post-Merge Main Verification | `.github/workflows/main-verify.yml` | Push `main`, dispatch | Bypass-proof post-merge compositional-loss net (catch-up base; stable-title tracking issue on failure) |
 
 ### Lockfile Update PAT Gate
 
@@ -843,6 +848,18 @@ Optional: register the same PAT under **Settings → Secrets → Dependabot** to
 
 - `.github/CODEOWNERS` -- Code ownership rules
 - `.github/dependabot.yml` -- Automated dependency updates
+
+### Sequence Safety (Compositional-Loss Net)
+
+Ported from juniper-ml (ml#873 / #880 / #928; the flood-remediation program) after the 2026-08-05 storm triage found *compositional loss* — a silently deleted def/class/method, a gutted body, or a net docs-section deletion that no per-PR check sees because a deleted test cannot fail — to be cascor's one remaining gap. Two pure-stdlib git-diff screens live in `util/sequence_safety/`:
+
+- `symbol_loss_check.py` — AST symbol inventory of BASE vs HEAD over `src/**/*.py` (includes `src/tests/**`); FAIL on a LOST / WEAKENED / DUPLICATED def, with a qualified-name / body-similarity relocation downgrade. Escape hatch: an `Allow-Symbol-Loss: <qualified.symbol>` commit trailer. (`@property`/`@x.setter` accessor pairs are disambiguated so they are never a false DUPLICATED — a cascor-src adaptation over the juniper-ml original.)
+- `docs_additions_check.py` — markdown deletion-magnitude screen over `AGENTS.md` + `docs/**` + `notes/**`; FAIL on a deleted heading or a run of ≥ N consecutive deleted lines, WARN on small in-place swaps. Escape hatch: an `Allow-Docs-Rewrite: <path>` commit trailer.
+
+Everything is **ADVISORY** — neither workflow is a required status check and this makes **no branch-ruleset change**.
+`sequence-safety.yml` surfaces findings per-PR at review (with WARN-only `allow-symbol-loss` / `docs-rewrite` label hatches); `main-verify.yml` is the bypass-proof post-merge net that fires on every merge to `main` (catch-up base sweeps any `[skip ci]` window; a stable-title tracking issue is upserted on failure).
+v1 defers the post-merge regression battery (cascor's suite is heavy) and Slack notify (no webhook secret) — see the workflow header comments.
+The screens are behaviourally identical to juniper-ml's, whose `tests/test_symbol_loss_check.py` + `tests/test_docs_additions_check.py` remain the authoritative regression suite.
 
 ---
 

--- a/util/sequence_safety/__init__.py
+++ b/util/sequence_safety/__init__.py
@@ -1,0 +1,42 @@
+"""Juniper sequence-safety gates -- compositional-loss screens for the PR flood.
+
+Ecosystem port (juniper-cascor) of juniper-ml's 2026-07-28 Cursor-fleet flood census
+(Proposal P2; the flood-remediation analysis
+``notes/JUNIPER_2026-07-28_JUNIPER-ML_CURSOR-PR-FLOOD-REMEDIATION-ANALYSIS.md`` S3 / S4
+item 8, which lives in the juniper-ml repo). The flood damage was *compositional*: every
+PR was individually green, but serial same-file merges into main fused or silently
+deleted sibling content, and a deleted test cannot fail -- so flake8 / mypy / pre-commit
+all stayed green while whole test classes and doc sections disappeared. The 2026-08-05
+cascor storm triage found this same compositional-loss net to be cascor's one remaining
+gap, which this package closes (ADVISORY, non-blocking).
+
+Two ref-diff screens answer the one question the per-PR checks could not:
+
+  * ``symbol_loss_check.py``    -- AST symbol inventory of BASE vs HEAD for the
+    in-scope Python surface (``src/**/*.py``, which includes ``src/tests/**``); FAIL on
+    a silently deleted (LOST) def/class/method, a shrunk-past-threshold (WEAKENED)
+    body, or a duplicated (DUPLICATED) member, with a qualified-name / body-similarity
+    relocation downgrade and a ``Allow-Symbol-Loss:`` commit-trailer escape hatch.
+  * ``docs_additions_check.py`` -- markdown deletion-magnitude screen of BASE vs HEAD
+    for ``AGENTS.md`` + ``docs/**`` + ``notes/**``; FAIL on a deleted heading or a run
+    of >= N consecutive deleted lines, WARN on small in-place swaps, with a
+    ``Allow-Docs-Rewrite:`` commit-trailer escape hatch.
+
+Both are pure git + stdlib (no network, no gh, no pip) and path-invoked. cascor's
+pre-commit scopes black / isort / flake8 to ``^src/``, so ``util/`` has no lint gate of
+its own; these modules are behaviourally identical to juniper-ml's, whose dedicated
+``tests/test_symbol_loss_check.py`` + ``tests/test_docs_additions_check.py`` remain the
+authoritative regression suite (see this PR's body for the cascor test-deferral note).
+The per-PR ``sequence-safety.yml`` workflow runs both ADVISORY over a PR's
+``base..HEAD``, and the post-merge ``main-verify.yml`` workflow runs both over a
+catch-up base .. ``<merge>`` so the compositional-loss net fires no matter who merged or
+what they bypassed -- the only gate the always-bypass actors cannot skip.
+
+Project: juniper-cascor
+Sub-Project: flood-remediation sequence-safety gates
+Application: juniper_cascor
+Author: Paul Calnon
+Created: 2026-08-07
+Status: permanent utility
+Provenance: ecosystem port of juniper-ml util/sequence_safety/ (ml#873 / #880 / #928).
+"""

--- a/util/sequence_safety/docs_additions_check.py
+++ b/util/sequence_safety/docs_additions_check.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Docs deletion-magnitude screen (G2 / G3 step 4) -- BASE vs HEAD markdown.
+
+Ported from juniper-ml's docs census screen (Proposal P2 S2), itself productionized
+(deletion-magnitude only, not the full LOST-IN-MERGE reconstruction) from
+``util/ad-hoc/2026-07-28_docs_census_v2_c2.py``. juniper-ml's flood docs class (its
+PR #801 / #803) was a *net section deletion* that no existing check could see: the
+doc-links validator only catches dangling anchors, and markdownlint excludes ``notes/``
++ ``docs/`` (cascor's ``.pre-commit-config.yaml`` excludes exactly the same). So a merge
+that dropped a whole runbook section stayed green -- the same gap the 2026-08-05 cascor
+storm triage flagged as this repo's one remaining compositional-loss exposure.
+
+A bare "any ``-`` hunk fails" rule is too blunt -- the UPDATE-target docs
+(``REFERENCE.md``, the runbooks, the cheatsheet) take legitimate line *replacements* on
+nearly every edit, so it would paint honest docs PRs red or train a reflex
+``docs-rewrite`` waiver. Instead a **magnitude-gated** rule:
+
+  * FAIL on a deleted Markdown **heading** line (a ``-`` hunk whose content matches
+    ``^\\s{0,3}#{1,6}\\s``) UNLESS the same hunk also adds a heading (a retitle -> WARN).
+  * FAIL on a run of **>= N consecutive deleted lines with no adjacent addition**
+    (``added == 0 and deleted >= min_run``; default N = 5) -- the net-section-removal
+    signature of the juniper-ml #801 / #803 incident.
+  * WARN (annotate, not fail) on smaller deletions and small in-place swaps (a few
+    deleted lines bracketed by additions -- a normal edit).
+
+Blind spot (stated honestly, mirrors the symbol screen's WEAKENED note). A *lopsided
+swap* that deletes a large block but adds a line or two in the same hunk evades the
+pure-run rule (added > 0). The heading-deletion rule usually still catches it (sections
+carry headings), but a section-body gut that removes no heading and adds one filler line
+can slip to WARN. That residue is for human review, not this magnitude screen.
+
+Escape hatch. A ``Allow-Docs-Rewrite: <path>[, ...]`` trailer in any commit of the
+BASE..HEAD range waives the enumerated files (``*`` waives all docs in the diff); it
+travels in git history so it works for both the per-PR and the post-merge gate. The
+ergonomic ``docs-rewrite`` PR label is WARN-only and lives in the per-PR (G2) job, not
+this ref-based module.
+
+Scope. Docs cluster = ``AGENTS.md`` (and its ``CLAUDE.md`` symlink), ``docs/**/*.md``,
+and ``notes/**/*.md``. An explicit ``--files`` list bypasses the scope filter (any
+``.md`` path).
+
+CLI::
+
+    python util/sequence_safety/docs_additions_check.py --base <ref> --head <ref> \
+        [--files PATH ...] [--repo-root DIR] [--min-run N] [--advisory] [--json]
+
+Exit codes: 0 = clean (no unwaived FAIL), 1 = >= 1 unwaived FAIL, 2 = usage /
+invocation error. WARN / WAIVED never fail.
+
+Advisory mode (``--advisory``). Print every finding as usual but exit 0 even on an
+unwaived FAIL (a top-level ``advisory: true`` is recorded and an ADVISORY note printed;
+finding severities are left intact so the artifact keeps the ground truth). This is the
+demotion the per-PR CI job applies when the owner attaches the ``docs-rewrite`` label --
+a blanket per-PR override downgraded to WARN-only (P2 SF5), so the auditable enumerated
+``Allow-Docs-Rewrite`` commit trailer stays the primary waiver. Exit 2 (invocation
+error) is NEVER masked by ``--advisory``.
+
+Project: juniper-cascor
+Sub-Project: flood-remediation sequence-safety gates
+Application: juniper_cascor
+Author: Paul Calnon
+Created: 2026-08-07
+Status: permanent utility
+Provenance: ports juniper-ml ``util/sequence_safety/docs_additions_check.py`` (ml#873 /
+    #880 / #928; flood-remediation analysis §4 item 8) unchanged in behaviour -- the docs
+    cluster scope (AGENTS.md + docs/** + notes/**) is identical for cascor, so only this
+    docstring's repo-specific provenance text differs from the juniper-ml original.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from typing import Optional
+
+DEFAULT_MIN_RUN = 5  # >= this many consecutive deleted lines (no adjacent add) -> FAIL
+
+_HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s")
+_HUNK_RE = re.compile(r"^@@ ")
+
+
+def in_docs_scope(path: str) -> bool:
+    """AGENTS.md (+ its CLAUDE.md symlink), docs/**/*.md, notes/**/*.md."""
+    if path in ("AGENTS.md", "CLAUDE.md"):
+        return True
+    if path.endswith(".md") and (path.startswith("docs/") or path.startswith("notes/")):
+        return True
+    return False
+
+
+# ---- git helpers (standalone so the script is path-invokable) --------------
+
+
+def _git(root: str, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", "-C", root, *args], capture_output=True, text=True)
+
+
+def resolve_ref(root: str, ref: str) -> Optional[str]:
+    cp = _git(root, "rev-parse", "--verify", "-q", f"{ref}^{{commit}}")
+    out = cp.stdout.strip()
+    return out if cp.returncode == 0 and out else None
+
+
+def changed_files(root: str, base: str, head: str) -> list[str]:
+    cp = _git(root, "diff", "--name-only", f"{base}...{head}")
+    return [ln for ln in cp.stdout.splitlines() if ln]
+
+
+def file_diff(root: str, base: str, head: str, path: str) -> str:
+    """Unified=0 base->head diff for one file (minimal, tight hunks)."""
+    return _git(root, "diff", "--unified=0", "--no-color", base, head, "--", path).stdout
+
+
+def range_messages(root: str, base: str, head: str) -> str:
+    return _git(root, "log", "--format=%B", f"{base}..{head}").stdout
+
+
+# ---- hunk parsing ----------------------------------------------------------
+
+
+@dataclass
+class Hunk:
+    deleted: list[str] = field(default_factory=list)  # content of '-' lines
+    added: list[str] = field(default_factory=list)  # content of '+' lines
+
+
+def parse_hunks(diff_text: str) -> list[Hunk]:
+    """Split a unified diff into hunks, collecting deleted / added line contents.
+
+    With ``--unified=0`` each hunk's deleted lines are contiguous in the old file, so a
+    hunk with ``added == 0`` is a run of that many consecutive deletions with no
+    adjacent addition -- exactly the P2 S2 magnitude signal.
+    """
+    hunks: list[Hunk] = []
+    cur: Optional[Hunk] = None
+    for line in diff_text.splitlines():
+        if _HUNK_RE.match(line):
+            cur = Hunk()
+            hunks.append(cur)
+            continue
+        if cur is None:
+            continue  # pre-hunk file header (diff --git / index / --- / +++)
+        if line.startswith("+++") or line.startswith("---"):
+            continue
+        if line.startswith("-"):
+            cur.deleted.append(line[1:])
+        elif line.startswith("+"):
+            cur.added.append(line[1:])
+    return hunks
+
+
+# ---- classification --------------------------------------------------------
+
+
+@dataclass
+class Finding:
+    path: str
+    reason: str  # heading-deletion | deletion-run | small-deletion
+    severity: str  # FAIL | WARN | WAIVED
+    detail: dict = field(default_factory=dict)
+
+
+def classify_file(path: str, hunks: list[Hunk], min_run: int) -> list[Finding]:
+    findings: list[Finding] = []
+    for h in hunks:
+        deleted, added = len(h.deleted), len(h.added)
+        if deleted == 0:
+            continue  # pure addition -- the additions-only happy path
+        del_headings = [ln for ln in h.deleted if _HEADING_RE.match(ln)]
+        add_headings = [ln for ln in h.added if _HEADING_RE.match(ln)]
+        if del_headings and not add_headings:
+            findings.append(Finding(path, "heading-deletion", "FAIL", {"headings": [ln.strip()[:120] for ln in del_headings], "deleted": deleted, "added": added}))
+        elif added == 0 and deleted >= min_run:
+            findings.append(Finding(path, "deletion-run", "FAIL", {"deleted": deleted, "min_run": min_run}))
+        else:
+            findings.append(Finding(path, "small-deletion", "WARN", {"deleted": deleted, "added": added}))
+    return findings
+
+
+# ---- escape-hatch trailer parsing ------------------------------------------
+
+_ALLOW_RE = re.compile(r"^\s*Allow-Docs-Rewrite:\s*(.+?)\s*$", re.IGNORECASE | re.MULTILINE)
+
+
+def parse_allow_trailers(messages: str) -> tuple[set[str], bool]:
+    """Return (enumerated file tokens, wildcard_seen). A ``*`` waives all docs files."""
+    allowed: set[str] = set()
+    wildcard = False
+    for m in _ALLOW_RE.finditer(messages or ""):
+        for tok in re.split(r"[,\s]+", m.group(1).strip()):
+            tok = tok.strip()
+            if not tok:
+                continue
+            if tok == "*":
+                wildcard = True
+                continue
+            allowed.add(tok)
+    return allowed, wildcard
+
+
+def _waives(path: str, allowed: set[str], wildcard: bool) -> bool:
+    if wildcard:
+        return True
+    return path in allowed or path.rsplit("/", 1)[-1] in allowed
+
+
+def apply_waivers(findings: list[Finding], allowed: set[str], wildcard: bool) -> None:
+    for f in findings:
+        if f.severity == "FAIL" and _waives(f.path, allowed, wildcard):
+            f.severity = "WAIVED"
+            f.detail = {**f.detail, "waived_by": "Allow-Docs-Rewrite trailer"}
+
+
+# ---- driver ----------------------------------------------------------------
+
+
+def run(root: str, base: str, head: str, files: Optional[list[str]], min_run: int) -> tuple[int, dict]:
+    base_sha = resolve_ref(root, base)
+    head_sha = resolve_ref(root, head)
+    if base_sha is None or head_sha is None:
+        bad = base if base_sha is None else head
+        return 2, {"error": f"could not resolve ref: {bad!r}"}
+
+    if files:
+        scoped = [p for p in files if p.endswith(".md")]
+        skipped = [p for p in files if p not in scoped]
+    else:
+        discovered = changed_files(root, base, head)
+        scoped = [p for p in discovered if in_docs_scope(p)]
+        skipped = [p for p in discovered if not in_docs_scope(p)]
+
+    findings: list[Finding] = []
+    for path in sorted(set(scoped)):
+        hunks = parse_hunks(file_diff(root, base_sha, head_sha, path))
+        findings.extend(classify_file(path, hunks, min_run))
+
+    allowed, wildcard = parse_allow_trailers(range_messages(root, base_sha, head_sha))
+    apply_waivers(findings, allowed, wildcard)
+
+    fails = [f for f in findings if f.severity == "FAIL"]
+    by_reason: dict[str, int] = {}
+    for f in findings:
+        by_reason[f.reason] = by_reason.get(f.reason, 0) + 1
+
+    report = {
+        "base": base_sha,
+        "head": head_sha,
+        "min_run": min_run,
+        "stats": {
+            "files_screened": len(scoped),
+            "skipped_out_of_scope": sorted(set(skipped)),
+            "findings_total": len(findings),
+            "fail_count": len(fails),
+            "by_reason": by_reason,
+            "waived_files": sorted(allowed),
+            "wildcard_waiver": wildcard,
+        },
+        "findings": [{"path": f.path, "reason": f.reason, "severity": f.severity, "detail": f.detail} for f in sorted(findings, key=lambda x: (x.path, x.reason))],
+    }
+    return (1 if fails else 0), report
+
+
+def _print_human(report: dict) -> None:
+    st = report["stats"]
+    print("=== sequence-safety: docs deletion-magnitude screen ===")
+    print(f"base={report['base'][:12]} head={report['head'][:12]} min_run={report['min_run']}")
+    print(f"files_screened={st['files_screened']} findings={st['findings_total']} " f"fail={st['fail_count']} by_reason={st['by_reason']}")
+    if st["waived_files"] or st["wildcard_waiver"]:
+        waived = "*" if st["wildcard_waiver"] else ", ".join(st["waived_files"])
+        print(f"waived (Allow-Docs-Rewrite): {waived}")
+    print()
+    for f in report["findings"]:
+        print(f"    [{f['severity']}/{f['reason']}] {f['path']}  {f['detail']}")
+    if st["fail_count"]:
+        print(f"\nFAIL: {st['fail_count']} unwaived docs-deletion finding(s). " "Declare intentional rewrites with a `Allow-Docs-Rewrite: <path>` commit trailer.")
+    else:
+        print("\nOK: no unwaived docs-deletion findings.")
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="docs_additions_check.py",
+        description="Docs deletion-magnitude screen: FAIL on a deleted heading or a run of >= N consecutive deleted lines between BASE and HEAD.",
+        epilog=("Default scope (auto-discovery): AGENTS.md (+ CLAUDE.md symlink), docs/**/*.md, notes/**/*.md. " "An explicit --files list bypasses the scope filter (any .md path). Exit 0=clean, 1=findings, " "2=usage. Escape hatch: a `Allow-Docs-Rewrite: <path>[, ...]` commit trailer in the BASE..HEAD " "range waives the enumerated files (`*` waives all)."),
+    )
+    ap.add_argument("--base", required=True, help="base ref (e.g. origin/main, <merge>^1, github.event.before)")
+    ap.add_argument("--head", required=True, help="head ref (e.g. HEAD, <merge>, github.sha)")
+    ap.add_argument("--files", nargs="*", default=None, help="explicit .md files to screen (bypasses the scope filter)")
+    ap.add_argument("--repo-root", default=".", help="repository root the git commands run in (default: cwd)")
+    ap.add_argument("--min-run", type=int, default=DEFAULT_MIN_RUN, help=f"consecutive-deletion FAIL threshold (default: {DEFAULT_MIN_RUN})")
+    ap.add_argument(
+        "--advisory",
+        action="store_true",
+        help="advisory mode: print findings but exit 0 even on an unwaived FAIL (the per-PR docs-rewrite label hatch, demoted to WARN-only; the Allow-Docs-Rewrite commit trailer stays the primary waiver). Exit 2 (invocation error) is never masked.",
+    )
+    ap.add_argument("--json", action="store_true", help="emit the machine-readable report to stdout")
+    args = ap.parse_args(argv)
+
+    if args.min_run < 1:
+        print("ERROR: --min-run must be >= 1", file=sys.stderr)
+        return 2
+
+    code, report = run(args.repo_root, args.base, args.head, args.files, args.min_run)
+    if code == 2:
+        print(f"ERROR: {report.get('error', 'invocation error')}", file=sys.stderr)
+        return 2
+    report["advisory"] = args.advisory
+    if args.json:
+        print(json.dumps(report, indent=1, sort_keys=True))
+    else:
+        _print_human(report)
+        if args.advisory and code == 1:
+            print("\nADVISORY (--advisory): the FAIL finding(s) above are downgraded to WARN-only for this run; exit 0. The auditable `Allow-Docs-Rewrite: <path>` commit trailer remains the primary waiver.")
+    return 0 if (args.advisory and code == 1) else code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/util/sequence_safety/symbol_loss_check.py
+++ b/util/sequence_safety/symbol_loss_check.py
@@ -1,0 +1,572 @@
+#!/usr/bin/env python3
+"""Symbol-loss screen (G1 / G3 step 1) -- AST inventory of BASE vs HEAD.
+
+Productionized from the flood census screen
+``util/ad-hoc/2026-07-28_flood_census_symbol_screen.py`` (Proposal P2 S1). Builds an
+AST symbol inventory for every in-scope touched file at BASE and at HEAD and classifies
+each symbol:
+
+  * LOST       -- present at base, absent at head (the silent-deletion class: a def a
+                  bad merge dropped, leaving no error behind -- nothing else in CI sees
+                  a clean deletion). FAIL for def/class/method and bash functions;
+                  WARN for a removed import / module constant (refactors churn those).
+  * WEAKENED   -- body shrunk past threshold: ``cur_lines <= ratio * base_lines`` AND
+                  ``base_lines - cur_lines >= min_delta`` (defaults 0.6 / 4, lifted from
+                  the census WEAKEN_RATIO / WEAKEN_MIN_DELTA). FAIL (py) / WARN (bash).
+  * DUPLICATED -- the same def/class/method id appears >= 2x at head (a fusion /
+                  redefinition). FAIL (py) / WARN (bash). NOTE (P2 S0): fusion is
+                  primarily netted by the REQUIRED pre-commit mypy (``no-redef``); this
+                  verdict is a best-effort overlap, not the primary net. cascor ADAPTATION:
+                  ``@property`` + ``@x.setter`` / ``@x.deleter`` accessor pairs (present in
+                  cascor ``src/``, absent from ml's scope) are disambiguated with a
+                  ``.setter`` / ``.deleter`` key suffix so a legitimate accessor pair is
+                  never a false DUPLICATED -- see ``_accessor_suffix``.
+
+Verdicts are qualified (``method:Class.name``, ``func:name``, ``class:Name``,
+``const:NAME``, ``import:name``) so a bare-name collision cannot mask a real deletion.
+
+Relocation (moves / renames are not loss). A ``LOST`` symbol is downgraded to
+``RELOCATED`` (WARN, never FAIL) ONLY when the *qualified* key reappears in another
+changed file at head, OR the deleted body matches a body newly present at head
+(body-similarity). It is NEVER downgraded on a bare-name match -- test files reuse
+``setUp`` / ``test_default`` across classes, so a bare lookup would mask a real
+``TestA.test_default`` deletion behind an unrelated ``TestB.test_default`` (a
+false-negative in the exact damage locus; P2 SF3).
+
+Escape hatch. A ``Allow-Symbol-Loss: <qualified.symbol>[, ...]`` trailer in any commit
+of the BASE..HEAD range waives the enumerated symbols (they become WAIVED, not FAIL).
+It travels in git history so it works for BOTH the per-PR gate and the post-merge gate
+(a PR label is invisible to ``push:main``). A blanket wildcard (``*``) is rejected so a
+mass deletion cannot hide behind one marker. The ergonomic per-PR ``allow-symbol-loss``
+label is WARN-only and lives in the per-PR (G1) job, not this ref-based module.
+
+Non-goal / blind spot. WEAKENED is a line-count heuristic: a *same-length* gutting
+(replacing a body with ``assert True`` or swapping equal-line-count logic) has delta 0
+and is invisible to it. That class needs mypy / human review, not this screen.
+
+Scope (default, auto-discovery). In-scope = every ``src/**/*.py`` -- which includes the
+``src/tests/**/*.py`` suite -- cascor's flood damage locus per the 2026-08-05 storm
+triage (``src/tests/unit/...``, ``src/api/...``). It EXCLUDES the repo-root sub-package
+trees (``juniper-cascor-model/``, ``juniper-cascor-protocol/``), ``util/``, ``scripts/``,
+and any non-``src/`` or non-``.py`` file. An explicit ``--files`` list bypasses the scope
+filter (any ``.py`` / ``.bash`` path; the module keeps bash-symbol support for override
+use even though the default scope is ``src`` Python only).
+
+CLI::
+
+    python util/sequence_safety/symbol_loss_check.py --base <ref> --head <ref> \
+        [--files PATH ...] [--repo-root DIR] [--advisory] [--json]
+
+Exit codes: 0 = clean (no unwaived FAIL), 1 = >= 1 unwaived FAIL finding, 2 = usage /
+invocation error (bad args, unresolvable ref). WARN / RELOCATED / WAIVED never fail.
+
+Advisory mode (``--advisory``). Print every finding as usual but exit 0 even on an
+unwaived FAIL (a top-level ``advisory: true`` is recorded in the report and an ADVISORY
+note is printed; the finding severities themselves are left intact so the artifact keeps
+the ground truth for a supervisor). This is the demotion the per-PR CI job applies when
+the owner attaches the ``allow-symbol-loss`` label -- a blanket per-PR override
+deliberately downgraded to WARN-only (P2 SF5), so the auditable enumerated
+``Allow-Symbol-Loss`` commit trailer stays the primary waiver. Exit 2 (invocation error)
+is NEVER masked by ``--advisory``.
+
+Project: juniper-cascor
+Sub-Project: flood-remediation sequence-safety gates
+Application: juniper_cascor
+Author: Paul Calnon
+Created: 2026-08-07
+Status: permanent utility
+Provenance: ports juniper-ml ``util/sequence_safety/symbol_loss_check.py`` (ml#873 / #880 /
+    #928; flood-remediation analysis §4 item 8). The CLI contract, trailer hatch,
+    ``--advisory`` / ``--files`` overrides, and exit codes are kept identical for ecosystem
+    consistency; only the default ``in_scope()`` is retuned to cascor's ``src/`` layout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from typing import Optional
+
+# ---- config (lifted from the census screen) --------------------------------
+
+WEAKEN_RATIO = 0.6  # flag when current_lines <= ratio * base_lines
+WEAKEN_MIN_DELTA = 4  # ...and the absolute line delta is at least this
+BODY_SIMILARITY_MIN_LINES = 3  # only body-match relocations for non-trivial bodies
+
+# Verdict -> whether it is a hard finding (FAIL) for python vs bash. Relocation and
+# waiver are applied afterwards and can only DOWNGRADE severity, never raise it.
+_PY_FAIL_VERDICTS = frozenset({"LOST", "WEAKENED", "DUPLICATED"})
+# For a removed import / module constant we only WARN (import/const churn is normal).
+_ADVISORY_KINDS = frozenset({"import", "const"})
+
+
+def in_scope(path: str) -> bool:
+    """src/**/*.py -- cascor's flood damage locus (includes src/tests/**/*.py).
+
+    Scopes to every Python file under ``src/`` (the application plus its test suite),
+    where the 2026-08-05 storm triage located cascor's compositional-loss exposure
+    (``src/tests/unit/...``, ``src/api/...``). The repo-root sub-package trees
+    (``juniper-cascor-model/`` / ``juniper-cascor-protocol/``) live outside ``src/`` and
+    are naturally excluded, as are ``util/`` / ``scripts/`` and any non-``.py`` file. An
+    explicit ``--files`` list bypasses this filter (and still accepts ``.bash``).
+    """
+    return path.startswith("src/") and path.endswith(".py")
+
+
+# ---- git helpers -----------------------------------------------------------
+
+
+def _git(root: str, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", "-C", root, *args], capture_output=True, text=True)
+
+
+def resolve_ref(root: str, ref: str) -> Optional[str]:
+    """Resolve a ref to a commit sha, or None if it does not resolve."""
+    cp = _git(root, "rev-parse", "--verify", "-q", f"{ref}^{{commit}}")
+    out = cp.stdout.strip()
+    return out if cp.returncode == 0 and out else None
+
+
+def blob_sha(root: str, ref: str, path: str) -> Optional[str]:
+    """Resolve <ref>:<path> to a blob sha, or None if the path is absent there."""
+    cp = _git(root, "rev-parse", "--verify", "-q", f"{ref}:{path}")
+    out = cp.stdout.strip()
+    return out if cp.returncode == 0 and out else None
+
+
+def blob_text(root: str, sha: str) -> str:
+    return _git(root, "cat-file", "-p", sha).stdout
+
+
+def changed_files(root: str, base: str, head: str) -> list[str]:
+    """Files changed on head since the merge-base of (base, head) -- the standard
+    three-dot merge-base recipe. For the intended invocations (a PR ``base..HEAD``; the
+    post-merge catch-up ``base..<merge>``) base is an ancestor of head, so the three-dot
+    range degenerates to the plain ``base..head`` change set.
+    """
+    cp = _git(root, "diff", "--name-only", f"{base}...{head}")
+    return [ln for ln in cp.stdout.splitlines() if ln]
+
+
+def range_messages(root: str, base: str, head: str) -> str:
+    """Concatenated commit messages for the base..head range (for trailer parsing)."""
+    return _git(root, "log", "--format=%B", f"{base}..{head}").stdout
+
+
+# ---- symbol extraction (lifted verbatim from the census screen) ------------
+
+
+@dataclass
+class Sym:
+    lines: int
+    chars: int
+    count: int = 1  # occurrences of this id within a single blob (dup detect)
+    body: str = ""  # normalized source segment (def/class/method only) for relocation
+
+
+def _norm_body(seg: Optional[str]) -> str:
+    if not seg:
+        return ""
+    return re.sub(r"\s+", " ", seg).strip()
+
+
+def _seg_len(src: str, node: ast.AST) -> tuple[int, int, str]:
+    try:
+        seg = ast.get_source_segment(src, node)
+    except Exception:
+        seg = None
+    if seg is not None:
+        return seg.count("\n") + 1, len(seg), seg
+    lo = getattr(node, "lineno", None)
+    hi = getattr(node, "end_lineno", None)
+    if lo and hi:
+        return hi - lo + 1, 0, ""
+    return 0, 0, ""
+
+
+def _add(d: dict[str, Sym], key: str, lines: int, chars: int, body: str = "") -> None:
+    if key in d:
+        d[key].count += 1
+        # keep the larger segment for a duplicated id
+        if lines > d[key].lines:
+            d[key].lines, d[key].chars, d[key].body = lines, chars, _norm_body(body)
+    else:
+        d[key] = Sym(lines, chars, body=_norm_body(body))
+
+
+def _accessor_suffix(node: ast.AST) -> str:
+    """Distinct key suffix for a ``@<name>.setter`` / ``@<name>.deleter`` accessor.
+
+    cascor ADAPTATION (not in the juniper-ml original): cascor's ``src/`` surface uses
+    ``@property`` + ``@x.setter`` accessor pairs (e.g. ``TrainingLifecycleManager.network``)
+    that share a method name. Without disambiguation the two ``FunctionDef`` nodes collide
+    on one qualified key and are miscounted as ``DUPLICATED`` -- a false positive on every
+    PR touching such a file. Suffixing the setter / deleter keeps the getter's bare key (so
+    ``LOST`` detection on the property is unchanged) while the accessors count independently.
+    ml's in-scope surface (``util/`` + top-level ``tests/``) has no such pairs, so the
+    upstream module never needed this.
+    """
+    for dec in getattr(node, "decorator_list", []):
+        if isinstance(dec, ast.Attribute) and dec.attr in ("setter", "deleter"):
+            return f".{dec.attr}"
+    return ""
+
+
+def _walk_class(src: str, cls: ast.ClassDef, prefix: str, out: dict[str, Sym]) -> None:
+    for n in cls.body:
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            ln, ch, seg = _seg_len(src, n)
+            _add(out, f"method:{prefix}.{n.name}{_accessor_suffix(n)}", ln, ch, seg)
+        elif isinstance(n, ast.ClassDef):
+            ln, ch, seg = _seg_len(src, n)
+            _add(out, f"class:{prefix}.{n.name}", ln, ch, seg)
+            _walk_class(src, n, f"{prefix}.{n.name}", out)
+
+
+def _target_names(t: ast.AST) -> list[str]:
+    if isinstance(t, ast.Name):
+        return [t.id]
+    if isinstance(t, (ast.Tuple, ast.List)):
+        names: list[str] = []
+        for e in t.elts:
+            names.extend(_target_names(e))
+        return names
+    return []
+
+
+def py_symbols(src: str) -> Optional[dict[str, Sym]]:
+    """Return None if the blob does not parse (record UNPARSEABLE upstream)."""
+    try:
+        tree = ast.parse(src)
+    except SyntaxError:
+        return None
+    out: dict[str, Sym] = {}
+    for n in tree.body:
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            ln, ch, seg = _seg_len(src, n)
+            _add(out, f"func:{n.name}", ln, ch, seg)
+        elif isinstance(n, ast.ClassDef):
+            ln, ch, seg = _seg_len(src, n)
+            _add(out, f"class:{n.name}", ln, ch, seg)
+            _walk_class(src, n, n.name, out)
+        elif isinstance(n, ast.Import):
+            for a in n.names:
+                _add(out, f"import:{a.asname or a.name}", 1, 0)
+        elif isinstance(n, ast.ImportFrom):
+            for a in n.names:
+                _add(out, f"import:{a.asname or a.name}", 1, 0)
+        elif isinstance(n, ast.Assign):
+            for t in n.targets:
+                for name in _target_names(t):
+                    _add(out, f"const:{name}", 1, 0)
+        elif isinstance(n, ast.AnnAssign):
+            for name in _target_names(n.target):
+                _add(out, f"const:{name}", 1, 0)
+    return out
+
+
+_BASH_FN = re.compile(r"^\s*(?:function\s+)?([A-Za-z_][A-Za-z0-9_-]*)\s*\(\s*\)\s*\{", re.M)
+_BASH_FN2 = re.compile(r"^\s*function\s+([A-Za-z_][A-Za-z0-9_-]*)\s*(?:\(\s*\))?\s*\{?", re.M)
+
+
+def bash_symbols(src: str) -> dict[str, Sym]:
+    out: dict[str, Sym] = {}
+    lines = src.splitlines()
+    seen_line: dict[str, int] = {}
+    for m in _BASH_FN.finditer(src):
+        name = m.group(1)
+        _add(out, f"fn:{name}", 1, 0)
+        seen_line.setdefault(name, src[: m.start()].count("\n"))
+    for m in _BASH_FN2.finditer(src):
+        name = m.group(1)
+        key = f"fn:{name}"
+        if key not in out:
+            _add(out, key, 1, 0)
+            seen_line.setdefault(name, src[: m.start()].count("\n"))
+    # crude body length: distance to next function or EOF (for the WEAKENED signal)
+    starts = sorted(seen_line.items(), key=lambda kv: kv[1])
+    for i, (name, ln) in enumerate(starts):
+        end = starts[i + 1][1] if i + 1 < len(starts) else len(lines)
+        out[f"fn:{name}"].lines = max(1, end - ln)
+    return out
+
+
+def symbols_for(path: str, src: str) -> tuple[Optional[dict[str, Sym]], bool]:
+    """(symbols, parseable). symbols is None + parseable False for a py SyntaxError."""
+    if path.endswith(".bash"):
+        return bash_symbols(src), True
+    syms = py_symbols(src)
+    if syms is None:
+        return None, False
+    return syms, True
+
+
+# ---- classification --------------------------------------------------------
+
+
+def _kind(key: str) -> str:
+    return key.split(":", 1)[0]
+
+
+def _is_fail(verdict: str, key: str, is_bash: bool) -> bool:
+    """Severity: bash verdicts other than LOST are WARN (the bash regex is crude);
+    a removed import / module constant is WARN; everything else in the FAIL set FAILs."""
+    if verdict not in _PY_FAIL_VERDICTS:
+        return False
+    if is_bash:
+        return verdict == "LOST"  # bash: only unambiguous deletion is a hard FAIL
+    if verdict == "LOST" and _kind(key) in _ADVISORY_KINDS:
+        return False  # import / const removal -> advisory WARN only
+    return True
+
+
+@dataclass
+class Finding:
+    path: str
+    symbol: str
+    verdict: str  # LOST | WEAKENED | DUPLICATED | RELOCATED | WAIVED
+    severity: str  # FAIL | WARN | WAIVED
+    detail: dict = field(default_factory=dict)
+
+
+def classify_file(path: str, base_inv: dict[str, Sym], head_inv: dict[str, Sym], is_bash: bool) -> list[Finding]:
+    """Raw per-file verdicts (before cross-file relocation + trailer waivers)."""
+    findings: list[Finding] = []
+    for key, bsym in sorted(base_inv.items()):
+        if key not in head_inv:
+            verdict = "LOST"
+            sev = "FAIL" if _is_fail(verdict, key, is_bash) else "WARN"
+            findings.append(Finding(path, key, verdict, sev, {"base_lines": bsym.lines}))
+            continue
+        hsym = head_inv[key]
+        kind = _kind(key)
+        # DUPLICATED only for real definitions (import/const dups are noise).
+        if kind in ("func", "class", "method", "fn") and hsym.count >= 2:
+            verdict = "DUPLICATED"
+            sev = "FAIL" if _is_fail(verdict, key, is_bash) else "WARN"
+            findings.append(Finding(path, key, verdict, sev, {"head_count": hsym.count}))
+            continue
+        # WEAKENED only for bodies with a meaningful line count.
+        if kind in ("func", "class", "method", "fn") and bsym.lines and hsym.lines:
+            if hsym.lines <= WEAKEN_RATIO * bsym.lines and (bsym.lines - hsym.lines) >= WEAKEN_MIN_DELTA:
+                verdict = "WEAKENED"
+                sev = "FAIL" if _is_fail(verdict, key, is_bash) else "WARN"
+                findings.append(
+                    Finding(
+                        path,
+                        key,
+                        verdict,
+                        sev,
+                        {"base_lines": bsym.lines, "head_lines": hsym.lines, "ratio": round(hsym.lines / bsym.lines, 2)},
+                    )
+                )
+    return findings
+
+
+def apply_relocation(findings: list[Finding], base_invs: dict[str, dict[str, Sym]], head_invs: dict[str, dict[str, Sym]]) -> None:
+    """Downgrade a LOST finding to RELOCATED (WARN) when the QUALIFIED key reappears in
+    another changed file at head, or the deleted body matches a body newly present at
+    head. Never on a bare-name match (P2 SF3) -- keys are class-qualified throughout."""
+    # qualified key -> set of files that hold it at head
+    head_key_files: dict[str, set[str]] = {}
+    for fpath, inv in head_invs.items():
+        for key in inv:
+            head_key_files.setdefault(key, set()).add(fpath)
+    # bodies present at base anywhere (to require the head match be genuinely "new")
+    base_bodies: set[str] = {s.body for inv in base_invs.values() for s in inv.values() if s.body}
+    # non-trivial bodies newly present at head
+    head_new_bodies: set[str] = {s.body for inv in head_invs.values() for s in inv.values() if s.body and s.body not in base_bodies and (s.body.count(" ") + 1) >= BODY_SIMILARITY_MIN_LINES}
+
+    for f in findings:
+        if f.verdict != "LOST":
+            continue
+        # qualified-name relocation: same class-qualified key in a DIFFERENT file at head
+        elsewhere = head_key_files.get(f.symbol, set()) - {f.path}
+        if elsewhere:
+            f.verdict, f.severity = "RELOCATED", "WARN"
+            f.detail = {**f.detail, "relocated_to": sorted(elsewhere), "match": "qualified-name"}
+            continue
+        # body-similarity relocation: the deleted body reappears verbatim at head
+        bsym = base_invs.get(f.path, {}).get(f.symbol)
+        if bsym and bsym.body and bsym.lines >= BODY_SIMILARITY_MIN_LINES and bsym.body in head_new_bodies:
+            f.verdict, f.severity = "RELOCATED", "WARN"
+            f.detail = {**f.detail, "match": "body-similarity"}
+
+
+# ---- escape-hatch trailer parsing ------------------------------------------
+
+_ALLOW_RE = re.compile(r"^\s*Allow-Symbol-Loss:\s*(.+?)\s*$", re.IGNORECASE | re.MULTILINE)
+
+
+def parse_allow_trailers(messages: str) -> tuple[set[str], bool]:
+    """Return (enumerated qualified names, wildcard_seen). A ``*`` (or bare/empty)
+    value is a rejected blanket wildcard -- it waives nothing and is reported."""
+    allowed: set[str] = set()
+    wildcard = False
+    for m in _ALLOW_RE.finditer(messages or ""):
+        for tok in re.split(r"[,\s]+", m.group(1).strip()):
+            tok = tok.strip()
+            if not tok:
+                continue
+            if tok == "*":
+                wildcard = True
+                continue
+            allowed.add(tok)
+    return allowed, wildcard
+
+
+def _waives(symbol_key: str, allowed: set[str]) -> bool:
+    """A trailer token matches a finding by full key (``method:TestA.test_default``) or
+    by the kind-stripped qualified name (``TestA.test_default``)."""
+    if symbol_key in allowed:
+        return True
+    stripped = symbol_key.split(":", 1)[1] if ":" in symbol_key else symbol_key
+    return stripped in allowed
+
+
+def apply_waivers(findings: list[Finding], allowed: set[str]) -> None:
+    for f in findings:
+        if f.severity == "FAIL" and _waives(f.symbol, allowed):
+            f.verdict, f.severity = "WAIVED", "WAIVED"
+            f.detail = {**f.detail, "waived_by": "Allow-Symbol-Loss trailer"}
+
+
+# ---- driver ----------------------------------------------------------------
+
+
+def run(root: str, base: str, head: str, files: Optional[list[str]]) -> tuple[int, dict]:
+    """Return (exit_code, report). exit_code: 0 clean, 1 findings, 2 invocation error."""
+    base_sha = resolve_ref(root, base)
+    head_sha = resolve_ref(root, head)
+    if base_sha is None or head_sha is None:
+        bad = base if base_sha is None else head
+        return 2, {"error": f"could not resolve ref: {bad!r}"}
+
+    if files:
+        # Explicit list bypasses the scope filter; only .py / .bash are screenable.
+        scoped = [p for p in files if p.endswith(".py") or p.endswith(".bash")]
+        skipped = [p for p in files if p not in scoped]
+    else:
+        discovered = changed_files(root, base, head)
+        scoped = [p for p in discovered if in_scope(p)]
+        skipped = [p for p in discovered if not in_scope(p)]
+
+    base_invs: dict[str, dict[str, Sym]] = {}
+    head_invs: dict[str, dict[str, Sym]] = {}
+    unparseable: list[str] = []
+    findings: list[Finding] = []
+
+    for path in sorted(set(scoped)):
+        is_bash = path.endswith(".bash")
+        bsha = blob_sha(root, base_sha, path)
+        hsha = blob_sha(root, head_sha, path)
+        b_inv: Optional[dict[str, Sym]] = None
+        h_inv: Optional[dict[str, Sym]] = None
+        if bsha is not None:
+            b_inv, ok = symbols_for(path, blob_text(root, bsha))
+            if not ok:
+                unparseable.append(f"{base_sha[:9]}:{path}")
+        if hsha is not None:
+            h_inv, ok = symbols_for(path, blob_text(root, hsha))
+            if not ok:
+                unparseable.append(f"{head_sha[:9]}:{path}")
+        # A file absent (or unparseable) at base contributes no base inventory -> no
+        # LOST is inferred against nothing. An unparseable HEAD is surfaced as a note
+        # (syntax is caught by check-ast / mypy, not this compositional screen).
+        base_invs[path] = b_inv or {}
+        head_invs[path] = h_inv or {}
+        findings.extend(classify_file(path, base_invs[path], head_invs[path], is_bash))
+
+    apply_relocation(findings, base_invs, head_invs)
+    allowed, wildcard = parse_allow_trailers(range_messages(root, base_sha, head_sha))
+    apply_waivers(findings, allowed)
+
+    fails = [f for f in findings if f.severity == "FAIL"]
+    by_verdict: dict[str, int] = {}
+    for f in findings:
+        by_verdict[f.verdict] = by_verdict.get(f.verdict, 0) + 1
+
+    report = {
+        "base": base_sha,
+        "head": head_sha,
+        "stats": {
+            "files_screened": len(scoped),
+            "skipped_out_of_scope": sorted(set(skipped)),
+            "unparseable_blobs": sorted(set(unparseable)),
+            "findings_total": len(findings),
+            "fail_count": len(fails),
+            "by_verdict": by_verdict,
+            "waived_symbols": sorted(allowed),
+            "wildcard_rejected": wildcard,
+        },
+        "findings": [{"path": f.path, "symbol": f.symbol, "verdict": f.verdict, "severity": f.severity, "detail": f.detail} for f in sorted(findings, key=lambda x: (x.path, x.symbol))],
+    }
+    return (1 if fails else 0), report
+
+
+def _print_human(report: dict) -> None:
+    st = report["stats"]
+    print("=== sequence-safety: symbol-loss screen ===")
+    print(f"base={report['base'][:12]} head={report['head'][:12]}")
+    print(f"files_screened={st['files_screened']} findings={st['findings_total']} " f"fail={st['fail_count']} by_verdict={st['by_verdict']}")
+    if st["waived_symbols"]:
+        print(f"waived (Allow-Symbol-Loss): {', '.join(st['waived_symbols'])}")
+    if st["wildcard_rejected"]:
+        print("NOTE: an Allow-Symbol-Loss: * wildcard was seen and REJECTED (waives nothing).")
+    if st["unparseable_blobs"]:
+        print(f"NOTE: unparseable blobs (out of scope for this screen): {', '.join(st['unparseable_blobs'])}")
+    print()
+    for f in report["findings"]:
+        print(f"    [{f['severity']}/{f['verdict']}] {f['path']} :: {f['symbol']}  {f['detail']}")
+    if st["fail_count"]:
+        print(f"\nFAIL: {st['fail_count']} unwaived symbol-loss finding(s). " "Declare intentional removals with a `Allow-Symbol-Loss: <qualified.symbol>` commit trailer.")
+    else:
+        print("\nOK: no unwaived symbol-loss findings.")
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="symbol_loss_check.py",
+        description="AST symbol-loss screen: FAIL on a silently deleted / gutted / duplicated def between BASE and HEAD.",
+        epilog=(
+            "Default scope (auto-discovery): src/**/*.py (includes src/tests/**/*.py). EXCLUDES the "
+            "repo-root sub-package trees (juniper-cascor-model/, juniper-cascor-protocol/), util/, scripts/, "
+            "and non-src/ or non-.py files. An explicit --files list bypasses the scope filter (and still "
+            "accepts .bash). Exit 0=clean, 1=findings, 2=usage. Escape hatch: a `Allow-Symbol-Loss: "
+            "<qualified.symbol>[, ...]` commit trailer in the BASE..HEAD range waives the enumerated symbols "
+            "(a `*` wildcard is rejected)."
+        ),
+    )
+    ap.add_argument("--base", required=True, help="base ref (e.g. origin/main, <merge>^1, github.event.before)")
+    ap.add_argument("--head", required=True, help="head ref (e.g. HEAD, <merge>, github.sha)")
+    ap.add_argument("--files", nargs="*", default=None, help="explicit .py/.bash files to screen (bypasses the scope filter)")
+    ap.add_argument("--repo-root", default=".", help="repository root the git commands run in (default: cwd)")
+    ap.add_argument(
+        "--advisory",
+        action="store_true",
+        help="advisory mode: print findings but exit 0 even on an unwaived FAIL (the per-PR allow-symbol-loss label hatch, demoted to WARN-only; the Allow-Symbol-Loss commit trailer stays the primary enumerated waiver). Exit 2 (invocation error) is never masked.",
+    )
+    ap.add_argument("--json", action="store_true", help="emit the machine-readable report to stdout")
+    args = ap.parse_args(argv)
+
+    code, report = run(args.repo_root, args.base, args.head, args.files)
+    if code == 2:
+        print(f"ERROR: {report.get('error', 'invocation error')}", file=sys.stderr)
+        return 2
+    report["advisory"] = args.advisory
+    if args.json:
+        print(json.dumps(report, indent=1, sort_keys=True))
+    else:
+        _print_human(report)
+        if args.advisory and code == 1:
+            print("\nADVISORY (--advisory): the FAIL finding(s) above are downgraded to WARN-only for this run; exit 0. The auditable `Allow-Symbol-Loss: <qualified.symbol>` commit trailer remains the primary, enumerated waiver.")
+    return 0 if (args.advisory and code == 1) else code
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Gives juniper-cascor the **sequence-safety advisory net** — the first ecosystem-rollout slice of juniper-ml's flood-remediation gates. Two pure-stdlib git-diff screens plus two standalone workflows detect the *compositional-loss* class (a silently deleted def/class/method, a gutted body, or a net docs-section deletion) that no per-PR check sees because a deleted test cannot fail. **Everything is ADVISORY** — neither workflow is a required status check and this PR makes **no branch-ruleset change** (the owner may promote later, ruleset-side only).

## Context / storm rationale

The 2026-08-05 storm triage found compositional loss to be cascor's **one remaining gap**: individually-green PRs whose serial same-file merges fuse or silently delete sibling content. juniper-ml productionized the fix under its flood-remediation program; this PR ports it (validated in ml#873 / #880 / #928). Analysis of record: juniper-ml `notes/JUNIPER_2026-07-28_JUNIPER-ML_CURSOR-PR-FLOOD-REMEDIATION-ANALYSIS.md` (§3/§4 item 8).

## What each piece does

**`util/sequence_safety/symbol_loss_check.py`** — AST symbol inventory of BASE vs HEAD; FAIL on `LOST` (silent deletion), `WEAKENED` (body shrunk past 0.6 ratio / 4-line delta), or `DUPLICATED` (fusion), with qualified-name / body-similarity relocation downgrades and a `Allow-Symbol-Loss: <qualified.symbol>` commit-trailer hatch.

**`util/sequence_safety/docs_additions_check.py`** — markdown deletion-magnitude screen; FAIL on a deleted heading or a run of ≥ N consecutive deleted lines (default 5), WARN on small in-place swaps, with a `Allow-Docs-Rewrite: <path>` commit-trailer hatch.

**`.github/workflows/sequence-safety.yml`** (per-PR, ADVISORY, standalone) — runs both screens over the PR's `base..HEAD` on `pull_request` (`main`/`develop`); owner-applied `allow-symbol-loss` / `docs-rewrite` labels demote that screen's FAIL to WARN-only (`--advisory`); uploads both JSON reports as the `sequence-safety-report` artifact. Standalone workflow → never a required context, never wired into the CI gate.

**`.github/workflows/main-verify.yml`** (post-merge, `push:main`) — the bypass-proof net that fires on every merge no matter who merged or what they bypassed. Per-SHA no-cancel concurrency; **catch-up base** = the last successful main-verify run head (ancestor-checked; sweeps any `[skip ci]` window) with `event.before` → `HEAD^1` fallbacks; on failure upserts a **stable-title** tracking issue (one per red streak; dedup binds to `creator=github-actions[bot]` + exact title + `.pull_request == null`, never the forgeable title alone — the ml#928 pattern).

**`AGENTS.md`** — documents the net (workflows table, directory tree, a "Sequence Safety" subsection).

## Adaptations (adapt, don't blind-copy)

- **Scope retune.** Symbol screen default `in_scope()` → `src/**/*.py` (includes `src/tests/**`) — cascor's damage locus (`src/tests/unit/...`, `src/api/...`); repo-root sub-packages `juniper-cascor-{model,protocol}/` are outside `src/` and excluded. Docs scope (`AGENTS.md` + `docs/**` + `notes/**`) is identical to ml (cascor has both dirs). CLI contracts, trailer hatches, `--advisory`, `--files`, and exit codes are **identical to ml** for ecosystem consistency.
- **`@property`/`@x.setter` accessor disambiguation** (cascor-src adaptation, `_accessor_suffix`). cascor's `src/` uses property/setter accessor pairs (e.g. `TrainingLifecycleManager.network`) that the raw DUPLICATED heuristic miscounts; ml's `util/`+`tests/` scope has none. Setters/deleters get a `.setter`/`.deleter` key suffix so a legitimate accessor pair is never a false DUPLICATED, while `LOST`/`WEAKENED` and real-duplicate detection are unchanged (proven below).
- **Battery deferred (v1).** juniper-ml re-runs its full unittest battery post-merge; cascor's suite is heavy (pytest + coverage, minutes not seconds), so v1 ships the **screens-only** post-merge net. `ci.yml` still runs the full suite pre-merge; a post-merge battery is a follow-up once the screens soak.
- **Slack deferred (v1).** cascor has no `SLACK_WEBHOOK_URL` workflow pattern, so v1 notifies via the stable-title tracking issue only.
- **Module tests deferred.** cascor's pytest is `src/`-rooted and coverage-gated; a cross-tree test importing `util/` would couple to shared conftest/coverage config (which the concurrent fleet automation also touches). The modules are behaviourally identical to juniper-ml's, whose `tests/test_symbol_loss_check.py` + `tests/test_docs_additions_check.py` remain the authoritative regression suite. Validation below dogfoods the screens against real cascor history and a synthetic LOST/WEAKENED/DUPLICATED/waiver/advisory scenario.

## Impact & SemVer

- **SemVer:** PATCH (additive tooling + docs; no `src/` behavior change).
- **Required checks / rulesets:** none changed. Both workflows are advisory/standalone.
- **File-disjointness:** only NEW files + the single AGENTS.md co-change — disjoint from the in-flight fleet PR set by construction. Landed as a **GitHub-signed / Verified** commit (createCommitOnBranch) to satisfy `required_signatures`.

## Testing & results (scratch clone, cascor pins)

- Screens **clean** on real history: symbol `--base HEAD~5/~12 --head HEAD` = 0 findings; docs `HEAD~5..HEAD` = 11 WARN small-swaps, **0 FAIL** (magnitude-gating working).
- Synthetic regression: a deleted method → `LOST`, a real re-def → `DUPLICATED`, a gutted body → `WEAKENED` all FAIL; a `@property`/`@setter` pair produces **no** finding (accessor fix) yet does not mask the real duplicate; `--advisory` → exit 0; an enumerated `Allow-Symbol-Loss:` trailer WAIVES only that symbol.
- Dogfood on this PR: symbol 0 findings (no `src/` change), docs 2 WARN small-swaps, 0 FAIL.
- Lint (cascor pins): `black 25.1.0 --line-length=512 --check` ✓, `flake8 7.1.1` (src args, `--max-complexity=15`) ✓, `actionlint -shellcheck=` ✓ (also with shellcheck) ✓, `yamllint -c .yamllint.yaml -s` ✓, `markdownlint-cli 0.42.0` on AGENTS.md ✓, `py_compile` ✓, workflow script paths verified.

## Risks & rollback

Advisory-only, so blast radius is a red advisory annotation / a tracking issue at worst. Rollback = delete the two workflow files (and optionally `util/sequence_safety/`); no rulesets or required checks to unwind. Known false-positive residue: WEAKENED is a line-count heuristic (equal-length gutting is invisible); a lopsided docs swap that adds one filler line can slip to WARN — both are the same honestly-stated blind spots as the juniper-ml original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
