### PR TITLE
fix(api): W-1 — reject non-spiral dataset.generator on POST /v1/training/start (422 + staging guidance)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **W-1: non-spiral `dataset.generator` on `POST /v1/training/start` is rejected 422 instead of silently ignored** (CLI experimentation plan §11, juniper-ml `notes/JUNIPER_2026-07-29_JUNIPER-ECOSYSTEM_CASCOR-RECURRENCE-CLI-TEST-VALIDATION-EXPERIMENTATION-PLAN.md`). The route materializes only the in-process `spiral` fallback; every other generator value was dropped with no error, so a start carrying e.g. `xor` trained on whatever data was already staged or retained — silent-wrong-data. The 422 detail names the staging path (`POST /v1/training/dataset` → applied at the next start). `generator: null` keeps its prior fall-through meaning. Consumers checked: canopy's start body carries no generator (its dataset changes ride the staging flow) and the experiment driver already stages non-spiral generators (its G-6 arm). Tests: `test_training_route_coverage.py` (updated pin + the retained-data sharp arm + the `generator: null` scope guard).
+
 ### Security
 
 - **Worker result ownership** — `WorkerCoordinator.submit_result` now rejects results whose submitting `worker_id` does not match the task's `assigned_worker_id`, so a peer worker cannot complete work it was never assigned. Tests: `test_worker_coordinator.py::TestSubmitResult::test_reject_wrong_worker_ownership`.

--- a/src/api/routes/training.py
+++ b/src/api/routes/training.py
@@ -75,6 +75,21 @@ async def start_training(request: Request, body: TrainingStartRequest = None) ->
                 y_val = torch.tensor(body.inline_data.val_y, dtype=torch.float32)
 
         # Handle dataset source (juniper-data generator)
+        # W-1 (CLI experimentation plan §11 / risk R-3): only the in-process
+        # ``spiral`` fallback is materialized on this route; every other
+        # generator value was previously IGNORED with no error, so a start
+        # carrying e.g. ``xor`` trained on whatever data was already staged or
+        # retained — the silent-wrong-data class. Reject non-spiral generators
+        # at the request boundary with guidance to the staging endpoint, which
+        # fetches the dataset from juniper-data and applies it at the next
+        # start (the path the canopy staging flow and the experiment driver's
+        # G-6 arm already use). ``generator is None`` keeps its prior meaning
+        # (no generator requested — inline/staged/retained data decide).
+        if body.dataset is not None and body.dataset.generator not in (None, "spiral"):
+            raise HTTPException(
+                status_code=422,
+                detail=(f"dataset.generator '{body.dataset.generator}' is not supported on POST /v1/training/start — " "only the in-process 'spiral' fallback is materialized here. Stage the dataset instead: " 'POST /v1/training/dataset with {"dataset_type": ..., "params": {...}}, then start training ' "(the staged config is fetched from juniper-data and applied at the next start; " "see GET /v1/training/dataset/pending)."),
+            )
         if body.dataset is not None and body.dataset.generator == "spiral":
             x, y = _generate_spiral_data(body.dataset.params or {})
 

--- a/src/tests/unit/api/test_training_route_coverage.py
+++ b/src/tests/unit/api/test_training_route_coverage.py
@@ -123,11 +123,13 @@ class TestStartTraining:
         assert body["data"]["status"] == "training_started"
 
     def test_start_training_unsupported_generator_rejected(self, client_with_network):
-        """Non-spiral dataset.generator must not silently succeed as spiral / empty start.
+        """W-1: a non-spiral dataset.generator is rejected 422 at the request boundary.
 
