### PR TITLE
fix(cascor): honour the configured output-epoch budget in the direct CLI (L-1)

### DIFF
--- a/src/cascade_correlation/cascade_correlation.py
+++ b/src/cascade_correlation/cascade_correlation.py
@@ -1871,6 +1871,14 @@ class CascadeCorrelationNetwork:
         # Initial training of the output layer
         self.logger.trace("CascadeCorrelationNetwork: fit: Starting initial training of the output layer.")
         self.logger.info("CascadeCorrelationNetwork: fit: Initial training of output layer")
+        # L-2 (scope note): ``max_epochs`` governs THIS initial output pass only. It is
+        # deliberately not forwarded to ``grow_network`` below, whose per-round output
+        # passes read ``self.output_epochs`` directly. The two therefore agree only while
+        # a caller leaves ``max_epochs`` unset (falling back to ``self.output_epochs``
+        # here) or passes a value equal to it. ``max_epochs`` is in the service's
+        # ``_FIT_KWARGS``, so an explicit PATCH can still split them; whether an explicit
+        # ``max_epochs`` should also re-budget the per-round passes is an open semantic
+        # question, not settled here. See the F-P1-3 root-cause note, finding L-2.
         max_epochs = (max_epochs, self.output_epochs)[max_epochs is None]
         # BUG-CC-09: re-validate after the ``self.output_epochs`` fall-back —
         # the earlier check only ran when ``max_epochs`` came in non-None,

--- a/src/spiral_problem/spiral_problem.py
+++ b/src/spiral_problem/spiral_problem.py
@@ -1332,10 +1332,20 @@ class SpiralProblem(object):
         self.logger.trace("SpiralProblem: solve_n_spiral_problem: Training the network on the N Spiral Problem dataset")
         self.logger.debug("SpiralProblem: solve_n_spiral_problem: Created Spiral Problem...")
         self.logger.debug(f"SpiralProblem: solve_n_spiral_problem: Spiral Problem: \n{self.network}")
+        # L-1: pass the *instance* budget, not the module constant. ``fit`` uses
+        # ``max_epochs`` for the initial output-layer pass only; every per-round
+        # output pass inside ``grow_network`` uses ``self.output_epochs``. Pinning
+        # the constant here made the two disagree whenever a caller configured
+        # ``output_epochs`` -- main.py's W-11 mapping sets
+        # ``_SpiralProblem__output_epochs`` from the experiment YAML, so a direct-CLI
+        # run with ``max_epochs: 100`` still trained the initial pass for the
+        # constant's 10000 epochs while every later pass correctly stopped at 100.
+        # It also contradicted the project's own cost model: TrainingLifecycleManager
+        # .derive_epochs_cap documents the initial pass as costing ``output_epochs``.
         self.history = self.network.fit(
             self.x,
             self.y,
-            max_epochs=_SPIRAL_PROBLEM_OUTPUT_EPOCHS,
+            max_epochs=self.output_epochs,
         )
         self.logger.debug(f"SpiralProblem: solve_n_spiral_problem: Training history: {self.history}")
 

