### PR TITLE
feat(settings): Wave 3.1 — experiment YAML config layer (service:-block projection, YAML > env)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Wave 3.1: experiment YAML config layer** (CLI experimentation plan §5.1/§5.2/§5.6, juniper-ml `notes/JUNIPER_2026-07-29_JUNIPER-ECOSYSTEM_CASCOR-RECURRENCE-CLI-TEST-VALIDATION-EXPERIMENTATION-PLAN.md`). New `ExperimentYamlSettingsSource` projects ONLY the experiment YAML's `service:` block into `Settings` with the ratified precedence `CLI/init > YAML > env > .env > defaults` — the stock `YamlConfigSettingsSource` would silently no-op under this model's `extra="ignore"` with the experiment YAML's nested top level. Fail-loud validation before boot: unknown top-level blocks, `schema_version` (1..1), unknown `service:` keys, and the launcher-owned infra keys (`host`/`port`/`juniper_data_url`, plus `eval_metrics_enabled` which belongs in `runtime:`) are rejected (§5.6 rules 1/2/6). Activated only by the new `JUNIPER_CASCOR_CONFIG_FILE` env var — inert for every existing env/compose deployment (risk R-4) — with a new `--config PATH` convenience flag on `server.py` and `main.py` that sets the env var before the first (`lru_cache`'d) settings load. Tests: `src/tests/unit/api/test_experiment_yaml_settings.py`.
+
+
 ### Fixed
 
 - **W-1: non-spiral `dataset.generator` on `POST /v1/training/start` is rejected 422 instead of silently ignored** (CLI experimentation plan §11, juniper-ml `notes/JUNIPER_2026-07-29_JUNIPER-ECOSYSTEM_CASCOR-RECURRENCE-CLI-TEST-VALIDATION-EXPERIMENTATION-PLAN.md`). The route materializes only the in-process `spiral` fallback; every other generator value was dropped with no error, so a start carrying e.g. `xor` trained on whatever data was already staged or retained — silent-wrong-data. The 422 detail names the staging path (`POST /v1/training/dataset` → applied at the next start). `generator: null` keeps its prior fall-through meaning. Consumers checked: canopy's start body carries no generator (its dataset changes ride the staging flow) and the experiment driver already stages non-spiral generators (its G-6 arm). Tests: `test_training_route_coverage.py` (updated pin + the retained-data sharp arm + the `generator: null` scope guard).

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -1,10 +1,14 @@
 """API configuration settings using pydantic-settings."""
 
+import logging
+import os
 from functools import lru_cache
+from pathlib import Path
 from typing import Annotated, Any
 
+import yaml
 from pydantic import AliasChoices, Field, field_validator, model_validator
-from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
+from pydantic_settings import BaseSettings, NoDecode, PydanticBaseSettingsSource, SettingsConfigDict
 
 from api.secrets import get_secret
 
@@ -114,6 +118,92 @@ _JUNIPER_CASCOR_API_WORKER_AUDIT_LOGGING_ENABLED_DEFAULT: bool = False
 _JUNIPER_CASCOR_API_WORKER_METRICS_ENABLED_DEFAULT: bool = False
 
 