-        The route currently only materializes ``generator == "spiral"``. A request
-        for ``xor`` (accepted by the request model) with no staged data must fail
-        clearly and must not invoke the spiral generator.
+        Pre-W-1 the route materialized only ``generator == "spiral"`` and silently
+        IGNORED every other value, so this request fell through to a downstream 409
+        only because the fixture holds no staged/retained data. Post-W-1 the route
+        rejects it up front with guidance naming the staging endpoint, and the
+        spiral generator is never invoked.
         """
         with patch("api.routes.training._generate_spiral_data") as spiral_gen:
             response = client_with_network.post(
@@ -140,10 +142,56 @@ class TestStartTraining:
                     "epochs": 1,
                 },
             )
-        assert response.status_code == 409
+        assert response.status_code == 422
         detail = response.json()["error"]["message"]
-        assert "Training cannot be started" in detail
+        assert "not supported" in detail
+        assert "/v1/training/dataset" in detail
         spiral_gen.assert_not_called()
+
+    def test_start_training_nonspiral_rejected_even_with_retained_data(self, client_with_network):
+        """W-1's sharp arm: the silent-wrong-data class is closed.
+
+        Seed the lifecycle with retained inline data (a completed start), then post a
+        start naming ``generator: "xor"``. Pre-W-1 the generator was silently dropped
+        and training STARTED on the retained inline data — succeeding on the wrong
+        dataset. Post-W-1 the request 422s before the lifecycle is touched and no new
+        training run begins.
+        """
+        seed = client_with_network.post(
+            "/v1/training/start",
+            json={
+                "inline_data": {
+                    "train_x": [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6], [0.7, 0.8]],
+                    "train_y": [[1.0, 0.0], [0.0, 1.0], [1.0, 0.0], [0.0, 1.0]],
+                },
+                "epochs": 1,
+            },
+        )
+        assert seed.status_code == 200
+        client_with_network.post("/v1/training/stop")
+
+        response = client_with_network.post(
+            "/v1/training/start",
+            json={
+                "dataset": {"generator": "xor", "params": {"n_samples": 20}},
+                "epochs": 1,
+            },
+        )
+        assert response.status_code == 422
+        assert "/v1/training/dataset" in response.json()["error"]["message"]
+        status = client_with_network.get("/v1/training/status").json()["data"]
+        assert status["training_active"] is False
+
+    def test_start_training_generator_none_keeps_prior_meaning(self, client_with_network):
+        """W-1 scope guard: ``dataset`` present with ``generator: null`` is NOT the
+        rejected class — it keeps its pre-W-1 fall-through (no generator requested,
+        inline/staged/retained data decide; here none exists, so the downstream 409)."""
+        response = client_with_network.post(
+            "/v1/training/start",
+            json={"dataset": {"source": "juniper-data", "params": {}}, "epochs": 1},
+        )
+        assert response.status_code == 409
+        assert "Training cannot be started" in response.json()["error"]["message"]
 
     def test_start_training_with_params(self, client_with_network):
         """start_training should accept training parameter overrides."""


### PR DESCRIPTION
## Summary

Implements **W-1** from the CLI experimentation plan (§11, juniper-ml `notes/JUNIPER_2026-07-29_JUNIPER-ECOSYSTEM_CASCOR-RECURRENCE-CLI-TEST-VALIDATION-EXPERIMENTATION-PLAN.md`) — called out there as the highest-value correctness item in the plan: `POST /v1/training/start` materializes only the in-process `spiral` fallback, and **every other `dataset.generator` value was silently ignored**, so a start carrying e.g. `xor` trained on whatever data was already staged or retained — silent-wrong-data, the worst of the three options the plan names.

Per the ratified R-3 direction ("prefer the 422-with-guidance variant"), a non-spiral generator is now rejected **422 at the request boundary**, with the detail naming the working path: `POST /v1/training/dataset` (staged, fetched from juniper-data, applied at the next start; `GET /v1/training/dataset/pending` to inspect). `generator: null` keeps its prior fall-through meaning.

## Consumers checked (R-3)

- **canopy**: its start body carries only `start_fresh` — dataset changes ride the Issue-#3 staging flow (`cascor_service_adapter.py`); no generator in start payloads.
- **juniper-cascor-client**: passthrough (`start_training(dataset=…)`); no caller in the ecosystem sends non-spiral generators on start.
- **juniper-ml experiment driver**: already stages non-spiral generators (its G-6 arm) and sends `dataset` inline only for `spiral` — unaffected.

## Tests

- Updated `test_start_training_unsupported_generator_rejected`: the prior pin asserted the downstream 409 — which only occurred because the fixture held **no** staged/retained data; it never exercised the dangerous arm. Now pins the 422 contract + staging-endpoint guidance + spiral-generator-not-called.
- **New sharp arm** `test_start_training_nonspiral_rejected_even_with_retained_data`: seeds retained inline data (completed start), then posts an `xor` start — pre-W-1 this silently trained on the retained data; now 422 and `training_active` stays false.
- New scope guard `test_start_training_generator_none_keeps_prior_meaning`.
- File: 22 passed. Full `tests/unit/api/` subset: exit 0. Pre-commit: all hooks pass.

## Observed while testing (pre-existing, not this PR)

The multi-file `tests/unit/api/ -q` run's final pytest summary line is missing from captured output (exit code correct; single-file runs print normally) — possibly the cascor#205 truncation class resurfacing; flagging for a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Di3TxAstqvPX3qVBiNJrjH