### PR TITLE
feat(api): W-3 — staged dataset_type Literal gains gaussian + checkerboard (with a real gaussian translation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **W-3: staged `dataset_type` Literal extended to `gaussian` + `checkerboard`** (CLI experimentation plan §11). New typed `n_squares` field (2–16, mirroring juniper-data's `CheckerboardParams`) surviving only for checkerboard; and a REAL gaussian translation —
+  juniper-data's `GaussianParams` has no `n_samples`, so a staged total previously passed through and was silently ignored (defaults generated — the silent-wrong-params class); it now divides by the requested `n_classes` (default 2) into `n_samples_per_class`,
+  mirroring spiral's per-arm division, with an explicit `n_samples_per_class` winning. Non-checkerboard generators strip `n_squares`. Tests: `TestTranslateStagedConfig` gaussian/checkerboard/strip arms.
+
 - **W-11: direct-CLI experiment-YAML mapping** (CLI experimentation plan §11 / Wave 3.6). `main.py`'s thin adapter maps the `--config` experiment YAML's `dataset.params` / `training.params` onto the direct CLI's overridable knobs
   (spiral shape/ratios/seed; learning-rate, correlation-threshold, max-hidden-units, patience, candidate/output epochs, with `max_epochs` aliasing to `output_epochs` per C2b) with `cascor_constants` as the fallback tier.
   Keys with no direct-CLI counterpart (service-tier knobs like `max_iterations`) are reported loudly, never dropped silently. The Settings source (Wave 3.1) fail-loud-validates the file before the adapter reads it.

--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -3312,18 +3312,39 @@ class TrainingLifecycleManager:
             rotations = params.pop("rotations", None)
             if rotations is not None:
                 params.setdefault("n_rotations", rotations)
+            params.pop("n_squares", None)
         elif generator == "xor":
             n_samples = params.pop("n_samples", None)
             if n_samples is not None:
                 params.setdefault("n_points_per_quadrant", max(1, int(n_samples) // 4))
             params.pop("rotations", None)
             params.pop("n_spirals", None)
-        else:
-            # circles / moon / mnist / gaussian take ``n_samples`` directly; drop
-            # the spiral-only typed fields so they never reach generators that do
-            # not declare them.
+            params.pop("n_squares", None)
+        elif generator == "gaussian":
+            # W-3: juniper-data's GaussianParams has NO ``n_samples`` — it takes a
+            # per-class count. A staged total would previously pass through and be
+            # silently ignored by the (extra-tolerant) params model, generating with
+            # defaults — the silent-wrong-params class. Divide by the requested
+            # class count (juniper-data GAUSSIAN_DEFAULT_N_CLASSES=2) like spiral's
+            # per-arm division.
+            n_classes = int(params.get("n_classes") or 2)
+            n_samples = params.pop("n_samples", None)
+            if n_samples is not None:
+                params.setdefault("n_samples_per_class", max(1, int(n_samples) // max(1, n_classes)))
             params.pop("rotations", None)
             params.pop("n_spirals", None)
+            params.pop("n_squares", None)
+        elif generator == "checkerboard":
+            # W-3: checkerboard takes ``n_samples`` AND ``n_squares`` directly; drop
+            # only the spiral-only fields.
+            params.pop("rotations", None)
+            params.pop("n_spirals", None)
+        else:
+            # circles / moon / mnist / equities take ``n_samples`` directly; drop
+            # every generator-specific typed field they do not declare.
+            params.pop("rotations", None)
+            params.pop("n_spirals", None)
+            params.pop("n_squares", None)
         return generator, params
 
     @staticmethod

--- a/src/api/models/training.py
+++ b/src/api/models/training.py
@@ -203,11 +203,14 @@ class StageDatasetRequest(BaseModel):
     clears any prior staging (idempotent with DELETE for that case).
     """
 
-    dataset_type: Optional[Literal["spirals", "xor", "mnist", "circles", "moons", "equities"]] = Field(None, description="Generator name forwarded to juniper-data")
+    dataset_type: Optional[Literal["spirals", "xor", "mnist", "circles", "moons", "equities", "gaussian", "checkerboard"]] = Field(None, description="Generator name forwarded to juniper-data")
     n_samples: Optional[int] = Field(None, ge=1, le=_PROJECT_API_MAX_DATASET_SAMPLES, description="Total dataset size")
     noise: Optional[float] = Field(None, ge=0.0, le=1.0, description="Generator noise factor (0–1)")
     rotations: Optional[float] = Field(None, ge=0.0, le=10.0, description="Spiral rotations (spirals generator only)")
     n_spirals: Optional[int] = Field(None, ge=2, le=10, description="Number of spirals (spirals generator only)")
+    # W-3 (CLI experimentation plan §11): checkerboard's distinctive typed knob; bounds mirror
+    # juniper-data CheckerboardParams (MIN_N_SQUARES=2, MAX_N_SQUARES=16).
+    n_squares: Optional[int] = Field(None, ge=2, le=16, description="Checkerboard squares per side (checkerboard generator only)")
     # Generic generator params for juniper-data generators whose inputs are not
     # covered by the typed convenience fields above (e.g. the ``equities``
     # generator: symbols, start_date, end_date, normalize_features, max_symbols).

--- a/src/tests/unit/api/test_lifecycle_manager_swap.py
+++ b/src/tests/unit/api/test_lifecycle_manager_swap.py
@@ -362,6 +362,35 @@ class TestTranslateStagedConfig:
         assert params["n_points_per_spiral"] >= 1
         assert params["n_spirals"] == 0
 
+    def test_gaussian_n_samples_translates_to_per_class(self):
+        """W-3: gaussian has no n_samples — a staged total divides by n_classes."""
+        generator, params = TrainingLifecycleManager._translate_staged_config("gaussian", {"n_samples": 600, "n_classes": 3, "noise": 0.05})
+        assert generator == "gaussian"
+        assert params["n_samples_per_class"] == 200
+        assert "n_samples" not in params
+
+    def test_gaussian_default_class_divisor(self):
+        """Absent n_classes uses juniper-data's default (2)."""
+        generator, params = TrainingLifecycleManager._translate_staged_config("gaussian", {"n_samples": 100})
+        assert params["n_samples_per_class"] == 50
+
+    def test_gaussian_explicit_per_class_wins(self):
+        generator, params = TrainingLifecycleManager._translate_staged_config("gaussian", {"n_samples": 600, "n_samples_per_class": 42})
+        assert params["n_samples_per_class"] == 42
+
+    def test_checkerboard_keeps_n_samples_and_n_squares(self):
+        """W-3: checkerboard takes both directly; spiral-only fields still strip."""
+        generator, params = TrainingLifecycleManager._translate_staged_config("checkerboard", {"n_samples": 2000, "n_squares": 4, "rotations": 1.0})
+        assert generator == "checkerboard"
+        assert params["n_samples"] == 2000
+        assert params["n_squares"] == 4
+        assert "rotations" not in params
+
+    def test_n_squares_stripped_from_non_checkerboard(self):
+        for dataset_type in ("spirals", "xor", "circles", "gaussian"):
+            _, params = TrainingLifecycleManager._translate_staged_config(dataset_type, {"n_samples": 40, "n_squares": 4})
+            assert "n_squares" not in params, dataset_type
+
     def test_non_spiral_strips_spiral_only_fields(self):
         generator, params = TrainingLifecycleManager._translate_staged_config(
             "circles",


### PR DESCRIPTION
## Summary

W-3 (CLI experimentation plan §11 / Wave 4.2): the staged `dataset_type` Literal admits `gaussian` and `checkerboard`, with the typed `n_squares` knob and — the substantive find — a **real gaussian translation**.

## The find

The register (and the in-code comment) claimed gaussian "takes `n_samples` directly". Ground truth: juniper-data's `GaussianParams` has **no `n_samples` field** (it takes `n_samples_per_class`), and its pydantic model tolerates extras — so a staged total would have passed through and been **silently ignored**, generating with defaults: the same silent-wrong-params class W-1 closed on the start route. The translation now divides the staged total by the requested `n_classes` (juniper-data default 2) into `n_samples_per_class`, mirroring spiral's per-arm division; an explicit `n_samples_per_class` wins.

## Also

- `n_squares` (2–16, mirroring `CheckerboardParams`) survives only for checkerboard; every other generator strips it — the same never-leak discipline as the spiral-only typed fields. The stale else-branch comment is corrected.
- Tests: `TestTranslateStagedConfig` gains the gaussian division/default/explicit-wins arms, the checkerboard keep arm, and the strip matrix; the route + swap suites are green; all pre-commit hooks pass.

## Follow-up

The juniper-ml driver's `STAGEABLE_GENERATOR_ALIASES` gains gaussian/checkerboard once this merges (separate small PR), retiring the driver's W-3 refusal hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Di3TxAstqvPX3qVBiNJrjH