### PR TITLE
fix(cascor): thread candidate patience and convergence to the pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Trade-off: a caller issuing many short sequential `fit` calls on one network now pays pool startup once per fit rather than once per process. RC-4's target — per-*round* overhead, of which there are many per fit — is untouched, and silent scientific corruption
   is not a defensible price for a warm pool between runs. Issue direction (2) (releasing the CUDA context inside the child) is not needed once the children actually exit: process exit releases the context. 8 new unit tests in
   `test_candidate_pool_release.py` cover both `fit` exit paths, both cleanup-failure directions, the helper, and the `atexit` registration.
+- **`candidate_patience` and `candidate_convergence_threshold` now reach the candidate pool** (#505). Both are accepted at the API boundary, whitelisted in `_apply_params_unlocked`, and set as network attributes — but the pool's workers
+  construct their own `CandidateUnit` in a separate process and cannot see `self`, and neither value was ever placed in the task payload. Every candidate therefore ran the `CandidateUnit` module defaults (patience 50, convergence 0.001)
+  no matter what was configured, while `GET /v1/training/params` echoed the requested value straight back off the network attribute. Confirmed live during the P4 E-A campaign: runs sent `candidate_patience: 100`, the API reported 100,
+  and the candidate logs still read `Early stopping at epoch 50 - no improvement for 50 epochs`.
+  `_generate_candidate_tasks` now carries both values in **both** payload shapes — the OPT-5 SharedMemory metadata dict and the legacy fallback tuple — `_build_candidate_inputs` surfaces them, and the worker's `CandidateUnit(...)` passes
+  them. The legacy tuple grows from 6 to 8 elements by **appending**, so the first six positions keep their meaning and a 6-element tuple built by an older caller still unpacks; both the short tuple and a metadata dict without the new keys
+  fall back to the same module defaults those callers already got, so nothing changes for them. The `_create_candidate_unit` factory (sequential path) already threaded both and is untouched; so is the result-reconstruction
+  `CandidateUnit` in `_collect_training_results`, which carries returned weights and never trains.
+  Impact beyond the API: every committed experiment config setting either key — `conf/experiments/spiral-baseline.yaml` among them — was silently running the pool at 50 / 0.001, so any study sweeping candidate patience or convergence
+  through the service was measuring one operating point. 10 new unit tests in `test_candidate_hyperparam_plumbing.py` pin the whole chain; the decisive ones assert on the **constructed unit's** `patience` / `convergence_threshold` rather
+  than on the payload dict, because this is the CASCOR-P0-005 key-name-mismatch class, where a key exists in the payload under one name and the constructor silently reads another.
 
 ## [0.8.0] - 2026-08-08
 

--- a/src/cascade_correlation/cascade_correlation.py
+++ b/src/cascade_correlation/cascade_correlation.py
@@ -75,6 +75,8 @@ from candidate_unit.candidate_unit import CandidateTrainingResult, CandidateUnit
 from cascade_correlation.cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
 from cascade_correlation.cascade_correlation_exceptions.cascade_correlation_exceptions import CandidateTrainingError, ConfigurationError, TrainingError, ValidationError  # CascadeCorrelationError,; NetworkInitializationError,
 from cascor_constants.constants import (  # TODO: Commented out for F401 compliance - may be needed for future activation function selection; _CASCADE_CORRELATION_NETWORK_ACTIVATION_FUNCTION_NN_RELU,; _CASCADE_CORRELATION_NETWORK_ACTIVATION_FUNCTION_NN_SIGMOID,; _CASCADE_CORRELATION_NETWORK_ACTIVATION_FUNCTION_NN_TANH,; _CASCADE_CORRELATION_NETWORK_ACTIVATION_FUNCTION_RELU,; _CASCADE_CORRELATION_NETWORK_ACTIVATION_FUNCTION_SIGMOID,; _CASCADE_CORRELATION_NETWORK_ACTIVATION_FUNCTION_TANH,APPROVED
+    _CANDIDATE_UNIT_CONVERGENCE_THRESHOLD,
+    _CANDIDATE_UNIT_PATIENCE,
     _CASCADE_CORRELATION_NETWORK_ACTIVATION_FUNCTION_DEFAULT,
     _CASCADE_CORRELATION_NETWORK_ACTIVATION_FUNCTION_NAME,
     _CASCADE_CORRELATION_NETWORK_ACTIVATION_FUNCTIONS_DICT,
@@ -2242,6 +2244,12 @@ class CascadeCorrelationNetwork:
             shm_metadata["candidate_epochs"] = self.candidate_epochs
             shm_metadata["candidate_learning_rate"] = self.candidate_learning_rate
             shm_metadata["candidate_display_frequency"] = self.candidate_display_frequency
+            # CASCOR-505: the candidate early-stopping controls are network attributes set from
+            # the API/config, but the pool workers construct their own CandidateUnit and cannot
+            # see `self`. Carry them in the task payload or every candidate silently runs the
+            # CandidateUnit module defaults.
+            shm_metadata["candidate_patience"] = self.candidate_patience
+            shm_metadata["candidate_convergence_threshold"] = self.candidate_convergence_threshold
             training_inputs = shm_metadata
             self.logger.debug(f"CascadeCorrelationNetwork: _generate_candidate_tasks: OPT-5 SharedMemory block created: {shm.name}")
         except Exception as shm_err:
@@ -2260,6 +2268,10 @@ class CascadeCorrelationNetwork:
                 residual_error,
                 self.candidate_learning_rate,
                 self.candidate_display_frequency,
+                # CASCOR-505: appended, not inserted, so a 6-element tuple built by an older
+                # caller still unpacks (see the length-guarded unpack in _build_candidate_inputs).
+                self.candidate_patience,
+                self.candidate_convergence_threshold,
             )
 
         # Generate candidate metadata
@@ -3292,6 +3304,12 @@ class CascadeCorrelationNetwork:
                     CandidateUnit__random_value_scale=candidate_inputs.get("random_value_scale"),
                     CandidateUnit__uuid=candidate_inputs.get("candidate_uuid"),
                     CandidateUnit__candidate_index=candidate_inputs.get("candidate_index"),
+                    # CASCOR-505: without these two the pool ran the module defaults no matter
+                    # what the API applied. Defaults are repeated here because a caller that
+                    # patches _build_candidate_inputs may hand back a dict without the keys, and
+                    # CandidateUnit does not coerce None for either field.
+                    CandidateUnit__patience=candidate_inputs.get("candidate_patience", _CANDIDATE_UNIT_PATIENCE),
+                    CandidateUnit__convergence_threshold=candidate_inputs.get("candidate_convergence_threshold", _CANDIDATE_UNIT_CONVERGENCE_THRESHOLD),
                 )
                 logger.debug(f"CascadeCorrelationNetwork: train_candidate_worker: Completed Instantiating CandidateUnit object: Worker ID: {worker_id}, Worker UUID: {worker_uuid}, Candidate UUID: {candidate.get_uuid()}")
             except Exception as e:
