### PR TITLE
fix(cascor): fail loudly when every candidate errors instead of reporting no_candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `juniper_cascor_protocol.worker.BinaryFrame` rather than a subclass of it; nothing in the tree performs `isinstance` / `issubclass` / identity checks against it. Regression coverage is unchanged and still green —
   `test_worker_protocol.py::TestBinaryFrame::test_decode_non_utf8_dtype_raises_value_error` now passes by way of the shared codec instead of the shim.
 
+### Fixed
+
+- **A round in which *every* candidate errors is no longer reported as a normal `no_candidate` completion** (#509, honest-outcome half). `grow_network` takes its `no_candidate` exit whenever the best candidate is `None`, which conflated two
+  unrelated outcomes: *no candidate was good enough* (a real algorithmic result — the network legitimately stops with the units it has) and *no candidate could be trained at all* (infrastructure — the observed trigger is an exhausted GPU, where
+  `CandidateUnit.__init__` dies with `AcceleratorError: CUDA error: out of memory`). In the second case the run reported `succeeded` / `no_candidate` / 1 hidden unit while having trained nothing, so downstream experiment campaigns silently
+  recorded a converged-looking result for a dead host. This is the mechanism behind the late-cell corruption seen in the P4 spiral campaigns.
+  The existing BUG-CC-18 / ROBUST-01 guards in `_execute_candidate_training` do not cover it: they fire only when *both* the parallel and sequential paths raise, or when the result list comes back empty. Neither holds here — the per-candidate
+  handlers catch the error and **return** a `CandidateTrainingResult(success=False, candidate=None)`, so a full-length set of all-failed results is produced through the normal path.
+  `TrainingResults.success_count` (candidates that trained *without erroring*) already distinguished the two and was simply never consulted; note that `failed_count` is **not** an error count — it is `len(results) - successful_candidates`, i.e.
+  candidates that missed the correlation threshold — so it could not have served. A new `_raise_if_candidate_training_failed` guard now raises the existing `CandidateTrainingError` when candidates were attempted and `success_count == 0`, after
+  setting a new `_completion_reason` of `candidate_training_failed` (set before the raise, and surviving it because `get_status` reads the value off the persisted network object). `TrainingLifecycleManager` already wraps `model.fit` in
+  `except Exception` → `mark_failed`, so the run now reaches the correct terminal **Failed** state, metric, and broadcast with no new plumbing. A partially-degraded round (at least one candidate trained) keeps its benign `no_candidate` exit.
+  `completion_reason` is a cross-repo-visible field, but canopy's consumer is forward-compatible by construction — `service_backend` passes it through and `DashboardManager._completion_reason_label` is a `dict.get` returning `None` for unknown
+  values (pinned by canopy's own `test_unknown_reason_stays_bare`) — so no canopy change is required. 8 new unit tests in `test_completion_reason.py` cover the raise, the reason string, error-text surfacing, both `error_messages` shapes, and the
+  three no-false-positive paths (partial success, nothing attempted, `None` results). The forkserver-lifecycle half of #509 is tracked separately.
+
 ## [0.8.0] - 2026-08-08
 
 ### Added

--- a/src/cascade_correlation/cascade_correlation.py
+++ b/src/cascade_correlation/cascade_correlation.py
@@ -3995,6 +3995,59 @@ class CascadeCorrelationNetwork:
         except Exception:
             self.logger.debug("set_candidate_correlation emission failed", exc_info=True)
 
+    def _raise_if_candidate_training_failed(self, training_results: Optional[TrainingResults]) -> None:
+        """Issue #509: refuse to report an infrastructure failure as ``no_candidate``.
+
+        ``grow_network`` reaches its ``no_candidate`` exit whenever the best candidate
+        is ``None``. Two very different things produce that state:
+
+        * **No candidate was good enough** — every candidate trained, none beat the
+          correlation threshold. A real algorithmic outcome; the run legitimately
+          completes with the units it already has.
+        * **No candidate could be trained at all** — every candidate errored. The
+          observed case is a full GPU, where ``CandidateUnit.__init__`` dies with
+          ``AcceleratorError: CUDA error: out of memory``.
+
+        The second case slips past the existing BUG-CC-18 / ROBUST-01 guards in
+        ``_execute_candidate_training`` because those only fire when *both* training
+        paths raise, or when the result list is empty. Here neither holds: the
+        per-candidate handlers catch the error and **return** a
+        ``CandidateTrainingResult(success=False, candidate=None)``, so a full set of
+        all-failed results comes back normally. The run then reported ``succeeded`` /
+        ``no_candidate`` / 1 hidden unit while having trained nothing — silently
+        corrupting downstream experiment campaigns.
+
+        ``success_count`` (candidates that trained *without erroring*) already
+        distinguishes the two and was simply never consulted. Note that
+        ``failed_count`` is **not** an error count — it is
+        ``len(results) - successful_candidates``, i.e. candidates that missed the
+        correlation threshold — so it cannot be used for this test.
+
+        Raises:
+            CandidateTrainingError: if candidates were attempted and none trained
+                successfully. ``TrainingLifecycleManager`` already wraps
+                ``model.fit`` in ``except Exception`` and marks the run Failed, so
+                raising yields the correct terminal state, metric, and broadcast
+                with no new plumbing. ``_completion_reason`` is set before the raise
+                and survives it, because ``get_status`` reads it off the persisted
+                network object.
+        """
+        if training_results is None:
+            return
+        attempted = len(training_results.candidate_ids or [])
+        if not attempted or (training_results.success_count or 0) > 0:
+            return
+
+        # ``error_messages`` is annotated ``List[str]`` but ``get_candidates_error_messages``
+        # returns a dict keyed by candidate id/uuid — accept either shape.
+        raw_errors = training_results.error_messages or {}
+        error_values = list(raw_errors.values()) if isinstance(raw_errors, dict) else list(raw_errors)
+        sample = "; ".join(str(message) for message in error_values[:3]) or "no error message recorded"
+
+        self._completion_reason = "candidate_training_failed"
+        self.logger.error(f"CascadeCorrelationNetwork: _raise_if_candidate_training_failed: All {attempted} candidate(s) failed to train (0 trained successfully). This is an infrastructure failure, not a converged network. First errors: {sample}")
+        raise CandidateTrainingError(f"All {attempted} candidate(s) failed to train (0 trained successfully). This is an infrastructure failure — commonly GPU exhaustion — not a converged network. Refusing to report it as a normal 'no_candidate' completion. First errors: {sample}")
+
     def _install_hidden_unit(
         self,
         weights: torch.Tensor,
@@ -4386,6 +4439,10 @@ class CascadeCorrelationNetwork:
 
             # Train candidate units
             if not (training_results := self._get_training_results(x_train=x_train, y_train=y_train, residual_error=residual_error)) or not training_results.best_candidate:
+                # Issue #509: "no candidate was good enough" and "no candidate could be
+                # trained at all" both land here. Separate them before recording the
+                # benign outcome — the infrastructure case raises instead of breaking.
+                self._raise_if_candidate_training_failed(training_results)
                 self.logger.warning("CascadeCorrelationNetwork: grow_network: Training results are None or best candidate is None, stopping growth of the network.")
                 self._completion_reason = "no_candidate"
                 break

--- a/src/tests/integration/test_golden_trajectory.py
+++ b/src/tests/integration/test_golden_trajectory.py
@@ -34,6 +34,9 @@ _KNOWN_COMPLETION_REASONS = {
     "below_threshold",
     "early_stopped",
     "max_iterations",
+    # Issue #509: every candidate errored (e.g. GPU exhaustion). Raises out of
+    # grow_network, so a golden run only ever sees this on a broken host.
+    "candidate_training_failed",
 }
 
 

--- a/src/tests/unit/test_completion_reason.py
+++ b/src/tests/unit/test_completion_reason.py
@@ -9,13 +9,15 @@ break path to its reason string. Producer side only — the canopy consumer is a
 separate follow-up.
 """
 
+import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
 
-from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
+from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork, TrainingResults
 from cascade_correlation.cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
+from cascade_correlation.cascade_correlation_exceptions.cascade_correlation_exceptions import CandidateTrainingError
 
 
 def _make_network():
@@ -26,6 +28,45 @@ def _make_network():
 def _xy():
     torch.manual_seed(0)
     return torch.randn(8, 2), torch.randn(8, 2)
+
+
+def _all_failed_results(count=3, success_count=0, best_candidate=None, error_messages=None):
+    """A ``TrainingResults`` shaped exactly like the all-candidates-errored return.
+
+    Issue #509: the per-candidate handlers catch a training error and *return* a
+    ``CandidateTrainingResult(success=False, candidate=None)``, so the result list
+    is full-length while ``success_count`` is 0 and ``best_candidate`` is ``None``.
+    A real dataclass (not a MagicMock) is used so the predicate is exercised
+    honestly — a MagicMock would make every attribute truthy.
+    """
+    now = datetime.datetime.now()
+    if error_messages is None:
+        error_messages = {index: f"Candidate ID {index}: CUDA error: out of memory" for index in range(count)}
+    return TrainingResults(
+        epochs_completed=[0] * count,
+        candidate_ids=list(range(count)),
+        candidate_uuids=[],
+        correlations=[],
+        candidate_objects=[],
+        best_candidate_id=-1,
+        best_candidate_uuid=None,
+        best_correlation=0.0,
+        best_candidate=best_candidate,
+        success_count=success_count,
+        successful_candidates=0,
+        failed_count=count,
+        error_messages=error_messages,
+        max_correlation=0.0,
+        start_time=now,
+        end_time=now,
+    )
+
+
+def _grow_with(net, results, **kwargs):
+    """Run grow_network with the residual error and candidate results pinned."""
+    x, y = _xy()
+    with patch.object(net, "_calculate_residual_error_safe", return_value=torch.ones(8, 2)), patch.object(net, "_get_training_results", return_value=results):
+        return net.grow_network(x_train=x, y_train=y, max_iterations=3, early_stopping=False, **kwargs)
 
 
 @pytest.mark.unit
@@ -83,3 +124,67 @@ class TestCompletionReason:
         with patch.object(net, "_calculate_residual_error_safe", return_value=torch.ones(8, 2)), patch.object(net, "_get_training_results", return_value=results), patch.object(net, "_effective_candidate_count", return_value=1), patch.object(net, "_add_best_candidate", return_value=(0.1, 0.9)), patch.object(net, "validate_training", return_value=validation):
             net.grow_network(x_train=x, y_train=y, max_iterations=3, early_stopping=True)
         assert net._completion_reason == "early_stopped"
+
+
+@pytest.mark.unit
+class TestCandidateTrainingFailed:
+    """Issue #509: an all-candidates-errored round must not masquerade as ``no_candidate``.
+
+    ``no_candidate`` means "no candidate was good enough" — a real algorithmic
+    outcome. When *every* candidate errors (the observed case is a full GPU), the
+    run trained nothing, and reporting that as a normal completion silently
+    corrupts experiment campaigns. These tests pin the separation.
+    """
+
+    def test_all_candidates_failed_raises(self):
+        """0 of N trained successfully → raise rather than break with a benign reason."""
+        net = _make_network()
+        with pytest.raises(CandidateTrainingError, match="failed to train"):
+            _grow_with(net, _all_failed_results())
+
+    def test_all_candidates_failed_sets_its_own_reason(self):
+        """The reason is set *before* the raise and survives it (get_status reads it off the network)."""
+        net = _make_network()
+        with pytest.raises(CandidateTrainingError):
+            _grow_with(net, _all_failed_results())
+        assert net._completion_reason == "candidate_training_failed"
+
+    def test_underlying_error_is_surfaced(self):
+        """The candidate error text reaches the message — that is what makes it diagnosable."""
+        net = _make_network()
+        with pytest.raises(CandidateTrainingError, match="out of memory"):
+            _grow_with(net, _all_failed_results())
+
+    def test_partial_success_still_reports_no_candidate(self):
+        """At least one candidate trained → genuine algorithmic outcome, not infrastructure.
+
+        Guards against the fix over-firing: a degraded-but-honest round must keep
+        its benign exit.
+        """
+        net = _make_network()
+        _grow_with(net, _all_failed_results(success_count=1))
+        assert net._completion_reason == "no_candidate"
+
+    def test_no_candidates_attempted_still_reports_no_candidate(self):
+        """Nothing attempted → nothing to call an infrastructure failure."""
+        net = _make_network()
+        _grow_with(net, _all_failed_results(count=0))
+        assert net._completion_reason == "no_candidate"
+
+    def test_none_results_still_reports_no_candidate(self):
+        """The pre-existing None path is untouched by the guard."""
+        net = _make_network()
+        _grow_with(net, None)
+        assert net._completion_reason == "no_candidate"
+
+    def test_error_messages_as_list_is_handled(self):
+        """``error_messages`` is annotated ``List[str]`` but produced as a dict — accept both."""
+        net = _make_network()
+        with pytest.raises(CandidateTrainingError, match="listed failure"):
+            _grow_with(net, _all_failed_results(error_messages=["listed failure"]))
+
+    def test_missing_error_messages_still_raises(self):
+        """An empty error map must not suppress the failure or crash the guard."""
+        net = _make_network()
+        with pytest.raises(CandidateTrainingError, match="no error message recorded"):
+            _grow_with(net, _all_failed_results(error_messages={}))


### PR DESCRIPTION
Closes the **honest-outcome half** of #509. The forkserver-lifecycle half (directions 1/2 of the issue) is larger and independent, and ships separately.

## Summary

`grow_network` takes its `no_candidate` exit whenever the best candidate is `None`. That conflates two unrelated outcomes:

- **No candidate was good enough** — every candidate trained, none beat the correlation threshold. A real algorithmic result; the network legitimately stops with the units it has.
- **No candidate could be trained at all** — every candidate errored. The observed trigger is an exhausted GPU, where `CandidateUnit.__init__` dies with `AcceleratorError: CUDA error: out of memory`.

In the second case the run reported `succeeded` / `no_candidate` / 1 hidden unit **while having trained nothing**. Downstream experiment campaigns recorded a converged-looking result for a dead host — the mechanism behind the late-cell corruption seen in the P4 spiral campaigns.

## Why the existing guards missed it

`_execute_candidate_training` already has the BUG-CC-18 / ROBUST-01 guards, but they fire only when **both** the parallel and sequential paths raise, or when the result list comes back **empty**. Neither holds here: the per-candidate handlers (`train_candidate_worker`, `_train_candidate_unit`, `_publish_failure_result`) catch the error and **return** a `CandidateTrainingResult(success=False, candidate=None)`. So a full-length set of all-failed results arrives through the normal path, `best_candidate` is `None`, and the benign exit fires.

## The fix

The signal already existed and was simply not consulted. In `_process_training_results`:

| field | meaning |
| --- | --- |
| `success_count` | candidates that trained **without erroring** — the discriminator |
| `successful_candidates` | candidates meeting the **correlation threshold** |
| `failed_count` | `len(results) - successful_candidates` — **not** an error count, so it cannot serve here |

A new `_raise_if_candidate_training_failed` guard raises the **existing** `CandidateTrainingError` when candidates were attempted and `success_count == 0`. No new exception type: that class docstring already describes this exact failure mode ("raising this error instead fails loudly").

`_completion_reason` is set to a new `candidate_training_failed` **before** the raise, and survives it because `get_status` reads the value off the persisted network object. `TrainingLifecycleManager` already wraps `model.fit` in `except Exception` → `mark_failed` → status `Failed`, so the run reaches the correct terminal state, metric, and broadcast **with no new plumbing**. The guard lives in a helper rather than inline so `grow_network` gains no branch (C901 ceiling).

A partially-degraded round — at least one candidate trained — keeps its benign `no_candidate` exit. The fix does not over-fire.

## Cross-repo contract

`completion_reason` is consumed by canopy, but its consumer is forward-compatible by construction: `service_backend.py` passes the field through, and `DashboardManager._completion_reason_label` is a `dict.get` returning `None` for unknown values — pinned by canopy own `test_unknown_reason_stays_bare`. Additionally this path now ends in **Failed**, not Completed, and `test_non_completed_ignores_reason` proves a non-completed status ignores the reason entirely. **No canopy change is required.** A friendly operator label for the new value is optional polish.

## Testing

- 8 new unit tests in `test_completion_reason.py`: the raise, the reason string, error-text surfacing, both `error_messages` shapes (it is annotated `List[str]` but produced as a dict), and the three no-false-positive paths (partial success, nothing attempted, `None` results).
- `_KNOWN_COMPLETION_REASONS` in `test_golden_trajectory.py` extended.
- **Bite check**: with the guard disabled, the 5 raise-asserting tests fail and the 3 negative tests still pass — confirming the guard is load-bearing and the negative tests do not depend on it.
- Regression sweep green: every `grow_network`-adjacent unit suite plus the four `test_cascade_correlation_coverage*` suites.
- `pre-commit` clean on all changed files (flake8 incl. C901, mypy, black, isort, bandit).

## Impact / SemVer

Patch-level behavioural fix. A run that previously reported a false success now correctly reports failure — that is the point. No API surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V67tBZgLg5VqFjsouBgi5C