### PR TITLE
ci: stop every job running twice per PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,16 @@ name: CI/CD Pipeline
 
 on:
   push:
+    # Topic-branch globs (feature/**, fix/**) removed 2026-08-13: once a PR is open,
+    # `push` and `pull_request` BOTH fire for the same commit, so every job ran twice.
+    # The concurrency group is keyed on github.ref, which differs between a branch push
+    # (refs/heads/...) and a PR (refs/pull/N/merge), so cancel-in-progress never collapsed
+    # the pair. Same fix as juniper-recurrence#108 / juniper-ml#1076 / juniper-canopy#488.
+    # `pull_request` covers every commit once a PR exists; workflow_dispatch remains for a
+    # branch with no PR open.
     branches:
       - main
       - develop
-      - feature/**
-      - fix/**
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Sweeps this repo into the duplicate-run fix already applied to juniper-recurrence#108, juniper-ml#1076 and juniper-canopy#488.

## The problem

`ci.yml` push-triggered on `feature/**`, `fix/**` **and** on `pull_request`. Once a PR is open both events fire for the same commit, so **every job ran twice**. The concurrency group is keyed on `github.ref`, which differs between a branch push (`refs/heads/…`) and a PR (`refs/pull/N/merge`), so `cancel-in-progress` never collapsed the pair — a straight 2x CI cost on every PR from a matching branch.

## The fix

Drop the topic-branch globs from `on.push`, leaving `[main, develop]`. `pull_request` is untouched and covers every commit once a PR exists; `workflow_dispatch` remains for a branch with no PR open. The only behaviour lost is CI on a topic branch with **no PR at all**.

## Not a concurrency-group change

Normalising the group (e.g. `github.head_ref || github.ref_name`) would also collapse the pair, but by **cancelling** one run — leaving `cancelled` check-runs on the PR alongside the survivors. That is the confusing signature that cost real diagnosis time on juniper-data#253, where a cancelled matrix job reported under its un-interpolated `${{ matrix.* }}` name. Dropping the duplicate trigger yields exactly one run and no cancelled artifacts.

## Deliberately untouched

`lockfile-update.yml` also pairs a push glob with `pull_request`, but it is a different mechanism, not a duplicate suite: its push arm targets `dependabot/pip/**` so the lockfile is regenerated in place on Dependabot's own branch (`permissions: contents: write`), while the PR arm fires on any `pyproject.toml` change. Removing either arm would change real behaviour.

## Verification

Edit applied line-wise (a YAML round-trip would strip every comment in this file) and scoped strictly to the `on:` -> `push:` -> `branches:` block, then re-parsed and asserted before push: `push.branches` equals the original minus its globs, `pull_request` is byte-identical, and the job graph and every job definition are unchanged.