### PR TITLE
fix(api): W-2 — non-2-D artifact rejections name the tier boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **W-2: the non-2-D artifact rejections now name the tier boundary** (CLI experimentation plan §11). The `_artifact_to_tensors` 2-D guards (landed with the InlineDataset/_reload_dataset hardening) satisfy W-2's minimum-viable rejection; the register additionally
+  asks that the error *name the tier boundary* — both messages now state that 3-D sequence artifacts belong to the juniper-recurrence tier (OQ-4 ingestion-gate design). Test pin sharpened to assert the boundary naming.
+
 - **W-11 amendment: `candidate_pool_size` is now a mapped direct-CLI knob.** `SpiralProblem` accepts `_SpiralProblem__candidate_pool_size` (forwarded into the network config) but `main()` never passed it, so the initial W-11 adapter
   classified the key service-tier-only. P1.2 re-run profiling showed the constants pool (156 candidates across 2 growth rounds) dominating smoke-scale wall time even with epochs/patience bounded — the YAML key now feeds the ctor,
   with the constants default unchanged.

--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -3371,7 +3371,7 @@ class TrainingLifecycleManager:
             raise RuntimeError(f"juniper-data artifact train arrays are malformed: {exc}") from exc
 
         if new_train_x.ndim != 2 or new_train_y.ndim != 2:
-            raise RuntimeError(f"juniper-data artifact train arrays must be 2-D; got X_train.ndim={new_train_x.ndim}, y_train.ndim={new_train_y.ndim}")
+            raise RuntimeError(f"juniper-data artifact train arrays must be 2-D; got X_train.ndim={new_train_x.ndim}, y_train.ndim={new_train_y.ndim} " "-- 3-D sequence artifacts belong to the juniper-recurrence tier, not cascade-correlation (W-2 tier boundary; " "see the OQ-4 3-D ingestion-gate design in juniper-ml notes/)")
         if new_train_x.shape[0] != new_train_y.shape[0]:
             raise RuntimeError(f"juniper-data artifact train sample count mismatch: X_train={new_train_x.shape[0]} y_train={new_train_y.shape[0]}")
 
@@ -3391,7 +3391,7 @@ class TrainingLifecycleManager:
         except (TypeError, ValueError, RuntimeError) as exc:
             raise RuntimeError(f"juniper-data artifact validation arrays are malformed: {exc}") from exc
         if new_val_x.ndim != 2 or new_val_y.ndim != 2:
-            raise RuntimeError(f"juniper-data artifact validation arrays must be 2-D; got X_test.ndim={new_val_x.ndim}, y_test.ndim={new_val_y.ndim}")
+            raise RuntimeError(f"juniper-data artifact validation arrays must be 2-D; got X_test.ndim={new_val_x.ndim}, y_test.ndim={new_val_y.ndim} " "-- 3-D sequence artifacts belong to the juniper-recurrence tier, not cascade-correlation (W-2 tier boundary)")
         if new_val_x.shape[0] != new_val_y.shape[0]:
             raise RuntimeError(f"juniper-data artifact validation sample count mismatch: X_test={new_val_x.shape[0]} y_test={new_val_y.shape[0]}")
         return new_train_x, new_train_y, new_val_x, new_val_y

--- a/src/tests/unit/api/test_lifecycle_manager_swap.py
+++ b/src/tests/unit/api/test_lifecycle_manager_swap.py
@@ -267,7 +267,7 @@ class TestReloadDataset:
         }
         mod, _ = _fake_data_client_module(arrays=arrays)
         with patch.dict(sys.modules, {"juniper_data_client": mod}), patch("api.secrets.get_secret", return_value=None), patch("api.settings.Settings"):
-            with pytest.raises(RuntimeError, match="train arrays must be 2-D"):
+            with pytest.raises(RuntimeError, match="train arrays must be 2-D.*juniper-recurrence tier"):
                 mgr._reload_dataset(dataset_type="spiral")
 
     def test_malformed_train_payload_raises(self, mgr):


### PR DESCRIPTION
## Summary

W-2 (CLI experimentation plan §11), closing the register's residual: the `_artifact_to_tensors` 2-D guards (which landed with the concurrent InlineDataset/`_reload_dataset` hardening and already satisfy W-2's minimum-viable "explicit rejection") now **name the tier boundary** — both messages state that 3-D sequence artifacts belong to the **juniper-recurrence tier** (per the OQ-4 3-D ingestion-gate design), so an operator staging a sequence generator at cascor is pointed at the right service instead of a bare shape error.

Micro-diff: two message extensions + the test pin sharpened to assert the boundary naming. Suites green; all hooks pass. With this, every W-1/W-2/W-3 item in the §11 register's cascor column is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Di3TxAstqvPX3qVBiNJrjH