+# ---------------------------------------------------------------------------------------------------
+# Experiment YAML config layer (Wave 3.1 -- CLI experimentation plan SS5.1/SS5.2/SS5.6, juniper-ml
+# notes/JUNIPER_2026-07-29_JUNIPER-ECOSYSTEM_CASCOR-RECURRENCE-CLI-TEST-VALIDATION-EXPERIMENTATION-PLAN.md)
+# ---------------------------------------------------------------------------------------------------
+
+_EXPERIMENT_CONFIG_ENV_VAR: str = "JUNIPER_CASCOR_CONFIG_FILE"
+_EXPERIMENT_SCHEMA_VERSION_MAX: int = 1
+# The SS5.4/SS5.5 top-level surface. Only ``service:`` is projected into Settings; the other
+# blocks belong to the driver / launcher layers (plan SS6) and are deliberately ignored here.
+_EXPERIMENT_TOP_LEVEL_BLOCKS: frozenset = frozenset({"schema_version", "experiment", "service", "dataset", "training", "train", "crossval", "predict", "runtime", "outputs"})
+# SS5.6 rule 6: infrastructure is launcher-owned (CLI flags / process env) and rejected
+# outright; ``eval_metrics_enabled`` is process-env territory (``runtime:``), not a Settings field.
+_EXPERIMENT_SERVICE_FORBIDDEN_KEYS: frozenset = frozenset({"host", "port", "juniper_data_url", "eval_metrics_enabled"})
+
+_experiment_config_logger = logging.getLogger("juniper_cascor.api.settings")
+
+
+class ExperimentConfigError(ValueError):
+    """Invalid experiment YAML for the ``service:`` projection -- fail loud BEFORE boot (SS5.6)."""
+
+
+class ExperimentYamlSettingsSource(PydanticBaseSettingsSource):
+    """Project ONLY the experiment YAML's ``service:`` block into Settings values (SS5.2).
+
+    The stock ``YamlConfigSettingsSource`` reads the file's TOP-LEVEL mapping as field
+    values, and an experiment YAML's top level is ``schema_version`` / ``experiment`` /
+    ``service`` / ``dataset`` / ... -- none of which is a Settings field. With this model's
+    ``extra="ignore"`` every key would be dropped silently: the stock source would no-op
+    the whole layer. This source parses the file once, validates fail-loud (unknown
+    top-level blocks, ``schema_version``, unknown or launcher-owned ``service:`` keys --
+    SS5.6 rules 1/2/6), and yields the ``service:`` keys so YAML sits ABOVE env in the
+    SS5.1 precedence (a run stays reproducible from its YAML even in a shell with stale
+    exported ``JUNIPER_CASCOR_*`` vars).
+    """
+
+    def __init__(self, settings_cls: type, yaml_file: str) -> None:
+        super().__init__(settings_cls)
+        self._yaml_file = yaml_file
+        self._service_block = self._load_and_validate()
+
+    def _load_and_validate(self) -> dict[str, Any]:
+        try:
+            raw = Path(self._yaml_file).read_text(encoding="utf-8")
+        except OSError as exc:
+            raise ExperimentConfigError(f"{_EXPERIMENT_CONFIG_ENV_VAR}={self._yaml_file!r} is unreadable: {exc}") from exc
+        try:
+            data = yaml.safe_load(raw)
+        except yaml.YAMLError as exc:
+            raise ExperimentConfigError(f"experiment config {self._yaml_file!r} is not valid YAML: {exc}") from exc
+        if not isinstance(data, dict):
+            raise ExperimentConfigError(f"experiment config {self._yaml_file!r} must be a YAML mapping, got {type(data).__name__}")
+
+        unknown_blocks = sorted(set(data) - _EXPERIMENT_TOP_LEVEL_BLOCKS)
+        if unknown_blocks:
+            raise ExperimentConfigError(f"experiment config {self._yaml_file!r}: unknown top-level block(s) {', '.join(unknown_blocks)} (allowed: {', '.join(sorted(_EXPERIMENT_TOP_LEVEL_BLOCKS))})")
+
+        version = data.get("schema_version")
+        if not isinstance(version, int) or isinstance(version, bool) or not 1 <= version <= _EXPERIMENT_SCHEMA_VERSION_MAX:
+            raise ExperimentConfigError(f"experiment config {self._yaml_file!r}: schema_version must be an integer in 1..{_EXPERIMENT_SCHEMA_VERSION_MAX}, got {version!r}")
+
+        service = data.get("service") or {}
+        if not isinstance(service, dict):
+            raise ExperimentConfigError(f"experiment config {self._yaml_file!r}: service must be a mapping, got {type(service).__name__}")
+
+        forbidden = sorted(set(service) & _EXPERIMENT_SERVICE_FORBIDDEN_KEYS)
+        if forbidden:
+            raise ExperimentConfigError(f"experiment config {self._yaml_file!r}: service key(s) {', '.join(forbidden)} rejected (SS5.6 rule 6) -- " "host/port/juniper_data_url are launcher-owned (CLI flags / process env), and eval_metrics_enabled belongs in runtime: (process env), not service:")
+
+        known_fields = set(self.settings_cls.model_fields)
+        unknown = sorted(key for key in service if key not in known_fields)
+        if unknown:
+            raise ExperimentConfigError(f"experiment config {self._yaml_file!r}: unknown service key(s) {', '.join(unknown)} -- " "Settings is extra='ignore', so an unvalidated key would be dropped silently; fix the YAML (fields include e.g. log_level, metrics_enabled, auto_start, auto_start_data_service)")
+
+        if service:
+            _experiment_config_logger.info("experiment config %s: projecting service keys %s (YAML > env, SS5.1)", self._yaml_file, sorted(service))
+        return dict(service)
+
+    def get_field_value(self, field: Any, field_name: str) -> tuple[Any, str, bool]:
+        if field_name in self._service_block:
+            return self._service_block[field_name], field_name, False
+        return None, field_name, False
+
+    def __call__(self) -> dict[str, Any]:
+        return dict(self._service_block)
+
+
 class Settings(BaseSettings):
     """Application settings loaded from environment variables.
 
@@ -128,6 +218,20 @@ class Settings(BaseSettings):
         case_sensitive=False,
         extra="ignore",
     )
+
+    @classmethod
+    def settings_customise_sources(cls, settings_cls, init_settings, env_settings, dotenv_settings, file_secret_settings):
+        """CLI/init > YAML ``service:`` block > env > .env > defaults (SS5.1; Wave 3.1).
+
+        The YAML source is inserted only when ``JUNIPER_CASCOR_CONFIG_FILE`` is set, so the
+        layer is inert for every existing env/compose deployment (plan risk R-4).
+        """
+        yaml_path = os.environ.get(_EXPERIMENT_CONFIG_ENV_VAR)
+        sources: list[Any] = [init_settings]
+        if yaml_path:
+            sources.append(ExperimentYamlSettingsSource(settings_cls, yaml_file=yaml_path))
+        sources += [env_settings, dotenv_settings, file_secret_settings]
+        return tuple(sources)
 
     host: str = _JUNIPER_CASCOR_API_HOST_DEFAULT
     port: int = _JUNIPER_CASCOR_API_PORT_DEFAULT

--- a/src/main.py
+++ b/src/main.py
@@ -439,6 +439,7 @@ Examples:
     parser.add_argument("--profile-output", type=str, default="./profiles", help="Directory for profile output files (default: ./profiles)")
 
     parser.add_argument("--profile-top-n", type=int, default=30, help="Number of top functions to display in profile output (default: 30)")
+    parser.add_argument("--config", type=str, default=None, help="Experiment YAML whose service: block overrides env (sets JUNIPER_CASCOR_CONFIG_FILE before settings load; Wave 3.1)")
 
     return parser.parse_args()
 
@@ -448,6 +449,10 @@ Examples:
 # This is the entry point for the script.
 if __name__ == "__main__":
     args = parse_args()
+
+    if args.config:
+        # Wave 3.1: must land before the first Settings()/get_settings() use (SS5.2).
+        os.environ["JUNIPER_CASCOR_CONFIG_FILE"] = args.config
 
     if args.profile:
         from profiling.deterministic import ProfileContext

--- a/src/server.py
+++ b/src/server.py
@@ -16,15 +16,18 @@ from api.app import create_app
 from api.settings import get_settings
 
 
-def main() -> None:
-    """Start the JuniperCascor API server."""
+def main(argv: list[str] | None = None) -> None:
+    """Start the JuniperCascor API server.
+
+    ``argv`` is injectable for tests (``None`` reads ``sys.argv`` -- the CLI path).
+    """
     parser = argparse.ArgumentParser(description="JuniperCascor API server")
     parser.add_argument(
         "--config",
         default=None,
         help="Experiment YAML whose service: block overrides env (sets JUNIPER_CASCOR_CONFIG_FILE; Wave-3 operator convenience -- the experiment stack threads the env var itself, plan SS5.2/SS6.1)",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     if args.config:
         # Must land before the first (lru_cache'd) get_settings() call (settings.py SS5.2).
         os.environ["JUNIPER_CASCOR_CONFIG_FILE"] = args.config

--- a/src/server.py
+++ b/src/server.py
@@ -2,9 +2,13 @@
 
 Usage:
     python server.py
+    python server.py --config conf/experiments/<name>.yaml
     # or:
     uvicorn api.app:app --host 127.0.0.1 --port 8200
 """