--- a/src/tests/unit/test_l1_spiral_output_epochs_budget.py
+++ b/src/tests/unit/test_l1_spiral_output_epochs_budget.py
@@ -1,0 +1,79 @@
+"""Tests for L-1: the direct CLI must honour the configured output-epoch budget.
+
+``solve_n_spiral_problem`` used to call ``self.network.fit(max_epochs=_SPIRAL_PROBLEM_OUTPUT_EPOCHS)``
+-- the module *constant* -- rather than ``self.output_epochs``, the instance attribute
+main.py's W-11 mapping populates from the experiment YAML. ``fit`` keeps a non-None
+``max_epochs`` as-is (``cascade_correlation.py``: ``max_epochs = (max_epochs, self.output_epochs)[max_epochs is None]``)
+and spends it on the initial output-layer pass, so the configured budget was silently
+discarded for that pass while every per-round pass inside ``grow_network`` -- which reads
+``self.output_epochs`` -- correctly honoured it.
+
+Measured on the preserved R-5 arm C run (YAML ``training.params.max_epochs: 100``): the
+initial pass ran the constant's full 10000 epochs, taking ~18 s of a ~40 s run, with the
+loss flat at 0.203637 from roughly epoch 150 onward; the two later per-round passes in the
+same log each stopped at exactly epoch 100.
+
+The defect also contradicted the project's own cost model:
+``TrainingLifecycleManager.derive_epochs_cap`` documents the initial pass as costing
+``output_epochs``, and ``_W11_TRAINING_KEY_MAP`` maps the YAML's ``max_epochs`` onto
+``output_epochs`` precisely so it can bound that pass.
+
+These tests pin the fix and the wiring it depends on.
+"""
+
+import ast
+import inspect
+import textwrap
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _fit_call_keywords():
+    """Return the keyword nodes of the ``fit`` call inside ``solve_n_spiral_problem``."""
+    import spiral_problem.spiral_problem as sp
+
+    source = textwrap.dedent(inspect.getsource(sp.SpiralProblem.solve_n_spiral_problem))
+    tree = ast.parse(source)
+    calls = [node for node in ast.walk(tree) if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "fit"]
+    assert len(calls) == 1, f"expected exactly one fit() call in solve_n_spiral_problem, found {len(calls)}"
+    return {kw.arg: kw.value for kw in calls[0].keywords}
+
+
+class TestSolveUsesInstanceBudget:
+    def test_fit_receives_self_output_epochs(self):
+        """The configured budget, not a module constant, bounds the initial output pass."""
+        max_epochs = _fit_call_keywords().get("max_epochs")
+        assert max_epochs is not None, "solve_n_spiral_problem must pass max_epochs explicitly"
+        assert isinstance(max_epochs, ast.Attribute), f"max_epochs must be an attribute lookup, got {type(max_epochs).__name__}"
+        assert isinstance(max_epochs.value, ast.Name) and max_epochs.value.id == "self"
+        assert max_epochs.attr == "output_epochs"
+
+    def test_fit_does_not_receive_a_module_constant(self):
+        """Anti-resurrection: a bare _SPIRAL_PROBLEM_* name here re-breaks the budget."""
+        max_epochs = _fit_call_keywords()["max_epochs"]
+        assert not isinstance(max_epochs, ast.Name), f"max_epochs must not be a bare module constant ({getattr(max_epochs, 'id', '')})"
+
+
+class TestOutputEpochsWiring:
+    """The fix reads ``self.output_epochs``; these pin what fills it."""
+
+    def test_constructor_kwarg_populates_the_attribute(self):
+        from spiral_problem.spiral_problem import SpiralProblem
+
+        assert SpiralProblem(_SpiralProblem__output_epochs=137).output_epochs == 137
+
+    def test_w11_maps_yaml_max_epochs_onto_output_epochs(self):
+        """C2b semantics: the YAML's max_epochs is the initial-output-pass budget."""
+        from main import _W11_TRAINING_KEY_MAP
+
+        assert _W11_TRAINING_KEY_MAP["max_epochs"] == "output_epochs"
+        assert _W11_TRAINING_KEY_MAP["output_epochs"] == "output_epochs"
+
+    def test_main_threads_the_w11_value_into_the_constructor(self):
+        """Without this hop the YAML budget never reaches the attribute the fix reads."""
+        import main
+
+        source = inspect.getsource(main)
+        assert '_SpiralProblem__output_epochs=_w11.get("output_epochs"' in source


### PR DESCRIPTION
## Summary

Finding **L-1** from the F-P1-3 root-cause note, filed there as *"Inert"*. It is **not inert** — it is live on the direct CLI, and the arc's own preserved evidence proves it.

