### PR TITLE
fix(cli): W-11 amendment — candidate_pool_size is a mappable direct-CLI knob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **W-11 amendment: `candidate_pool_size` is now a mapped direct-CLI knob.** `SpiralProblem` accepts `_SpiralProblem__candidate_pool_size` (forwarded into the network config) but `main()` never passed it, so the initial W-11 adapter
+  classified the key service-tier-only. P1.2 re-run profiling showed the constants pool (156 candidates across 2 growth rounds) dominating smoke-scale wall time even with epochs/patience bounded — the YAML key now feeds the ctor,
+  with the constants default unchanged.
+
 - **W-3: staged `dataset_type` Literal extended to `gaussian` + `checkerboard`** (CLI experimentation plan §11). New typed `n_squares` field (2–16, mirroring juniper-data's `CheckerboardParams`) surviving only for checkerboard; and a REAL gaussian translation —
   juniper-data's `GaussianParams` has no `n_samples`, so a staged total previously passed through and was silently ignored (defaults generated — the silent-wrong-params class); it now divides by the requested `n_classes` (default 2) into `n_samples_per_class`,
   mirroring spiral's per-arm division, with an explicit `n_samples_per_class` winning. Non-checkerboard generators strip `n_squares`. Tests: `TestTranslateStagedConfig` gaussian/checkerboard/strip arms.

--- a/src/main.py
+++ b/src/main.py
@@ -61,6 +61,7 @@ from cascor_constants.constants import (
     _CASCOR_ACTIVATION_FUNCTION,
     _CASCOR_CANDIDATE_DISPLAY_FREQUENCY,
     _CASCOR_CANDIDATE_EPOCHS,
+    _CASCOR_CANDIDATE_POOL_SIZE,
     _CASCOR_CLOCKWISE,
     _CASCOR_CORRELATION_THRESHOLD,
     _CASCOR_DEFAULT_ORIGIN,
@@ -240,6 +241,7 @@ _W11_TRAINING_KEY_MAP = {
     "max_hidden_units": "max_hidden_units",
     "patience": "patience",
     "candidate_epochs": "candidate_epochs",
+    "candidate_pool_size": "candidate_pool_size",
     "output_epochs": "output_epochs",
     # C2b semantics: TrainingParams.max_epochs is the initial output-training pass budget
     # and defaults to output_epochs -- the closest direct-CLI knob. An explicit
@@ -426,6 +428,7 @@ def main():
         _SpiralProblem__activation_function=_CASCOR_ACTIVATION_FUNCTION,
         _SpiralProblem__candidate_display_frequency=_CASCOR_CANDIDATE_DISPLAY_FREQUENCY,
         _SpiralProblem__candidate_epochs=_w11.get("candidate_epochs", _CASCOR_CANDIDATE_EPOCHS),
+        _SpiralProblem__candidate_pool_size=_w11.get("candidate_pool_size", _CASCOR_CANDIDATE_POOL_SIZE),
         _SpiralProblem__clockwise=_CASCOR_CLOCKWISE,
         _SpiralProblem__correlation_threshold=_w11.get("correlation_threshold", _CASCOR_CORRELATION_THRESHOLD),
         _SpiralProblem__default_origin=_CASCOR_DEFAULT_ORIGIN,

--- a/src/tests/unit/test_w11_cli_yaml_mapping.py
+++ b/src/tests/unit/test_w11_cli_yaml_mapping.py
@@ -69,9 +69,14 @@ class TestResolveCliOverrides:
         )
         assert "dataset.params.algorithm" in unmapped
         assert "training.params.max_iterations" in unmapped
-        assert "training.params.candidate_pool_size" in unmapped
         assert "training.params.early_stopping" in unmapped
         assert "max_iterations" not in overrides
+        # candidate_pool_size IS mappable since the W-11 pool amendment: SpiralProblem
+        # takes _SpiralProblem__candidate_pool_size (spiral_problem.py:129) — P1.2
+        # re-run profiling showed the constants pool (156 candidates over 2 rounds)
+        # dominating smoke-scale wall time.
+        assert overrides["candidate_pool_size"] == 8
+        assert "training.params.candidate_pool_size" not in unmapped
 
     def test_empty_blocks_are_inert(self):
         from main import _resolve_cli_overrides


### PR DESCRIPTION
## Summary

A small W-11 amendment out of the P1.2 re-run profiling: `SpiralProblem` **does** accept `_SpiralProblem__candidate_pool_size` (forwarded into the network config) — `main()` just never passed it, so the initial adapter (#489) misclassified the key as service-tier-only. The YAML `training.params.candidate_pool_size` now feeds the ctor with the constants default unchanged. **Verified live**: 156 candidates (constants pool × 2 rounds) → 12 with `candidate_pool_size: 4`.

## Honest residual (raised to the owner separately as F-P1-3b)

Even fully bounded — pool 4, `candidate_epochs` 100, `output_epochs` 50, `max_hidden_units` 2, and a `WARNING`-level run producing 6 stdout lines — the direct-CLI training path exceeds a 590 s smoke bound on this host, where the **service** path completes the identical shape in 24 s. Compute-bound, not log-bound. That's a §12 performance-lane scenario (`main.py --profile` exists for exactly this); P1.2's full-completion row stays open against it.

## Tests

The service-tier-only reporting test updated (pool now maps, `max_iterations`/`early_stopping` remain reported); suite green; hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Di3TxAstqvPX3qVBiNJrjH