+
+import argparse
+import os
 
 import uvicorn
 
@@ -14,6 +18,16 @@ from api.settings import get_settings
 
 def main() -> None:
     """Start the JuniperCascor API server."""
+    parser = argparse.ArgumentParser(description="JuniperCascor API server")
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="Experiment YAML whose service: block overrides env (sets JUNIPER_CASCOR_CONFIG_FILE; Wave-3 operator convenience -- the experiment stack threads the env var itself, plan SS5.2/SS6.1)",
+    )
+    args = parser.parse_args()
+    if args.config:
+        # Must land before the first (lru_cache'd) get_settings() call (settings.py SS5.2).
+        os.environ["JUNIPER_CASCOR_CONFIG_FILE"] = args.config
     settings = get_settings()
     app = create_app(settings)
 

--- a/src/tests/unit/api/test_experiment_yaml_settings.py
+++ b/src/tests/unit/api/test_experiment_yaml_settings.py
@@ -1,0 +1,134 @@
+"""Tests for the experiment YAML config layer (Wave 3.1 -- CLI experimentation plan SS5.1/SS5.2/SS5.6).
+
+``ExperimentYamlSettingsSource`` projects ONLY the experiment YAML's ``service:`` block
+into ``Settings`` (YAML > env in the SS5.1 precedence), validating fail-loud: unknown
+top-level blocks, ``schema_version``, unknown ``service:`` keys (the model is
+``extra="ignore"``, so silent dropping must be impossible), and the launcher-owned
+infra keys (SS5.6 rule 6). The layer is inert when ``JUNIPER_CASCOR_CONFIG_FILE`` is
+unset, and init-kwargs (the CLI tier) still beat the YAML.
+"""
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_BASE_YAML = """
+schema_version: 1
+experiment:
+  name: layer-test
+  seed: 1
+service:
+  log_level: DEBUG
+  metrics_enabled: true
+dataset:
+  generator: spiral
+  params:
+    seed: 1
+training:
+  params:
+    max_iterations: 2
+runtime:
+  blas_threads: 2
+outputs:
+  plots: []
+"""
+
+
+def _write_yaml(tmp_path, body):
+    path = tmp_path / "experiment.yaml"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+class TestExperimentYamlLayer:
+    """SS5.1 precedence + inertness."""
+
+    def test_inert_without_env_var(self, monkeypatch):
+        monkeypatch.delenv("JUNIPER_CASCOR_CONFIG_FILE", raising=False)
+        monkeypatch.setenv("JUNIPER_CASCOR_LOG_LEVEL", "WARNING")
+        from api.settings import Settings
+
+        assert Settings().log_level == "WARNING"
+
+    def test_yaml_beats_env(self, tmp_path, monkeypatch):
+        path = _write_yaml(tmp_path, _BASE_YAML)
+        monkeypatch.setenv("JUNIPER_CASCOR_CONFIG_FILE", str(path))
+        monkeypatch.setenv("JUNIPER_CASCOR_LOG_LEVEL", "ERROR")
+        monkeypatch.setenv("JUNIPER_CASCOR_METRICS_ENABLED", "false")
+        from api.settings import Settings
+
+        settings = Settings()
+        assert settings.log_level == "DEBUG"
+        assert settings.metrics_enabled is True
+
+    def test_init_kwargs_beat_yaml(self, tmp_path, monkeypatch):
+        path = _write_yaml(tmp_path, _BASE_YAML)
+        monkeypatch.setenv("JUNIPER_CASCOR_CONFIG_FILE", str(path))
+        from api.settings import Settings
+
+        assert Settings(log_level="WARNING").log_level == "WARNING"
+
+    def test_env_still_wins_for_unprojected_fields(self, tmp_path, monkeypatch):
+        path = _write_yaml(tmp_path, _BASE_YAML)
+        monkeypatch.setenv("JUNIPER_CASCOR_CONFIG_FILE", str(path))
+        monkeypatch.setenv("JUNIPER_CASCOR_AUTO_START", "true")
+        from api.settings import Settings
+
+        settings = Settings()
+        assert settings.auto_start is True
+        assert settings.log_level == "DEBUG"
+
+    def test_non_service_blocks_are_ignored_by_settings(self, tmp_path, monkeypatch):
+        path = _write_yaml(tmp_path, _BASE_YAML)
+        monkeypatch.setenv("JUNIPER_CASCOR_CONFIG_FILE", str(path))
+        from api.settings import Settings
+
+        settings = Settings()
+        assert settings.host == "127.0.0.1"
+        assert settings.port == 8200
+
+
+class TestExperimentYamlValidation:
+    """SS5.6 rules 1/2/6 -- fail loud before boot."""
+
+    def _expect_error(self, tmp_path, monkeypatch, body, match):
+        from api.settings import ExperimentConfigError, Settings
+
+        path = _write_yaml(tmp_path, body)
+        monkeypatch.setenv("JUNIPER_CASCOR_CONFIG_FILE", str(path))
+        with pytest.raises(ExperimentConfigError, match=match):
+            Settings()
+
+    @pytest.mark.parametrize("key", ["host", "port", "juniper_data_url", "eval_metrics_enabled"])
+    def test_launcher_owned_service_keys_rejected(self, tmp_path, monkeypatch, key):
+        body = f"schema_version: 1\nservice:\n  {key}: anything\n"
+        self._expect_error(tmp_path, monkeypatch, body, match="rule 6")
+
+    def test_unknown_service_key_rejected(self, tmp_path, monkeypatch):
+        body = "schema_version: 1\nservice:\n  log_levle: DEBUG\n"
+        self._expect_error(tmp_path, monkeypatch, body, match="log_levle")
+
+    def test_unknown_top_level_block_rejected(self, tmp_path, monkeypatch):
+        body = "schema_version: 1\nsurprise: {}\nservice:\n  log_level: DEBUG\n"
+        self._expect_error(tmp_path, monkeypatch, body, match="surprise")
+
+    def test_schema_version_required(self, tmp_path, monkeypatch):
+        body = "service:\n  log_level: DEBUG\n"
+        self._expect_error(tmp_path, monkeypatch, body, match="schema_version")
+
+    def test_future_schema_version_rejected(self, tmp_path, monkeypatch):
+        body = "schema_version: 99\nservice:\n  log_level: DEBUG\n"
+        self._expect_error(tmp_path, monkeypatch, body, match="schema_version")
+
+    def test_missing_file_fails_loud(self, tmp_path, monkeypatch):
+        from api.settings import ExperimentConfigError, Settings
+
+        monkeypatch.setenv("JUNIPER_CASCOR_CONFIG_FILE", str(tmp_path / "nope.yaml"))
+        with pytest.raises(ExperimentConfigError, match="unreadable"):
+            Settings()
+
+    def test_non_mapping_yaml_rejected(self, tmp_path, monkeypatch):
+        self._expect_error(tmp_path, monkeypatch, "- just\n- a\n- list\n", match="mapping")
+
+    def test_invalid_yaml_rejected(self, tmp_path, monkeypatch):
+        self._expect_error(tmp_path, monkeypatch, "service: [unclosed\n", match="not valid YAML")