`solve_n_spiral_problem` called `self.network.fit(max_epochs=_SPIRAL_PROBLEM_OUTPUT_EPOCHS)` — the module **constant** — instead of `self.output_epochs`, the instance attribute `main.py`'s W-11 mapping populates from the experiment YAML. `fit` keeps a non-None `max_epochs` as-is (`max_epochs = (max_epochs, self.output_epochs)[max_epochs is None]`) and spends it on the **initial** output-layer pass, so the configured budget was silently discarded for that pass, while every per-round pass inside `grow_network` — which reads `self.output_epochs` — honoured it.

## Evidence

From the preserved R-5 arm C run's own parent log, YAML `training.params.max_epochs: 100`:

| pass | source of budget | epochs reached |
| --- | --- | --- |
| initial (`fit` → `train_output_layer`) | `_SPIRAL_PROBLEM_OUTPUT_EPOCHS` | **10000** |
| per-round #1 (`grow_network`) | `self.output_epochs` | 100 |
| per-round #2 (`grow_network`) | `self.output_epochs` | 100 |

`Starting main training loop with max_epochs: 10000` while the YAML asked for 100. The initial pass ran **17:49:18 → 17:49:36 — ~18 s of a ~40 s run** — with the loss flat at `0.203637` from roughly epoch 150 onward. Same function, same run, two different budgets.

## Why it is a defect, not a preference

The repo already specifies the intended semantics in two places:

- `_W11_TRAINING_KEY_MAP` maps the YAML's `max_epochs` onto `output_epochs` *specifically so it can bound this pass* — `"C2b semantics: TrainingParams.max_epochs is the initial output-training pass budget"` (`main.py:246`).
- `TrainingLifecycleManager.derive_epochs_cap` documents the cost model as `output_epochs + effective_iterations * (candidate_epochs + output_epochs)` — "one initial output-training pass, plus …", i.e. the initial pass costs `output_epochs`.

## Scope

`solve_n_spiral_problem` has **no non-test caller outside the direct CLI**, so the service path is untouched.

The companion comment in `fit` records finding **L-2**: `max_epochs` deliberately does not re-budget `grow_network`'s per-round passes, and because `max_epochs` is in the service's `_FIT_KWARGS`, an explicit PATCH can still split the two. Whether it *should* is an open semantic question, deliberately left open here rather than settled in a fix PR.

**L-3 is not addressed and its filed recommendation should be withdrawn** — see below.

## Testing

`src/tests/unit/test_l1_spiral_output_epochs_budget.py` (5 tests) pins:

- the `fit` call passes `self.output_epochs` (AST, not substring);
- anti-resurrection — it is not a bare module constant;
- the W-11 wiring the fix depends on (`max_epochs` → `output_epochs` → `_SpiralProblem__output_epochs` → the attribute).

Verified to **fail against the pre-fix source** (`max_epochs` node is `Name _SPIRAL_PROBLEM_OUTPUT_EPOCHS`; both assertions trip).

Full cascor **unit suite passes**. The single failure, `test_version_matches_pyproject` (installed `0.6.0` vs pyproject `0.9.0`), is the pre-existing local conda-env drift and is CI-invisible. `pre-commit` clean on all changed files.

## Note for the follow-up: L-3 must NOT be deleted

The root-cause note recommends "deleting L-3 outright". **That would break the build.** `epochs_max` is not dead code — C2b/Q1 already retired it as an *input* while deliberately keeping the attribute:

- `snapshot_serializer.py:354` writes `config_group.attrs["epochs_max"]`; `test_snapshot_serializer.py::test_epochs_max_roundtrip` asserts `loaded.epochs_max == 777`.
- `test_c2b_epochs_cap_and_surfaces.py:136` asserts `getattr(lifecycle.network, "epochs_max", None) is not None  # legacy attribute still exists (snapshot compat)`.

`cascade_correlation.py:714` **is** that snapshot-compat attribute. "The engine never reads it" is already documented at `manager.py:1618-1625` — that is the intended state, not a latent defect.
