### PR TITLE
feat(conf): Wave 3.2 — reference experiment YAMLs under conf/experiments/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Wave 3.2: reference experiment YAMLs** under `conf/experiments/` (CLI experimentation plan §5.3/§14): `spiral-baseline.yaml` (the §5.4 reference — full cascade budget, all five §8.1 plots, snapshot + Grafana bridge), `spiral-smoke.yaml` (the P1.1 minimal-budget smoke, live-proven 2026-08-07), and `xor-staged.yaml` (the non-spiral G-6 staging-path reference — start-time generators other than spiral are rejected 422 per W-1). Each file validates against BOTH consumers: the app-side `ExperimentYamlSettingsSource` (`service:` projection, Wave 3.1) and the juniper-ml driver's `load_config` (§5.6).
+
+
+### Added
+
 - **Wave 3.1: experiment YAML config layer** (CLI experimentation plan §5.1/§5.2/§5.6, juniper-ml `notes/JUNIPER_2026-07-29_JUNIPER-ECOSYSTEM_CASCOR-RECURRENCE-CLI-TEST-VALIDATION-EXPERIMENTATION-PLAN.md`). New `ExperimentYamlSettingsSource` projects ONLY the experiment YAML's `service:` block into `Settings` with the ratified precedence `CLI/init > YAML > env > .env > defaults` — the stock `YamlConfigSettingsSource` would silently no-op under this model's `extra="ignore"` with the experiment YAML's nested top level. Fail-loud validation before boot: unknown top-level blocks, `schema_version` (1..1), unknown `service:` keys, and the launcher-owned infra keys (`host`/`port`/`juniper_data_url`, plus `eval_metrics_enabled` which belongs in `runtime:`) are rejected (§5.6 rules 1/2/6). Activated only by the new `JUNIPER_CASCOR_CONFIG_FILE` env var — inert for every existing env/compose deployment (risk R-4) — with a new `--config PATH` convenience flag on `server.py` and `main.py` that sets the env var before the first (`lru_cache`'d) settings load. Tests: `src/tests/unit/api/test_experiment_yaml_settings.py`.
 
 

--- a/conf/experiments/spiral-baseline.yaml
+++ b/conf/experiments/spiral-baseline.yaml
@@ -1,0 +1,62 @@
+# spiral-baseline — the reference cascor experiment (CLI experimentation plan §5.4, Wave 3.2).
+# Drive with the juniper-ml stack:
+#   util/experiment_stack.bash --up --cascor --config conf/experiments/spiral-baseline.yaml
+#   python util/experiments/run_experiment.py --config .../spiral-baseline.yaml --run-dir $RUN_DIR
+# The service: block is consumed by the app's ExperimentYamlSettingsSource (YAML > env, §5.1);
+# dataset:/training: by the driver; runtime:/outputs: by the launcher/driver — never Settings.
+schema_version: 1
+experiment:
+  name: spiral-baseline
+  description: "Two-arm spiral, default cascade budget, decision-boundary plots"
+  seed: 20260729
+
+service:                               # -> juniper-cascor Settings (launcher CLI still owns the bind)
+  log_level: INFO
+  metrics_enabled: true                # code default is FALSE — must be set for /metrics (G-3)
+  auto_start: false                    # the driver starts training
+  auto_start_data_service: false       # never let cascor spawn a data service
+  # host / port / juniper_data_url are launcher-owned and REJECTED here (§5.6 rule 6)
+
+dataset:                               # -> juniper-data POST /v1/datasets (driver)
+  generator: spiral
+  persist: true
+  tags: ["experiment", "spiral-baseline"]
+  ttl_seconds: 86400
+  params:
+    n_spirals: 2
+    n_points_per_spiral: 500
+    n_rotations: 3.0
+    noise: 0.05
+    algorithm: modern
+    train_ratio: 0.8
+    test_ratio: 0.2
+    seed: 20260729
+
+training:                              # -> POST /v1/training/start (driver)
+  start_fresh: true
+  params:                              # TrainingParams — extra="forbid" server-side
+    max_epochs: 2000
+    max_iterations: 12
+    early_stopping: true
+    learning_rate: 0.05
+    candidate_learning_rate: 0.05
+    correlation_threshold: 0.2
+    candidate_pool_size: 8
+    max_hidden_units: 24
+    patience: 200
+    convergence_threshold: 1.0e-5
+    candidate_patience: 100
+    candidate_epochs: 500
+
+runtime:                               # launcher-exported process env, never Settings
+  num_processes: 4
+  blas_threads: 2
+  eval_metrics_enabled: true
+
+outputs:                               # driver/launcher-consumed
+  decision_boundary_resolution: 200
+  metrics_history_count: 1000
+  plots: [dataset, decision_boundary, training_history, candidate_correlation, eval_metrics]
+  snapshot_at_end: true
+  max_wall_seconds: 3600
+  grafana_bridge: true

