### PR TITLE
fix(snapshots): restore five snapshot modules deleted alongside old .h5 artifacts

### DIFF
--- a/src/snapshots/snapshot_cli.py
+++ b/src/snapshots/snapshot_cli.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python
+"""
+Command-line interface for HDF5 network snapshot management.
+Provides tools for saving, loading, and managing network snapshots.
+"""
+
+import argparse
+import os
+import sys
+
+# Add parent directories for imports
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from .snapshot_serializer import CascadeHDF5Serializer
+from .snapshot_utils import HDF5Utils
+
+
+def save_network_snapshot(
+    network_file: str,
+    output_file: str,
+    include_training: bool = False,
+) -> bool:
+    """Save a network snapshot to HDF5."""
+    print(f"Saving network snapshot to {output_file}...")
+
+    try:
+        return _object_to_file(output_file, include_training)
+    except Exception as e:
+        print(f"✗ Error saving snapshot: {e}")
+        return False
+
+
+def _object_to_file(output_file, include_training) -> bool:
+    # For demonstration, create a simple network. In practice, you would load an existing network
+    from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
+    from cascade_correlation.cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
+
+    # Create a simple network for demonstration
+    config = CascadeCorrelationConfig(input_size=2, output_size=1)
+    network = CascadeCorrelationNetwork(config=config)
+
+    if success := network.save_to_hdf5(
+        filepath=output_file,
+        include_training_state=include_training,
+        include_training_data=False,
+    ):
+        return _get_saved_snapshot_file_data(output_file, success)
+    print("✗ Failed to save network snapshot")
+    return False
+
+
+def _get_saved_snapshot_file_data(output_file, success) -> bool:
+    print(f"✓ Successfully saved network snapshot to {output_file}, success: {success}")
+
+    # Show file info
+    info = HDF5Utils.get_file_info(output_file)
+    print(f"  File size: {info.get('size_mb', 0):.2f} MB")
+    print(f"  Groups: {len(info.get('groups', []))}")
+    print(f"  Datasets: {len(info.get('datasets', []))}")
+    return True
+
+
+def load_network_snapshot(snapshot_file: str, output_file: str = None):
+    """Load a network from HDF5 snapshot."""
+    print(f"Loading network snapshot from {snapshot_file}...")
+
+    try:
+        # Verify file first
+        serializer = CascadeHDF5Serializer()
+        verification = serializer.verify_saved_network(snapshot_file)
+
+        if not verification.get("valid", False):
+            print(f"✗ Invalid snapshot file: {verification.get('error', 'Unknown error')}")
+            return False
+
+        print("✓ Snapshot file verification passed")
+        print(f"  Network UUID: {verification.get('network_uuid', 'unknown')}")
+        print(f"  Architecture: {verification.get('input_size', 0)} → {verification.get('num_hidden_units', 0)} → {verification.get('output_size', 0)}")
+        print(f"  Created: {verification.get('created', 'unknown')}")
+        print(f"  Format: {verification.get('format', 'unknown')} v{verification.get('format_version', 'unknown')}")
+
+        # Load the network
+        from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
+
+        if network := CascadeCorrelationNetwork.load_from_hdf5(snapshot_file):
+            print("✓ Successfully loaded network from snapshot")
+
+            # Show network info
+            print(f"  Input size: {network.input_size}")
+            print(f"  Output size: {network.output_size}")
+            print(f"  Hidden units: {len(network.hidden_units)}")
+            print(f"  Activation function: {network.activation_function_name}")
+
+            # Save in different format if requested
+            if output_file:
+                print(f"Saving loaded network to {output_file}...")
+                if network.save_to_hdf5(output_file):
+                    print(f"✓ Network saved to {output_file}")
+                else:
+                    print(f"✗ Failed to save network to {output_file}")
+
+            return True
+        else:
+            print("✗ Failed to load network from snapshot")
+            return False
+
+    except Exception as e:
+        print(f"✗ Error loading snapshot: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+def list_snapshots(directory: str):
+    """List all network snapshots in a directory."""
+    print(f"Scanning directory: {directory}")
+
+    try:
+        networks = HDF5Utils.list_networks_in_directory(directory)
+
+        if not networks:
+            print("No valid network snapshots found")
+            return
+
+        print(f"\nFound {len(networks)} network snapshots:")
+        print("-" * 100)
+        print(f"{'Filename':<30} {'Size (MB)':<10} {'Architecture':<15} {'Hidden':<8} {'Format':<10} {'Created':<20}")
+        print("-" * 100)
+
+        for network in sorted(networks, key=lambda x: x.get("created", "")):
+            filename = network.get("filename", "unknown")[:28]
+            size_mb = network.get("file_size", 0) / (1024 * 1024)
+            arch = f"{network.get('input_size', 0)}→{network.get('output_size', 0)}"
+            hidden_units = network.get("num_hidden_units", 0)
+            format_ver = network.get("format_version", "unknown")
+            created = str(network.get("created", "unknown"))[:18]
+
+            print(f"{filename:<30} {size_mb:<10.2f} {arch:<15} {hidden_units:<8} {format_ver:<10} {created:<20}")
+
+        print("-" * 100)
+
+    except Exception as e:
+        print(f"✗ Error listing snapshots: {e}")
+
+
+def verify_snapshot(filepath: str):
+    """Verify a network snapshot file."""
+    print(f"Verifying snapshot: {filepath}")
+
+    try:
+        serializer = CascadeHDF5Serializer()
+        verification = serializer.verify_saved_network(filepath)
+
+        if verification.get("valid", False):
+            print("✓ File is a valid network snapshot")
+            print(f"  Format: {verification.get('format', 'unknown')} v{verification.get('format_version', 'unknown')}")
+            print(f"  Network UUID: {verification.get('network_uuid', 'unknown')}")
+            print(f"  Architecture: {verification.get('input_size', 0)} → {verification.get('num_hidden_units', 0)} → {verification.get('output_size', 0)}")
+            print(f"  Activation: {verification.get('activation_function', 'unknown')}")
+            print(f"  File size: {verification.get('file_size', 0) / (1024 * 1024):.2f} MB")
+            print(f"  Created: {verification.get('created', 'unknown')}")
+
+            # Check for optional sections
+            optional_sections = ["has_history", "has_mp", "has_data"]
+            for section in optional_sections:
+                if verification.get(section, False):
+                    section_name = section.replace("has_", "").replace("mp", "multiprocessing")
+                    print(f"  ✓ Contains {section_name}")
+
+            return True
+        else:
+            print(f"✗ Invalid snapshot file: {verification.get('error', 'Unknown error')}")
+            return False
+
+    except Exception as e:
+        print(f"✗ Error verifying snapshot: {e}")
+        return False
+
+
+def compare_snapshots(filepath1: str, filepath2: str):
+    """Compare two network snapshots."""
+    print("Comparing snapshots:")
+    print(f"  File 1: {filepath1}")
+    print(f"  File 2: {filepath2}")
+
+    try:
+        comparison = HDF5Utils.compare_networks(filepath1, filepath2)
+
+        if not comparison.get("comparable", False):
+            print(f"✗ Cannot compare files: {comparison.get('error', 'Unknown error')}")
+            return False
+
+        print("\nComparison results:")
+        print(f"  Same architecture: {'✓' if comparison['same_architecture'] else '✗'}")
+        print(f"  Same hidden units: {'✓' if comparison['same_hidden_units'] else '✗'}")
+        print(f"  Same activation: {'✓' if comparison['same_activation'] else '✗'}")
+
+        if not comparison["same_architecture"]:
+            diff = comparison["architecture_diff"]
+            print("\nArchitecture differences:")
+            print(f"  Input size: {diff['input_size'][0]} vs {diff['input_size'][1]}")
+            print(f"  Output size: {diff['output_size'][0]} vs {diff['output_size'][1]}")
+            print(f"  Hidden units: {diff['num_hidden_units'][0]} vs {diff['num_hidden_units'][1]}")
+            print(f"  Activation: {diff['activation_function'][0]} vs {diff['activation_function'][1]}")
+
+        return True
+
+    except Exception as e:
+        print(f"✗ Error comparing snapshots: {e}")
+        return False
+
+
+def cleanup_old_snapshots(directory: str, keep_count: int = 10):
+    """Clean up old snapshot files."""
+    print(f"Cleaning up old snapshots in {directory} (keeping {keep_count} most recent)")
+
+    try:
+        deleted_count = HDF5Utils.cleanup_old_files(directory, keep_count)
+        if deleted_count > 0:
+            print(f"✓ Deleted {deleted_count} old snapshot files")
+        else:
+            print("No old files to delete")
+        return True
+
+    except Exception as e:
+        print(f"✗ Error cleaning up files: {e}")
+        return False
+
+
+def main():
+    """Main CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="HDF5 Network Snapshot Management Tool",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+    %(prog)s save network.pkl snapshot.h5
+    %(prog)s load snapshot.h5
+    %(prog)s list ./snapshots/
+    %(prog)s verify snapshot.h5
+    %(prog)s compare snapshot1.h5 snapshot2.h5
+    %(prog)s cleanup ./snapshots/ --keep 5
+        """,
+    )
+
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # Save command
+    save_parser = subparsers.add_parser("save", help="Save network to HDF5 snapshot")
+    save_parser.add_argument("network_file", help="Input network file")
+    save_parser.add_argument("output_file", help="Output HDF5 file")
+    save_parser.add_argument("--include-training", action="store_true", help="Include training history")
+
+    # Load command
+    load_parser = subparsers.add_parser("load", help="Load network from HDF5 snapshot")
+    load_parser.add_argument("snapshot_file", help="HDF5 snapshot file")
+    load_parser.add_argument("--output", help="Save loaded network to file")
+
+    # List command
+    list_parser = subparsers.add_parser("list", help="List snapshots in directory")
+    list_parser.add_argument("directory", help="Directory to scan")
+
+    # Verify command
+    verify_parser = subparsers.add_parser("verify", help="Verify snapshot file")
+    verify_parser.add_argument("filepath", help="Snapshot file to verify")
+
+    # Compare command
+    compare_parser = subparsers.add_parser("compare", help="Compare two snapshots")
+    compare_parser.add_argument("file1", help="First snapshot file")
+    compare_parser.add_argument("file2", help="Second snapshot file")
+
+    # Cleanup command
+    cleanup_parser = subparsers.add_parser("cleanup", help="Clean up old snapshots")
+    cleanup_parser.add_argument("directory", help="Directory to clean")
+    cleanup_parser.add_argument("--keep", type=int, default=10, help="Number of recent files to keep (default: 10)")
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        return 1
+
+    # Execute commands
+    success = False
+    try:
+        if args.command == "save":
+            success = save_network_snapshot(args.network_file, args.output_file, args.include_training)
+        elif args.command == "load":
+            success = load_network_snapshot(args.snapshot_file, args.output)
+        elif args.command == "list":
+            list_snapshots(args.directory)
+            success = True
+        elif args.command == "verify":
+            success = verify_snapshot(args.filepath)
+        elif args.command == "compare":
+            success = compare_snapshots(args.file1, args.file2)
+        elif args.command == "cleanup":
+            success = cleanup_old_snapshots(args.directory, args.keep)
+        else:
+            parser.print_help()
+            return 1
+
+    except KeyboardInterrupt:
+        print("\nOperation cancelled by user")
+        return 130
+    except Exception as e:
+        print(f"✗ Unexpected error: {e}")
+        return 1
+
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/src/snapshots/snapshot_common.py
+++ b/src/snapshots/snapshot_common.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python
+"""
+Common utilities for HDF5 serialization operations.
+Provides robust string and tensor I/O helpers.
+"""
+
+
+import contextlib
+import hashlib
+from typing import Any, Optional, Union
+
+import h5py
+import numpy as np
+import torch
+
+
+def write_str_attr(obj: Union[h5py.Group, h5py.Dataset], key: str, value: Any) -> None:
+    """
+    Safely write a string attribute to HDF5 object.
+
+    Args:
+        obj: HDF5 group or dataset
+        key: Attribute key
+        value: Value to store as string
+    """
+    if value is None:
+        return
+    # Use np.bytes_ for NumPy 2.0+ compatibility (np.string_ was removed)
+    obj.attrs[key] = np.bytes_(str(value))
+
+
+def read_str_attr(obj: Union[h5py.Group, h5py.Dataset], key: str, default: Optional[str] = None) -> Optional[str]:
+    """
+    Safely read a string attribute from HDF5 object.
+
+    Args:
+        obj: HDF5 group or dataset
+        key: Attribute key
+        default: Default value if key doesn't exist
+
+    Returns:
+        String value or default
+    """
+    if key not in obj.attrs:
+        return default
+
+    val = obj.attrs[key]
+
+    # Handle bytes-like objects
+    if isinstance(val, (bytes, np.bytes_)):
+        return val.decode("utf-8")
+
+    # Handle objects with decode method
+    if hasattr(val, "decode"):
+        try:
+            return val.decode("utf-8")
+        except (UnicodeDecodeError, AttributeError):
+            return str(val)
+
+    return str(val)
+
+
+def write_str_dataset(group: h5py.Group, name: str, value: Any, **kwargs) -> h5py.Dataset:
+    """
+    Write a string dataset with proper UTF-8 encoding.
+
+    Args:
+        group: HDF5 group
+        name: Dataset name
+        value: String value to store
+        **kwargs: Additional dataset creation arguments (compression/chunks excluded for scalar strings)
+
+    Returns:
+        Created dataset
+    """
+    # Use UTF-8 string dtype
+    dt = h5py.string_dtype("utf-8")
+
+    # Remove existing dataset if present
+    if name in group:
+        del group[name]
+
+    # Remove compression/chunk options that don't work with scalar string datasets
+    kwargs_filtered = {k: v for k, v in kwargs.items() if k not in ["compression", "compression_opts", "chunks"]}
+
+    return group.create_dataset(name, data=str(value), dtype=dt, **kwargs_filtered)
+
+
+def read_str_dataset(group: h5py.Group, name: str, default: Optional[str] = None) -> Optional[str]:
+    """
+    Read a string dataset with proper decoding.
+
+    Args:
+        group: HDF5 group
+        name: Dataset name
+        default: Default value if dataset doesn't exist
+
+    Returns:
+        String value or default
+    """
+    if name not in group:
+        return default
+
+    dataset = group[name]
+
+    try:
+        # Try to use asstr() for string datasets
+        return dataset.asstr()[()]
+    except (AttributeError, TypeError):
+        # Fallback to manual decoding
+        data = dataset[()]
+        if isinstance(data, (bytes, np.bytes_)):
+            return data.decode("utf-8")
+        return str(data)
+
+
+def save_tensor(group: h5py.Group, name: str, tensor: torch.Tensor, compression: str = "gzip", compression_opts: int = 4) -> h5py.Dataset:
+    """
+    Save a PyTorch tensor to HDF5 with metadata preservation.
+
+    Args:
+        group: HDF5 group
+        name: Dataset name
+        tensor: PyTorch tensor to save
+        compression: Compression method
+        compression_opts: Compression level
+
+    Returns:
+        Created dataset
+    """
+    # Convert to numpy on CPU
+    arr = tensor.detach().cpu().numpy()
+
+    # Create dataset with compression
+    dataset = group.create_dataset(name, data=arr, compression=compression, compression_opts=compression_opts)
+
+    # Store tensor metadata
+    write_str_attr(dataset, "tensor_type", "torch.Tensor")
+    write_str_attr(dataset, "dtype", str(tensor.dtype))
+    write_str_attr(dataset, "device", str(tensor.device))
+    dataset.attrs["requires_grad"] = bool(getattr(tensor, "requires_grad", False))
+
+    # Store shape for verification
+    dataset.attrs["shape"] = tensor.shape
+
+    return dataset
+
+
+def load_tensor(dataset: h5py.Dataset) -> torch.Tensor:
+    """
+    Load a PyTorch tensor from HDF5 dataset with metadata restoration.
+
+    Args:
+        dataset: HDF5 dataset containing tensor data
+
+    Returns:
+        Reconstructed PyTorch tensor
+    """
+    # Load numpy array
+    data = dataset[:]
+
+    # Convert to tensor
+    tensor = torch.from_numpy(data)
+
+    # Restore requires_grad
+    if "requires_grad" in dataset.attrs:
+        tensor.requires_grad_(bool(dataset.attrs["requires_grad"]))
+
+    # Restore device (if not CPU and CUDA available)
+    device = read_str_attr(dataset, "device", "cpu")
+    if device != "cpu" and torch.cuda.is_available():
+        with contextlib.suppress(RuntimeError):
+            tensor = tensor.to(device)
+    return tensor
+
+
+def save_numpy_array(group: h5py.Group, name: str, array: np.ndarray, compression: str = "gzip", compression_opts: int = 4) -> h5py.Dataset:
+    """
+    Save a numpy array to HDF5 with metadata.
+
+    Args:
+        group: HDF5 group
+        name: Dataset name
+        array: Numpy array to save
+        compression: Compression method
+        compression_opts: Compression level
+
+    Returns:
+        Created dataset
+    """
+    # h5py rejects chunk/filter options on scalar (0-d) datasets, so we
+    # only request compression for arrays that have at least one axis.
+    if array.ndim == 0:
+        dataset = group.create_dataset(name, data=array)
+    else:
+        dataset = group.create_dataset(name, data=array, compression=compression, compression_opts=compression_opts)
+
+    # Store metadata
+    write_str_attr(dataset, "array_type", "numpy.ndarray")
+    write_str_attr(dataset, "dtype", str(array.dtype))
+    dataset.attrs["shape"] = array.shape
+
+    return dataset
+
+
+def load_numpy_array(dataset: h5py.Dataset) -> np.ndarray:
+    """
+    Load a numpy array from HDF5 dataset.
+
+    Args:
+        dataset: HDF5 dataset containing array data
+
+    Returns:
+        Numpy array
+    """
+    # ``dataset[:]`` raises ``ValueError: Illegal slicing argument for
+    # scalar dataspace`` on 0-d datasets. Use ``dataset[()]`` for those
+    # so callers get the expected ndarray uniformly.
+    if dataset.ndim == 0:
+        return np.asarray(dataset[()])
+    return dataset[:]
+
+
+def validate_tensor_dataset(dataset: h5py.Dataset) -> bool:
+    """
+    Validate that a dataset contains valid tensor data.
+
+    Args:
+        dataset: HDF5 dataset to validate
+
+    Returns:
+        True if valid tensor dataset
+    """
+    try:
+        # Check for required attributes
+        tensor_type = read_str_attr(dataset, "tensor_type")
+        if tensor_type != "torch.Tensor":
+            return False
+
+        # Check data shape consistency
+        if "shape" in dataset.attrs:
+            expected_shape = tuple(dataset.attrs["shape"])
+            actual_shape = dataset.shape
+            if expected_shape != actual_shape:
+                return False
+
+        return True
+
+    except Exception:
+        return False
+
+
+def calculate_tensor_checksum(tensor: torch.Tensor) -> str:
+    """
+    Calculate SHA256 checksum of tensor data.
+
+    Args:
+        tensor: PyTorch tensor to checksum
+
+    Returns:
+        Hexadecimal checksum string
+    """
+    tensor_bytes = tensor.detach().cpu().numpy().tobytes()
+    return hashlib.sha256(tensor_bytes).hexdigest()
+
+
+def verify_tensor_checksum(tensor: torch.Tensor, expected_checksum: str) -> bool:
+    """
+    Verify tensor checksum matches expected value.
+
+    Args:
+        tensor: PyTorch tensor to verify
+        expected_checksum: Expected checksum value
+
+    Returns:
+        True if checksums match
+    """
+    actual_checksum = calculate_tensor_checksum(tensor)
+    return actual_checksum == expected_checksum