@@ -3404,6 +3422,22 @@ class CascadeCorrelationNetwork:
             candidate_epochs = training_inputs["candidate_epochs"]
             candidate_learning_rate = training_inputs["candidate_learning_rate"]
             candidate_display_frequency = training_inputs["candidate_display_frequency"]
+            # CASCOR-505: absent keys mean a payload built before this fix — fall back to the
+            # CandidateUnit module defaults, which is exactly what those workers already used.
+            candidate_patience = training_inputs.get("candidate_patience", _CANDIDATE_UNIT_PATIENCE)
+            candidate_convergence_threshold = training_inputs.get("candidate_convergence_threshold", _CANDIDATE_UNIT_CONVERGENCE_THRESHOLD)
+        elif len(training_inputs) >= 8:
+            # CASCOR-505: 8-element legacy tuple carries the candidate early-stopping controls.
+            (
+                candidate_input,
+                candidate_epochs,
+                y,
+                residual_error,
+                candidate_learning_rate,
+                candidate_display_frequency,
+                candidate_patience,
+                candidate_convergence_threshold,
+            ) = training_inputs
         else:
             (
                 candidate_input,
@@ -3413,6 +3447,8 @@ class CascadeCorrelationNetwork:
                 candidate_learning_rate,
                 candidate_display_frequency,
             ) = training_inputs