--- a/src/tests/unit/test_server_coverage.py
+++ b/src/tests/unit/test_server_coverage.py
@@ -32,7 +32,7 @@ class TestServerMain:
         with patch("server.get_settings", return_value=mock_settings) as mock_get_settings, patch("server.create_app", return_value=mock_app) as mock_create_app, patch("server.uvicorn.run") as mock_uvicorn_run:
             from server import main
 
-            main()
+            main([])
 
             mock_get_settings.assert_called_once()
             mock_create_app.assert_called_once_with(mock_settings)
@@ -53,7 +53,7 @@ class TestServerMain:
         with patch("server.get_settings", return_value=mock_settings), patch("server.create_app", return_value=MagicMock()), patch("server.uvicorn.run") as mock_uvicorn_run:
             from server import main
 
-            main()
+            main([])
 
             call_kwargs = mock_uvicorn_run.call_args
             assert call_kwargs[1]["log_level"] == "warning" or call_kwargs.kwargs["log_level"] == "warning"
@@ -68,7 +68,7 @@ class TestServerMain:
         with patch("server.get_settings", return_value=mock_settings), patch("server.create_app", return_value=MagicMock()), patch("server.uvicorn.run") as mock_uvicorn_run:
             from server import main
 
-            main()
+            main([])
 
             _, kwargs = mock_uvicorn_run.call_args
             assert kwargs["host"] == "192.168.1.100"