--- a/src/snapshots/snapshot_errors.py
+++ b/src/snapshots/snapshot_errors.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+"""
+Typed exceptions for the snapshot subsystem.
+
+Kept in a dedicated stdlib-only module so API route modules can import the
+exception types at module scope without pulling the heavy serializer stack
+(h5py / numpy / torch) into their import graph — the serializer itself is
+deliberately imported lazily by the lifecycle manager.
+"""
+
+
+class SnapshotSaveError(RuntimeError):
+    """A snapshot write failed after the save was attempted.
+
+    C1 (I-3 upstream half — see juniper-ml
+    ``notes/JUNIPER_2026-07-11_JUNIPER-CANOPY_TRAINING-RUNTIME-DEFECTS-PLAN.md``):
+    ``CascadeHDF5Serializer.save_network`` used to swallow every exception
+    into ``False``, which the lifecycle collapsed to ``None`` and the API
+    route mapped to a 404 "No network available to snapshot" — a failed
+    save masquerading as a missing network. The serializer now raises this
+    exception (chaining the underlying cause) so the lifecycle and route
+    can propagate the real reason with a correct 500 status, while the
+    no-network case keeps its 404.
+    """

--- a/src/snapshots/snapshot_serializer.py
+++ b/src/snapshots/snapshot_serializer.py
@@ -1,0 +1,1679 @@
+#!/usr/bin/env python
+"""
+HDF5 Serializer for CascadeCorrelationNetwork objects.
+Provides comprehensive state capture and restoration with full multiprocessing support.
+"""
+
+import datetime
+import io
+import json
+import multiprocessing as mp
+import os
+import pathlib as pl
+import pickle  # trunk-ignore(bandit/B403)
+import random
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+# SEC-11: allowlist for the snapshot RNG-state unpickler. Only modules we
+# know Python's ``random.getstate()`` payloads reference (plus their pickle
+# helpers) and a tight set of builtin container types are permitted. Any
+# other ``find_class`` lookup — including torch, numpy, or user code — is
+# rejected so a crafted HDF5 file cannot smuggle an RCE-capable pickle
+# payload into the snapshot restore path.
+_SNAPSHOT_UNPICKLER_ALLOWED_MODULES = frozenset(
+    {
+        "random",
+        "_random",
+        "collections",
+        "collections.abc",
+        "_codecs",
+        "copyreg",
+    }
+)
+_SNAPSHOT_UNPICKLER_ALLOWED_BUILTINS = frozenset(
+    {
+        "dict",
+        "list",
+        "tuple",
+        "set",
+        "frozenset",
+        "int",
+        "float",
+        "str",
+        "bool",
+        "bytes",
+        "complex",
+        "slice",
+        "range",
+        "type",
+    }
+)
+
+
+class SnapshotUnpicklingError(pickle.UnpicklingError):
+    """Raised when a snapshot pickle references a class outside the allowlist."""
+
+
+class _SnapshotRestrictedUnpickler(pickle.Unpickler):
+    """Unpickler used to restore Python RNG state from HDF5 snapshots.
+
+    Overrides ``find_class`` to fail closed on anything outside the
+    allowlists above. This is the last line of defense for snapshot
+    integrity: even a legitimately-signed snapshot file must still pass
+    this check, so a compromised signing key or a file swapped on disk
+    cannot escalate to arbitrary code execution.
+    """
+
+    def find_class(self, module: str, name: str):  # type: ignore[override]
+        if module in _SNAPSHOT_UNPICKLER_ALLOWED_MODULES:
+            return super().find_class(module, name)
+        if module == "builtins" and name in _SNAPSHOT_UNPICKLER_ALLOWED_BUILTINS:
+            return super().find_class(module, name)
+        raise SnapshotUnpicklingError(f"Blocked unpickling of {module}.{name} — not in snapshot allowlist")
+
+
+def _snapshot_restricted_loads(data: bytes):
+    """Run ``pickle.loads`` equivalent against ``_SnapshotRestrictedUnpickler``."""
+    return _SnapshotRestrictedUnpickler(io.BytesIO(data)).load()
+
+
+import h5py
+import numpy as np
+import torch
+
+# Add parent directories for imports
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from cascor_constants.constants_hdf5.constants_hdf5 import _HDF5_FORMAT_NAME_CURRENT, _HDF5_FORMAT_NAME_LEGACY
+from log_config.logger.logger import Logger
+from utils.activation import ActivationWithDerivative
+
+from .snapshot_common import calculate_tensor_checksum, load_numpy_array, load_tensor, read_str_attr, read_str_dataset, save_numpy_array, save_tensor, verify_tensor_checksum, write_str_attr, write_str_dataset
+from .snapshot_errors import SnapshotSaveError
+
+
+class CascadeHDF5Serializer:
+    """
+    Comprehensive HDF5 serialization system for CascadeCorrelationNetwork objects.
+
+    Captures complete state including:
+    - Network architecture and weights
+    - Training history and statistics
+    - Configuration parameters
+    - Multiprocessing state
+    - Hidden units and candidate pools
+
+    Format Version: 2.0
+    """
+
+    def __init__(self, logger: Logger = None):
+        """Initialize the HDF5 serializer."""
+        self.logger = logger or Logger
+        self.version = "2.0.0"
+        self.format_version = "2"
+        self.format_name = _HDF5_FORMAT_NAME_CURRENT
+
+    def save_network(
+        self,
+        network,
+        filepath: Union[str, Path],
+        include_training_state: bool = False,
+        include_training_data: bool = False,
+        compression: str = "gzip",
+        compression_opts: int = 4,
+    ) -> bool:
+        """
+        Save a CascadeCorrelationNetwork to HDF5 format.
+
+        Args:
+            network: CascadeCorrelationNetwork instance to serialize
+            filepath: Target file path for HDF5 file
+            include_training_state: Whether to include training history
+            include_training_data: Whether to include training datasets (excluded by default)
+            compression: HDF5 compression method
+            compression_opts: Compression level (0-9)
+
+        Returns:
+            bool: True on success.
+
+        Raises:
+            SnapshotSaveError: when the write fails, chaining the underlying
+                exception so callers can surface the real reason (C1 / I-3 —
+                pre-C1 every failure was swallowed into ``False`` and a failed
+                save was indistinguishable from a missing network at the API
+                route). Callers that want bool semantics catch it.
+        """
+        try:
+            self.logger.info(f"CascadeHDF5Serializer: Saving network to {filepath}")
+
+            # Ensure directory exists
+            Path(filepath).parent.mkdir(parents=True, exist_ok=True)
+
+            with h5py.File(filepath, "w") as hdf5_file:
+                self._save_network_objects_helper(hdf5_file, network, compression, compression_opts)
+                # Save training history if requested
+                if include_training_state:
+                    self._save_training_history(hdf5_file, network, compression, compression_opts)
+
+                # Save training data if explicitly requested (normally excluded)
+                if include_training_data:
+                    self._save_training_data(hdf5_file, network, compression, compression_opts)
+
+            self.logger.info(f"CascadeHDF5Serializer: Successfully saved network to {filepath}")
+            return True
+
+        except Exception as e:
+            # C1 (I-3): keep the ERROR + stacktrace logging, then raise a typed
+            # error carrying the reason instead of collapsing to ``False`` — a
+            # failed save must not be indistinguishable from "no network".
+            self._log_exception_stacktrace("CascadeHDF5Serializer: Error saving network: ", e, False)
+            raise SnapshotSaveError(f"{type(e).__name__}: {e}") from e
+
+    def save_object(
+        self,
+        # objectify: any = None,
+        objectify: Any = None,
+        filepath: str = "./snapshots/object.h5",
+        compression: str = "gzip",
+        compression_opts: int = 4,
+    ) -> bool:
+        """
+        Save a generic object to HDF5 format.
+        Args:
+            objectify: Object to serialize (should have similar interface to CascadeCorrelationNetwork)
+            filepath: Target file path for HDF5 file
+            compression: HDF5 compression method
+            compression_opts: Compression level (0-9)
+        Returns:
+            bool: Success status
+        """
+        try:
+            self.logger.info(f"CascadeHDF5Serializer: Saving object to {filepath}")
+
+            # Ensure directory exists
+            Path(filepath).parent.mkdir(parents=True, exist_ok=True)
+
+            with h5py.File(filepath, "w") as hdf5_file:
+                # CASCOR-P0-004 FIX: Changed from _save_root_attributes (wrong arg count) to _save_network_objects_helper
+                # OLD (TypeError - 4 args passed to 2-arg method):
+                # self._save_root_attributes(hdf5_file, objectify, compression, compression_opts)
+                self._save_network_objects_helper(hdf5_file, objectify, compression, compression_opts)
+            self.logger.info(f"CascadeHDF5Serializer: Successfully saved object to {filepath}")
+            return True
+
+        except Exception as e:
+            return self._log_exception_stacktrace("CascadeHDF5Serializer: Error saving object: ", e, False)
+
+    def _save_root_attributes(self, hdf5_file: h5py.File, network) -> None:
+        """Save root-level file attributes."""
+        write_str_attr(hdf5_file, "format", self.format_name)
+        write_str_attr(hdf5_file, "format_version", self.format_version)
+        write_str_attr(hdf5_file, "serializer_version", self.version)
+        write_str_attr(hdf5_file, "created", datetime.datetime.now().isoformat())
+        # BUG-CC-04: read juniper-cascor version at runtime from package metadata.
+        try:
+            import importlib.metadata as _ilmd
+
+            _juniper_version = _ilmd.version("juniper-cascor")
+        except Exception:
+            _juniper_version = "0.0.0-dev"
+        write_str_attr(hdf5_file, "juniper_version", _juniper_version)
+        self.logger.debug("CascadeHDF5Serializer: _save_root_attributes: Saved root attributes")
+
+    def _save_metadata(self, hdf5_file: h5py.File, network) -> None:
+        """Save metadata information."""
+        meta_group = hdf5_file.create_group("meta")
+
+        # Object metadata
+        write_str_attr(meta_group, "uuid", str(network.get_uuid()))
+        write_str_attr(meta_group, "creation_timestamp", datetime.datetime.now().isoformat())
+
+        # Training state counters for resuming training
+        meta_group.attrs["snapshot_counter"] = getattr(network, "snapshot_counter", 0)
+        meta_group.attrs["current_epoch"] = getattr(network, "current_epoch", 0)
+        meta_group.attrs["patience_counter"] = getattr(network, "patience_counter", 0)
+        meta_group.attrs["best_value_loss"] = getattr(network, "best_value_loss", float("inf"))
+
+        # Environment metadata
+        write_str_attr(meta_group, "python_version", sys.version)
+        write_str_attr(meta_group, "torch_version", torch.__version__)
+        write_str_attr(meta_group, "h5py_version", h5py.__version__)
+        self.logger.debug("CascadeHDF5Serializer: _save_metadata: Saved metadata with training counters")
+
+    def _save_network_objects_helper(self, hdf5_file, arg1, compression, compression_opts):
+        self._save_root_attributes(hdf5_file, arg1)
+        self._save_metadata(hdf5_file, arg1)
+        self._save_configuration(hdf5_file, arg1, compression, compression_opts)
+        self._save_architecture(hdf5_file, arg1)
+        self._save_parameters(hdf5_file, arg1, compression, compression_opts)
+        self._save_hidden_units(hdf5_file, arg1, compression, compression_opts)
+        self._save_random_state(hdf5_file, arg1, compression, compression_opts)
+        self._save_multiprocessing_state(hdf5_file, arg1)
+
+    def verify_saved_network(self, filepath: Union[str, Path]) -> Dict[str, Any]:
+        """
+        Verify a saved network file and return summary information.
+
+        Args:
+            filepath: Path to HDF5 file to verify
+
+        Returns:
+            Dictionary with verification results and network summary
+        """
+        try:
+            with h5py.File(filepath, "r") as hdf5_file:
+                if not self._validate_format(hdf5_file):
+                    return {"valid": False, "error": "Invalid format"}
+
+                # Extract summary information
+                summary = {
+                    "valid": True,
+                    "format": read_str_attr(hdf5_file, "format", "unknown"),
+                    "format_version": read_str_attr(hdf5_file, "format_version", "unknown"),
+                    "serializer_version": read_str_attr(hdf5_file, "serializer_version", "unknown"),
+                    "created": read_str_attr(hdf5_file, "created", "unknown"),
+                    "file_size": os.path.getsize(filepath),
+                }
+
+                # Get metadata if available
+                if "meta" in hdf5_file:
+                    meta_group = hdf5_file["meta"]
+                    summary["network_uuid"] = read_str_attr(meta_group, "uuid", "unknown")
+                    summary["python_version"] = read_str_attr(meta_group, "python_version", "unknown")
+                    summary["torch_version"] = read_str_attr(meta_group, "torch_version", "unknown")
+
+                # Get architecture if available
+                if "arch" in hdf5_file:
+                    arch_group = hdf5_file["arch"]
+                    summary["input_size"] = arch_group.attrs.get("input_size", 0)
+                    summary["output_size"] = arch_group.attrs.get("output_size", 0)
+                    summary["num_hidden_units"] = arch_group.attrs.get("num_hidden_units", 0)
+                    summary["activation_function"] = read_str_attr(arch_group, "activation_function_name", "unknown")
+
+                # Check for optional sections
+                optional_sections = ["history", "mp", "data"]
+                for section in optional_sections:
+                    summary[f"has_{section}"] = section in hdf5_file
+
+                return summary
+
+        except Exception as e:
+            return {"valid": False, "error": str(e)}
+
+    # CASCOR-P0-004 FIX: Removed duplicate _save_root_attributes and _save_metadata definitions
+    # that existed here (lines 236-270). The canonical definitions are at lines 147-174.
+    # Python would silently use these later definitions, making the earlier ones dead code.
+
+    def _save_configuration(
+        self,
+        hdf5_file: h5py.File,
+        network,
+        compression: str,
+        compression_opts: int,
+    ) -> None:
+        """Save configuration parameters."""
+        config_group = hdf5_file.create_group("config")
+
+        # Serialize config object to JSON
+        config_dict = self._config_to_dict(network.config)
+        config_json = json.dumps(config_dict, indent=2, default=str)
+
+        # Save as UTF-8 string dataset
+        write_str_dataset(
+            config_group,
+            "config_json",
+            config_json,
+            compression=compression,
+            compression_opts=compression_opts,
+        )
+
+        # Save key parameters as attributes for quick access
+        write_str_attr(config_group, "activation_function_name", network.activation_function_name)
+        config_group.attrs["input_size"] = network.input_size
+        config_group.attrs["output_size"] = network.output_size
+        config_group.attrs["learning_rate"] = network.learning_rate
+        config_group.attrs["candidate_learning_rate"] = network.candidate_learning_rate
+        config_group.attrs["max_hidden_units"] = network.max_hidden_units
+        config_group.attrs["correlation_threshold"] = network.correlation_threshold
+        config_group.attrs["candidate_pool_size"] = network.candidate_pool_size
+        config_group.attrs["patience"] = network.patience
+        config_group.attrs["random_seed"] = network.random_seed
+
+        # CAN-014 (Phase 6E Sprint A-5): persist the runtime-tunable training
+        # params that ``update_params``' whitelist exposes so a snapshot
+        # restore brings back the values the operator actually trained with.
+        # Without this, ``epochs_max`` / ``max_iterations`` / etc. silently
+        # revert to construction-time defaults on restore — defeating the
+        # whole point of the wire-throughs in PRs #157, #158, #162. Each
+        # field is read with ``getattr(..., default)`` so older networks
+        # (or a partially-initialized network from a corner case) still
+        # serialize cleanly. The load path mirrors the same ``getattr``
+        # pattern in ``_load_config_to_network``.
+        config_group.attrs["epochs_max"] = getattr(network, "epochs_max", 0)
+        config_group.attrs["max_iterations"] = getattr(network, "max_iterations", 0)
+        config_group.attrs["output_epochs"] = getattr(network, "output_epochs", 0)
+        config_group.attrs["candidate_patience"] = getattr(network, "candidate_patience", 0)
+        config_group.attrs["candidate_epochs"] = getattr(network, "candidate_epochs", 0)
+        config_group.attrs["convergence_threshold"] = getattr(network, "convergence_threshold", 0.0)
+        config_group.attrs["candidate_convergence_threshold"] = getattr(network, "candidate_convergence_threshold", 0.0)
+        write_str_attr(config_group, "init_output_weights", getattr(network, "init_output_weights", "zero"))
+
+        self.logger.debug("CascadeHDF5Serializer: Saved configuration")
+
+    def _save_architecture(self, hdf5_file: h5py.File, network) -> None:
+        """Save network architecture information."""
+        arch_group = hdf5_file.create_group("arch")
+
+        # Basic architecture parameters
+        arch_group.attrs["input_size"] = network.input_size
+        arch_group.attrs["output_size"] = network.output_size
+        arch_group.attrs["num_hidden_units"] = len(network.hidden_units)
+        arch_group.attrs["max_hidden_units"] = network.max_hidden_units
+        write_str_attr(arch_group, "activation_function_name", network.activation_function_name)
+
+        # Save connectivity information if needed
+        connectivity_group = arch_group.create_group("connectivity")
+        connectivity_group.attrs["input_to_output_connections"] = network.input_size * network.output_size
+
+        # Hidden unit connectivity
+        for i, unit in enumerate(network.hidden_units):
+            unit_info = connectivity_group.create_group(f"hidden_unit_{i}")
+            unit_info.attrs["input_connections"] = len(unit["weights"]) if "weights" in unit else 0
+            if "activation_fn" in unit:
+                write_str_attr(
+                    unit_info,
+                    "activation_function",
+                    getattr(unit["activation_fn"], "__name__", "unknown"),
+                )
+
+        self.logger.debug("CascadeHDF5Serializer: Saved architecture")
+
+    def _save_parameters(
+        self,
+        hdf5_file: h5py.File,
+        network,
+        compression: str,
+        compression_opts: int,
+    ) -> None:
+        """Save model weights and biases."""
+        params_group = hdf5_file.create_group("params")
+
+        # Save output layer parameters
+        output_group = params_group.create_group("output_layer")
+
+        if hasattr(network, "output_weights") and network.output_weights is not None:
+            save_tensor(
+                output_group,
+                "weights",
+                network.output_weights,
+                compression,
+                compression_opts,
+            )
+
+        if hasattr(network, "output_bias") and network.output_bias is not None:
+            save_tensor(output_group, "bias", network.output_bias, compression, compression_opts)
+
+        # Calculate and save checksums
+        checksum_data = {}
+        if hasattr(network, "output_weights") and network.output_weights is not None:
+            checksum_data["output_weights"] = calculate_tensor_checksum(network.output_weights)
+        if hasattr(network, "output_bias") and network.output_bias is not None:
+            checksum_data["output_bias"] = calculate_tensor_checksum(network.output_bias)
+
+        if checksum_data:
+            write_str_dataset(output_group, "checksums", json.dumps(checksum_data))
+            self.logger.debug("CascadeHDF5Serializer: Saved parameter checksums")
+
+        # Save optimizer state if it exists
+        if hasattr(network, "output_optimizer") and network.output_optimizer is not None:
+            opt_group = output_group.create_group("optimizer")
+            try:
+                self._save_network_parameters_to_hdf5_helper(network, opt_group)
+            except Exception as e:
+                self.logger.warning(f"CascadeHDF5Serializer: Could not save optimizer state: {e}")
+
+        self.logger.debug("CascadeHDF5Serializer: Saved parameters")
+
+    def _save_network_parameters_to_hdf5_helper(self, network, opt_group):
+        opt_state = network.output_optimizer.state_dict()
+        # Convert optimizer state to JSON-serializable format
+        opt_state_serializable = {
+            "state": {str(k): {inner_k: (inner_v.tolist() if hasattr(inner_v, "tolist") else inner_v) for inner_k, inner_v in v.items()} for k, v in opt_state.get("state", {}).items()},
+            "param_groups": opt_state.get("param_groups", []),
+        }
+        write_str_dataset(opt_group, "state_dict", json.dumps(opt_state_serializable))
+        write_str_attr(opt_group, "optimizer_type", type(network.output_optimizer).__name__)
+        write_str_attr(opt_group, "learning_rate", network.learning_rate)
+        self.logger.debug("CascadeHDF5Serializer: Saved optimizer state")
+
+    def _save_hidden_units(self, hdf5_file: h5py.File, network, compression: str, compression_opts: int) -> None:
+        """Save hidden units with integrity checksums."""
+        if not network.hidden_units:
+            return
+
+        hidden_group = hdf5_file.create_group("hidden_units")
+        hidden_group.attrs["num_units"] = len(network.hidden_units)
+
+        for i, unit in enumerate(network.hidden_units):
+            unit_group = hidden_group.create_group(f"unit_{i}")
+
+            # Save weights and bias
+            if "weights" in unit:
+                save_tensor(
+                    unit_group,
+                    "weights",
+                    unit["weights"],
+                    compression,
+                    compression_opts,
+                )
+            if "bias" in unit:
+                save_tensor(unit_group, "bias", unit["bias"], compression, compression_opts)
+
+            # Calculate and save checksums for integrity verification
+            checksum_data = {}
+            if "weights" in unit:
+                checksum_data["weights"] = calculate_tensor_checksum(unit["weights"])
+            if "bias" in unit:
+                checksum_data["bias"] = calculate_tensor_checksum(unit["bias"])
+            if checksum_data:
+                write_str_dataset(unit_group, "checksums", json.dumps(checksum_data))
+
+            # Save correlation
+            if "correlation" in unit:
+                unit_group.attrs["correlation"] = float(unit["correlation"])
+
+            # Save activation function name (per unit, in case they differ)
+            if "activation_fn" in unit:
+                af_name = getattr(unit["activation_fn"], "_activation_name", network.activation_function_name)
+                write_str_attr(unit_group, "activation_function_name", af_name)
+            else:
+                write_str_attr(
+                    unit_group,
+                    "activation_function_name",
+                    network.activation_function_name,
+                )
+
+        self.logger.debug(f"CascadeHDF5Serializer: Saved {len(network.hidden_units)} hidden units with checksums")
+
+    def _save_random_state(self, hdf5_file: h5py.File, network, compression: str, compression_opts: int) -> None:
+        """Save random state for deterministic reproducibility."""
+        random_group = hdf5_file.create_group("random")
+
+        # Save random parameters
+        random_group.attrs["seed"] = getattr(network, "random_seed", 0)
+        random_group.attrs["max_value"] = getattr(network, "random_max_value", 1000000)
+        random_group.attrs["sequence_max_value"] = getattr(network, "sequence_max_value", 1000000)
+        random_group.attrs["value_scale"] = getattr(network, "random_value_scale", 0.1)
+
+        # Save RNG states
+        try:
+            # Python random state (for candidate seeding, etc.)
+            python_state = random.getstate()
+            python_state_bytes = pickle.dumps(python_state)
+            # Save as fixed-length byte array (not variable-length)
+            python_state_array = np.frombuffer(python_state_bytes, dtype=np.uint8)
+            save_numpy_array(
+                random_group,
+                "python_state",
+                python_state_array,
+                compression,
+                compression_opts,
+            )
+
+            # NumPy random state
+            np_state = np.random.get_state()
+            np_group = random_group.create_group("numpy_state")
+            write_str_attr(np_group, "state_type", np_state[0])
+            save_numpy_array(np_group, "state_array", np_state[1], compression, compression_opts)
+            np_group.attrs["pos"] = np_state[2]
+            np_group.attrs["has_gauss"] = np_state[3]
+            np_group.attrs["cached_gaussian"] = np_state[4]
+
+            # PyTorch random state
+            torch_state = torch.get_rng_state()
+            save_numpy_array(
+                random_group,
+                "torch_state",
+                torch_state.numpy(),
+                compression,
+                compression_opts,
+            )
+
+            # CUDA random state if available
+            if torch.cuda.is_available():
+                try:
+                    cuda_states = torch.cuda.get_rng_state_all()
+                    cuda_group = random_group.create_group("cuda_states")
+                    for i, state in enumerate(cuda_states):
+                        save_numpy_array(
+                            cuda_group,
+                            f"device_{i}",
+                            state.cpu().numpy(),
+                            compression,
+                            compression_opts,
+                        )
+
+                except Exception as e:
+                    self.logger.warning(f"Could not save CUDA random states: {e}")
+
+            self.logger.debug("CascadeHDF5Serializer: Saved all random states (Python, NumPy, PyTorch, CUDA)")
+
+        except Exception as e:
+            self.logger.warning(f"Could not save random states: {e}")
+
+        self.logger.debug("CascadeHDF5Serializer: Saved random state")
+
+    def _save_multiprocessing_state(self, hdf5_file: h5py.File, network) -> None:
+        """Save multiprocessing configuration for restoration."""
+        mp_group = hdf5_file.create_group("mp")
+
+        # Save MP configuration (not live objects)
+        try:
+            self._save_cascor_network_state_to_hdf5_helper(network, mp_group)
+        except Exception as e:
+            self.logger.warning(f"Could not save multiprocessing state: {e}")
+
+        self.logger.debug("CascadeHDF5Serializer: Saved multiprocessing state")
+
+    def _save_cascor_network_state_to_hdf5_helper(self, network, mp_group):
+        # Determine role (server/client/none)
+        role = "none"  # Default
+        if hasattr(network, "candidate_training_manager") and network.candidate_training_manager:
+            role = "server"
+        elif hasattr(network, "candidate_training_queue_address") and network.candidate_training_queue_address:
+            role = "client"
+
+        write_str_attr(mp_group, "role", role)
+
+        # Save multiprocessing context information
+        if hasattr(network, "candidate_training_context"):
+            ctx = network.candidate_training_context
+            write_str_attr(mp_group, "start_method", ctx.get_start_method() if ctx else "spawn")
+        else:
+            write_str_attr(mp_group, "start_method", "spawn")
+
+        # Save address and authentication
+        if hasattr(network, "candidate_training_queue_address"):
+            addr = network.candidate_training_queue_address
+            if isinstance(addr, (list, tuple)) and len(addr) >= 2:
+                write_str_attr(mp_group, "address_host", str(addr[0]))
+                mp_group.attrs["address_port"] = int(addr[1])
+            else:
+                write_str_attr(mp_group, "address_host", "127.0.0.1")
+                mp_group.attrs["address_port"] = 0
+        else:
+            write_str_attr(mp_group, "address_host", "127.0.0.1")
+            mp_group.attrs["address_port"] = 0
+
+        if hasattr(network, "candidate_training_queue_authkey"):
+            authkey = network.candidate_training_queue_authkey
+            authkey_hex = authkey.hex() if isinstance(authkey, bytes) else str(authkey)
+            write_str_attr(mp_group, "authkey_hex", authkey_hex)
+
+        # Save timeouts
+        if hasattr(network, "candidate_training_tasks_queue_timeout"):
+            mp_group.attrs["tasks_queue_timeout"] = float(network.candidate_training_tasks_queue_timeout)
+        if hasattr(network, "candidate_training_shutdown_timeout"):
+            mp_group.attrs["shutdown_timeout"] = float(network.candidate_training_shutdown_timeout)
+
+        # Save queue configuration
+        queues_config = {"task_queue": "BaseManager", "result_queue": "BaseManager"}
+        write_str_dataset(mp_group, "queues_to_create", json.dumps(queues_config))
+
+        # Save policy flags
+        mp_group.attrs["autostart"] = True  # Default to autostart on restore
+
+    @staticmethod
+    def _snapshot_history_view(network) -> Dict[str, Any]:
+        """Return a shallow, point-in-time copy of the network's history dict.
+
+        C1 (I-3 write-isolation hardening): ``save_network`` can run
+        concurrently with the training thread, which appends per-epoch
+        entries to the history lists (``cascade_correlation.py`` — no lock is
+        shared with the serializer, so no manager-side lock can exclude those
+        appends). The HDF5 writes below are slow; iterating the live lists
+        risks mid-iteration mutation. Copying the top-level dict and each
+        list value is a handful of GIL-atomic operations taken up front,
+        giving every subsequent write a stable iteration target. Per-element
+        objects (floats, unit-metadata dicts, swap events) are appended
+        fully built and at most attr-backfilled afterwards, so a shallow
+        copy is sufficient to prevent crashes; deep consistency of element
+        internals is not claimed.
+        """
+        history = getattr(network, "history", None)
+        if not history:
+            return {}
+        view: Dict[str, Any] = {}
+        for key in list(history.keys()):
+            value = history.get(key)
+            view[key] = list(value) if isinstance(value, list) else value
+        return view
+
+    def _save_training_history(self, hdf5_file: h5py.File, network, compression: str, compression_opts: int) -> None:  # noqa: C901
+        """Save training history.
+
+        C1 (I-3): serializes from ``_snapshot_history_view``'s point-in-time
+        copy rather than the live history dict, so a mid-training snapshot
+        cannot crash on concurrent list mutation by the training thread.
+        """
+        history = self._snapshot_history_view(network)
+        if not history:
+            return
+
+        history_group = hdf5_file.create_group("history")
+
+        # Save numeric arrays - use network's actual keys (value_* not val_*)
+        key_mapping = {
+            "train_loss": "train_loss",
+            "value_loss": "value_loss",  # Match network history keys
+            "train_accuracy": "train_accuracy",
+            "value_accuracy": "value_accuracy",  # Match network history keys
+        }
+
+        for network_key, save_key in key_mapping.items():
+            if network_key in history and history[network_key]:
+                data = np.array(history[network_key])
+                save_numpy_array(history_group, save_key, data, compression, compression_opts)
+
+        # Save hidden units added history (metadata-only since CR-063;
+        # legacy weight/bias arrays are still handled for backward compat)
+        if "hidden_units_added" in history:
+            units_group = history_group.create_group("hidden_units_added")
+            for i, unit_data in enumerate(history["hidden_units_added"]):
+                unit_group = units_group.create_group(f"unit_{i}")
+                if isinstance(unit_data, dict):
+                    if "correlation" in unit_data:
+                        unit_group.attrs["correlation"] = float(unit_data["correlation"])
+                    # New metadata-only fields (CR-063)
+                    if "weight_shape" in unit_data:
+                        unit_group.attrs["weight_shape"] = list(unit_data["weight_shape"])
+                    if "unit_index" in unit_data:
+                        unit_group.attrs["unit_index"] = int(unit_data["unit_index"])
+                    # Legacy weight/bias arrays (kept for backward compat with old snapshots)
+                    if "weights" in unit_data:
+                        save_numpy_array(
+                            unit_group,
+                            "weights",
+                            unit_data["weights"],
+                            compression,
+                            compression_opts,
+                        )
+                    if "bias" in unit_data:
+                        save_numpy_array(
+                            unit_group,
+                            "bias",
+                            unit_data["bias"],
+                            compression,
+                            compression_opts,
+                        )
+
+        # P2-2 (Issue #3): persist live-dataset-swap events. Each event is
+        # a subgroup under ``history/dataset_swaps/`` named ``event_{i}``
+        # with the schema:
+        #   * ``timestamp``                (str attr, ISO-8601 UTC)
+        #   * ``before_cfg``               (JSON-encoded str attr; ``"null"`` for None)
+        #   * ``after_cfg``                (JSON-encoded str attr; ``"null"`` for None)
+        #   * ``arch_changes``             (JSON-encoded str attr)
+        #   * ``pre_swap_snapshot_id``     (str attr, optional — P2-3 backfill)
+        #   * ``post_swap_snapshot_id``    (str attr, optional — P2-3 backfill)
+        # Nested dicts go through JSON because HDF5 attrs are flat and the
+        # ``arch_changes`` block has variable shape (``appended_nodes`` is
+        # itself a dict). Missing snapshot-ID attrs decode back to None on
+        # load so the §3.9 schema is faithfully reproduced.
+        if "dataset_swaps" in history and history["dataset_swaps"]:
+            swaps_group = history_group.create_group("dataset_swaps")
+            for i, swap_event in enumerate(history["dataset_swaps"]):
+                if not isinstance(swap_event, dict):
+                    continue
+                ev_group = swaps_group.create_group(f"event_{i}")
+                if "timestamp" in swap_event and swap_event["timestamp"] is not None:
+                    ev_group.attrs["timestamp"] = str(swap_event["timestamp"])
+                ev_group.attrs["before_cfg"] = json.dumps(swap_event.get("before_cfg"))
+                ev_group.attrs["after_cfg"] = json.dumps(swap_event.get("after_cfg"))
+                ev_group.attrs["arch_changes"] = json.dumps(swap_event.get("arch_changes", {}))
+                if swap_event.get("pre_swap_snapshot_id") is not None:
+                    ev_group.attrs["pre_swap_snapshot_id"] = str(swap_event["pre_swap_snapshot_id"])
+                if swap_event.get("post_swap_snapshot_id") is not None:
+                    ev_group.attrs["post_swap_snapshot_id"] = str(swap_event["post_swap_snapshot_id"])
+
+        # CAN-015g (Phase 6E follow-on, g-1): per-sample weight history
+        # for Replay V2. Persisted only when the network exposes a
+        # ``weight_history`` dict (populated by the lifecycle in g-2);
+        # absence is the V1 / pre-g case and silently skipped so all
+        # existing snapshots and the metric-only Replay V1 path keep
+        # working unchanged.
+        if hasattr(network, "weight_history") and network.weight_history:
+            self._save_weight_history(history_group, network.weight_history, compression, compression_opts)
+
+        self.logger.debug("CascadeHDF5Serializer: Saved training history")
+
+    # ------------------------------------------------------------------
+    # CAN-015g (Phase 6E follow-on): per-sample weight history
+    # ------------------------------------------------------------------
+    # Schema v2 layout under ``history/weights/``:
+    #   meta/                               (subgroup, attrs only)
+    #     schema_version       (int64 attr) — always 2 for this writer
+    #     sampling_strategy    (str attr)   — "adaptive" | "every_n" | "trigger"
+    #     sampling_interval    (int64 attr) — N (epochs); 0 == trigger-only
+    #     num_samples          (int64 attr) — len(sample_indices)
+    #   sample_indices         (int64 dataset, [num_samples])
+    #   output_weights/                     (subgroup of per-sample datasets)
+    #     0000  (float32 dataset, [in + hid_at_sample_0, out])
+    #     0001  (float32 dataset, [in + hid_at_sample_1, out])
+    #     ...
+    #   output_bias/                        (subgroup of per-sample datasets)
+    #     0000  (float32 dataset, [out])
+    #     ...
+    #   hidden_units/
+    #     0000/                             (one subgroup per unit)
+    #       first_sample_index (int64 attr)
+    #       activation         (str attr)
+    #       weights/                        (subgroup of per-sample datasets)
+    #         0050  (float32 dataset, [in + cascade_index])
+    #         ...
+    #       bias/                           (subgroup of per-sample datasets)
+    #         0050  (float32 dataset, [])   — scalar
+    #         ...
+    #
+    # Per-sample subgroups are used (rather than a single 3D dataset) because
+    # the output-layer width grows with each cascade-add event — there is no
+    # single fixed shape. The numeric subgroup names are zero-padded so they
+    # sort lexicographically (HDF5 returns keys in insertion order, but the
+    # readers tolerate either).
+
+    _WEIGHT_HISTORY_SCHEMA_VERSION = 2
+
+    def _save_weight_history(self, history_group: h5py.Group, weight_history: Dict[str, Any], compression: str, compression_opts: int) -> None:
+        """Persist per-sample weight tensors under ``history/weights/``."""
+        weights_group = history_group.create_group("weights")
+        meta_group = weights_group.create_group("meta")
+
+        sample_indices = list(weight_history.get("sample_indices", []))
+        meta_group.attrs["schema_version"] = self._WEIGHT_HISTORY_SCHEMA_VERSION
+        meta_group.attrs["num_samples"] = len(sample_indices)
+        write_str_attr(meta_group, "sampling_strategy", str(weight_history.get("sampling_strategy", "adaptive")))
+        meta_group.attrs["sampling_interval"] = int(weight_history.get("sampling_interval", 0))
+
+        if not sample_indices:
+            self.logger.debug("CascadeHDF5Serializer: weight_history has no samples — wrote meta only")
+            return
+
+        save_numpy_array(weights_group, "sample_indices", np.asarray(sample_indices, dtype=np.int64), compression, compression_opts)
+
+        output_weights = list(weight_history.get("output_weights", []))
+        output_bias = list(weight_history.get("output_bias", []))
+        if len(output_weights) != len(sample_indices) or len(output_bias) != len(sample_indices):
+            raise ValueError(f"weight_history output arrays length mismatch: got {len(output_weights)} weights, {len(output_bias)} biases for {len(sample_indices)} samples")
+
+        ow_group = weights_group.create_group("output_weights")
+        ob_group = weights_group.create_group("output_bias")
+        for i, (w, b) in enumerate(zip(output_weights, output_bias)):
+            sample_key = f"{i:04d}"
+            save_numpy_array(ow_group, sample_key, np.ascontiguousarray(w, dtype=np.float32), compression, compression_opts)
+            save_numpy_array(ob_group, sample_key, np.ascontiguousarray(b, dtype=np.float32), compression, compression_opts)
+
+        hidden_units = list(weight_history.get("hidden_units", []))
+        if hidden_units:
+            units_group = weights_group.create_group("hidden_units")
+            for unit_idx, unit in enumerate(hidden_units):
+                unit_group = units_group.create_group(f"{unit_idx:04d}")
+                unit_group.attrs["first_sample_index"] = int(unit.get("first_sample_index", 0))
+                write_str_attr(unit_group, "activation", str(unit.get("activation", "")))
+                unit_w = unit.get("weights", [])
+                unit_b = unit.get("bias", [])
+                if len(unit_w) != len(unit_b):
+                    raise ValueError(f"weight_history hidden unit {unit_idx} weights/bias length mismatch: {len(unit_w)} vs {len(unit_b)}")
+                w_group = unit_group.create_group("weights")
+                b_group = unit_group.create_group("bias")
+                for j, (w, b) in enumerate(zip(unit_w, unit_b)):
+                    sample_key = f"{j:04d}"
+                    save_numpy_array(w_group, sample_key, np.ascontiguousarray(w, dtype=np.float32), compression, compression_opts)
+                    save_numpy_array(b_group, sample_key, np.asarray(b, dtype=np.float32), compression, compression_opts)
+
+        self.logger.debug(f"CascadeHDF5Serializer: Saved weight_history with {len(sample_indices)} samples, {len(hidden_units)} hidden units")
+
+    def _save_training_data(
+        self,
+        hdf5_file: h5py.File,
+        network,
+        compression: str,
+        compression_opts: int,
+    ) -> None:
+        """Save training data (normally excluded)."""
+        if not hasattr(network, "_training_data"):
+            return
+
+        data_group = hdf5_file.create_group("data")
+
+        # Save training datasets if present
+        training_data = network._training_data
+        if isinstance(training_data, dict):
+            for key, dataset in training_data.items():
+                if hasattr(dataset, "numpy"):  # PyTorch tensor
+                    save_tensor(data_group, key, dataset, compression, compression_opts)
+                elif isinstance(dataset, np.ndarray):
+                    save_numpy_array(data_group, key, dataset, compression, compression_opts)
+        self.logger.debug("CascadeHDF5Serializer: Saved training data")
+
+    # def load_network(self, filepath: Union[str, Path], restore_multiprocessing: bool = True) -> Optional:  # Original - invalid Optional usage
+    def load_network(self, filepath: Union[str, Path], restore_multiprocessing: bool = True) -> Optional[Any]:
+        """
+        Load a CascadeCorrelationNetwork from HDF5 format.
+
+        Args:
+            filepath: Path to HDF5 file
+            restore_multiprocessing: Whether to restore multiprocessing state
+
+        Returns:
+            CascadeCorrelationNetwork instance or None if failed
+        """
+        try:
+            self.logger.info(f"CascadeHDF5Serializer: Loading network from {filepath}")
+            if not os.path.exists(filepath):
+                self.logger.error(f"CascadeHDF5Serializer: File not found: {filepath}")
+                return None
+            with h5py.File(filepath, "r") as hdf5_file:
+                if not self._validate_format(hdf5_file):
+                    return None
+                network = self._create_network_from_file(hdf5_file)
+                if not network:
+                    return None
+                self._load_architecture(hdf5_file, network)
+                # CAN-014 (Phase 6E Sprint A-5): restore the runtime-tunable
+                # training params persisted in the ``config`` group so the
+                # rehydrated network actually reflects the values the
+                # operator trained with — not just construction-time
+                # defaults from CascadeCorrelationConfig.
+                self._load_config_to_network(hdf5_file, network)
+                self._load_parameters(hdf5_file, network)
+                self._load_hidden_units(hdf5_file, network)
+                self._load_random_state(hdf5_file, network)
+                if "history" in hdf5_file:
+                    self._load_training_history(hdf5_file, network)
+                if restore_multiprocessing and "mp" in hdf5_file:
+                    self._restore_multiprocessing_state(hdf5_file, network)
+                if not self._validate_shapes(network):
+                    self.logger.warning("CascadeHDF5Serializer: Network loaded but shape validation found issues")
+            self.logger.info(f"CascadeHDF5Serializer: Successfully loaded network from {filepath}")
+            return network
+        except Exception as e:
+            return self._log_exception_stacktrace("CascadeHDF5Serializer: Error loading network: ", e, None)
+
+    def _load_architecture(self, hdf5_file: h5py.File, network) -> None:
+        """Load network architecture."""
+        if "arch" not in hdf5_file:
+            return
+
+        arch_group = hdf5_file["arch"]
+
+        # Verify architecture matches
+        saved_input_size = arch_group.attrs.get("input_size", network.input_size)
+        saved_output_size = arch_group.attrs.get("output_size", network.output_size)
+
+        if saved_input_size != network.input_size:
+            self.logger.warning(f"Input size mismatch: {saved_input_size} != {network.input_size}")
+
+        if saved_output_size != network.output_size:
+            self.logger.warning(f"Output size mismatch: {saved_output_size} != {network.output_size}")
+
+        # Load activation function name
+        af_name = read_str_attr(arch_group, "activation_function_name", network.activation_function_name)
+        network.activation_function_name = af_name
+
+        # Reinitialize activation function with the loaded name--ensures activation_fn and activation_functions_dict are properly set
+        network._init_activation_function()
+
+        self.logger.debug(f"CascadeHDF5Serializer: Loaded architecture with activation function: {af_name}")
+
+    def _load_config_to_network(self, hdf5_file: h5py.File, network) -> None:
+        """CAN-014 (Phase 6E Sprint A-5): restore runtime-tunable params
+        from the ``config`` HDF5 group onto the live network.
+
+        ``_save_configuration`` persists every field listed in
+        ``update_params``' whitelist. This method restores them, mirrored
+        as direct attributes on ``network`` so subsequent
+        ``get_training_params`` reflects the snapshot rather than
+        whatever ``CascadeCorrelationConfig`` defaults the constructor
+        used.
+
+        Each load is gated on ``is_attr`` so older snapshots that
+        pre-date a given field still load cleanly — the missing field
+        simply falls back to whatever the freshly-constructed network
+        already has. The list of fields here matches
+        ``_save_configuration`` exactly; keep them in sync when adding
+        new tunables.
+        """
+        if "config" not in hdf5_file:
+            return
+        config_group = hdf5_file["config"]
+
+        # Numeric attributes — straight setattr, but only when the field
+        # was actually persisted (older snapshots may be missing some).
+        for key in (
+            "learning_rate",
+            "candidate_learning_rate",
+            "max_hidden_units",
+            "correlation_threshold",
+            "candidate_pool_size",
+            "patience",
+            "epochs_max",
+            "max_iterations",
+            "output_epochs",
+            "candidate_patience",
+            "candidate_epochs",
+            "convergence_threshold",
+            "candidate_convergence_threshold",
+        ):
+            if key in config_group.attrs:
+                value = config_group.attrs[key]
+                # ``getattr`` rather than ``hasattr`` so a freshly-loaded
+                # network missing the attribute still picks up the value
+                # — none of cascor's tunables are read-only properties.
+                setattr(network, key, value)
+
+        # String attribute — ``init_output_weights`` round-trip.
+        if "init_output_weights" in config_group.attrs:
+            value = read_str_attr(config_group, "init_output_weights", getattr(network, "init_output_weights", "zero"))
+            network.init_output_weights = value
+
+        self.logger.debug("CascadeHDF5Serializer: Loaded runtime-tunable params from config group")
+
+    def _load_parameters(self, hdf5_file: h5py.File, network) -> None:
+        """Load model parameters."""
+        if "params" not in hdf5_file:
+            return
+
+        params_group = hdf5_file["params"]
+
+        # Load output layer parameters
+        if "output_layer" in params_group:
+            output_group = params_group["output_layer"]
+
+            if "weights" in output_group:
+                network.output_weights = load_tensor(output_group["weights"])
+
+            if "bias" in output_group:
+                network.output_bias = load_tensor(output_group["bias"])
+
+            # Verify checksums if they exist
+            if "checksums" in output_group:
+                try:
+                    checksums_json = read_str_dataset(output_group, "checksums")
+                    checksums = json.loads(checksums_json)
+
+                    if "output_weights" in checksums and hasattr(network, "output_weights"):
+                        if not verify_tensor_checksum(network.output_weights, checksums["output_weights"]):
+                            self.logger.error("CascadeHDF5Serializer: Output weights checksum verification failed!")
+                        else:
+                            self.logger.debug("CascadeHDF5Serializer: Output weights checksum verified")
+
+                    if "output_bias" in checksums and hasattr(network, "output_bias"):
+                        if not verify_tensor_checksum(network.output_bias, checksums["output_bias"]):
+                            self.logger.error("CascadeHDF5Serializer: Output bias checksum verification failed!")
+                        else:
+                            self.logger.debug("CascadeHDF5Serializer: Output bias checksum verified")
+
+                except Exception as e:
+                    self.logger.warning(f"CascadeHDF5Serializer: Could not verify checksums: {e}")
+
+            # Load optimizer state if it exists
+            if "optimizer" in output_group:
+                opt_group = output_group["optimizer"]
+                try:
+                    self._load_optimizer_state_from_hdf5_helper(opt_group, network)
+                except Exception as e:
+                    self.logger.warning(f"CascadeHDF5Serializer: Could not restore optimizer: {e}")
+                    network.output_optimizer = None
+
+        self.logger.debug("CascadeHDF5Serializer: Loaded parameters")
+
+    def _load_optimizer_state_from_hdf5_helper(self, opt_group, network):
+        import torch.optim as optim
+
+        # Get optimizer type
+        opt_type = read_str_attr(opt_group, "optimizer_type", "Adam")
+        learning_rate = opt_group.attrs.get("learning_rate", network.learning_rate)
+
+        # Create temporary output layer to get parameters for optimizer
+        input_size = network.output_weights.shape[0]
+        output_layer = torch.nn.Linear(input_size, network.output_size)
+        with torch.no_grad():
+            output_layer.weight.copy_(network.output_weights.t())
+            output_layer.bias.copy_(network.output_bias)
+
+        # Create optimizer (currently only Adam supported)
+        # TODO: Extend to support more optimizers
+        if opt_type != "Adam":
+            self.logger.warning(f"Unknown optimizer type: {opt_type}, using Adam")
+        network.output_optimizer = optim.Adam(output_layer.parameters(), lr=learning_rate)
+
+        # Load optimizer state if state_dict exists
+        if "state_dict" in opt_group:
+            opt_state_json = read_str_dataset(opt_group, "state_dict")
+            opt_state_dict = json.loads(opt_state_json)
+            # Note: State restoration is complex and may not fully restore momentum. This provides the structure but training may need a few warmup steps
+            self.logger.debug("CascadeHDF5Serializer: Loaded optimizer state")
+            self.logger.debug(f"CascadeHDF5Serializer: Note that optimizer state restoration may be incomplete: {opt_state_dict.keys()}")
+        else:
+            self.logger.debug("CascadeHDF5Serializer: Created optimizer without state dict")
+
+    def _load_hidden_units(self, hdf5_file: h5py.File, network) -> None:
+        """Load hidden units."""
+        if "hidden_units" not in hdf5_file:
+            network.hidden_units = []
+            return
+
+        hidden_group = hdf5_file["hidden_units"]
+        num_units = hidden_group.attrs.get("num_units", 0)
+
+        network.hidden_units = []
+        for i in range(num_units):
+            unit_group_name = f"unit_{i}"
+            if unit_group_name not in hidden_group:
+                continue
+
+            unit_group = hidden_group[unit_group_name]
+            unit = {}
+
+            # Load weights and bias
+            if "weights" in unit_group:
+                unit["weights"] = load_tensor(unit_group["weights"])
+            if "bias" in unit_group:
+                unit["bias"] = load_tensor(unit_group["bias"])
+
+            # Verify checksums if they exist
+            if "checksums" in unit_group:
+                try:
+                    checksums_json = read_str_dataset(unit_group, "checksums")
+                    checksums = json.loads(checksums_json)
+
+                    if "weights" in checksums and "weights" in unit:
+                        if not verify_tensor_checksum(unit["weights"], checksums["weights"]):
+                            self.logger.error(f"CascadeHDF5Serializer: Hidden unit {i} weights checksum verification failed!")
+                        else:
+                            self.logger.debug(f"CascadeHDF5Serializer: Hidden unit {i} weights checksum verified")
+
+                    if "bias" in checksums and "bias" in unit:
+                        if not verify_tensor_checksum(unit["bias"], checksums["bias"]):
+                            self.logger.error(f"CascadeHDF5Serializer: Hidden unit {i} bias checksum verification failed!")
+                        else:
+                            self.logger.debug(f"CascadeHDF5Serializer: Hidden unit {i} bias checksum verified")
+
+                except Exception as e:
+                    self.logger.warning(f"CascadeHDF5Serializer: Could not verify checksums for hidden unit {i}: {e}")
+
+            # Load correlation
+            if "correlation" in unit_group.attrs:
+                unit["correlation"] = float(unit_group.attrs["correlation"])
+
+            # Load activation function (per unit), wrapped in ActivationWithDerivative for consistency with runtime-created units
+            af_name = read_str_attr(unit_group, "activation_function_name", network.activation_function_name)
+            if hasattr(network, "activation_functions_dict") and af_name in network.activation_functions_dict:
+                unit["activation_fn"] = ActivationWithDerivative(network.activation_functions_dict[af_name])
+            else:
+                unit["activation_fn"] = ActivationWithDerivative(network.activation_fn) if not isinstance(network.activation_fn, ActivationWithDerivative) else network.activation_fn
+
+            network.hidden_units.append(unit)
+
+        self.logger.debug(f"CascadeHDF5Serializer: Loaded {num_units} hidden units")
+
+    def _load_random_state(self, hdf5_file: h5py.File, network) -> None:
+        """Load random state for deterministic reproducibility."""
+        if "random" not in hdf5_file:
+            return
+
+        random_group = hdf5_file["random"]
+
+        # Load random parameters
+        network.random_seed = random_group.attrs.get("seed", network.random_seed)
+        network.random_max_value = random_group.attrs.get("max_value", network.random_max_value)
+        network.sequence_max_value = random_group.attrs.get("sequence_max_value", network.sequence_max_value)
+        network.random_value_scale = random_group.attrs.get("value_scale", network.random_value_scale)
+
+        # Restore RNG states
+        try:
+            # Python random state
+            if "python_state" in random_group:
+                python_state_array = load_numpy_array(random_group["python_state"])
+                python_state_bytes = python_state_array.tobytes()
+                # SEC-11: route RNG-state deserialization through the
+                # restricted unpickler so even a tampered snapshot cannot
+                # escalate to arbitrary code execution. ``find_class`` is
+                # locked to the ``random``/``_random`` modules and a small
+                # set of builtin container types; anything else raises
+                # ``SnapshotUnpicklingError`` and aborts the restore.
+                python_state = _snapshot_restricted_loads(python_state_bytes)
+                random.setstate(python_state)
+                self.logger.debug("CascadeHDF5Serializer: Restored Python random state")
+
+            # NumPy random state
+            if "numpy_state" in random_group:
+                self._restore_np_random_state_helper(random_group)
+            # PyTorch random state
+            if "torch_state" in random_group:
+                torch_state_array = load_numpy_array(random_group["torch_state"])
+                torch_state = torch.from_numpy(torch_state_array).to(torch.uint8)
+                torch.set_rng_state(torch_state)
+                self.logger.debug("CascadeHDF5Serializer: Restored PyTorch random state")
+
+            # CUDA random states
+            if "cuda_states" in random_group and torch.cuda.is_available():
+                cuda_group = random_group["cuda_states"]
+                cuda_states = []
+                i = 0
+                while f"device_{i}" in cuda_group:
+                    state_array = load_numpy_array(cuda_group[f"device_{i}"])
+                    cuda_states.append(torch.from_numpy(state_array).to(torch.uint8))
+                    i += 1
+                if cuda_states:
+                    torch.cuda.set_rng_state_all(cuda_states)
+                    self.logger.debug(f"CascadeHDF5Serializer: Restored CUDA random states for {len(cuda_states)} devices")
+
+        except Exception as e:
+            self.logger.warning(f"Could not restore random states: {e}")
+            import traceback
+
+            self.logger.debug(traceback.format_exc())
+
+        self.logger.debug("CascadeHDF5Serializer: Loaded random state")
+
+    def _restore_np_random_state_helper(self, random_group):
+        np_group = random_group["numpy_state"]
+        state_type = read_str_attr(np_group, "state_type", "MT19937")
+        state_array = load_numpy_array(np_group["state_array"])
+        pos = np_group.attrs.get("pos", 0)
+        has_gauss = np_group.attrs.get("has_gauss", 0)
+        cached_gaussian = np_group.attrs.get("cached_gaussian", 0.0)
+
+        np_state = (state_type, state_array, pos, has_gauss, cached_gaussian)
+        np.random.set_state(np_state)
+        self.logger.debug("CascadeHDF5Serializer: Restored NumPy random state")
+
+    def _load_training_history(self, hdf5_file: h5py.File, network) -> None:  # noqa: C901
+        """Load training history."""
+        if "history" not in hdf5_file:
+            return
+
+        history_group = hdf5_file["history"]
+
+        # Initialize history with network's actual keys. ``dataset_swaps``
+        # is P2-2 (Issue #3) — empty list when loading a pre-P2-2 snapshot,
+        # so the network attribute stays consistent with construction-time
+        # defaults regardless of snapshot vintage.
+        network.history = {
+            "train_loss": [],
+            "value_loss": [],  # Use value_* to match network.history
+            "train_accuracy": [],
+            "value_accuracy": [],  # Use value_* to match network.history
+            "hidden_units_added": [],
+            "dataset_swaps": [],
+        }
+
+        # Load numeric arrays - handle both old (val_*) and new (value_*) key formats
+        key_mappings = [
+            ("train_loss", "train_loss"),
+            ("value_loss", "value_loss"),  # Prefer new format
+            ("val_loss", "value_loss"),  # Fallback to old format
+            ("train_accuracy", "train_accuracy"),
+            ("value_accuracy", "value_accuracy"),  # Prefer new format
+            ("val_accuracy", "value_accuracy"),  # Fallback to old format
+        ]
+
+        for save_key, network_key in key_mappings:
+            if save_key in history_group and not network.history[network_key]:
+                data = load_numpy_array(history_group[save_key])
+                network.history[network_key] = data.tolist()
+                # self.logger.debug(f"CascadeHDF5Serializer: Loaded history key '{save_key}' as '{network_key}'")  # B907
+                self.logger.debug(f"CascadeHDF5Serializer: Loaded history key {save_key!r} as {network_key!r}")
+
+        # Load hidden units history (supports both metadata-only and legacy weight/bias formats)
+        if "hidden_units_added" in history_group:
+            units_group = history_group["hidden_units_added"]
+            for unit_name in sorted(units_group.keys()):
+                unit_group = units_group[unit_name]
+                unit_data = {}
+
+                if "correlation" in unit_group.attrs:
+                    unit_data["correlation"] = float(unit_group.attrs["correlation"])
+                # New metadata-only fields (CR-063)
+                if "weight_shape" in unit_group.attrs:
+                    unit_data["weight_shape"] = tuple(unit_group.attrs["weight_shape"])
+                if "unit_index" in unit_group.attrs:
+                    unit_data["unit_index"] = int(unit_group.attrs["unit_index"])
+                # Legacy weight/bias arrays (from old snapshots)
+                if "weights" in unit_group:
+                    unit_data["weights"] = load_numpy_array(unit_group["weights"])
+                if "bias" in unit_group:
+                    unit_data["bias"] = load_numpy_array(unit_group["bias"])
+
+                network.history["hidden_units_added"].append(unit_data)
+
+        # P2-2 (Issue #3): live dataset swap event history. Decoding lives
+        # in ``_decode_dataset_swap_events_from_group`` so the P2-7 follow-up
+        # endpoint (``GET /v1/snapshots/{id}/history/dataset_swaps``) can
+        # read the same schema without instantiating a full network.
+        if "dataset_swaps" in history_group:
+            events = self._decode_dataset_swap_events_from_group(history_group["dataset_swaps"], logger=self.logger)
+            network.history["dataset_swaps"].extend(events)
+            self.logger.debug(f"CascadeHDF5Serializer: Loaded {len(events)} dataset_swap event(s)")
+
+        # CAN-015g (g-1): per-sample weight history. Loaded into a sibling
+        # ``weight_history`` attribute on the network so g-2's
+        # ``_ReplaySession`` weight cache can consume it. Absent in V1
+        # snapshots — silently no-op so V1 files load identically to
+        # before this change.
+        if "weights" in history_group:
+            try:
+                network.weight_history = self._load_weight_history(history_group["weights"])
+            except Exception as e:
+                # Don't fail the whole snapshot load if the weight history is
+                # corrupt — degrade to V1 behaviour with a WARNING. The
+                # replay session checks ``weights_available`` before using
+                # this attribute.
+                self.logger.warning(f"CascadeHDF5Serializer: Failed to load weight_history; degrading to V1 replay: {e}")
+                network.weight_history = None
+
+        self.logger.debug("CascadeHDF5Serializer: Loaded training history")
+
+    @staticmethod
+    def _decode_dataset_swap_events_from_group(swaps_group: h5py.Group, logger: Optional[Logger] = None) -> List[Dict[str, Any]]:
+        """Decode the ``history/dataset_swaps`` event subgroup into a list.
+
+        Schema and ordering match the writer in ``_save_training_history``:
+        each ``event_<N>`` carries timestamp, before_cfg / after_cfg /
+        arch_changes (JSON-encoded), and optional pre/post_swap_snapshot_id
+        attrs. Events are returned in chronological order — sorted by the
+        numeric ``<N>`` suffix, falling back to dictionary order when the
+        suffix can't be parsed.
+
+        A JSON decode error on one event degrades that event's bad field to
+        its schema default (with a warning) so a single corrupt event can't
+        kill the whole history load.
+        """
+
+        def _event_sort_key(name: str) -> int:
+            try:
+                return int(name.split("_", 1)[1])
+            except (IndexError, ValueError):
+                return -1
+
+        events: List[Dict[str, Any]] = []
+        for event_name in sorted(swaps_group.keys(), key=_event_sort_key):
+            ev_group = swaps_group[event_name]
+            event: Dict[str, Any] = {
+                "timestamp": None,
+                "before_cfg": None,
+                "after_cfg": None,
+                "arch_changes": {},
+                "pre_swap_snapshot_id": None,
+                "post_swap_snapshot_id": None,
+            }
+            if "timestamp" in ev_group.attrs:
+                event["timestamp"] = read_str_attr(ev_group, "timestamp", None)
+            for json_key, default in (("before_cfg", None), ("after_cfg", None), ("arch_changes", {})):
+                if json_key in ev_group.attrs:
+                    try:
+                        event[json_key] = json.loads(read_str_attr(ev_group, json_key, "null"))
+                    except (json.JSONDecodeError, ValueError) as exc:
+                        if logger is not None:
+                            logger.warning(f"CascadeHDF5Serializer: failed to decode {json_key!r} for {event_name!r}: {exc}; using default {default!r}")
+                        event[json_key] = default
+            if "pre_swap_snapshot_id" in ev_group.attrs:
+                event["pre_swap_snapshot_id"] = read_str_attr(ev_group, "pre_swap_snapshot_id", None)
+            if "post_swap_snapshot_id" in ev_group.attrs:
+                event["post_swap_snapshot_id"] = read_str_attr(ev_group, "post_swap_snapshot_id", None)
+            events.append(event)
+        return events
+
+    def read_dataset_swap_events(self, filepath: Union[str, Path]) -> List[Dict[str, Any]]:
+        """Read just the ``history/dataset_swaps`` events from a snapshot file.
+
+        P2-7 follow-up (Issue #3): the ``GET /v1/snapshots/{id}/history/dataset_swaps``
+        route uses this to surface a stored snapshot's own swap history to
+        the canopy Replay timeline (parent spec §4.4 — markers on the
+        loaded snapshot's timeline) without paying the cost of a full
+        network restore.
+
+        Returns ``[]`` when the snapshot has no ``history`` group or no
+        ``dataset_swaps`` subgroup — both legitimate cases (pre-P2-2
+        snapshots, or training runs with no live swap).
+        """
+        with h5py.File(filepath, "r") as hdf5_file:
+            if "history" not in hdf5_file:
+                return []
+            history_group = hdf5_file["history"]
+            if "dataset_swaps" not in history_group:
+                return []
+            return self._decode_dataset_swap_events_from_group(history_group["dataset_swaps"], logger=self.logger)
+
+    def _load_weight_history(self, weights_group: h5py.Group) -> Dict[str, Any]:
+        """Restore per-sample weight history written by ``_save_weight_history``.
+
+        Returns the same dict shape that the writer expects, so the lifecycle
+        layer can ``network.weight_history = serializer.load(...)`` round-trip
+        without re-shaping.
+        """
+        meta_group = weights_group.get("meta")
+        if meta_group is None:
+            raise ValueError("weight_history is missing required 'meta' subgroup")
+
+        schema_version = int(meta_group.attrs.get("schema_version", 0))
+        if schema_version != self._WEIGHT_HISTORY_SCHEMA_VERSION:
+            raise ValueError(f"Unsupported weight_history schema_version: {schema_version} (expected {self._WEIGHT_HISTORY_SCHEMA_VERSION})")
+
+        result: Dict[str, Any] = {
+            "schema_version": schema_version,
+            "sampling_strategy": read_str_attr(meta_group, "sampling_strategy", "adaptive"),
+            "sampling_interval": int(meta_group.attrs.get("sampling_interval", 0)),
+            "sample_indices": [],
+            "output_weights": [],
+            "output_bias": [],
+            "hidden_units": [],
+        }
+
+        if "sample_indices" not in weights_group:
+            return result
+
+        result["sample_indices"] = load_numpy_array(weights_group["sample_indices"]).astype(np.int64).tolist()
+
+        ow_group = weights_group.get("output_weights")
+        ob_group = weights_group.get("output_bias")
+        if ow_group is not None and ob_group is not None:
+            for sample_key in sorted(ow_group.keys()):
+                result["output_weights"].append(load_numpy_array(ow_group[sample_key]))
+                result["output_bias"].append(load_numpy_array(ob_group[sample_key]))
+
+        units_group = weights_group.get("hidden_units")
+        if units_group is not None:
+            for unit_key in sorted(units_group.keys()):
+                unit_group = units_group[unit_key]
+                w_subgroup = unit_group.get("weights")
+                b_subgroup = unit_group.get("bias")
+                unit_weights = []
+                unit_bias = []
+                if w_subgroup is not None and b_subgroup is not None:
+                    for sample_key in sorted(w_subgroup.keys()):
+                        unit_weights.append(load_numpy_array(w_subgroup[sample_key]))
+                        unit_bias.append(load_numpy_array(b_subgroup[sample_key]))
+                result["hidden_units"].append(
+                    {
+                        "first_sample_index": int(unit_group.attrs.get("first_sample_index", 0)),
+                        "activation": read_str_attr(unit_group, "activation", ""),
+                        "weights": unit_weights,
+                        "bias": unit_bias,
+                    }
+                )
+
+        return result
+
+    def _restore_multiprocessing_state(self, hdf5_file: h5py.File, network) -> None:
+        """Restore multiprocessing state."""
+        if "mp" not in hdf5_file:
+            return
+        mp_group = hdf5_file["mp"]
+        try:
+            self._restore_multiprocessing_state_helper(mp_group, network)
+        except Exception as e:
+            self.logger.warning(f"Could not restore multiprocessing state: {e}")
+
+    def _restore_multiprocessing_state_helper(self, mp_group, network):
+        # Load MP configuration
+        role = read_str_attr(mp_group, "role", "none")
+        start_method = read_str_attr(mp_group, "start_method", "spawn")
+        address_host = read_str_attr(mp_group, "address_host", "127.0.0.1")
+        address_port = mp_group.attrs.get("address_port", 0)
+        authkey_hex = read_str_attr(mp_group, "authkey_hex", "")
+        autostart = mp_group.attrs.get("autostart", True)
+
+        # Restore timeouts
+        network.candidate_training_tasks_queue_timeout = mp_group.attrs.get("tasks_queue_timeout", 30.0)
+        network.candidate_training_shutdown_timeout = mp_group.attrs.get("shutdown_timeout", 10.0)
+
+        # Set multiprocessing context
+        network.candidate_training_context = mp.get_context(start_method)
+
+        # Restore address and authkey
+        network.candidate_training_queue_address = (address_host, address_port)
+        if authkey_hex:
+            try:
+                network.candidate_training_queue_authkey = bytes.fromhex(authkey_hex)
+            except ValueError:
+                network.candidate_training_queue_authkey = authkey_hex.encode("utf-8")
+
+        # Recreate multiprocessing components based on role
+        if role == "server" and autostart:
+            # Reinitialize as server
+            network._init_multiprocessing()
+
+        self.logger.debug(f"CascadeHDF5Serializer: Restored multiprocessing state (role: {role})")
+
+    def _create_network_from_file(self, hdf5_file: h5py.File):
+        """Create a network instance from HDF5 configuration."""
+        try:
+            from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
+            from cascade_correlation.cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
+
+            if "config" not in hdf5_file:
+                self.logger.error("No configuration found in file")
+                return None
+            config_group = hdf5_file["config"]
+            if "config_json" in config_group:
+                config_json = read_str_dataset(config_group, "config_json")
+                config_dict = json.loads(config_json)
+                config_dict.pop("activation_functions_dict", None)
+                config_dict.pop("log_config", None)
+                config_dict.pop("logger", None)
+                # Remove runtime-only attributes not in CascadeCorrelationConfig
+                config_dict.pop("candidates_per_layer", None)
+                config_dict.pop("layer_selection_strategy", None)
+                if "meta" in hdf5_file:
+                    meta_group = hdf5_file["meta"]
+                    if saved_uuid := read_str_attr(meta_group, "uuid", None):
+                        config_dict["uuid"] = saved_uuid
+                        self.logger.debug(f"CascadeHDF5Serializer: Injecting UUID {saved_uuid} into config")
+                config = CascadeCorrelationConfig(**config_dict)
+            else:
+                config = CascadeCorrelationConfig()
+                for attr_name in config_group.attrs.keys():
+                    if hasattr(config, attr_name):
+                        setattr(config, attr_name, config_group.attrs[attr_name])
+                if "meta" in hdf5_file:
+                    meta_group = hdf5_file["meta"]
+                    if saved_uuid := read_str_attr(meta_group, "uuid", None):
+                        config.uuid = saved_uuid
+                        self.logger.debug(f"CascadeHDF5Serializer: Setting UUID {saved_uuid} on config")
+            network = CascadeCorrelationNetwork(config=config)
+            if "meta" in hdf5_file:
+                self._restore_training_state_helper(hdf5_file, network)
+            self.logger.debug(f"CascadeHDF5Serializer: Created network instance (UUID: {network.get_uuid()})")
+            return network
+        except Exception as e:
+            return self._log_exception_stacktrace("Could not create network from file: ", e, None)
+
+    def _restore_training_state_helper(self, hdf5_file, network):
+        meta_group = hdf5_file["meta"]
+        network.snapshot_counter = meta_group.attrs.get("snapshot_counter", 0)
+        if "current_epoch" in meta_group.attrs:
+            network.current_epoch = meta_group.attrs.get("current_epoch", 0)
+        network.patience_counter = meta_group.attrs.get("patience_counter", 0)
+        network.best_value_loss = meta_group.attrs.get("best_value_loss", float("inf"))
+        self.logger.debug(f"CascadeHDF5Serializer: Restored training counters - snapshot: {network.snapshot_counter}, patience: {network.patience_counter}")
+
+    def _validate_shapes(self, network) -> bool:
+        """
+        Validate tensor shapes match expected dimensions.
+
+        Args:
+            network: CascadeCorrelationNetwork instance to validate
+
+        Returns:
+            bool: True if all shapes are valid, False otherwise
+        """
+        try:
+            expected_output_input = network.input_size + len(network.hidden_units)
+            if network.output_weights.shape != (
+                expected_output_input,
+                network.output_size,
+            ):
+                self.logger.error(f"Output weights shape mismatch: {network.output_weights.shape} != ({expected_output_input}, {network.output_size})")
+                return False
+            if network.output_bias.shape != (network.output_size,):
+                self.logger.error(f"Output bias shape mismatch: {network.output_bias.shape} != ({network.output_size},)")
+                return False
+            for i, unit in enumerate(network.hidden_units):
+                expected_input_size = network.input_size + i
+                if "weights" in unit and unit["weights"].shape[0] != expected_input_size:
+                    self.logger.error(f"Hidden unit {i} weight shape mismatch: {unit['weights'].shape[0]} != {expected_input_size}")
+                    return False
+                if "bias" in unit and unit["bias"].numel() != 1:
+                    self.logger.error(f"Hidden unit {i} bias shape mismatch: {unit['bias'].shape} should be scalar or (1,)")
+                    return False
+            self.logger.debug("CascadeHDF5Serializer: Shape validation passed")
+            return True
+        except Exception as e:
+            return self._log_exception_stacktrace("Shape validation failed: ", e, False)
+
+    def _validate_format(self, hdf5_file: h5py.File) -> bool:  # noqa: C901 - validation requires multiple checks
+        """
+        Validate HDF5 file format with comprehensive checks.
+
+        Validates:
+        - Format name and version compatibility
+        - Required groups and datasets
+        - Hidden units consistency
+        - Parameter dataset shapes
+
+        Returns:
+            bool: True if file format is valid, False otherwise
+        """
+        try:
+            # Check format identifier
+            format_name = read_str_attr(hdf5_file, "format")
+            if format_name not in [
+                self.format_name,
+                _HDF5_FORMAT_NAME_LEGACY,
+                _HDF5_FORMAT_NAME_CURRENT,
+            ]:
+                self.logger.error(f"Invalid format: {format_name}")
+                return False
+
+            # Check format version compatibility
+            format_version = read_str_attr(hdf5_file, "format_version", "1")
+            try:
+                file_major_version = int(format_version.split(".")[0] if "." in format_version else format_version)
+                serializer_major_version = int(self.format_version.split(".")[0])
+
+                if file_major_version > serializer_major_version:
+                    self.logger.error(f"Incompatible format version: file={format_version}, " f"serializer={self.format_version}")
+                    return False
+            except (ValueError, IndexError):
+                self.logger.warning(f"Could not parse format version: {format_version}")
+
+            # Check for required groups
+            required_groups = ["meta", "config", "params", "arch", "random"]
+            for group in required_groups:
+                if group not in hdf5_file:
+                    self.logger.error(f"Missing required group: {group}")
+                    return False
+
+            # Check for required datasets in params group
+            if "params" in hdf5_file:
+                params_group = hdf5_file["params"]
+                if "output_layer" in params_group:
+                    output_group = params_group["output_layer"]
+                    if "weights" not in output_group:
+                        self.logger.error("Missing output layer weights dataset")
+                        return False
+                    if "bias" not in output_group:
+                        self.logger.error("Missing output layer bias dataset")
+                        return False
+                else:
+                    self.logger.error("Missing output_layer group in params")
+                    return False
+
+            # Verify hidden units consistency
+            if "hidden_units" in hdf5_file:
+                hidden_group = hdf5_file["hidden_units"]
+                num_units_attr = hidden_group.attrs.get("num_units", 0)
+                actual_units = len([k for k in hidden_group.keys() if k.startswith("unit_")])
+
+                if num_units_attr != actual_units:
+                    self.logger.error(f"Hidden units count mismatch: num_units={num_units_attr}, " f"actual groups={actual_units}")
+                    return False
+
+                # Verify each hidden unit has required datasets
+                for i in range(num_units_attr):
+                    unit_name = f"unit_{i}"
+                    if unit_name in hidden_group:
+                        unit_group = hidden_group[unit_name]
+                        if "weights" not in unit_group:
+                            self.logger.error(f"Hidden unit {i} missing weights dataset")
+                            return False
+                        if "bias" not in unit_group:
+                            self.logger.error(f"Hidden unit {i} missing bias dataset")
+                            return False
+
+            self.logger.debug("CascadeHDF5Serializer: Format validation passed")
+            return True
+
+        except Exception as e:
+            return self._log_exception_stacktrace("Format validation failed: ", e, False)
+
+    def _log_exception_stacktrace(self, arg0, e, arg2):
+        self.logger.error(f"{arg0}{e}")
+        import traceback
+
+        self.logger.debug(traceback.format_exc())
+        return arg2
+
+    def _config_to_dict(self, config) -> Dict[str, Any]:
+        """
+        Convert configuration object to dictionary.
+
+        Excludes non-serializable objects like callables, log_config, and activation_functions_dict.
+        Only includes primitive types and serializable containers that can be safely JSON-encoded.
+        """
+        config_dict = {}
+
+        # Whitelist of safe serializable attributes
+        excluded_attrs = {
+            "activation_functions_dict",  # Contains callable functions
+            "log_config",  # Complex logging object, will be recreated on load
+            "logger",  # Runtime object
+        }
+
+        # Get all attributes from config object
+        for attr_name in dir(config):
+            if attr_name.startswith("_") or attr_name in excluded_attrs:
+                continue
+            try:
+                attr_value = getattr(config, attr_name)
+
+                # Skip callable attributes
+                if callable(attr_value):
+                    continue
+
+                # Handle different types
+                if isinstance(attr_value, (str, int, float, bool, type(None))):
+                    config_dict[attr_name] = attr_value
+                elif isinstance(attr_value, (list, tuple)):
+
+                    # Only include if items are primitive types
+                    if all(isinstance(item, (str, int, float, bool, type(None))) for item in attr_value):
+                        config_dict[attr_name] = list(attr_value)
+                elif isinstance(attr_value, dict):
+
+                    # Only include if values are primitive types
+                    if all(isinstance(v, (str, int, float, bool, type(None))) for v in attr_value.values()):
+                        config_dict[attr_name] = dict(attr_value)
+                elif isinstance(attr_value, pl.Path):
+                    config_dict[attr_name] = str(attr_value)
+                # Skip other complex types
+
+            except Exception as e:
+                self.logger.debug(f"Skipping attribute {attr_name}: {e}")
+                continue
+
+        return config_dict

