### PR TITLE
fix(cascor): release the RC-4 candidate pool when the run ends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `juniper_cascor_protocol.worker.BinaryFrame` rather than a subclass of it; nothing in the tree performs `isinstance` / `issubclass` / identity checks against it. Regression coverage is unchanged and still green —
   `test_worker_protocol.py::TestBinaryFrame::test_decode_non_utf8_dtype_raises_value_error` now passes by way of the shared codec instead of the shim.
 
+### Fixed
+
+- **The RC-4 persistent candidate pool is now released when the run ends, instead of outliving it** (#509, forkserver-lifecycle half). RC-4 deliberately keeps candidate workers alive **across growth rounds** — that optimization is unchanged and still applies to
+  every round within a `fit`. What was missing is the other end of that lifetime: `_shutdown_worker_pool`'s docstring claims it runs "when the network is being serialized/destroyed", but its only production caller was `_ensure_worker_pool` recycling a *stale* pool,
+  so a **healthy** pool was never torn down at all. Nothing else covered the gap — the constructor's `atexit` hook registered only `_cleanup_shared_memory`, and there is no `__del__`.
+  The orphaned forkserver children keep their CUDA context (~116 MiB each) and reparent to `systemd --user`; the forkserver's parent-death detection uses a pipe heartbeat that can take many minutes to fire, so they accumulate at roughly **285 MiB per experiment
+  cell** and exhaust an 8 GiB card after ~4–5 cells (measured 2026-08-10/11: 63 compute processes, 180 MiB free of 8192; reaping recovered 5058 MiB). Once the card is full every `CandidateUnit.__init__` dies with `AcceleratorError: CUDA error: out of memory`, and
+  the run reports a plausible-looking result computed from nothing — degradation that tracks **position in a campaign** rather than any experimental variable, which is what made it so expensive to diagnose.
+  `fit` now releases the pool in a **`finally`**, so a failed run cleans up too — that is exactly the GPU-pressure case where the next run must not inherit more orphans, and it is newly reachable now that the honest-outcome half raises on an all-candidates-errored
+  round. A guarded `_release_candidate_worker_pool` wrapper logs and swallows any teardown failure so cleanup can never mask the outcome of the work it follows (in either direction: a teardown error neither hides a training exception nor fails a good run), and it
+  is also registered with `atexit` alongside the existing shared-memory hook for pools created outside a `fit`.
+  Trade-off: a caller issuing many short sequential `fit` calls on one network now pays pool startup once per fit rather than once per process. RC-4's target — per-*round* overhead, of which there are many per fit — is untouched, and silent scientific corruption
+  is not a defensible price for a warm pool between runs. Issue direction (2) (releasing the CUDA context inside the child) is not needed once the children actually exit: process exit releases the context. 8 new unit tests in
+  `test_candidate_pool_release.py` cover both `fit` exit paths, both cleanup-failure directions, the helper, and the `atexit` registration.
+
 ## [0.8.0] - 2026-08-08
 
 ### Added

--- a/src/cascade_correlation/cascade_correlation.py
+++ b/src/cascade_correlation/cascade_correlation.py
@@ -1095,6 +1095,12 @@ class CascadeCorrelationNetwork:
         # OPT-5: Track active SharedMemory blocks for cleanup on error/shutdown
         self._active_shm_blocks = []
         atexit.register(self._cleanup_shared_memory)
+        # Issue #509: the RC-4 pool is released at the end of every fit(); this is the
+        # belt-and-braces arm for a pool created outside a fit (a direct
+        # train_candidates call) or left behind by an abrupt exit. Registering a bound
+        # method pins the instance for the process lifetime — the same trade the
+        # _cleanup_shared_memory registration above already makes.
+        atexit.register(self._release_candidate_worker_pool)
 
         # Phase 1b: Remote worker coordinator reference (set via set_worker_coordinator)
         self._worker_coordinator = None
@@ -1900,16 +1906,22 @@ class CascadeCorrelationNetwork:
         max_iterations = max_iterations if max_iterations is not None else self.max_iterations
         self._validate_positive_integer(max_iterations, "max_iterations")
         self.logger.info(f"CascadeCorrelationNetwork: fit: Starting main training loop with max_epochs: {max_epochs}, max_iterations: {max_iterations}, early stopping: {early_stopping}")
-        self.grow_network(
-            x_train=x_train,
-            y_train=y_train,
-            max_iterations=max_iterations,
-            early_stopping=early_stopping,
-            patience_counter=patience_counter,
-            best_value_loss=best_value_loss,
-            x_val=x_val,
-            y_val=y_val,
-        )
+        try:
+            self.grow_network(
+                x_train=x_train,
+                y_train=y_train,
+                max_iterations=max_iterations,
+                early_stopping=early_stopping,
+                patience_counter=patience_counter,
+                best_value_loss=best_value_loss,
+                x_val=x_val,
+                y_val=y_val,
+            )
+        finally:
+            # Issue #509: the growth rounds are over, so the RC-4 pool's reason to
+            # persist is too. In a ``finally`` because a failed run is exactly when
+            # leaked GPU-holding children do the most damage to the next one.
+            self._release_candidate_worker_pool()
         self.history["hidden_units_added"].append({"correlation": 0.0, "weight_shape": (), "unit_index": -1})
         self.logger.info("CascadeCorrelationNetwork: fit: Training completed.")
         self.logger.debug(f"CascadeCorrelationNetwork: fit: Final history: {len(self.history.get('train_loss', []))} epochs recorded")
@@ -3711,6 +3723,35 @@ class CascadeCorrelationNetwork:
         self._cleanup_shared_memory_blocks()
 
         self.logger.debug("CascadeCorrelationNetwork: _shutdown_worker_pool: Persistent pool shut down")
+
+    def _release_candidate_worker_pool(self) -> None:
+        """Issue #509: end the RC-4 pool's persistence when the *run* ends.
+
+        RC-4 deliberately keeps candidate workers alive **across growth rounds** —
+        that is the optimization, and it is preserved. What was missing is the other
+        end of that lifetime: nothing ever released the pool when the run finished.
+        ``_shutdown_worker_pool``'s own docstring claims it runs "when the network is
+        being serialized/destroyed", but its only production caller was
+        ``_ensure_worker_pool`` recycling a stale pool, so a healthy pool simply
+        outlived every run that created it.
+
+        The consequence is not a tidy-up nit. The orphaned forkserver children keep
+        their CUDA context (~116 MiB each) and reparent to ``systemd --user``; the
+        forkserver's parent-death detection uses a pipe heartbeat that can take many
+        minutes to fire, so they accumulate at roughly 285 MiB per experiment cell
+        until the card is full. Once it is, ``CandidateUnit.__init__`` dies with
+        ``AcceleratorError: CUDA error: out of memory`` for every candidate, and the
+        run reports a plausible-looking result computed from nothing — degradation
+        that tracks position in a campaign rather than any experimental variable.
+
+        Cleanup must never mask the outcome of the work it follows, so every failure
+        here is logged and swallowed: this runs from a ``finally`` in ``fit`` where a
+        training exception may already be in flight, and from ``atexit``.
+        """
+        try:
+            self._shutdown_worker_pool()
+        except Exception:  # nosec B110 — cleanup must not propagate exceptions
+            self.logger.warning("CascadeCorrelationNetwork: _release_candidate_worker_pool: Failed to release the candidate worker pool; forkserver children may survive this run", exc_info=True)
 
     def _cleanup_shared_memory(self):
         """Emergency cleanup of SharedMemory blocks on process exit (OPT-5)."""

--- a/src/tests/unit/cascade_correlation/test_candidate_pool_release.py
+++ b/src/tests/unit/cascade_correlation/test_candidate_pool_release.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+"""The RC-4 candidate pool is released when the *run* ends (issue #509).
+
+RC-4 keeps candidate workers alive **across growth rounds** — that is the
+optimization, and these tests do not challenge it. What was missing is the other
+end of that lifetime: ``_shutdown_worker_pool``'s only production caller was
+``_ensure_worker_pool`` recycling a stale pool, so a *healthy* pool outlived
+every run that created it. The orphaned forkserver children keep a CUDA context
+(~116 MiB each), reparent to ``systemd --user``, and accumulate until the card is
+full — at which point every candidate dies with ``AcceleratorError`` and runs
+report plausible results computed from nothing.
+
+These are fast unit tests driven by mock seams: ``grow_network`` is patched out
+and ``_shutdown_worker_pool`` is a mock, so no worker process is ever spawned.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+import cascade_correlation.cascade_correlation as cc_mod
+from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
+from cascade_correlation.cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
+
+pytestmark = pytest.mark.unit
+
+
+def _make_network():
+    config = CascadeCorrelationConfig(input_size=2, output_size=2, candidate_pool_size=2, candidate_epochs=1)
+    return CascadeCorrelationNetwork(config=config)
+
+
+def _xy():
+    torch.manual_seed(0)
+    return torch.randn(8, 2), torch.randn(8, 2)
+
+
+class TestFitReleasesPool:
+    """``fit`` ends the pool's persistence, on every exit path."""
+
+    def test_successful_fit_releases_the_pool(self):
+        """The growth rounds are over, so the pool's reason to persist is too."""
+        net = _make_network()
+        x, y = _xy()
+        with patch.object(net, "grow_network", return_value=None), patch.object(net, "_shutdown_worker_pool") as shutdown:
+            net.fit(x_train=x, y_train=y, max_epochs=1, max_iterations=1)
+        shutdown.assert_called_once()
+
+    def test_failed_fit_still_releases_the_pool(self):
+        """The ``finally`` arm — a failed run is when leaked children do the most damage.
+
+        Issue #509's honest-outcome half made this path live: a round in which
+        every candidate errors now raises out of ``grow_network``, and that is
+        precisely the GPU-pressure situation where the next run must not inherit
+        more orphans.
+        """
+        net = _make_network()
+        x, y = _xy()
+        with patch.object(net, "grow_network", side_effect=RuntimeError("training blew up")), patch.object(net, "_shutdown_worker_pool") as shutdown:
+            with pytest.raises(RuntimeError, match="training blew up"):
+                net.fit(x_train=x, y_train=y, max_epochs=1, max_iterations=1)
+        shutdown.assert_called_once()
+
+    def test_release_failure_does_not_mask_the_training_error(self):
+        """Cleanup must never overwrite the outcome of the work it follows."""
+        net = _make_network()
+        x, y = _xy()
+        with patch.object(net, "grow_network", side_effect=RuntimeError("the real failure")), patch.object(net, "_shutdown_worker_pool", side_effect=OSError("teardown also failed")):
+            with pytest.raises(RuntimeError, match="the real failure"):
+                net.fit(x_train=x, y_train=y, max_epochs=1, max_iterations=1)
+
+    def test_release_failure_does_not_fail_a_good_run(self):
+        """A teardown problem is logged, not raised — the training result stands."""
+        net = _make_network()
+        x, y = _xy()
+        with patch.object(net, "grow_network", return_value=None), patch.object(net, "_shutdown_worker_pool", side_effect=OSError("teardown failed")):
+            history = net.fit(x_train=x, y_train=y, max_epochs=1, max_iterations=1)
+        assert history is net.history
+
+
+class TestReleaseHelper:
+    """``_release_candidate_worker_pool`` is the guarded wrapper."""
+
+    def test_delegates_to_shutdown_worker_pool(self):
+        net = _make_network()
+        with patch.object(net, "_shutdown_worker_pool") as shutdown:
+            net._release_candidate_worker_pool()
+        shutdown.assert_called_once()
+
+    def test_swallows_and_logs_shutdown_failure(self):
+        net = _make_network()
+        net.logger = MagicMock()
+        with patch.object(net, "_shutdown_worker_pool", side_effect=OSError("boom")):
+            net._release_candidate_worker_pool()  # must not raise
+        assert net.logger.warning.called
+
+    def test_no_pool_is_a_noop(self):
+        """A network that never trained has nothing to release."""
+        net = _make_network()
+        net._persistent_workers = []
+        net._release_candidate_worker_pool()  # must not raise
+
+
+class TestAtexitRegistration:
+    """The belt-and-braces arm for pools created outside a fit."""
+
+    def test_release_is_registered_at_construction(self):
+        with patch.object(cc_mod.atexit, "register") as register:
+            net = _make_network()
+        registered = {getattr(call.args[0], "__name__", None) for call in register.call_args_list if call.args}
+        assert "_release_candidate_worker_pool" in registered
+        # The pre-existing OPT-5 shared-memory registration must survive alongside it.
+        assert "_cleanup_shared_memory" in registered
+        assert net is not None


### PR DESCRIPTION
Closes the **forkserver-lifecycle half** of #509 (issue directions 1/2). The honest-outcome half is #511; the two are independent and this branch is cut from `main`, not from #511.

## Summary

RC-4 keeps candidate workers alive **across growth rounds**. That optimization is unchanged here and still applies to every round within a `fit`. What was missing is the *other end* of that lifetime.

`_shutdown_worker_pool` documents itself as running "when the network is being serialized/destroyed" — but its only production caller was `_ensure_worker_pool`, recycling a **stale** pool (size change / dead workers). A **healthy** pool was therefore never torn down at all. Nothing else covered the gap: the constructor `atexit` hook registers only `_cleanup_shared_memory`, and there is no `__del__`.

## Why it matters

The orphaned forkserver children keep their CUDA context (~116 MiB each) and reparent to `systemd --user`. The forkserver parent-death detection uses a pipe heartbeat that can take many minutes to fire, so they survive and accumulate at roughly **285 MiB per experiment cell** — exhausting an 8 GiB card after ~4–5 cells.

Measured during the F-P4-1 spiral re-surface campaign (2026-08-10/11, RTX 2080): **63 GPU compute processes, 180 MiB free of 8192**; reaping recovered **5058 MiB**.

Once the card is full, every `CandidateUnit.__init__` dies with `AcceleratorError: CUDA error: out of memory`, and the run reports a plausible-looking result computed from nothing. The tell is that results degrade with **position in a campaign** rather than with any experimental variable — which is what made this so expensive to diagnose. Partial contamination is subtler than total: one cell with 202 OOM errors returned val accuracy 0.585 versus 0.645 clean — depressed, not collapsed, and easy to accept as real.

## The fix

- **`fit` releases the pool in a `finally`.** The growth rounds are over, so the pool has no reason to persist. `finally` rather than a trailing call because a *failed* run is precisely when leaked GPU-holding children do the most damage to the next one — and that path is newly reachable now that #511 raises on an all-candidates-errored round.
- **`_release_candidate_worker_pool`** is a guarded wrapper that logs and swallows teardown failures, so cleanup can never mask the outcome of the work it follows — in **either** direction: a teardown error neither hides a training exception nor fails an otherwise-good run.
- **`atexit` registration** alongside the existing shared-memory hook, as belt-and-braces for a pool created outside a `fit` (a direct `train_candidates` call) or left by an abrupt exit.

Issue **direction (2)** — releasing the CUDA context inside the child — is not needed once the children actually exit: process exit releases the context.

## Trade-off

A caller issuing many short sequential `fit` calls on one network now pays pool startup once per fit rather than once per process. RC-4 targets per-**round** overhead, of which there are many per fit, so its benefit is untouched. Silent scientific corruption is not a defensible price for a warm pool between runs.

## Testing

- 8 new unit tests in `test_candidate_pool_release.py`: both `fit` exit paths (success and raise), both cleanup-failure directions, the helper delegation/swallow/no-op, and the `atexit` registration (asserting the pre-existing shared-memory hook survives alongside it). Mock seams throughout — no worker process is spawned.
- Full `tests/unit/` suite green apart from one **pre-existing, environment-only** failure: `test_version_matches_pyproject` fails on pristine `main` too, because the installed `juniper-cascor` in the local `JuniperCascor1` env is a stale 0.6.0 against pyproject 0.8.0. Unrelated to this change; CI installs fresh.
- `pre-commit` clean on all changed files.

## Impact / SemVer

Patch-level resource-lifecycle fix. No API surface changes. Operationally this is what makes multi-cell experiment campaigns trustworthy without reaping orphans before every cell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V67tBZgLg5VqFjsouBgi5C