### PR TITLE
feat(snapshots): W-6 — JUNIPER_CASCOR_SNAPSHOTS_DIR override (service + direct CLI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **W-6: `JUNIPER_CASCOR_SNAPSHOTS_DIR` snapshot-directory override, service + direct CLI** (CLI experimentation plan §11; H-4/H-5). The service tier's `_get_snapshots_dir` (sole construction site for every `save_snapshot`/list/replay path) reads the env var
+  at call time; the direct-CLI tier's `constants_hdf5._HDF5_PROJECT_SNAPSHOTS_DIR` (the default flowing through `CascadeCorrelationConfig` into the trainer) reads it at import time. Unset or blank keeps the legacy `<repo>/src/snapshots` /
+  `<repo>/src/cascor_snapshots` paths byte-identically, so nothing changes for existing deployments; a per-run experiment launcher can now point each instance at its own `RUN_DIR/snapshots`, retiring the one-cascor-instance-per-checkout
+  interim rule for the snapshots class (the F-P1-4 `.h5`-debris finding). 7 new unit tests (`test_w6_snapshots_dir_override.py`) pin override/fallback/blank + call-time (service) and import-time (constants) semantics.
+
 - **W-2: the non-2-D artifact rejections now name the tier boundary** (CLI experimentation plan §11). The `_artifact_to_tensors` 2-D guards (landed with the InlineDataset/_reload_dataset hardening) satisfy W-2's minimum-viable rejection; the register additionally
   asks that the error *name the tier boundary* — both messages now state that 3-D sequence artifacts belong to the juniper-recurrence tier (OQ-4 ingestion-gate design). Test pin sharpened to assert the boundary naming.
 

--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -4401,8 +4401,20 @@ class TrainingLifecycleManager:
     # ------------------------------------------------------------------
 
     def _get_snapshots_dir(self) -> Path:
-        """Return the snapshots directory, creating it if needed."""
-        snapshots_dir = Path(__file__).resolve().parent.parent.parent / "snapshots"
+        """Return the snapshots directory, creating it if needed.
+
+        W-6 (CLI experimentation plan §11 / H-4): ``JUNIPER_CASCOR_SNAPSHOTS_DIR``
+        overrides the legacy hard-coded ``<repo>/src/snapshots`` so a per-run
+        launcher can point each cascor instance at its own ``RUN_DIR/snapshots``
+        (per-run config travels as process env, H-3). Read at call time — not
+        import time — so tests and long-lived processes see the current env. A
+        set-but-blank value is treated as unset (the blank-env guard class).
+        """
+        override = os.environ.get("JUNIPER_CASCOR_SNAPSHOTS_DIR", "").strip()
+        if override:
+            snapshots_dir = Path(override).expanduser()
+        else:
+            snapshots_dir = Path(__file__).resolve().parent.parent.parent / "snapshots"
         snapshots_dir.mkdir(parents=True, exist_ok=True)
         return snapshots_dir
 

--- a/src/cascor_constants/constants_hdf5/constants_hdf5.py
+++ b/src/cascor_constants/constants_hdf5/constants_hdf5.py
@@ -29,6 +29,7 @@
 #
 #
 #####################################################################################################################################################################################################
+import os
 import pathlib
 
 # import torch
@@ -43,7 +44,17 @@ _HDF5_PROJECT_SOURCE_DIR = _HDF5_PROJECT_CONSTANTS_DIR.parent.resolve()
 _HDF5_PROJECT_DIR = _HDF5_PROJECT_SOURCE_DIR.parent.resolve()
 
 _HDF5_PROJECT_SNAPSHOTS_DIR_NAME = "cascor_snapshots"
-_HDF5_PROJECT_SNAPSHOTS_DIR = pathlib.Path(_HDF5_PROJECT_SOURCE_DIR).joinpath(_HDF5_PROJECT_SNAPSHOTS_DIR_NAME)
+# W-6 (CLI experimentation plan §11 / H-5): JUNIPER_CASCOR_SNAPSHOTS_DIR overrides the legacy
+# <repo>/src/cascor_snapshots so a per-run launcher can point the direct CLI's snapshots at its own
+# RUN_DIR/snapshots. Constants resolve at import time, so the override must be in the process env
+# before the first cascor_constants import (the launcher exports it before exec). A set-but-blank
+# value is treated as unset (the blank-env guard class). Shares one env var with the service tier
+# (api/lifecycle/manager.py _get_snapshots_dir).
+_HDF5_PROJECT_SNAPSHOTS_DIR_OVERRIDE = os.environ.get("JUNIPER_CASCOR_SNAPSHOTS_DIR", "").strip()
+if _HDF5_PROJECT_SNAPSHOTS_DIR_OVERRIDE:
+    _HDF5_PROJECT_SNAPSHOTS_DIR = pathlib.Path(_HDF5_PROJECT_SNAPSHOTS_DIR_OVERRIDE).expanduser()
+else:
+    _HDF5_PROJECT_SNAPSHOTS_DIR = pathlib.Path(_HDF5_PROJECT_SOURCE_DIR).joinpath(_HDF5_PROJECT_SNAPSHOTS_DIR_NAME)
 
 
 # Define HDF5 Storage class Constants to provide reasonable defaults

--- a/src/tests/unit/api/test_w6_snapshots_dir_override.py
+++ b/src/tests/unit/api/test_w6_snapshots_dir_override.py
@@ -1,0 +1,95 @@
+"""W-6 (CLI experimentation plan §11 / H-4+H-5) — ``JUNIPER_CASCOR_SNAPSHOTS_DIR`` override.
+
+Service tier: ``TrainingLifecycleManager._get_snapshots_dir`` must honour the env
+override at call time (created on demand), fall back to the legacy
+``<repo>/src/snapshots`` when unset, and treat a set-but-blank value as unset
+(the blank-env guard class). Direct-CLI tier: ``constants_hdf5`` resolves
+``_HDF5_PROJECT_SNAPSHOTS_DIR`` from the same env var at import time — pinned via
+a module re-exec so the test does not depend on this process's import order.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
+
+from api.lifecycle.manager import TrainingLifecycleManager
+
+pytestmark = pytest.mark.unit
+
+_SRC_DIR = Path(__file__).resolve().parent.parent.parent.parent
+_CONSTANTS_HDF5 = _SRC_DIR / "cascor_constants" / "constants_hdf5" / "constants_hdf5.py"
+
+
+@pytest.fixture
+def mgr():
+    m = TrainingLifecycleManager()
+    try:
+        yield m
+    finally:
+        m.shutdown()
+
+
+def _reexec_constants_hdf5(env_value: "str | None", monkeypatch) -> Path:
+    """Re-execute constants_hdf5.py under a controlled env and return its snapshots dir.
+
+    A fresh module object (not ``importlib.reload``) so the pin is hermetic to
+    this test regardless of what the suite already imported.
+    """
+    if env_value is None:
+        monkeypatch.delenv("JUNIPER_CASCOR_SNAPSHOTS_DIR", raising=False)
+    else:
+        monkeypatch.setenv("JUNIPER_CASCOR_SNAPSHOTS_DIR", env_value)
+    spec = importlib.util.spec_from_file_location("_w6_constants_hdf5_probe", _CONSTANTS_HDF5)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return Path(module._HDF5_PROJECT_SNAPSHOTS_DIR)
+
+
+class TestServiceTierOverride:
+    def test_env_override_wins_and_is_created(self, mgr, tmp_path, monkeypatch):
+        target = tmp_path / "run" / "snapshots"
+        monkeypatch.setenv("JUNIPER_CASCOR_SNAPSHOTS_DIR", str(target))
+        resolved = mgr._get_snapshots_dir()
+        assert resolved == target
+        assert resolved.is_dir()
+
+    def test_unset_falls_back_to_legacy_src_snapshots(self, mgr, monkeypatch):
+        monkeypatch.delenv("JUNIPER_CASCOR_SNAPSHOTS_DIR", raising=False)
+        resolved = mgr._get_snapshots_dir()
+        assert resolved == _SRC_DIR / "snapshots"
+
+    def test_blank_value_is_treated_as_unset(self, mgr, monkeypatch):
+        monkeypatch.setenv("JUNIPER_CASCOR_SNAPSHOTS_DIR", "   ")
+        resolved = mgr._get_snapshots_dir()
+        assert resolved == _SRC_DIR / "snapshots"
+
+    def test_call_time_read_not_cached(self, mgr, tmp_path, monkeypatch):
+        """Two calls under different env values resolve differently — the
+        override is read per call, never captured at import/instance time."""
+        first = tmp_path / "a"
+        second = tmp_path / "b"
+        monkeypatch.setenv("JUNIPER_CASCOR_SNAPSHOTS_DIR", str(first))
+        assert mgr._get_snapshots_dir() == first
+        monkeypatch.setenv("JUNIPER_CASCOR_SNAPSHOTS_DIR", str(second))
+        assert mgr._get_snapshots_dir() == second
+
+
+class TestDirectCliTierOverride:
+    def test_env_override_wins(self, tmp_path, monkeypatch):
+        target = tmp_path / "cli-snapshots"
+        assert _reexec_constants_hdf5(str(target), monkeypatch) == target
+
+    def test_unset_keeps_legacy_cascor_snapshots(self, monkeypatch):
+        resolved = _reexec_constants_hdf5(None, monkeypatch)
+        assert resolved == _SRC_DIR / "cascor_snapshots"
+
+    def test_blank_value_is_treated_as_unset(self, monkeypatch):
+        resolved = _reexec_constants_hdf5("", monkeypatch)
+        assert resolved == _SRC_DIR / "cascor_snapshots"


### PR DESCRIPTION
## Summary

CLI experimentation plan §11 register item **W-6** (Wave 5.1): a `JUNIPER_CASCOR_SNAPSHOTS_DIR` env override for the snapshot directory, covering **both** tiers named by the hazard register — the service's hard-coded `<repo>/src/snapshots` (H-4) and the direct CLI's `<repo>/src/cascor_snapshots` (H-5) — so a per-run experiment launcher can point each instance at its own `RUN_DIR/snapshots` and the one-cascor-instance-per-checkout interim rule retires for the snapshots class (the F-P1-4 `.h5`-debris finding).

## Changes
- **`src/api/lifecycle/manager.py`** — `_get_snapshots_dir` (verified sole construction site; all 5 save/list/replay call sites flow through it) reads the env var **at call time**; unset or blank (the blank-env guard class) keeps the legacy path byte-identically.
- **`src/cascor_constants/constants_hdf5/constants_hdf5.py`** — `_HDF5_PROJECT_SNAPSHOTS_DIR` honors the same env var **at import time** (constants tier; the launcher exports before exec). The override flows through the existing chain: `constants.py` re-export → `CascadeCorrelationConfig` default → `cascade_correlation.py` fallbacks — no other site constructs the path.
- **`src/tests/unit/api/test_w6_snapshots_dir_override.py`** — 7 arms: service override-wins+created / legacy fallback / blank-is-unset / call-time-not-cached; constants override / legacy / blank via hermetic module re-exec (fresh `importlib` exec, not `reload`, so suite import order can't mask it).
- CHANGELOG bullet.

## Testing
- New file + adjacent `test_save_snapshot_collision.py` → **11 passed** (JuniperCascor1).
- Default behavior byte-identical when the var is absent — no existing test touched.

## Follow-up (juniper-ml, Wave 5.3)
The experiment launcher will export `JUNIPER_CASCOR_SNAPSHOTS_DIR=$RUN_DIR/snapshots` in `cascor_up` and document it in the REFERENCE experiment-stack section.

## Requirements
References JR-CASCOR-API-001 (service snapshot lifecycle) ; References JR-ML-EXP-001 (experimentation concurrency invariants §9.2).