--- a/src/snapshots/snapshot_utils.py
+++ b/src/snapshots/snapshot_utils.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python
+"""
+Utility functions for HDF5 operations and file management.
+Consolidated from hdf5_utilities.py with fixes for string handling.
+"""
+
+import datetime
+import os
+import shutil
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+import h5py
+
+from log_config.logger.logger import Logger
+
+# from cascade_correlation.hdf5.common import read_str_attr
+# from hdf5.common import read_str_attr
+from snapshots.snapshot_common import read_str_attr
+
+# from hdf5.serializer import CascadeHDF5Serializer
+from snapshots.snapshot_serializer import CascadeHDF5Serializer
+
+
+class HDF5Utils:
+    """Utility functions for HDF5 file operations."""
+
+    @staticmethod
+    def create_backup(filepath: str, backup_dir: Optional[str] = None) -> str:
+        """
+        Create a backup of an HDF5 file.
+
+        Args:
+            filepath: Path to original file
+            backup_dir: Directory for backup (default: same directory as original)
+
+        Returns:
+            Path to backup file
+
+        Raises:
+            FileNotFoundError: If original file doesn't exist
+        """
+        if not os.path.exists(filepath):
+            raise FileNotFoundError(f"Original file not found: {filepath}")
+
+        # Determine backup location
+        if backup_dir is None:
+            backup_dir = os.path.dirname(filepath)
+
+        # Create backup filename with timestamp
+        base_name = Path(filepath).stem
+        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        backup_filename = f"{base_name}_backup_{timestamp}.h5"
+        backup_path = os.path.join(backup_dir, backup_filename)
+
+        # Ensure backup directory exists
+        Path(backup_dir).mkdir(parents=True, exist_ok=True)
+
+        # Copy file
+        shutil.copy2(filepath, backup_path)
+
+        Logger.info(f"HDF5Utils: Created backup at {backup_path}")
+        return backup_path
+
+    @staticmethod
+    def list_hdf5_files(directory: Union[str, Path]) -> List[Path]:
+        """
+        List all HDF5 files (.h5 / .hdf5) in a directory.
+
+        Args:
+            directory: Directory to search
+
+        Returns:
+            Sorted list of HDF5 file paths (empty if the directory does not exist)
+        """
+        if not os.path.isdir(directory):
+            return []
+        return sorted(Path(directory, filename) for filename in os.listdir(directory) if filename.endswith((".h5", ".hdf5")))
+
+    @staticmethod
+    def list_networks_in_directory(directory: str) -> List[Dict[str, Any]]:
+        """
+        List all valid cascade correlation network files in a directory.
+
+        Args:
+            directory: Directory to search
+
+        Returns:
+            List of dictionaries with file information
+        """
+        networks = []
+        serializer = CascadeHDF5Serializer()
+
+        if not os.path.exists(directory):
+            return networks
+
+        for filename in os.listdir(directory):
+            if filename.endswith((".h5", ".hdf5")):
+                filepath = os.path.join(directory, filename)
+                try:
+                    verification = serializer.verify_saved_network(filepath)
+                    if verification.get("valid", False):
+                        verification["filename"] = filename
+                        verification["filepath"] = filepath
+                        networks.append(verification)
+                except Exception as e:
+                    Logger.warning(f"HDF5Utils: Could not verify {filepath}: {e}")
+
+        return networks
+
+    @staticmethod
+    def compare_networks(filepath1: str, filepath2: str) -> Dict[str, Any]:
+        """
+        Compare two saved networks and return differences.
+
+        Args:
+            filepath1: Path to first network file
+            filepath2: Path to second network file
+
+        Returns:
+            Dictionary with comparison results
+        """
+        serializer = CascadeHDF5Serializer()
+
+        # Verify both files
+        info1 = serializer.verify_saved_network(filepath1)
+        info2 = serializer.verify_saved_network(filepath2)
+
+        if not (info1.get("valid") and info2.get("valid")):
+            return {"comparable": False, "error": "One or both files are invalid", "file1_valid": info1.get("valid", False), "file2_valid": info2.get("valid", False)}
+
+        # Compare key attributes
+        comparison = {
+            "comparable": True,
+            "same_architecture": (info1.get("input_size", 0) == info2.get("input_size", 0) and info1.get("output_size", 0) == info2.get("output_size", 0)),
+            "same_hidden_units": info1.get("num_hidden_units", 0) == info2.get("num_hidden_units", 0),
+            "same_activation": info1.get("activation_function", "") == info2.get("activation_function", ""),
+            "architecture_diff": {"input_size": (info1.get("input_size", 0), info2.get("input_size", 0)), "output_size": (info1.get("output_size", 0), info2.get("output_size", 0)), "num_hidden_units": (info1.get("num_hidden_units", 0), info2.get("num_hidden_units", 0)), "activation_function": (info1.get("activation_function", ""), info2.get("activation_function", ""))},
+            "file1_info": info1,
+            "file2_info": info2,
+        }
+
+        Logger.debug(f"HDF5Utils: Compared networks - same architecture: {comparison['same_architecture']}")
+        return comparison
+
+    @staticmethod
+    def compress_hdf5_file(input_filepath: str, output_filepath: str, compression: str = "gzip", compression_opts: int = 9) -> bool:
+        """
+        Recompress an HDF5 file with different compression settings.
+
+        Args:
+            input_filepath: Path to input file
+            output_filepath: Path to output file
+            compression: Compression method
+            compression_opts: Compression level
+
+        Returns:
+            Success status
+        """
+        try:
+            with h5py.File(input_filepath, "r") as input_file:
+                with h5py.File(output_filepath, "w") as output_file:
+
+                    def copy_group(src_group, dst_group):
+                        """Recursively copy groups with compression."""
+                        for key in src_group.keys():
+                            if isinstance(src_group[key], h5py.Group):
+                                new_group = dst_group.create_group(key)
+                                # Copy attributes
+                                for attr_key, attr_val in src_group[key].attrs.items():
+                                    new_group.attrs[attr_key] = attr_val
+                                copy_group(src_group[key], new_group)
+                            else:
+                                # Copy dataset with new compression
+                                dataset = src_group[key]
+                                new_dataset = dst_group.create_dataset(key, data=dataset[:], compression=compression, compression_opts=compression_opts)
+                                # Copy attributes
+                                for attr_key, attr_val in dataset.attrs.items():
+                                    new_dataset.attrs[attr_key] = attr_val
+
+                    # Copy root attributes
+                    for attr_key, attr_val in input_file.attrs.items():
+                        output_file.attrs[attr_key] = attr_val
+
+                    # Copy all groups
+                    copy_group(input_file, output_file)
+
+            Logger.info(f"HDF5Utils: Successfully compressed {input_filepath} to {output_filepath}")
+            return True
+
+        except Exception as e:
+            Logger.error(f"HDF5Utils: Error compressing file: {e}")
+            return False
+
+    @staticmethod
+    def get_file_info(filepath: str) -> Dict[str, Any]:
+        """
+        Get detailed information about an HDF5 file.
+
+        Args:
+            filepath: Path to HDF5 file
+
+        Returns:
+            Dictionary with file information
+        """
+        if not os.path.exists(filepath):
+            return {"exists": False, "error": "File not found"}
+
+        try:
+            info = {"exists": True, "filepath": filepath, "size_bytes": os.path.getsize(filepath), "size_mb": round(os.path.getsize(filepath) / (1024 * 1024), 2), "modified_time": datetime.datetime.fromtimestamp(os.path.getmtime(filepath)), "groups": [], "datasets": [], "attributes": {}}
+
+            with h5py.File(filepath, "r") as hdf5_file:
+
+                def explore_group(group, path=""):
+                    """Recursively explore HDF5 structure."""
+                    for key in group.keys():
+                        full_path = f"{path}/{key}" if path else key
+
+                        if isinstance(group[key], h5py.Group):
+                            # Safely read group attributes
+                            group_attrs = {}
+                            for attr_key, attr_val in group[key].attrs.items():
+                                group_attrs[attr_key] = read_str_attr(group[key], attr_key, str(attr_val))
+
+                            info["groups"].append({"path": full_path, "attributes": group_attrs})
+                            explore_group(group[key], full_path)
+                        else:
+                            dataset = group[key]
+
+                            # Safely read dataset attributes
+                            dataset_attrs = {}
+                            for attr_key, attr_val in dataset.attrs.items():
+                                dataset_attrs[attr_key] = read_str_attr(dataset, attr_key, str(attr_val))
+
+                            info["datasets"].append({"path": full_path, "shape": dataset.shape, "dtype": str(dataset.dtype), "size_bytes": dataset.size * dataset.dtype.itemsize if hasattr(dataset.dtype, "itemsize") else dataset.nbytes, "compression": dataset.compression, "attributes": dataset_attrs})
+
+                # Safely read root attributes
+                root_attrs = {}
+                for attr_key, attr_val in hdf5_file.attrs.items():
+                    root_attrs[attr_key] = read_str_attr(hdf5_file, attr_key, str(attr_val))
+                info["attributes"] = root_attrs
+
+                # Explore structure
+                explore_group(hdf5_file)
+
+            return info
+
+        except Exception as e:
+            Logger.warning(f"HDF5Utils: Error reading file info for {filepath}: {e}")
+            return {"exists": True, "error": str(e)}
+
+    @staticmethod
+    def validate_network_file(filepath: str) -> Dict[str, Any]:
+        """
+        Validate a network file and return detailed validation results.
+
+        Args:
+            filepath: Path to HDF5 file to validate
+
+        Returns:
+            Dictionary with validation results
+        """
+        serializer = CascadeHDF5Serializer()
+        return serializer.verify_saved_network(filepath)
+
+    @staticmethod
+    def get_network_summary(filepath: str) -> Optional[Dict[str, Any]]:
+        """
+        Get a quick summary of a network file.
+
+        Args:
+            filepath: Path to HDF5 file
+
+        Returns:
+            Dictionary with network summary or None if invalid
+        """
+        validation = HDF5Utils.validate_network_file(filepath)
+        if not validation.get("valid", False):
+            return None
+
+        file_info = HDF5Utils.get_file_info(filepath)
+
+        summary = {
+            "filepath": filepath,
+            "filename": os.path.basename(filepath),
+            "size_mb": file_info.get("size_mb", 0),
+            "modified": file_info.get("modified_time", "unknown"),
+            "uuid": validation.get("network_uuid", "unknown"),
+            "input_size": validation.get("input_size", 0),
+            "output_size": validation.get("output_size", 0),
+            "num_hidden_units": validation.get("num_hidden_units", 0),
+            "activation_function": validation.get("activation_function", "unknown"),
+            "format_version": validation.get("format_version", "unknown"),
+            "has_training_history": validation.get("has_history", False),
+            "has_multiprocessing": validation.get("has_mp", False),
+        }
+        Logger.debug(f"HDF5Utils: Network summary for {filepath}: {summary}")
+
+        return summary
+
+    @staticmethod
+    def cleanup_old_files(directory: str, keep_count: int = 10) -> int:
+        """
+        Clean up old network files, keeping only the most recent ones.
+
+        Args:
+            directory: Directory containing network files
+            keep_count: Number of most recent files to keep
+
+        Returns:
+            Number of files deleted
+        """
+        if not os.path.exists(directory):
+            return 0
+
+        # Find all HDF5 files
+        hdf5_files = []
+        for filename in os.listdir(directory):
+            if filename.endswith((".h5", ".hdf5")):
+                filepath = os.path.join(directory, filename)
+                if os.path.isfile(filepath):
+                    mtime = os.path.getmtime(filepath)
+                    hdf5_files.append((filepath, mtime))
+
+        # Sort by modification time (newest first)
+        hdf5_files.sort(key=lambda x: x[1], reverse=True)
+
+        # Delete old files
+        deleted_count = 0
+        for filepath, _ in hdf5_files[keep_count:]:
+            try:
+                os.remove(filepath)
+                deleted_count += 1
+                Logger.info(f"HDF5Utils: Deleted old file: {filepath}")
+            except Exception as e:
+                Logger.warning(f"HDF5Utils: Could not delete {filepath}: {e}")
+
+        return deleted_count