+            candidate_patience = _CANDIDATE_UNIT_PATIENCE
+            candidate_convergence_threshold = _CANDIDATE_UNIT_CONVERGENCE_THRESHOLD
         logger.debug(f"CascadeCorrelationNetwork: _build_candidate_inputs: Successfully Unpacked Training inputs: Worker ID: {worker_id}, Worker UUID: {worker_uuid}, Candidate UUID: {candidate_uuid}.")
         logger.debug(f"CascadeCorrelationNetwork: _build_candidate_inputs: Unpacked Task data, Candidate data, and Training inputs: Worker ID: {worker_id}, Worker UUID: {worker_uuid}, Candidate Index: {candidate_index}, Candidate UUID: {candidate_uuid}, Training Inputs: x shape: {candidate_input.shape}, epochs: {candidate_epochs}, y shape: {y.shape}, residual_error shape: {residual_error.shape}, learning_rate: {candidate_learning_rate}, display_frequency: {candidate_display_frequency}")
         logger.verbose(f"CascadeCorrelationNetwork: _build_candidate_inputs: Training inputs: x shape: {candidate_input.shape}, epochs: {candidate_epochs}, y shape: {y.shape}, residual_error shape: {residual_error.shape}, learning_rate: {candidate_learning_rate}, display_frequency: {candidate_display_frequency}")
@@ -3439,6 +3475,8 @@ class CascadeCorrelationNetwork:
             "residual_error": residual_error,
             "candidate_learning_rate": candidate_learning_rate,
             "candidate_display_frequency": candidate_display_frequency,
+            "candidate_patience": candidate_patience,  # CASCOR-505
+            "candidate_convergence_threshold": candidate_convergence_threshold,  # CASCOR-505
             "activation_fn": activation_fn,
             "round_id": round_id,
             "_shm_handle": shm_handle,  # OPT-5: SharedMemory handle for deferred close (None if legacy path)

