### PR TITLE
fix(cascor): terminate the direct CLI after training instead of blocking on plt.show()

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -295,7 +295,16 @@ def _resolve_cli_overrides(dataset_params, training_params):
     return overrides, sorted(unmapped)
 
 
-def main():
+def main(generate_plots: bool = _CASCOR_GENERATE_PLOTS_DEFAULT):
+    """
+    Run the spiral problem end to end.
+
+    Args:
+        generate_plots: Whether to build the dataset / decision-boundary / training-history
+            figures. Defaults to the project constant; `--no-plots` turns them off, which is
+            what an automated or headless run wants (F-P1-3) since the figures are
+            display-only and are never saved to disk.
+    """
     Logger.info("Cascor: main: Starting the Cascade Correlation Neural Network project")
     Logger.info(f"Cascor: main: Project constants: Log Level: {_CASCOR_LOG_LEVEL}, Log Level Name: {_CASCOR_LOG_LEVEL_NAME}")
     Logger.info(f"Cascor: main: Project constants: Log File Name: {_CASCOR_LOG_FILE_NAME}, Log File Path: {_CASCOR_LOG_FILE_PATH}")
@@ -435,7 +444,7 @@ def main():
         _SpiralProblem__default_radius=_CASCOR_DEFAULT_RADIUS,
         _SpiralProblem__distribution=_CASCOR_DISTRIBUTION_FACTOR,
         _SpiralProblem__epochs_max=_CASCOR_EPOCHS_MAX,
-        _SpiralProblem__generate_plots_default=_CASCOR_GENERATE_PLOTS_DEFAULT,
+        _SpiralProblem__generate_plots_default=generate_plots,
         _SpiralProblem__input_size=_CASCOR_INPUT_SIZE,
         _SpiralProblem__learning_rate=_w11.get("learning_rate", _CASCOR_LEARNING_RATE),
         _SpiralProblem__log_config=log_config,
@@ -498,7 +507,7 @@ def main():
         train_ratio=_w11.get("train_ratio", _CASCOR_TRAIN_RATIO),
         test_ratio=_w11.get("test_ratio", _CASCOR_TEST_RATIO),
         noise=_w11.get("noise", _CASCOR_NOISE_FACTOR_DEFAULT),
-        plot=_CASCOR_GENERATE_PLOTS_DEFAULT,
+        plot=generate_plots,
     )
     logger.info("Main: Completed solving SpiralProblem instance")
 
