### PR TITLE
ci: heal juniper-ci-tools pin ceiling to >=0.8.0,<0.9.0 (rollout W2 rider)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
       - name: Install juniper-ci-tools (workflow-path + agents-md lints)
         run: |
           python -m pip install --upgrade "pip>=26.1.1"
-          pip install "juniper-ci-tools>=0.2.0,<0.7.0"
+          pip install "juniper-ci-tools>=0.8.0,<0.9.0"
 
       - name: Lint .github/workflows/ script paths
         run: |
@@ -550,7 +550,7 @@ jobs:
         shell: bash -l {0}
         run: |
           python -m pip install --upgrade "pip>=26.1.1"
-          pip install "juniper-ci-tools>=0.2.0,<0.7.0"
+          pip install "juniper-ci-tools>=0.8.0,<0.9.0"
 
       - name: Generate Dependency Documentation
         shell: bash -l {0}


### PR DESCRIPTION
One-line heal of the pre-existing `<0.7.0` dep-docs pin — the W2 rider applied to the pioneer repo, which never got a W2 consumer pass (flagged by W3-CASCOR in #495). Verified: 0.8.0 ships every console script this workflow uses.

## Requirements

No tracked JR-ID applies (rollout pin heal).