--- a/src/tests/unit/cascade_correlation/test_candidate_hyperparam_plumbing.py
+++ b/src/tests/unit/cascade_correlation/test_candidate_hyperparam_plumbing.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python
+"""Candidate early-stopping hyperparameter plumbing (CASCOR-505).
+
+``candidate_patience`` and ``candidate_convergence_threshold`` are accepted at
+the API boundary, whitelisted in ``_apply_params_unlocked``, and set as network
+attributes — but the candidate pool constructs its own ``CandidateUnit`` in a
+worker process that cannot see ``self``. Before this fix the two values were
+never placed in the task payload, so every candidate silently ran the
+``CandidateUnit`` module defaults while ``GET /v1/training/params`` echoed the
+configured value back.
+
+These tests pin the whole chain, hermetically and without worker processes:
+
+    network attrs
+      -> _generate_candidate_tasks   (shm-metadata dict AND legacy tuple)
+      -> _build_candidate_inputs     (both payload shapes, plus back-compat)
+      -> CandidateUnit(...)          (the constructed unit's own attributes)
+
+The last hop is the one that matters most: this is the CASCOR-P0-005
+key-name-mismatch class, where a payload key exists but the constructor reads a
+different name and silently receives ``None``/the default. Asserting on the
+*constructed unit* rather than on the payload dict is what makes that
+undetectable-by-inspection failure visible.
+
+Back-compat is pinned deliberately: a 6-element ``training_inputs`` tuple (the
+shape every pre-fix caller and several existing fixtures build) must still
+unpack and must still yield the module defaults.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+import cascade_correlation.cascade_correlation as cc_mod
+from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
+from cascade_correlation.cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
+from cascor_constants.constants import _CANDIDATE_UNIT_CONVERGENCE_THRESHOLD, _CANDIDATE_UNIT_PATIENCE
+
+pytestmark = pytest.mark.unit
+
+
+# Deliberately unlike any default in the tree, so a passing assertion cannot be
+# a default coincidentally matching the configured value.
+_PATIENCE = 7
+_CONVERGENCE = 0.25
+
+
+def _candidate_data(input_size=2):
+    """The candidate-metadata tuple shape unpacked by ``_build_candidate_inputs``."""
+    return (
+        0,  # candidate_index (element [0], skipped by the [1:] unpack)
+        input_size,
+        "Tanh",
+        0.1,  # random_value_scale
+        "test-uuid",
+        42,  # candidate_seed
+        1.0,  # random_max_value
+        100,  # sequence_max_value
+    )
+
+
+def _tensors(rows=10, cols=2):
+    return torch.randn(rows, cols), torch.randn(rows, cols), torch.randn(rows, cols)
+
+
+def _legacy_tuple(x, y, residual, *, with_controls):
+    """Build a training_inputs tuple in either the 8- or the pre-fix 6-element shape."""
+    base = (x, 3, y, residual, 0.01, 10)
+    return base + (_PATIENCE, _CONVERGENCE) if with_controls else base
+
+
+class TestGenerateCandidateTasksCarriesControls:
+    """``_generate_candidate_tasks`` must put both controls in the task payload."""
+
+    def _network(self):
+        config = CascadeCorrelationConfig.create_simple_config(
+            input_size=3,
+            output_size=2,
+            max_hidden_units=3,
+            candidate_patience=_PATIENCE,
+            candidate_convergence_threshold=_CONVERGENCE,
+        )
+        return CascadeCorrelationNetwork(config=config)
+
+    def test_shm_metadata_payload_carries_both_controls(self):
+        """OPT-5 SharedMemory path: both controls ride in the metadata dict."""
+        net = self._network()
+        block = MagicMock()
+        block.get_metadata.return_value = {}
+        block.name = "fake-shm"
+
+        with patch.object(cc_mod, "SharedTrainingMemory", return_value=block):
+            tasks = net._generate_candidate_tasks(torch.zeros(4, 3), torch.zeros(4, 2), torch.zeros(4, 2))
+
+        training_inputs = tasks[0][2]
+        assert isinstance(training_inputs, dict)
+        assert training_inputs["candidate_patience"] == _PATIENCE
+        assert training_inputs["candidate_convergence_threshold"] == _CONVERGENCE
+
+    def test_legacy_tuple_fallback_carries_both_controls(self):
+        """SharedMemory-creation failure falls back to a tuple that still carries them."""
+        net = self._network()
+        failing_block = MagicMock()
+        failing_block.get_metadata.side_effect = RuntimeError("shm metadata boom")
+
+        with patch.object(cc_mod, "SharedTrainingMemory", return_value=failing_block):
+            tasks = net._generate_candidate_tasks(torch.zeros(4, 3), torch.zeros(4, 2), torch.zeros(4, 2))
+
+        training_inputs = tasks[0][2]
+        assert isinstance(training_inputs, tuple)
+        # Appended, not inserted — the first six positions keep their meaning.
+        assert len(training_inputs) == 8
+        assert training_inputs[1] == net.candidate_epochs
+        assert training_inputs[4] == net.candidate_learning_rate
+        assert training_inputs[6] == _PATIENCE
+        assert training_inputs[7] == _CONVERGENCE
+
+
+class TestBuildCandidateInputsSurfacesControls:
+    """``_build_candidate_inputs`` must surface both controls from either shape."""
+
+    def test_legacy_eight_tuple_surfaces_controls(self):
+        x, y, residual = _tensors()
+        task = (0, _candidate_data(), _legacy_tuple(x, y, residual, with_controls=True))
+
+        result = CascadeCorrelationNetwork._build_candidate_inputs(task_data_input=task, worker_uuid="w", worker_id=1)
+
+        assert result["candidate_patience"] == _PATIENCE
+        assert result["candidate_convergence_threshold"] == _CONVERGENCE
+        # The pre-existing positional fields are untouched by the extension.
+        assert result["candidate_epochs"] == 3
+        assert result["candidate_learning_rate"] == 0.01
+        assert result["candidate_display_frequency"] == 10
+        assert torch.equal(result["candidate_input"], x)
+
+    def test_legacy_six_tuple_falls_back_to_module_defaults(self):
+        """Back-compat: a pre-fix 6-tuple still unpacks, with the defaults it always had."""
+        x, y, residual = _tensors()
+        task = (0, _candidate_data(), _legacy_tuple(x, y, residual, with_controls=False))
+
+        result = CascadeCorrelationNetwork._build_candidate_inputs(task_data_input=task, worker_uuid="w", worker_id=1)
+
+        assert result["candidate_patience"] == _CANDIDATE_UNIT_PATIENCE
+        assert result["candidate_convergence_threshold"] == _CANDIDATE_UNIT_CONVERGENCE_THRESHOLD
+
+    def _dict_payload_result(self, payload):
+        x, y, residual = _tensors()
+        task = (0, _candidate_data(), payload)
+        with patch.object(cc_mod.SharedTrainingMemory, "reconstruct_tensors", return_value=([x, y, residual], None)):
+            return CascadeCorrelationNetwork._build_candidate_inputs(task_data_input=task, worker_uuid="w", worker_id=1)
+
+    def test_shm_dict_payload_surfaces_controls(self):
+        result = self._dict_payload_result(
+            {
+                "shm_name": "fake",
+                "candidate_epochs": 3,
+                "candidate_learning_rate": 0.01,
+                "candidate_display_frequency": 10,
+                "candidate_patience": _PATIENCE,
+                "candidate_convergence_threshold": _CONVERGENCE,
+            }
+        )
+        assert result["candidate_patience"] == _PATIENCE
+        assert result["candidate_convergence_threshold"] == _CONVERGENCE
+
+    def test_shm_dict_payload_without_controls_falls_back(self):
+        """Back-compat: a metadata dict built before this fix keeps the module defaults."""
+        result = self._dict_payload_result(
+            {
+                "shm_name": "fake",
+                "candidate_epochs": 3,
+                "candidate_learning_rate": 0.01,
+                "candidate_display_frequency": 10,
+            }
+        )
+        assert result["candidate_patience"] == _CANDIDATE_UNIT_PATIENCE
+        assert result["candidate_convergence_threshold"] == _CANDIDATE_UNIT_CONVERGENCE_THRESHOLD
+
+
+class TestWorkerConstructsUnitWithControls:
+    """The CASCOR-P0-005 hop: assert on the *constructed* unit, not the payload."""
+
+    def test_worker_builds_candidate_with_configured_controls(self):
+        x, y, residual = _tensors()
+        task = (0, _candidate_data(), _legacy_tuple(x, y, residual, with_controls=True))
+
+        result = CascadeCorrelationNetwork.train_candidate_worker(task_data_input=task, parallel=False)
+
+        assert result.candidate is not None, "worker returned no candidate; cannot assert construction"
+        assert result.candidate.patience == _PATIENCE
+        assert result.candidate.convergence_threshold == _CONVERGENCE
+
+    def test_worker_falls_back_to_defaults_for_legacy_payload(self):
+        """Negative control — the pre-fix payload must still yield the old behaviour."""
+        x, y, residual = _tensors()
+        task = (0, _candidate_data(), _legacy_tuple(x, y, residual, with_controls=False))
+
+        result = CascadeCorrelationNetwork.train_candidate_worker(task_data_input=task, parallel=False)
+
+        assert result.candidate is not None
+        assert result.candidate.patience == _CANDIDATE_UNIT_PATIENCE
+        assert result.candidate.convergence_threshold == _CANDIDATE_UNIT_CONVERGENCE_THRESHOLD
+
+
+class TestNetworkToConstructedUnitRoundTrip:
+    """End-to-end: a network attribute reaches the constructed candidate unit.
+
+    This is the assertion the defect would have failed. It deliberately goes
+    through the real ``_generate_candidate_tasks`` -> ``_build_candidate_inputs``
+    -> ``CandidateUnit`` chain rather than hand-building a payload, so a future
+    change that drops a key anywhere along it fails here.
+    """
+
+    @pytest.mark.parametrize("shm_available", [True, False], ids=["shm-dict", "legacy-tuple"])
+    def test_configured_controls_reach_the_candidate_unit(self, shm_available):
+        config = CascadeCorrelationConfig.create_simple_config(
+            input_size=2,
+            output_size=2,
+            max_hidden_units=3,
+            candidate_patience=_PATIENCE,
+            candidate_convergence_threshold=_CONVERGENCE,
+        )
+        net = CascadeCorrelationNetwork(config=config)
+        assert net.candidate_patience == _PATIENCE, "fixture precondition: config value reached the network"
+
+        x, y, residual = _tensors()
+
+        if shm_available:
+            block = MagicMock()
+            block.get_metadata.return_value = {"shm_name": "fake"}
+            with patch.object(cc_mod, "SharedTrainingMemory", return_value=block):
+                tasks = net._generate_candidate_tasks(x, y, residual)
+            with patch.object(cc_mod.SharedTrainingMemory, "reconstruct_tensors", return_value=([x, y, residual], None)):
+                result = CascadeCorrelationNetwork.train_candidate_worker(task_data_input=tasks[0], parallel=False)
+        else:
+            failing_block = MagicMock()
+            failing_block.get_metadata.side_effect = RuntimeError("shm metadata boom")
+            with patch.object(cc_mod, "SharedTrainingMemory", return_value=failing_block):
+                tasks = net._generate_candidate_tasks(x, y, residual)
+            result = CascadeCorrelationNetwork.train_candidate_worker(task_data_input=tasks[0], parallel=False)
+
+        assert result.candidate is not None
+        assert result.candidate.patience == _PATIENCE
+        assert result.candidate.convergence_threshold == _CONVERGENCE


### PR DESCRIPTION
## Summary

`TrainingParams.candidate_patience` and `candidate_convergence_threshold` were accepted at the API boundary, whitelisted in `_apply_params_unlocked`, and correctly set as **network attributes** — but never threaded into the candidate pool. The pool's workers construct their own `CandidateUnit` in a separate process and cannot see `self`, so every candidate ran the module defaults (**patience 50, convergence 0.001**) regardless of configuration.

The failure was invisible from the outside: `GET /v1/training/params` reads the value straight back off the network attribute, so a `PATCH` reported `applied` and the readback agreed — while nothing the pool observed had changed.

Confirmed live during the P4 E-A campaign: runs sent `candidate_patience: 100`, the API echoed 100, and the candidate logs still read `Early stopping at epoch 50 - no improvement for 50 epochs`.

## The chain

```
network attrs (self.candidate_patience / self.candidate_convergence_threshold)
  -> _generate_candidate_tasks    <- BROKEN: not in either payload shape
  -> _build_candidate_inputs      <- BROKEN: not unpacked
  -> CandidateUnit(...)           <- BROKEN: kwargs never passed
```

All three hops are fixed, in both payload shapes (the OPT-5 SharedMemory metadata dict **and** the legacy fallback tuple).

## Backward compatibility

The legacy tuple grows from 6 to 8 elements by **appending**, so the first six positions keep their meaning:

- a 6-element tuple from an older caller still unpacks, via a length-guarded branch (the RC-5 `round_id` pattern);
- a metadata dict without the new keys falls back through `.get(..., default)`;
- both fall back to the **same `CandidateUnit` module defaults those callers already received**, so nothing changes for them.

Two existing fixtures in `test_cascade_correlation_coverage_deep.py` build 6-tuples; both still pass.

## Sites deliberately not changed

| Site | Why |
|---|---|
| `_create_candidate_unit` (`cascade_correlation.py:~1742`) | Already threads both from `self` — the sequential path was never broken. |
| `CandidateUnit` in `_collect_training_results` (`~1301`) | A carrier for weights returned by a distributed worker. It never trains, so early-stopping controls are meaningless there. |

## Testing

10 new tests in `src/tests/unit/cascade_correlation/test_candidate_hyperparam_plumbing.py`, hermetic — no worker processes, no GPU, no `/dev/shm`.

The decisive ones assert on the **constructed unit's** `patience` / `convergence_threshold`, not on the payload dict. That is deliberate: this is the CASCOR-P0-005 key-name-mismatch class, where a key exists in the payload under one name while the constructor reads another and silently takes its default. A payload-level assertion would have passed against the defect.

**Verified against pre-fix code** (throwaway worktree at `origin/main`, same test file): **9 of 10 fail**, including the money assertion

```
E   AssertionError: assert 50 == 7
E    +  where 50 = <CandidateUnit>.patience
```

which reproduces the live symptom exactly. The one test that passes pre-fix is `test_worker_falls_back_to_defaults_for_legacy_payload` — the back-compat control, which must pass on both sides.

Regression run: `src/tests/unit/cascade_correlation/` + `test_cascade_correlation_coverage_deep.py` — **224 passed**. `black` / `isort` / `flake8` clean under the repo's exact hook args.

## Impact

Beyond the API surface, every committed experiment config that sets either key — `conf/experiments/spiral-baseline.yaml` among them — was silently running the pool at 50 / 0.001. Any study sweeping candidate patience or convergence through the service was measuring a single operating point.

## Observation, not fixed here

`_PROJECT_MODEL_CANDIDATE_PATIENCE` is defined **twice** — `constants_model.py:544` (50) and `constants_candidates.py:297` (30) — and which one wins is decided by import order in `constants.py`. Live behaviour is 50, so `constants_model` currently wins. That shadowing is a latent hazard independent of this defect; flagging rather than changing it, since resolving it would move a default.

## Requirements

No tracked `JR-*` requirement applies.

Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)