### PR DESCRIPTION
## Summary

Commit `4081f5b` ("removing old snapshots") removed the stale `src/snapshots/snapshot_*.h5` artifacts **and accidentally swept away five live source modules** — `snapshot_cli.py`, `snapshot_common.py`, `snapshot_errors.py`, `snapshot_serializer.py`, `snapshot_utils.py` (2,635 lines). Production code still imports them (`api/routes/snapshots.py:11` imports `snapshots.snapshot_errors` at module load; `cascade_correlation.py` imports the serializer), so `create_app` dies on import and the API cannot boot. **Post-Merge Main Verification and the Golden Regression (WS-6 Gate) are both red on main** for that push — this PR is the heal.

- Restores the five `.py` modules **byte-for-byte from `4081f5b^`**
- Keeps the `.h5` artifact deletions (the commit's stated intent)
- No other changes

## Verification

In `JuniperCascor1`: `import snapshots.snapshot_errors, snapshot_common, snapshot_utils, snapshot_serializer, snapshot_cli` plus `from api.routes import snapshots` all succeed against this branch (`IMPORT-CHAIN-OK`). The dozen snapshot test modules that reference these files re-collect.

## Context

Found during **Phase 0 of the canopy E2E validation arc** (juniper-ml#1036): the isolated stack's cascor leg failed its health gate because uvicorn could not import `api.app:create_app` at main HEAD. This is precisely the symbol-loss class the sequence-safety `juniper-symbol-loss-check` screen exists for; the deletion bypassed per-PR screening by landing as a direct push.

Headless merge pre-authorized for this work arc (canopy E2E validation); flagged prominently to the owner in the session report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXu8jTSRVijQ5NpW7QdgVi