@@ -516,6 +525,7 @@ def parse_args():
         epilog="""
 Examples:
   python main.py                      # Run normally
+  python main.py --no-plots           # Run headless / automated (no blocking figures)
   python main.py --profile            # Run with cProfile profiling
   python main.py --profile-memory     # Run with memory profiling
   python main.py --profile --profile-output ./my_profiles
@@ -530,6 +540,7 @@ Examples:
 
     parser.add_argument("--profile-top-n", type=int, default=30, help="Number of top functions to display in profile output (default: 30)")
     parser.add_argument("--config", type=str, default=None, help="Experiment YAML whose service: block overrides env (sets JUNIPER_CASCOR_CONFIG_FILE before settings load; Wave 3.1)")
+    parser.add_argument("--no-plots", action="store_true", help="Skip the dataset / decision-boundary / training-history figures. Recommended for automated and headless runs: the figures are display-only (never saved), and under an interactive backend showing them blocks the process after training finishes (F-P1-3)")
 
     return parser.parse_args()
 
@@ -544,12 +555,17 @@ if __name__ == "__main__":
         # Wave 3.1: must land before the first Settings()/get_settings() use (SS5.2).
         os.environ["JUNIPER_CASCOR_CONFIG_FILE"] = args.config
 
+    # F-P1-3: resolved once so every entry path below (plain, cProfile, tracemalloc) honours
+    # --no-plots. A profiling run is automated by definition, so it is exactly the path that
+    # must not park in a GUI event loop after training finishes.
+    generate_plots = _CASCOR_GENERATE_PLOTS_DEFAULT and not args.no_plots
+
     if args.profile:
         from profiling.deterministic import ProfileContext
 
         Logger.info("Cascor: Starting with cProfile profiling enabled")
         with ProfileContext("main_training", output_dir=args.profile_output) as profiler:
-            main()
+            main(generate_plots=generate_plots)
         profiler.print_stats(top_n=args.profile_top_n)
         profiler.save()
 
@@ -558,10 +574,10 @@ if __name__ == "__main__":
 
         Logger.info("Cascor: Starting with memory profiling enabled")
         with MemoryTracker("main_training") as tracker:
-            main()
+            main(generate_plots=generate_plots)
         tracker.print_summary()
         tracker.print_top_allocations(top_n=args.profile_top_n)
         tracker.print_diff(top_n=args.profile_top_n)
 
     else:
-        main()
+        main(generate_plots=generate_plots)

--- a/src/spiral_problem/spiral_problem.py
+++ b/src/spiral_problem/spiral_problem.py
@@ -48,6 +48,7 @@ import warnings
 # from inspect import currentframe, getframeinfo
 from typing import Any, Callable, Tuple
 
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
@@ -110,6 +111,32 @@ from cascor_constants.constants import (  # _PROJECT_MODEL_AUTHKEY,; _PROJECT_MO
 )
 from log_config.log_config import LogConfig
 from log_config.logger.logger import Logger
+
+#####################################################################################################################################################################################################
+# F-P1-3: backends that never open a window, so plt.show() returns immediately instead of
+# parking the caller in a GUI event loop. Only consulted if the modern registry API is
+# unavailable (matplotlib < 3.9 or a future rename).
+_NON_INTERACTIVE_MPL_BACKENDS = frozenset({"agg", "cairo", "pdf", "pgf", "ps", "svg", "template"})
+
+
+def _backend_is_interactive() -> bool:
+    """
+    Description:
+        Report whether the active matplotlib backend opens windows, i.e. whether plt.show()
+        blocks until the user closes them. Used to keep a headless/automated run from
+        parking forever in the GUI event loop after training has already finished (F-P1-3).
+    Returns:
+        True if the backend is interactive (plt.show() blocks), False otherwise.
+    """
+    backend = matplotlib.get_backend()
+    try:
+        from matplotlib.backends import BackendFilter, backend_registry
+
+        interactive = backend_registry.list_builtin(BackendFilter.INTERACTIVE)
+    except (ImportError, AttributeError):
+        # Pre-3.9 matplotlib (or a renamed registry): fall back to the static name set.
+        return backend.lower() not in _NON_INTERACTIVE_MPL_BACKENDS
+    return backend.lower() in {name.lower() for name in interactive}
 
 
 #####################################################################################################################################################################################################
@@ -1323,8 +1350,21 @@ class SpiralProblem(object):
             self.network.plot_training_history()
         self.logger.trace("SpiralProblem: solve_n_spiral_problem: Completed solving N Spiral Problem")
         if self.plot:
-            plt.show()
-            self.plotter.join()
+            # F-P1-3: both calls below BLOCK under an interactive backend -- plt.show() parks
+            # this process in the GUI event loop and self.plotter.join() waits on the
+            # (non-daemon) dataset-plot child, which is itself parked in its own plt.show().
+            # Training has already finished here, so on a headless/automated run the process
+            # simply never exits and never reports: the run is killed at whatever bound the
+            # caller set and looks, from the outside, exactly like a compute-bound run.
+            #
+            # A non-interactive backend (Agg -- headless default, or MPLBACKEND=Agg) opens no
+            # windows, so there is nothing to wait for. Skipping loses no artifact: the
+            # plot_* helpers only ever show figures, they never savefig.
+            if _backend_is_interactive():
+                plt.show()
+                self.plotter.join()
+            else:
+                self.logger.info(f"SpiralProblem: solve_n_spiral_problem: Non-interactive matplotlib backend ({matplotlib.get_backend()}) -- skipping the blocking plt.show()/join. Figures are display-only and are not saved.")
 
     def evaluate(
         self,

--- a/src/tests/unit/test_fp13_direct_cli_termination.py
+++ b/src/tests/unit/test_fp13_direct_cli_termination.py
@@ -1,0 +1,118 @@
+"""Tests for F-P1-3: the direct CLI must terminate after training finishes.
+
+The direct CLI used to hang forever once the cascade stopped growing.
+``solve_n_spiral_problem`` ends with ``plt.show()`` followed by
+``self.plotter.join()``; under an interactive backend the first parks the process
+in the GUI event loop and the second waits on a (non-daemon) child parked in its
+own ``plt.show()``. Plotting is on by default and, before this change, had no
+CLI or experiment-YAML knob, so an automated run could only be killed at whatever
+bound the caller set -- which read from outside as a compute-bound run.
+
+Measured on the P1/R-5 smoke arm (2 hidden units, pool 4): training finished in
+~39 s in every arm; unfixed + interactive backend hung past a 240 s bound, while
+``--no-plots`` terminated cleanly in ~38-40 s.
+
+These tests pin the two halves of the fix:
+  * ``--no-plots`` exists and reaches ``main(generate_plots=...)``;
+  * the blocking pair is guarded by ``_backend_is_interactive()``, which is
+    False for the non-interactive backends a headless run resolves to.
+"""
+
+import inspect
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class TestNoPlotsFlag:
+    def test_no_plots_defaults_to_false(self, monkeypatch):
+        import sys
+
+        from main import parse_args
+
+        monkeypatch.setattr(sys, "argv", ["main.py"])
+        assert parse_args().no_plots is False
+
+    def test_no_plots_sets_true(self, monkeypatch):
+        import sys
+
+        from main import parse_args
+
+        monkeypatch.setattr(sys, "argv", ["main.py", "--no-plots"])
+        assert parse_args().no_plots is True
+
+    def test_main_accepts_generate_plots(self):
+        """--no-plots is inert unless main() actually takes the flag through."""
+        import main
+
+        assert "generate_plots" in inspect.signature(main.main).parameters
+
+    def test_entrypoint_threads_flag_into_every_main_call(self):
+        """cProfile / tracemalloc runs are automated too -- none may call a bare main()."""
+        import main
+
+        source = inspect.getsource(main)
+        entrypoint = source.split('if __name__ == "__main__":', 1)[1]
+        assert "not args.no_plots" in entrypoint
+        # Every main() call on the entrypoint path must pass the resolved flag.
+        assert "main()" not in entrypoint
+        assert entrypoint.count("main(generate_plots=generate_plots)") == 3
+
+
+class TestBackendIsInteractive:
+    @pytest.mark.parametrize("backend", ["agg", "Agg", "pdf", "svg", "template", "ps"])
+    def test_non_interactive_backends(self, backend, monkeypatch):
+        import spiral_problem.spiral_problem as sp
+
+        monkeypatch.setattr(sp.matplotlib, "get_backend", lambda: backend)
+        assert sp._backend_is_interactive() is False
+
+    @pytest.mark.parametrize("backend", ["tkagg", "TkAgg", "qtagg"])
+    def test_interactive_backends(self, backend, monkeypatch):
+        import spiral_problem.spiral_problem as sp
+
+        monkeypatch.setattr(sp.matplotlib, "get_backend", lambda: backend)
+        assert sp._backend_is_interactive() is True
+
+    def test_falls_back_when_registry_unavailable(self, monkeypatch):
+        """matplotlib < 3.9 (or a renamed registry) must still classify Agg correctly."""
+        import builtins
+
+        import spiral_problem.spiral_problem as sp
+
+        real_import = builtins.__import__
+
+        def _no_registry(name, *args, **kwargs):
+            if name == "matplotlib.backends":
+                raise ImportError("simulated: no backend_registry")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _no_registry)
+        monkeypatch.setattr(sp.matplotlib, "get_backend", lambda: "agg")
+        assert sp._backend_is_interactive() is False
+        monkeypatch.setattr(sp.matplotlib, "get_backend", lambda: "tkagg")
+        assert sp._backend_is_interactive() is True
+
+
+class TestTerminalBlockIsGuarded:
+    def test_show_and_join_sit_behind_the_backend_guard(self):
+        """The anti-regression pin: neither blocking call may run unguarded again.
+
+        Matched on whole code lines rather than substrings -- the guarded block's own
+        comment and log message mention ``plt.show()`` in prose, and a substring count
+        would score those as call sites.
+        """
+        from spiral_problem.spiral_problem import SpiralProblem
+
+        lines = [line.strip() for line in inspect.getsource(SpiralProblem.solve_n_spiral_problem).splitlines()]
+
+        guard_idx = [i for i, line in enumerate(lines) if line == "if _backend_is_interactive():"]
+        show_idx = [i for i, line in enumerate(lines) if line == "plt.show()"]
+        join_idx = [i for i, line in enumerate(lines) if line == "self.plotter.join()"]
+
+        assert len(guard_idx) == 1, "expected exactly one backend guard"
+        assert len(show_idx) == 1, "expected exactly one plt.show() call site"
+        assert len(join_idx) == 1, "expected exactly one plotter.join() call site"
+        assert show_idx[0] > guard_idx[0], "plt.show() must sit inside the backend guard"
+        assert join_idx[0] > guard_idx[0], "plotter.join() must sit inside the backend guard"


### PR DESCRIPTION
## Summary

Closes **F-P1-3**: the cascor direct CLI (`src/main.py`) never terminates once the cascade
stops growing, so it has never been run to completion at a controlled budget anywhere in the
CLI-experimentation arc.

The cause is not the training budget. `solve_n_spiral_problem` ends with:

```python
if self.plot:
    plt.show()            # parks THIS process in the GUI event loop
    self.plotter.join()   # waits on a non-daemon child parked in its own plt.show()
```

Under an interactive backend both calls block forever — there are windows open and nobody
will close them. Plotting is on by default (`_SPIRAL_PROBLEM_GENERATE_PLOTS_DEFAULT = True`)
and had **no** CLI flag and no entry in the W-11 experiment-YAML key maps, so an automated run
had no way to turn it off and could only be killed at whatever bound the caller set.

From the outside that is indistinguishable from a slow run, which is how it was recorded as
finding **F-P1-3b**, *"structural CLI-path compute overhead"*. That conclusion is wrong:
training finishes in ~39 s on the P1/R-5 smoke arm, and every second past that was spent
blocked, not computing.

## The measurement

Three arms, same dataset service (per-run juniper-data on `:8110`), same smoke YAML
(`max_hidden_units: 2`, `candidate_pool_size: 4`, `candidate_epochs: 50`):

| arm | checkout | backend | flags | result |
| --- | --- | --- | --- | --- |
| treatment | `main` `1d04989` | `Agg` (forced) | — | **exit 0, 39 s** |
| control | `main` `1d04989` | `tkagg` (inherited, `DISPLAY=:0`) | — | **hung past a 240 s bound** |
| fix | this branch | `tkagg` (inherited) | `--no-plots` | **exit 0, 38–40 s** |

In all three, `fit: Training completed.` lands at **+39 s** and the network reaches its 2-unit
cap (train 0.960 / test 0.970). Only the terminal phase differs. The control's log stops dead
after the two `Started plotting process PID: …` lines and never reaches
`main.py: Completed solving SpiralProblem instance` — 0 occurrences across the whole 241 s.

## The change

Two halves, because they cover different failure conditions:

1. **`--no-plots`** skips the figures entirely. Threaded through *every* entrypoint — plain,
   `--profile`, `--profile-memory` — since a profiling run is automated by definition and is
   exactly the path that must not park in an event loop. This is the operative fix on any host
   with `DISPLAY` set.
2. **The blocking pair now sits behind `_backend_is_interactive()`.** A genuinely headless run
   (Agg) no longer depends on `plt.show()` *happening* to be a no-op, `plotter.join()` no
   longer depends on the child's behaviour, and the fact that display-only figures are being
   silently discarded is now logged instead of invisible.

The `plot_*` helpers only ever `show()` figures — they never `savefig` — so skipping them
loses no artifact.

### Deliberately not in this PR

`solve_n_spiral_problem` passes `max_epochs=_SPIRAL_PROBLEM_OUTPUT_EPOCHS` (the module
constant) to `fit()` rather than `self.output_epochs` (the W-11 override), and `fit()` never
forwards `max_epochs` to `grow_network` at all — it only logs it. Both are inert today
(the effective output-epoch budget arrives via the config object, which *does* carry the
override), so this is a latent trap rather than a live defect, and it is filed in the evidence
note rather than bundled into a hang fix.

## Testing

- `src/tests/unit/test_fp13_direct_cli_termination.py` — new. Pins `--no-plots` (default,
  set, reaches `main(generate_plots=...)`, and that no entrypoint calls a bare `main()`),
  `_backend_is_interactive()` across interactive/non-interactive backends plus the
  pre-3.9-matplotlib fallback path, and an anti-regression check that neither blocking call
  can return to an unguarded position.
- `pytest tests/unit/test_fp13_direct_cli_termination.py tests/unit/test_main_coverage.py tests/unit/test_main_profiling_coverage.py tests/unit/test_w11_cli_yaml_mapping.py` → **44 passed**
- `pre-commit run --files …` → all hooks pass (black, isort, flake8, mypy, bandit, async-route audit)
- Live: the three-arm table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8QXymq1H6YghpuGEQoxh5