### PR DESCRIPTION
## Summary

Wave 3.1 of the CLI experimentation plan (§14; design §5.1/§5.2/§5.6 in juniper-ml `notes/JUNIPER_2026-07-29_JUNIPER-ECOSYSTEM_CASCOR-RECURRENCE-CLI-TEST-VALIDATION-EXPERIMENTATION-PLAN.md`): the experiment YAML config layer for cascor, exactly per the ratified mechanism.

## What's included

- **`ExperimentYamlSettingsSource`** — a custom `PydanticBaseSettingsSource` that parses the experiment YAML once and projects **only its `service:` block** into `Settings`. The stock `YamlConfigSettingsSource` reads the file's *top-level* mapping, and this model is `extra="ignore"` — the stock source would silently no-op the entire layer (the §5.2 rationale, verbatim).
- **Ratified precedence** `CLI/init > YAML > env > .env > defaults` via `settings_customise_sources`, per the plan's snippet. The YAML source is inserted **only when `JUNIPER_CASCOR_CONFIG_FILE` is set** → the layer is inert for every existing env/compose deployment (risk R-4), and a projection log line records which keys the YAML supplied.
- **Fail-loud before boot** (§5.6 rules 1/2/6): unknown top-level blocks; `schema_version` gated (integer 1..1); unknown `service:` keys (silent dropping made impossible — mirroring the `TrainingParams` `extra="forbid"` precedent); and the launcher-owned infra keys `host`/`port`/`juniper_data_url` + `eval_metrics_enabled` (which belongs in `runtime:` as process env) all raise `ExperimentConfigError`.
- **`--config PATH`** on `server.py` and `main.py` (operator convenience): sets the env var **before** the first `lru_cache`'d settings load (§5.2's explicitly-called-out ordering constraint). The experiment stack itself threads the env var through the uvicorn-factory launch and stays the bind owner (§6.1/§6.2 — YAML can never override the launcher's port allocation).

## Tests

`src/tests/unit/api/test_experiment_yaml_settings.py` — the precedence arms (inert without the env var; YAML beats env; init-kwargs beat YAML; env still wins for unprojected fields; non-`service:` blocks ignored) and the full §5.6 rejection matrix (all four infra keys parametrized, unknown service key, unknown top-level block, missing/future `schema_version`, missing file, non-mapping YAML, invalid YAML). **41 passed** together with the existing settings suite; all pre-commit hooks pass.

## Wave boundaries

Reference YAMLs (`conf/experiments/`) are Wave 3.2; the recurrence mirror is Wave 3.3 (in flight); the direct-CLI `training:`/`dataset:` mapping is W-11 (Wave 3.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Di3TxAstqvPX3qVBiNJrjH