### PR TITLE
fix(api): classify serialisation faults as 500, not 400

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Serialisation faults are reported as `500`, not `400` (`APD-CASCOR-002`).** The blanket
+  `@app.exception_handler(ValueError)` returned `400 VALIDATION_ERROR`, and
+  `pydantic_core.PydanticSerializationError` subclasses `ValueError` — so when the app failed to
+  serialise its *own* response, the caller was told they had sent a bad request. The defect was
+  invisible to 5xx alerting (it never produced a 5xx), misattributed to the client, and stripped of
+  its diagnostic by the generic `"Invalid request parameters"` message. `PydanticSerializationError`
+  is now classified as the 500 it is and logged at exception level so the traceback survives.
+  `coerce_native_scalars` remains as the narrow pre-emption for the numpy-scalar case inside
+  `success_response`, but it only ever covered that one call path. A plain `ValueError` is unchanged
+  and still returns `400`.
+
 ### Changed
 
 - **`juniper-cascor-protocol` floor raised to `>=0.2.0`** (was the alpha `>=0.1.0a0`). `juniper-cascor-protocol` 0.2.0 went live on PyPI 2026-08-10 and is the release that wraps non-UTF-8 dtype bytes in `BinaryFrame.decode` as

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -14,6 +14,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from juniper_service_core import enforce_auth_posture
+from pydantic_core import PydanticSerializationError
 
 from api import provenance
 from api.lifecycle.manager import TrainingLifecycleManager
@@ -677,6 +678,21 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     # Exception handlers
     @app.exception_handler(ValueError)
     async def value_error_handler(request: Request, exc: ValueError) -> JSONResponse:
+        # ``PydanticSerializationError`` subclasses ValueError, but it is a SERVER
+        # fault: the app failed to serialise its own response. Reporting it as 400
+        # misattributes our defect to the caller, hides it from 5xx alerting, and
+        # replaces the diagnostic with "Invalid request parameters". Classify it as
+        # the 500 it is, and log at exception level so the traceback survives.
+        #
+        # ``coerce_native_scalars`` (api/models/common.py) pre-empts the common
+        # numpy-scalar case inside ``success_response``; this catches every other
+        # serialisation fault, which that helper by construction cannot.
+        if isinstance(exc, PydanticSerializationError):
+            logger.exception("Response serialization failed")
+            return JSONResponse(
+                status_code=500,
+                content=error_response("INTERNAL_ERROR", "Internal server error"),
+            )
         logger.debug("Validation error: %s", exc)
         return JSONResponse(
             status_code=400,

--- a/src/tests/unit/api/test_api_app.py
+++ b/src/tests/unit/api/test_api_app.py
@@ -2,6 +2,7 @@
 
 import pytest
 from fastapi.testclient import TestClient
+from pydantic_core import PydanticSerializationError
 
 from api.app import _API_VERSION, create_app
 from api.settings import Settings
@@ -77,6 +78,27 @@ class TestAppFactory:
         body = response.json()
         assert body["status"] == "error"
         assert body["error"]["code"] == "VALIDATION_ERROR"
+
+    def test_serialization_fault_returns_500_not_400(self):
+        """APD-CASCOR-002: a serialisation fault is the server's, not the caller's.
+
+        ``PydanticSerializationError`` subclasses ``ValueError``, so the blanket
+        handler reported the app's own failure to serialise a response as a 400 --
+        invisible to 5xx alerting, misattributed to the client, and stripped of its
+        diagnostic by the generic "Invalid request parameters" message.
+        """
+        app = create_app(Settings(auto_start=False))
+
+        @app.get("/test-serialization-error")
+        async def raise_serialization_error():
+            raise PydanticSerializationError("Unable to serialize unknown type: <class 'numpy.float32'>")
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get("/test-serialization-error")
+        assert response.status_code == 500
+        body = response.json()
+        assert body["status"] == "error"
+        assert body["error"]["code"] == "INTERNAL_ERROR"
 
     def test_general_exception_handler(self):
         """Test that unhandled exceptions return 500."""


### PR DESCRIPTION
## Summary

Fixes **`APD-CASCOR-002`** from the [Juniper defect register](https://github.com/pcalnon/juniper-ml/blob/main/notes/JUNIPER_2026-08-14_JUNIPER-ECOSYSTEM_DEFECT-REGISTER.md) — ranked second on its next-steps list. The identical handler in `juniper-data` (`APD-DATA-034`) is fixed in its own PR.

## The problem

The blanket handler returns a client error for a server fault:

```python
@app.exception_handler(ValueError)
async def value_error_handler(request, exc):
    return JSONResponse(status_code=400, content=error_response("VALIDATION_ERROR", "Invalid request parameters"))
```

`pydantic_core.PydanticSerializationError` **subclasses `ValueError`**. So when the app fails to serialise its *own* response, the caller is told they sent a bad request. Three consequences:

- **Invisible to 5xx alerting** — the defect never produces a 5xx, so nothing pages.
- **Misattributed to the client**, who cannot act on it.
- **Diagnostic destroyed** — the generic `"Invalid request parameters"` replaces the real message naming which type failed to serialise, so the logs don't identify it either.

## Why the existing workaround isn't the fix

`coerce_native_scalars` was written specifically to dodge this — the failure mode is survivable today only because it exists. But it runs **only inside `success_response`**, so any serialisation fault arising anywhere else is still misclassified. A workaround for one call path is not a fix for the handler.

## The change

`PydanticSerializationError` is classified as the 500 it is, logged at `exception` level so the traceback survives, and returned in the same `INTERNAL_ERROR` envelope the general handler already uses.

**A plain `ValueError` is untouched and still returns 400.** The existing `test_value_error_handler` passes unchanged — that's the point: this *narrows* the handler rather than redefining it. `coerce_native_scalars` stays as the cheap pre-emption for the common numpy-scalar case.

## Verification

- New test confirmed to bite: with the fix reverted it fails `assert 400 == 500` against a raised `PydanticSerializationError`. The two neighbouring handler tests pass either way.
- `tests/unit/api/` green — ~2066 tests, exit 0
- `pre-commit` clean: Black, isort, Flake8 (source + tests), MyPy, Bandit, async-route audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AK45mcdNE5ifkxqTr6BxTU