--- a/conf/experiments/spiral-smoke.yaml
+++ b/conf/experiments/spiral-smoke.yaml
@@ -1,0 +1,42 @@
+# spiral-smoke — the P1.1 smoke configuration, live-proven 2026-08-07 (exit 0, COMPLETED 24s;
+# evidence: juniper-ml notes/JUNIPER_2026-08-07_JUNIPER-ECOSYSTEM_CLI-EXPERIMENTATION-P1-SMOKE-EVIDENCE.md).
+# Minimal budgets for a fast end-to-end sanity run of the launcher + driver + plots + stats.
+schema_version: 1
+experiment:
+  name: spiral-smoke
+  description: "P1.1 minimal-budget spiral smoke (launcher + driver end-to-end)"
+  seed: 20260807
+
+service:
+  log_level: INFO
+  metrics_enabled: true
+  auto_start: false
+  auto_start_data_service: false
+
+dataset:
+  generator: spiral
+  params:
+    n_spirals: 2
+    n_points_per_spiral: 200
+    n_rotations: 2.0
+    noise: 0.05
+    train_ratio: 0.8
+    test_ratio: 0.2
+    seed: 20260807
+
+training:
+  params:
+    max_epochs: 50
+    max_iterations: 2
+    max_hidden_units: 2
+    candidate_pool_size: 4
+    early_stopping: true
+
+runtime:
+  blas_threads: 2
+
+outputs:
+  plots: [dataset, decision_boundary, training_history]
+  metrics_history_count: 500
+  max_wall_seconds: 600
+  grafana_bridge: true

--- a/conf/experiments/xor-staged.yaml
+++ b/conf/experiments/xor-staged.yaml
@@ -1,0 +1,38 @@
+# xor-staged — a non-spiral reference showing the G-6 staging path (CLI experimentation plan §6.3/§10.3).
+# Non-spiral generators are REJECTED 422 on POST /v1/training/start (W-1); the driver stages them via
+# POST /v1/training/dataset instead and asserts the loaded input width after the run (G-6 anti-silence).
+schema_version: 1
+experiment:
+  name: xor-staged
+  description: "XOR quadrants via the staging path, small budgets, boundary plot"
+  seed: 20260807
+
+service:
+  log_level: INFO
+  metrics_enabled: true
+  auto_start: false
+  auto_start_data_service: false
+
+dataset:
+  generator: xor                       # staged as dataset_type "xor" (driver alias map)
+  params:
+    n_points_per_quadrant: 250
+    noise: 0.05
+    seed: 20260807
+
+training:
+  params:
+    max_epochs: 200
+    max_iterations: 4
+    max_hidden_units: 6
+    candidate_pool_size: 4
+    early_stopping: true
+
+runtime:
+  blas_threads: 2
+
+outputs:
+  plots: [dataset, decision_boundary, training_history]
+  metrics_history_count: 500
+  max_wall_seconds: 1200
+  grafana_bridge: true


### PR DESCRIPTION
## Summary

Wave 3.2 of the CLI experimentation plan (§5.3/§14): the reference experiment YAMLs under the new `conf/experiments/` (the dir `conf/` already hosts runtime-loaded YAML per §5.3).

Three references, each **validated against both consumers before commit** — the Wave-3.1 `ExperimentYamlSettingsSource` (`service:` projection; constructed `Settings` live with `JUNIPER_CASCOR_CONFIG_FILE` pointing at each file) and the juniper-ml driver's §5.6 `load_config`:

| File | What it references |
|---|---|
| `spiral-baseline.yaml` | The §5.4 reference verbatim-adjusted: full cascade budget, all five §8.1 plots, `snapshot_at_end`, Grafana bridge |
| `spiral-smoke.yaml` | The P1.1 minimal-budget smoke — **live-proven 2026-08-07** (exit 0, COMPLETED in 24 s; evidence in juniper-ml `notes/…P1-SMOKE-EVIDENCE.md`) |
| `xor-staged.yaml` | The non-spiral **G-6 staging-path** reference: start-time non-spiral generators are rejected 422 (W-1, #483), so the driver stages via `POST /v1/training/dataset` and asserts the loaded input width post-run |

The juniper-ml drift gate over these files (`test_experiment_config_schemas.py`, Wave 3.5) follows in juniper-ml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Di3TxAstqvPX3qVBiNJrjH