### PR TITLE
docs(protocol): document the #463 UTF-8 dtype wrap in [Unreleased]

### DIFF
--- a/juniper-cascor-protocol/CHANGELOG.md
+++ b/juniper-cascor-protocol/CHANGELOG.md
@@ -8,6 +8,27 @@ with [PEP 440](https://peps.python.org/pep-0440/) pre-release identifiers.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`BinaryFrame.decode` no longer leaks the raw codec error for a non-UTF-8 dtype string**
+  ([pcalnon/juniper-cascor#463](https://github.com/pcalnon/juniper-cascor/pull/463)).
+  Decoding the dtype field was a bare `data[...].decode("utf-8")`, so a frame whose dtype bytes are not valid UTF-8
+  surfaced Python's `'utf-8' codec can't decode byte 0xff in position 0: invalid start byte` verbatim. The cascor
+  server echoes that text back to the submitting worker as the frame error, so a wire-level fault was reported in
+  codec terms rather than frame terms. The decode is now wrapped and re-raised as
+  `ValueError("Binary frame dtype string is not valid UTF-8")` — chained via `from exc`, so the original codec error
+  is preserved on `__cause__` — matching the frame-level wording of every other malformed-frame rejection in
+  `decode` and its documented `Raises: ValueError` contract. Pinned by `tests/test_worker.py`.
+
+### Changed
+
+- **Non-UTF-8 dtype bytes now raise plain `ValueError` instead of `UnicodeDecodeError`.**
+  Same change as the entry above, called out separately because it is caller-visible. `UnicodeDecodeError` is a
+  `ValueError` subclass, so consumers catching `ValueError` — including the cascor server's `except ValueError`
+  around `BinaryFrame.decode` — are unaffected. A consumer catching `UnicodeDecodeError` *specifically* will no
+  longer match this path and should widen to `ValueError`. Every other raised exception type, the frame format, and
+  `encode` are unchanged.
+
 ## [0.1.0] - 2026-04-30
 
 ### Changed


### PR DESCRIPTION
## Summary

Unblocks the release-train propose run for `juniper-cascor-protocol`, which refused with:

> `UNRELEASED_CHANGES but CHANGELOG [Unreleased] has no feature/fix/security bullets (under-documented)`

The subpackage had shipped a source change since `v0.1.0` while its `[Unreleased]` section was empty.

## Scope check

`git log origin/main -- juniper-cascor-protocol/` returns exactly three commits; two are the releases themselves (`062a4b9` = 0.1.0a0, `9e551cd` = 0.1.0). Since the v0.1.0 release there is **one** commit:

- `703933b` (#463) — touches `juniper_cascor_protocol/worker/binary_frame.py` (the registry `ship_paths` entry) and `tests/test_worker.py`.

Nothing else in the subpackage is undocumented.

## Changelog path

`juniper-cascor-protocol/CHANGELOG.md` already exists and is the file the detector reads — `detect.py:760` resolves `os.path.join(entry.path, "CHANGELOG.md")` against the registry's `path: "juniper-cascor-protocol/"`. No new file invented.

## Categories (and the version consequence)

Documented under **both** categories, on merit:

- **Fixed** — decode of a non-UTF-8 dtype string leaked Python's raw codec text (`'utf-8' codec can't decode byte 0xff in position 0: invalid start byte`) which the cascor server echoes verbatim to the submitting worker. It now raises the frame-level `ValueError("Binary frame dtype string is not valid UTF-8")`, chained via `from exc` so the original codec error survives on `__cause__`.
- **Changed** — the raised type narrows from `UnicodeDecodeError` to plain `ValueError`. `UnicodeDecodeError` is a `ValueError` subclass, so consumers catching `ValueError` (including cascor's own `except ValueError` around `BinaryFrame.decode`) are unaffected; a consumer catching `UnicodeDecodeError` *specifically* no longer matches and should widen.

**This choice sets the version.** Verified by running `detect.py`'s own functions against the edited file:

| Changelog content | parsed categories | `changelog_conflict` | proposed |
|---|---|---|---|
| as written (Fixed + Changed) | `['fixed', 'changed']` | `NONE` | **minor → 0.2.0** |
| Fixed only | `['fixed']` | `NONE` | patch → 0.1.1 |

`0.2.0` matches the version the propose run was already targeting. If you consider the type narrowing too minor to be caller-visible, drop the `### Changed` bullet and the train will propose `0.1.1` instead — the refusal clears either way.

## Testing

- `pre-commit run --files juniper-cascor-protocol/CHANGELOG.md` — clean (markdownlint MD013 required wrapping both bullets under the 512-char limit; re-verified the wrapped form still parses).
- Re-ran `detect.py`'s `read_changelog_unreleased` / `changelog_conflict` / `propose_semver` against the final file: categories `['fixed', 'changed']`, conflict `NONE`.

Docs only — no code change.

## Requirements

No tracked `JR-*` requirement applies — release-train hygiene follow-up.