### PR TITLE
ci(lockfile): sign the regen commit and skip release/** heads

### DIFF
--- a/.github/workflows/lockfile-update.yml
+++ b/.github/workflows/lockfile-update.yml
@@ -5,10 +5,10 @@
 # Application:   juniper_cascor
 # File Name:     lockfile-update.yml
 # Author:        Paul Calnon
-# Version:       0.1.0
+# Version:       0.2.0
 #
 # Date Created:  2026-03-02
-# Last Modified: 2026-07-28
+# Last Modified: 2026-08-14
 #
 # License:       MIT License
 # Copyright:     Copyright (c) 2024-2026 Paul Calnon
@@ -30,8 +30,28 @@
 #    A missing PAT on a NON-Dependabot run still fails loudly. Mirrors
 #    juniper-canopy #476.
 #
+#    required_signatures (2026-08-14, juniper-ml#1099): the 2026-08-12 branch-
+#    protection normalization made every repo reject UNSIGNED commits, and a
+#    local `git commit` on a runner is unsigned -- so this lane's regen commit
+#    turned every branch it touched UNMERGEABLE (an unsigned commit anywhere in
+#    the history blocks the merge; squash does not rescue it). The regen now
+#    lands through the GitHub API (createCommitOnBranch), which GitHub signs.
+#    CROSS_REPO_DISPATCH_TOKEN is still the identity, so the CI re-trigger
+#    property is unchanged. Live repro: juniper-cascor#518, where 20/20 checks
+#    were green and the PR was BLOCKED solely by this lane's commit.
+#
+#    release/** exclusion (same change): a release-train proposal PR must stay
+#    single-purpose -- version bump + CHANGELOG move. Its pyproject.toml edit is
+#    a version bump that cannot change dependency resolution, but it matched the
+#    `paths: [pyproject.toml]` filter and dragged unrelated upstream drift
+#    (charset-normalizer/filelock/sentry-sdk on #518) into the release PR. The
+#    required `Lockfile Freshness` gate is constraint-mode and does NOT fail on
+#    newer-upstream-exists, so skipping release/** leaves it green.
+#
 # References:
 #    - Step 7.5.2: Dependency Update Workflow (POLYREPO_MIGRATION_PLAN.md)
+#    - juniper-ml#1099 (runner-commit signing), juniper-ml#1096 (propose.py
+#      create_signed_commit -- the reference implementation)
 #####################################################################################################################################################################################################
 
 name: Update Lockfile (Dependabot)
@@ -58,9 +78,16 @@ jobs:
     #     leave main red after merge). Skip PRs from forks since they
     #     cannot push back with our token.
     # Replicates juniper-canopy PR #250 / juniper-data PR #122 hardening.
+    #
+    # release/** is excluded (juniper-ml#1099): a release-train proposal bumps
+    # pyproject.toml's version, which matches the paths filter but cannot change
+    # dependency resolution -- regenerating there only smuggles unrelated
+    # upstream drift into a PR that must stay single-purpose.
     if: |
       (github.event_name == 'push' && github.actor == 'dependabot[bot]') ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+      (github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.full_name == github.repository
+        && !startsWith(github.head_ref, 'release/'))
 
     steps:
       - name: Gate on CROSS_REPO_DISPATCH_TOKEN availability
@@ -118,15 +145,49 @@ jobs:
 
           mv /tmp/requirements.lock.check requirements.lock
 
-      - name: Commit updated lockfile
+      # The regen commit is created through the GitHub API rather than by a
+      # local `git commit` + `git push`, because GitHub SIGNS API-created
+      # commits and the repo now enforces required_signatures (juniper-ml#1099).
+      # CROSS_REPO_DISPATCH_TOKEN stays the identity so the resulting commit
+      # still re-triggers CI (GITHUB_TOKEN would not).
+      - name: Commit updated lockfile (GitHub-signed, via API)
         if: steps.gate.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_REPO_DISPATCH_TOKEN }}
+          BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add requirements.lock
-          if git diff --cached --quiet; then
+          set -euo pipefail
+
+          if git diff --quiet -- requirements.lock; then
             echo "::notice::Lockfile already up to date — no commit needed"
-          else
-            git commit -m "[dependabot skip] Update requirements.lock"
-            git push
+            exit 0
           fi
+
+          # expectedHeadOid makes this a compare-and-swap: if anything landed on
+          # the branch since checkout, the mutation fails loudly rather than
+          # clobbering it (the old `git push` had the same protection).
+          HEAD_OID=$(git rev-parse HEAD)
+
+          jq -n \
+            --arg repo "${GITHUB_REPOSITORY}" \
+            --arg branch "${BRANCH}" \
+            --arg oid "${HEAD_OID}" \
+            --arg contents "$(base64 -w0 requirements.lock)" \
+            '{query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid url } } }",
+              variables: {input: {
+                branch: {repositoryNameWithOwner: $repo, branchName: $branch},
+                message: {headline: "[dependabot skip] Update requirements.lock"},
+                expectedHeadOid: $oid,
+                fileChanges: {additions: [{path: "requirements.lock", contents: $contents}]}
+              }}}' > /tmp/lockfile-commit.json
+
+          gh api graphql --input /tmp/lockfile-commit.json > /tmp/lockfile-commit-result.json
+
+          if jq -e '.errors' /tmp/lockfile-commit-result.json > /dev/null; then
+            echo "::error::createCommitOnBranch failed — lockfile NOT committed:"
+            jq '.errors' /tmp/lockfile-commit-result.json
+            exit 1
+          fi
+
+          jq -r '"Signed lockfile commit: " + .data.createCommitOnBranch.commit.url' \
+            /tmp/lockfile-commit-result.json


### PR DESCRIPTION
## Summary

The lockfile auto-regen lane makes an **unsigned** commit, which the 2026-08-12
`required_signatures` normalization now rejects — so every branch this lane touches
becomes unmergeable. This PR makes the regen commit **GitHub-signed** and stops the
lane from firing on release-train proposal branches.

Part of the juniper-ml#1099 fan-out (the same root cause fixed for `propose.py` in
juniper-ml#1096).

## The live repro

[juniper-cascor#518](https://github.com/pcalnon/juniper-cascor/pull/518) — the
`juniper-cascor v0.9.0` release proposal:

| Signal | Value |
| --- | --- |
| Checks | **20 / 20 pass** |
| Unresolved review threads | none (`reviewThreads: []`) |
| `mergeable` | `MERGEABLE` |
| `mergeStateStatus` | **`BLOCKED`** |
| `efd2bbf8` (proposal commit) | `signature.isValid: true`, `state: VALID` |
| `7589fdcd` (this lane's commit) | **`signature: null`** |

Everything green, nothing to review, and it cannot merge — because of one unsigned
commit from this workflow.

## Two defects, two fixes

**1. Unsigned commit → sign it via the API.**
A local `git commit` on a runner is unsigned. An unsigned commit *anywhere* in the
branch history blocks the merge, and squash does not rescue it. The regen now lands
through `createCommitOnBranch`, which GitHub signs.

`CROSS_REPO_DISPATCH_TOKEN` remains the identity, so the "push re-triggers CI"
property this lane depends on is unchanged (`GITHUB_TOKEN` would not re-trigger).
`expectedHeadOid` keeps the compare-and-swap safety the old `git push` had — a
concurrent commit makes the mutation fail loudly rather than clobber.

**2. Lane fires on release proposals → skip `release/**` heads.**
The trigger is `pull_request` + `paths: [pyproject.toml]`. A release proposal
*always* bumps `pyproject.toml`, so the lane always fires on it and regenerates the
lock against latest upstream — dragging unrelated drift into a PR that must stay
single-purpose (bump + CHANGELOG move). On #518 that was
`charset-normalizer 3.4.9→3.5.0`, `filelock`, `sentry-sdk` (+5/−5), none of it
related to the release.

A version bump cannot change dependency resolution, so there is nothing to regen
on these branches anyway.

## Why this does not break `Lockfile Freshness`

`Lockfile Freshness` is a **required** check, so skipping the regen lane must not
make it fail. It cannot: that job resolves with `--constraint requirements.lock`
and its own comment states it

> Does NOT fail just because newer versions exist on PyPI — that is the whole point
> of pinning. Fails only when `pyproject.toml` has drifted from what the lockfile
> can support.

A release-branch version bump is exactly the case it tolerates.

## Scope / risk

- The job `name:` (`Update requirements.lock`) is **unchanged**, so no status-check
  context name moves. It is not a required context on this repo.
- The dependabot `push` arm is untouched — it also gets signing, which it needs for
  the same reason.
- No change to what the lockfile *contains*, only to how the commit is created and
  when the lane runs.
- yamllint clean against this repo's `.yamllint.yaml`.

## Verification

After merge, the intended sequence is: close #518 and delete its branch, then
re-run the release-train propose lane for `juniper-cascor` — the new proposal PR
should carry exactly one signed commit and no lockfile commit at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
