### PR TITLE
feat(logging): JUNIPER_CASCOR_LOG_DIR override, service + direct CLI (Q-6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Q-6: `JUNIPER_CASCOR_LOG_DIR` log-directory override, service + direct CLI** (CLI experimentation plan §11; H-7). Mirrors the W-6 `JUNIPER_CASCOR_SNAPSHOTS_DIR` override in shape and semantics, against the same class of problem: a
+  checkout-shared path that concurrent cascor processes collide on. The direct-CLI tier resolves `constants._PROJECT_LOG_DIR_DEFAULT` from the env var at import time (and with it `_PROJECT_LOG_FILE_PATH` and the `_LOGGER_*` /
+  `_LOG_CONFIG_*` constants the file handlers default to); the service tier's two `_resolve_log_dir` helpers (`api/observability.py`, `api/service_launcher.py`) read it at call time — deliberately **before** their `cascor_constants`
+  import, so the override also holds on the `ImportError` fallback, which never consults the constants and would otherwise write to the shared checkout path in precisely the degraded case that fallback exists for. Unset or blank keeps
+  `<repo>/logs` byte-identically, so nothing changes for existing deployments. 20 new unit tests (`test_q6_log_dir_override.py`) pin override / fallback / blank / whitespace / `~`-expansion, call-time-not-cached for both service
+  helpers, the `ImportError`-fallback arm, and that the downstream logger constants follow the override rather than drifting from it.
+- Why this is an evidence-integrity fix and not only a concurrency nicety: cascor's parent logger writes **only** to this file — stdout carries just candidate-worker lines — so the markers that decide a run's verdict (`Training
+  completed`, `Completed solving …`) exist nowhere else. Two cascor processes sharing a checkout interleave and rotate away each other's evidence. That is not hypothetical: it is how the F-P1-3 arm A/B logs were lost when a long-lived
+  service rotated the shared file mid-investigation. A per-run launcher can now point each instance at its own `RUN_DIR/logs`, which is the precondition H-7 named for retiring the one-cascor-instance-per-checkout rule (Wave 5.3, and
+  `run_suite`'s refusal of `app: cascor` with `parallel > 1`).
+
 ## [0.9.0] - 2026-08-14
 
 ### Fixed

--- a/src/api/observability.py
+++ b/src/api/observability.py
@@ -50,10 +50,20 @@ _NAMESPACE_DEFAULT: str = "juniper_cascor"
 def _resolve_log_dir() -> Path:
     """Resolve the absolute log directory path.
 
-    Uses the project constants if available, otherwise falls back to
-    a ``logs/`` directory relative to the project root (two levels up
-    from ``src/api/``).
+    Honours the ``JUNIPER_CASCOR_LOG_DIR`` override first (Q-6 / H-7), so a per-run
+    launcher can keep this service's file log inside its own ``RUN_DIR/logs`` rather
+    than the checkout-shared ``<repo>/logs`` that concurrent cascor processes interleave
+    and rotate away. Read at call time, not import time, so the override also holds on
+    the ``ImportError`` fallback below — which never consults the constants and would
+    otherwise silently write to the shared checkout path. A set-but-blank value is
+    treated as unset (the blank-env guard class).
+
+    Otherwise uses the project constants if available, and finally falls back to a
+    ``logs/`` directory relative to the project root (two levels up from ``src/api/``).
     """
+    override = os.environ.get("JUNIPER_CASCOR_LOG_DIR", "").strip()
+    if override:
+        return Path(override).expanduser()
     try:
         from cascor_constants.constants import _PROJECT_LOG_DIR_DEFAULT
 

--- a/src/api/service_launcher.py
+++ b/src/api/service_launcher.py
@@ -83,7 +83,17 @@ atexit.register(_cleanup_at_exit)
 
 
 def _resolve_log_dir() -> Path:
-    """Resolve the canonical log directory for subprocess output."""
+    """Resolve the canonical log directory for subprocess output.
+
+    Honours the ``JUNIPER_CASCOR_LOG_DIR`` override first (Q-6 / H-7) so a per-run
+    launcher keeps subprocess output inside its own ``RUN_DIR/logs`` rather than the
+    checkout-shared ``<repo>/logs``. Read at call time, not import time, so the
+    override also holds on the ``ImportError`` fallback below, which never consults
+    the constants. A set-but-blank value is treated as unset (the blank-env guard class).
+    """
+    override = os.environ.get("JUNIPER_CASCOR_LOG_DIR", "").strip()
+    if override:
+        return Path(override).expanduser()
     try:
         from cascor_constants.constants import _PROJECT_LOG_DIR_DEFAULT
 

--- a/src/cascor_constants/constants.py
+++ b/src/cascor_constants/constants.py
@@ -416,7 +416,26 @@ _PROJECT_SOURCE_DIR = _PROJECT_CONSTANTS_DIR.parent.resolve()
 _PROJECT_DIR = _PROJECT_SOURCE_DIR.parent.resolve()
 
 _PROJECT_LOG_DIR_NAME_DEFAULT = "logs"
-_PROJECT_LOG_DIR_DEFAULT = pathlib.Path(_PROJECT_DIR, _PROJECT_LOG_DIR_NAME_DEFAULT)
+# Q-6 (CLI experimentation plan §11 / H-7): JUNIPER_CASCOR_LOG_DIR overrides the checkout-shared
+# <repo>/logs so a per-run launcher can point this process's file log at its own RUN_DIR/logs.
+# Mirrors the W-6 JUNIPER_CASCOR_SNAPSHOTS_DIR override (constants_hdf5.py) in shape and semantics.
+#
+# Why this is not merely a concurrency nicety: cascor's parent logger writes ONLY to this file --
+# stdout carries just candidate-worker lines -- so the markers that decide a run's verdict
+# ("Training completed", "Completed solving ...") exist nowhere else. Two cascor processes sharing a
+# checkout therefore interleave and rotate away each other's evidence. Not hypothetical: that is how
+# the F-P1-3 arm A/B logs were lost when a long-lived service rotated the shared file mid-arc.
+#
+# Constants resolve at import time, so the override must be in the process env before the first
+# cascor_constants import (the launcher exports it before exec). A set-but-blank value is treated as
+# unset (the blank-env guard class). Shares one env var with the service tier
+# (api/service_launcher.py and api/observability.py, both _resolve_log_dir), which reads it at call
+# time so the override holds even on their ImportError fallback path.
+_PROJECT_LOG_DIR_OVERRIDE = os.environ.get("JUNIPER_CASCOR_LOG_DIR", "").strip()
+if _PROJECT_LOG_DIR_OVERRIDE:
+    _PROJECT_LOG_DIR_DEFAULT = pathlib.Path(_PROJECT_LOG_DIR_OVERRIDE).expanduser()
+else:
+    _PROJECT_LOG_DIR_DEFAULT = pathlib.Path(_PROJECT_DIR, _PROJECT_LOG_DIR_NAME_DEFAULT)
 
 _PROJECT_CONFIG_DIR_NAME_DEFAULT = "conf"
 _PROJECT_CONFIG_DIR_DEFAULT = pathlib.Path(_PROJECT_DIR, _PROJECT_CONFIG_DIR_NAME_DEFAULT)

--- a/src/tests/unit/api/test_q6_log_dir_override.py
+++ b/src/tests/unit/api/test_q6_log_dir_override.py
@@ -1,0 +1,158 @@
+"""Q-6 (CLI experimentation plan §11 / H-7) — ``JUNIPER_CASCOR_LOG_DIR`` override.
+
+Modelled on ``test_w6_snapshots_dir_override.py``; the two overrides are the same
+shape against the same class of problem (a checkout-shared path that concurrent
+cascor processes collide on).
+
+Service tier: both ``_resolve_log_dir`` helpers (``api/observability.py`` and
+``api/service_launcher.py``) must honour the env override at call time, fall back to
+the constants default when unset, and treat a set-but-blank value as unset (the
+blank-env guard class).
+
+The arm that distinguishes this from W-6: each helper carries an ``ImportError``
+fallback that never consults the constants. Reading the env at call time means the
+override holds there too — an import-time-only override would silently write to the
+shared checkout path in exactly the degraded environment the fallback exists for.
+
+Direct-CLI tier: ``constants.py`` resolves ``_PROJECT_LOG_DIR_DEFAULT`` from the same
+env var at import time — pinned via a module re-exec so the test does not depend on
+this process's import order.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
+
+from api import observability as _observability
+from api import service_launcher as _service_launcher
+
+pytestmark = pytest.mark.unit
+
+_SRC_DIR = Path(__file__).resolve().parent.parent.parent.parent
+_REPO_DIR = _SRC_DIR.parent
+_CONSTANTS = _SRC_DIR / "cascor_constants" / "constants.py"
+
+_ENV = "JUNIPER_CASCOR_LOG_DIR"
+
+# Both service-tier helpers are the same contract; drive them from one parametrisation
+# so a future divergence between the two copies fails rather than hides.
+_RESOLVERS = [
+    pytest.param(_observability._resolve_log_dir, "observability", id="observability"),
+    pytest.param(_service_launcher._resolve_log_dir, "service_launcher", id="service_launcher"),
+]
+
+
+def _reexec_constants(env_value: "str | None", monkeypatch) -> Path:
+    """Re-execute constants.py under a controlled env and return its log dir.
+
+    A fresh module object (not ``importlib.reload``) so the pin is hermetic to this
+    test regardless of what the suite already imported.
+    """
+    if env_value is None:
+        monkeypatch.delenv(_ENV, raising=False)
+    else:
+        monkeypatch.setenv(_ENV, env_value)
+    spec = importlib.util.spec_from_file_location("_q6_constants_probe", _CONSTANTS)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return Path(module._PROJECT_LOG_DIR_DEFAULT)
+
+
+class TestServiceTierOverride:
+    @pytest.mark.parametrize("resolver,_name", _RESOLVERS)
+    def test_env_override_wins(self, resolver, _name, tmp_path, monkeypatch):
+        target = tmp_path / "run" / "logs"
+        monkeypatch.setenv(_ENV, str(target))
+        assert resolver() == target
+
+    @pytest.mark.parametrize("resolver,_name", _RESOLVERS)
+    def test_unset_falls_back_to_repo_logs(self, resolver, _name, monkeypatch):
+        monkeypatch.delenv(_ENV, raising=False)
+        assert resolver() == _REPO_DIR / "logs"
+
+    @pytest.mark.parametrize("resolver,_name", _RESOLVERS)
+    def test_blank_value_is_treated_as_unset(self, resolver, _name, monkeypatch):
+        monkeypatch.setenv(_ENV, "   ")
+        assert resolver() == _REPO_DIR / "logs"
+
+    @pytest.mark.parametrize("resolver,_name", _RESOLVERS)
+    def test_call_time_read_not_cached(self, resolver, _name, tmp_path, monkeypatch):
+        """Two calls under different env values resolve differently — the override is
+        read per call, never captured at import or first-call time."""
+        first = tmp_path / "a"
+        second = tmp_path / "b"
+        monkeypatch.setenv(_ENV, str(first))
+        assert resolver() == first
+        monkeypatch.setenv(_ENV, str(second))
+        assert resolver() == second
+
+    @pytest.mark.parametrize("resolver,_name", _RESOLVERS)
+    def test_user_home_is_expanded(self, resolver, _name, monkeypatch):
+        monkeypatch.setenv(_ENV, "~/q6-logs")
+        assert resolver() == Path.home() / "q6-logs"
+
+
+class TestServiceTierImportErrorFallback:
+    """The arm W-6 has no equivalent of.
+
+    Each helper falls back to a checkout-relative ``logs/`` when ``cascor_constants``
+    cannot be imported. That path never reads the constants, so an import-time-only
+    override would be silently dropped there — writing to the shared checkout log in
+    precisely the degraded case the fallback exists to cover.
+    """
+
+    @pytest.mark.parametrize("resolver,_name", _RESOLVERS)
+    def test_override_still_wins_when_constants_unimportable(self, resolver, _name, tmp_path, monkeypatch):
+        target = tmp_path / "fallback" / "logs"
+        monkeypatch.setenv(_ENV, str(target))
+        # A ``None`` entry in sys.modules makes the ``import`` statement raise ImportError.
+        with patch.dict(sys.modules, {"cascor_constants": None, "cascor_constants.constants": None}):
+            assert resolver() == target
+
+    @pytest.mark.parametrize("resolver,_name", _RESOLVERS)
+    def test_unset_keeps_checkout_relative_fallback(self, resolver, _name, monkeypatch):
+        monkeypatch.delenv(_ENV, raising=False)
+        with patch.dict(sys.modules, {"cascor_constants": None, "cascor_constants.constants": None}):
+            assert resolver() == _REPO_DIR / "logs"
+
+
+class TestDirectCliTierOverride:
+    def test_env_override_wins(self, tmp_path, monkeypatch):
+        target = tmp_path / "cli-logs"
+        assert _reexec_constants(str(target), monkeypatch) == target
+
+    def test_unset_keeps_repo_logs(self, monkeypatch):
+        assert _reexec_constants(None, monkeypatch) == _REPO_DIR / "logs"
+
+    def test_blank_value_is_treated_as_unset(self, monkeypatch):
+        assert _reexec_constants("", monkeypatch) == _REPO_DIR / "logs"
+
+    def test_whitespace_only_value_is_treated_as_unset(self, monkeypatch):
+        assert _reexec_constants("  \t ", monkeypatch) == _REPO_DIR / "logs"
+
+    def test_user_home_is_expanded(self, monkeypatch):
+        assert _reexec_constants("~/q6-cli-logs", monkeypatch) == Path.home() / "q6-cli-logs"
+
+    def test_downstream_log_file_path_follows_the_override(self, tmp_path, monkeypatch):
+        """The override must reach the constants the logger actually consumes.
+
+        ``_PROJECT_LOG_FILE_PATH`` is what ``log_config``/``logger`` default their
+        handler paths to, so pinning only ``_PROJECT_LOG_DIR_DEFAULT`` would let the
+        two drift apart and leave the file log on the shared checkout path.
+        """
+        target = tmp_path / "downstream"
+        monkeypatch.setenv(_ENV, str(target))
+        spec = importlib.util.spec_from_file_location("_q6_constants_downstream_probe", _CONSTANTS)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        assert Path(module._PROJECT_LOG_FILE_PATH) == target
+        assert Path(module._LOGGER_LOG_FILE_PATH) == target
+        assert Path(module._LOG_CONFIG_LOG_FILE_PATH) == target


### PR DESCRIPTION
## Summary

Resolves open question **Q-6** (CLI experimentation plan §11) in favour of the override, and closes the **H-7** residual risk it was conditional on.

Mirrors the **W-6** `JUNIPER_CASCOR_SNAPSHOTS_DIR` override in shape and semantics — same pattern, same class of problem: a checkout-shared path that concurrent cascor processes collide on.

## Why the original deferral was wrong

H-7 filed the shared `logs/juniper_cascor.log` as *accepted residual risk* — explicitly **conditional on the one-cascor-per-checkout rule**. That framed Q-6 as a *concurrency* question and assumed run-dir stdout capture was an equivalent substitute.

It isn't. **cascor's parent logger writes only to this file.** Stdout carries just candidate-worker lines, so the markers that decide a run's verdict — `Training completed`, `Completed solving …` — exist nowhere else.

So the failure mode is **evidence loss**, not merely interleaving, and it is not hypothetical: the **F-P1-3 arm A/B logs were destroyed** when a long-lived service rotated the shared file mid-investigation. Those runs are unrecoverable.

Note the sharpest part: **a single experiment run is enough to hit this.** One other cascor process in the same checkout suffices — so the one-instance rule never actually protected an individual run, and the current mitigation ("remember to use a dedicated worktree") is a convention where a mechanism belongs.

## What changed

| Tier | Site | Read |
|---|---|---|
| Direct CLI | `constants._PROJECT_LOG_DIR_DEFAULT` | import time |
| Service | `api/observability.py::_resolve_log_dir` | **call time** |
| Service | `api/service_launcher.py::_resolve_log_dir` | **call time** |

The direct-CLI tier carries `_PROJECT_LOG_FILE_PATH` and the `_LOGGER_*` / `_LOG_CONFIG_*` constants (what the file handlers actually default to) along with it.

**The arm W-6 has no equivalent of:** both service helpers read the env **before** their `cascor_constants` import. Each has an `ImportError` fallback to a checkout-relative `logs/` that never consults the constants — so an import-time-only override would be silently dropped there, writing to the shared path in precisely the degraded case the fallback exists to cover. Separately pinned.

## Compatibility

Unset or blank keeps `<repo>/logs` **byte-identically** (the blank-env guard class). Nothing changes for existing deployments; this is purely additive.

## What it unblocks

A per-run launcher can point each instance at its own `RUN_DIR/logs` — the precondition H-7 named for retiring the one-instance-per-checkout rule (Wave 5.3, and `run_suite`'s hard refusal of `app: cascor` with `parallel > 1`). The juniper-ml launcher half follows as a separate PR, in dependency order.

## Testing

- **20 new unit tests** (`src/tests/unit/api/test_q6_log_dir_override.py`): override / fallback / blank / whitespace-only / `~`-expansion; call-time-not-cached for both service helpers; the `ImportError`-fallback arm; and that the downstream logger constants follow the override rather than drifting from it.
- The two service helpers are driven from **one parametrisation**, so a future divergence between the two copies fails rather than hides.
- Full `tests/unit/api` suite **green** (exit 0), including the W-6 and service-launcher tests that touch the same constants.
- `pre-commit` clean on all changed files (black, isort, flake8, mypy, bandit, doc-links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)