### PR TITLE
fix(security): throttle failed authentication attempts before auth runs (APD-CASCOR-004)

### DIFF
--- a/src/api/middleware.py
+++ b/src/api/middleware.py
@@ -1,13 +1,17 @@
 """FastAPI middleware for security and request processing."""
 
-from fastapi import HTTPException, Request, Response
+import logging
+
+from fastapi import HTTPException, Request, Response, status
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp
 
 from cascor_constants.constants_api import _PROJECT_API_HTTP_400_BAD_REQUEST, _PROJECT_API_HTTP_413_PAYLOAD_TOO_LARGE, _PROJECT_API_MAX_REQUEST_BODY_BYTES
 
-from .security import APIKeyAuth, RateLimiter
+from .security import APIKeyAuth, FailedAuthThrottle, RateLimiter, build_failed_auth_throttle
+
+logger = logging.getLogger(__name__)
 
 EXEMPT_PATHS = {
     "/v1/health",
@@ -125,6 +129,15 @@ class SecurityMiddleware(BaseHTTPMiddleware):
     explicitly exempt paths (health checks, docs). WebSocket upgrade
     requests are not intercepted by BaseHTTPMiddleware, so /ws/* paths
     are inherently exempt.
+
+    The identity-keyed :class:`~api.security.RateLimiter` runs *after* authentication and is
+    therefore never reached when auth raises, so before APD-CASCOR-004 the 401 path consumed no
+    budget at all and credential guessing was unthrottled. The fix is not to reorder -- that
+    trades a real protection for a worse one, collapsing every authenticated caller behind one
+    NAT into a single ``ip:`` bucket -- but to add a coarse, IP-keyed
+    :class:`~api.security.FailedAuthThrottle` *ahead* of authentication. It only consumes budget
+    on a failed attempt, so a caller with a valid key is never counted and well-behaved traffic
+    is unaffected.
     """
 
     def __init__(
@@ -132,6 +145,7 @@ class SecurityMiddleware(BaseHTTPMiddleware):
         app: ASGIApp,
         api_key_auth: APIKeyAuth,
         rate_limiter: RateLimiter,
+        failed_auth_throttle: FailedAuthThrottle | None = None,
     ) -> None:
         """Initialize the security middleware.
 
@@ -139,10 +153,16 @@ class SecurityMiddleware(BaseHTTPMiddleware):
             app: The ASGI application.
             api_key_auth: API key authentication handler.
             rate_limiter: Rate limiter instance.
+            failed_auth_throttle: Pre-authentication, IP-keyed throttle for failed attempts.
+                Defaults to an enabled throttle at the library default budget. Pass
+                ``build_failed_auth_throttle(enabled=False)`` to opt out. Defaulting to enabled
+                is safe because budget is consumed only on a *failed* attempt, so a caller with
+                valid credentials never sees a behaviour change.
         """
         super().__init__(app)
         self._api_key_auth = api_key_auth
         self._rate_limiter = rate_limiter
+        self._failed_auth_throttle = failed_auth_throttle if failed_auth_throttle is not None else build_failed_auth_throttle()
 
     async def dispatch(
         self,
@@ -163,6 +183,21 @@ class SecurityMiddleware(BaseHTTPMiddleware):
         if self._is_exempt(path):
             return await call_next(request)
 
+        client_ip = request.client.host if request.client else "unknown"
+
+        # Pre-authentication throttle. Checked first so an IP already over its failed-attempt
+        # budget is rejected without burning an auth comparison, and -- crucially -- so the
+        # rejection happens on a path that auth failure cannot skip past.
+        if self._failed_auth_throttle.enabled:
+            blocked, retry_after = self._failed_auth_throttle.check(client_ip)
+            if blocked:
+                logger.warning("Too many failed authentication attempts from %s; throttled for %ss", client_ip, retry_after)
+                return JSONResponse(
+                    status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                    content={"detail": f"Too many failed authentication attempts. Try again in {retry_after} seconds."},
+                    headers={"Retry-After": str(retry_after)},
+                )
+
         api_key = None
         try:
             if self._api_key_auth.enabled:
@@ -171,6 +206,11 @@ class SecurityMiddleware(BaseHTTPMiddleware):
             if self._rate_limiter.enabled:
                 await self._rate_limiter(request, api_key)
         except HTTPException as exc:
+            # Record the attempt only for authentication failures. A 429 from the identity-keyed
+            # limiter is a quota outcome, not a credential guess, and counting it here would let
+            # a caller throttle itself out of the auth path by exceeding its own quota.
+            if exc.status_code == status.HTTP_401_UNAUTHORIZED and self._failed_auth_throttle.enabled:
+                self._failed_auth_throttle.record_failure(client_ip)
             return JSONResponse(
                 status_code=exc.status_code,
                 content={"detail": exc.detail},

--- a/src/api/security.py
+++ b/src/api/security.py
@@ -234,6 +234,170 @@ class RateLimiter:
             self._request_count_since_cleanup = 0
 
 
+class FailedAuthThrottle:
+    """IP-keyed throttle for *failed* authentication attempts.
+
+    Ported from :class:`juniper_service_core.security.FailedAuthThrottle` (juniper-ml#1082) to
+    close APD-CASCOR-004. juniper-cascor maintains its own copy of the service-tier security code
+    rather than consuming ``juniper-service-core``, so the shared fix did not reach it; see the
+    ``pre-auth-throttle`` row of ``juniper-ml/tests/test_service_fork_drift.py``.
+
+    :class:`RateLimiter` cannot cover this. It is keyed on the authenticated identity
+    (``key:{api_key}``, falling back to ``ip:{client_ip}``), which means it can only run *after*
+    authentication -- and :class:`~api.middleware.SecurityMiddleware` therefore never reaches it
+    when auth raises. The result is that the entire 401 path consumes no budget at all: an
+    attacker guessing API keys, or simply flooding with garbage credentials, is not rate limited
+    by anything.
+
+    Reordering is the wrong fix. Running the identity-keyed limiter first would mean ``api_key``
+    is always ``None`` at that point, so every caller shares one ``ip:`` bucket -- collapsing all
+    authenticated callers behind a single NAT into one quota. The right shape is two limiters: a
+    coarse one here, before authentication, and the identity-keyed one after.
+
+    This throttle only ever consumes budget on a **failed** attempt, which is what makes it safe
+    to enable by default: a caller presenting a valid key is never counted, so well-behaved
+    traffic sees no behaviour change whatsoever. It is a security control, not a fairness quota,
+    which is also why it should not be made to fail open -- see the note in :meth:`check`.
+
+    Fixed-window, in-memory, and thread-safe: suitable for single-process deployments. Behind
+    multiple replicas each process keeps its own counters, so the effective budget multiplies by
+    the replica count; a shared store is required for exact enforcement across a fleet.
+    """
+
+    _CLEANUP_INTERVAL = 100  # Prune every N recorded failures.
+    _MAX_ENTRIES = 10_000  # Hard cap on tracked source IPs.
+
+    def __init__(
+        self,
+        max_failures: int = 10,
+        window_seconds: int = 60,
+        enabled: bool = True,
+    ) -> None:
+        """Initialize the failed-authentication throttle.
+
+        Args:
+            max_failures: Failed attempts allowed per source IP per window.
+            window_seconds: Window duration in seconds.
+            enabled: Whether the throttle is active.
+        """
+        self._max_failures = max_failures
+        self._window = window_seconds
+        self._enabled = enabled
+        self._failures: dict[str, tuple[int, float]] = defaultdict(lambda: (0, 0.0))
+        self._lock = Lock()
+        self._records_since_cleanup = 0
+
+    @property
+    def enabled(self) -> bool:
+        """Whether the throttle is active."""
+        return self._enabled
+
+    @property
+    def max_failures(self) -> int:
+        """Failed attempts allowed per source IP per window."""
+        return self._max_failures
+
+    def _maybe_cleanup(self) -> None:
+        """Lazy-prune expired buckets. Caller must hold ``_lock``.
+
+        Mirrors :meth:`RateLimiter._maybe_cleanup` (BUG-CC-13) -- an unbounded dict keyed by
+        attacker-supplied source IPs is itself a denial-of-service vector.
+        """
+        now = time.time()
+        cutoff = now - (2 * self._window)
+        expired = [ip for ip, (_, ts) in self._failures.items() if ts < cutoff]
+        for ip in expired:
+            del self._failures[ip]
+        if expired:
+            logger.debug("FailedAuthThrottle: pruned %d expired entries", len(expired))
+        if len(self._failures) > self._MAX_ENTRIES:
+            oldest = sorted(self._failures, key=lambda ip: self._failures[ip][1])
+            for ip in oldest[: len(self._failures) - self._MAX_ENTRIES]:
+                del self._failures[ip]
+
+    def check(self, client_ip: str) -> tuple[bool, int]:
+        """Report whether a source IP is currently over its failed-attempt budget.
+
+        This is a read-only probe -- it does not consume budget. Budget is consumed only by
+        :meth:`record_failure`, so a caller presenting valid credentials is never counted.
+
+        Note this never fails open on error, because it is a security control rather than a
+        fairness quota: a throttle that disables itself under stress hands an attacker a
+        denial-of-protection primitive, where breaking the limiter is the cheapest first move.
+
+        Args:
+            client_ip: The source address to check.
+
+        Returns:
+            Tuple of ``(blocked, retry_after_seconds)``. ``retry_after`` is 0 when not blocked.
+        """
+        if not self._enabled:
+            return (False, 0)
+
+        now = time.time()
+        with self._lock:
+            count, window_start = self._failures[client_ip]
+            if now - window_start >= self._window:
+                return (False, 0)  # Window rolled over; the old count no longer applies.
+            if count >= self._max_failures:
+                return (True, max(1, int(self._window - (now - window_start))))
+            return (False, 0)
+
+    def record_failure(self, client_ip: str) -> None:
+        """Record one failed authentication attempt against a source IP.
+
+        Args:
+            client_ip: The source address that failed to authenticate.
+        """
+        if not self._enabled:
+            return
+
+        now = time.time()
+        with self._lock:
+            self._records_since_cleanup += 1
+            if self._records_since_cleanup >= self._CLEANUP_INTERVAL:
+                self._maybe_cleanup()
+                self._records_since_cleanup = 0
+
+            count, window_start = self._failures[client_ip]
+            if now - window_start >= self._window:
+                self._failures[client_ip] = (1, now)
+            else:
+                self._failures[client_ip] = (count + 1, window_start)
+
+    def reset(self) -> None:
+        """Clear all recorded failures. Useful for testing."""
+        with self._lock:
+            self._failures.clear()
+
+
+def build_failed_auth_throttle(
+    max_failures: int = 10,
+    window_seconds: int = 60,
+    enabled: bool = True,
+) -> FailedAuthThrottle:
+    """Build a :class:`FailedAuthThrottle` from injected config.
+
+    Pure factory: no global settings read and no module-level singleton, matching
+    :func:`juniper_service_core.security.build_failed_auth_throttle`. There is deliberately no
+    ``CASCOR_*`` settings field for the throttle -- neither juniper-service-core nor
+    juniper-recurrence exposes one, and adding a knob here would diverge the forks further.
+
+    Args:
+        max_failures: Failed attempts allowed per source IP per window.
+        window_seconds: Window duration in seconds.
+        enabled: Whether the throttle is active.
+
+    Returns:
+        A configured :class:`FailedAuthThrottle` instance.
+    """
+    return FailedAuthThrottle(
+        max_failures=max_failures,
+        window_seconds=window_seconds,
+        enabled=enabled,
+    )
+
+
 _api_key_auth: APIKeyAuth | None = None
 _rate_limiter: RateLimiter | None = None
 _singleton_lock = Lock()

--- a/src/tests/unit/api/test_api_middleware.py
+++ b/src/tests/unit/api/test_api_middleware.py
@@ -5,18 +5,21 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from api.middleware import EXEMPT_PATHS, RequestBodyLimitMiddleware, SecurityHeadersMiddleware, SecurityMiddleware
-from api.security import APIKeyAuth, RateLimiter
+from api.security import APIKeyAuth, FailedAuthThrottle, RateLimiter, build_failed_auth_throttle
 
 
 @pytest.fixture
 def app_with_middleware():
     """Create a FastAPI app with security middleware."""
 
-    def _create(api_keys=None, rate_limit_enabled=False, rpm=60):
+    def _create(api_keys=None, rate_limit_enabled=False, rpm=60, throttle=None):
         app = FastAPI()
         auth = APIKeyAuth(api_keys)
         limiter = RateLimiter(requests_per_minute=rpm, enabled=rate_limit_enabled)
-        app.add_middleware(SecurityMiddleware, api_key_auth=auth, rate_limiter=limiter)
+        # ``throttle=None`` deliberately exercises the production default (an enabled
+        # FailedAuthThrottle at the library budget), so the pre-existing arms below prove the
+        # default is transparent to well-behaved traffic.
+        app.add_middleware(SecurityMiddleware, api_key_auth=auth, rate_limiter=limiter, failed_auth_throttle=throttle)
 
         @app.get("/v1/health")
         async def health():
@@ -154,8 +157,22 @@ class TestSecurityMiddlewareAuthRateLimitInterplay:
 
         Swapping auth/rate-limit order would let an attacker exhaust a shared
         IP budget with forged keys, then lock out a legitimate principal.
+
+        The failed-auth throttle is given a deliberately generous budget so that this test keeps
+        measuring what it was written to measure -- the *identity-keyed limiter's* counters --
+        rather than tripping the pre-auth throttle. Mirrors the inverse move in
+        ``juniper-service-core``'s own harness, which uses a generous ``requests_per_minute`` so
+        any 429 it sees must have come from the throttle. The 10 failed attempts below are
+        exactly the throttle's default budget, so without this the final valid request is
+        throttled at the door; APD-CASCOR-004 coverage lives in
+        ``TestFailedAuthThrottleIntegration``.
         """
-        app = app_with_middleware(api_keys=["secret"], rate_limit_enabled=True, rpm=2)
+        app = app_with_middleware(
+            api_keys=["secret"],
+            rate_limit_enabled=True,
+            rpm=2,
+            throttle=build_failed_auth_throttle(max_failures=100, window_seconds=60),
+        )
         # Reach into the middleware instance to inspect counters after failed auth.
         middleware = next(m for m in app.user_middleware if m.cls is SecurityMiddleware)
         limiter: RateLimiter = middleware.kwargs["rate_limiter"]
@@ -446,3 +463,135 @@ class TestRequestBodyLimitMiddleware:
         assert response.status_code == 200
         # Handler echoes received_bytes; presence + 200 confirm body was readable downstream.
         assert "received_bytes" in response.json()
+
+
+@pytest.mark.unit
+class TestFailedAuthThrottleIntegration:
+    """APD-CASCOR-004: the 401 path must consume budget.
+
+    Mirrors the corpus in ``juniper-service-core/tests/test_middleware.py`` so the fork and the
+    shared package cannot drift apart silently again.
+    """
+
+    def test_failed_auth_attempts_are_throttled(self, app_with_middleware):
+        """The arm that catches a half-port.
+
+        Wiring only the pre-auth ``check()`` and omitting ``record_failure()`` yields a throttle
+        that never accumulates -- a silent no-op -- and every request below would stay 401
+        forever instead of turning 429.
+        """
+        app = app_with_middleware(api_keys=["secret"], throttle=build_failed_auth_throttle(max_failures=3, window_seconds=60))
+        client = TestClient(app)
+
+        for _ in range(3):
+            assert client.get("/v1/network", headers={"X-API-Key": "wrong"}).status_code == 401
+
+        response = client.get("/v1/network", headers={"X-API-Key": "wrong"})
+        assert response.status_code == 429
+        assert int(response.headers["Retry-After"]) >= 1
+
+    def test_valid_credentials_never_consume_the_throttle_budget(self, app_with_middleware):
+        """Well-behaved traffic sees no behaviour change, which is why the default is enabled."""
+        app = app_with_middleware(api_keys=["secret"], throttle=build_failed_auth_throttle(max_failures=2, window_seconds=60))
+        client = TestClient(app)
+
+        for _ in range(25):
+            assert client.get("/v1/network", headers={"X-API-Key": "secret"}).status_code == 200
+
+    def test_throttle_is_enabled_by_default(self, app_with_middleware):
+        """No throttle passed: the production ``add_middleware`` call site must still be covered.
+
+        ``api/app.py`` constructs SecurityMiddleware without a throttle argument, so a default of
+        ``None`` that meant "disabled" would leave the running service exactly as unprotected as
+        before the fix.
+        """
+        app = app_with_middleware(api_keys=["secret"])
+        client = TestClient(app)
+
+        for _ in range(10):
+            assert client.get("/v1/network", headers={"X-API-Key": "wrong"}).status_code == 401
+        assert client.get("/v1/network", headers={"X-API-Key": "wrong"}).status_code == 429
+
+    def test_throttle_can_be_opted_out(self, app_with_middleware):
+        app = app_with_middleware(api_keys=["secret"], throttle=build_failed_auth_throttle(enabled=False))
+        client = TestClient(app)
+
+        for _ in range(25):
+            assert client.get("/v1/network", headers={"X-API-Key": "wrong"}).status_code == 401
+
+    def test_quota_429_is_not_counted_as_an_authentication_failure(self, app_with_middleware):
+        """Only a 401 feeds the throttle.
+
+        A 429 from the identity-keyed limiter is a quota outcome, not a credential guess.
+        Counting it would let an authenticated caller throttle *itself* out of the auth path
+        merely by exceeding its own quota.
+        """
+        throttle = build_failed_auth_throttle(max_failures=2, window_seconds=60)
+        app = app_with_middleware(api_keys=["secret"], rate_limit_enabled=True, rpm=1, throttle=throttle)
+        client = TestClient(app)
+
+        assert client.get("/v1/network", headers={"X-API-Key": "secret"}).status_code == 200
+        for _ in range(5):
+            assert client.get("/v1/network", headers={"X-API-Key": "secret"}).status_code == 429
+
+        # None of those quota 429s were recorded, so the failure budget is still intact.
+        assert throttle.check("testclient")[0] is False
+
+    def test_exempt_paths_bypass_the_throttle(self, app_with_middleware):
+        """Health checks stay reachable even from an IP that is currently throttled."""
+        app = app_with_middleware(api_keys=["secret"], throttle=build_failed_auth_throttle(max_failures=1, window_seconds=60))
+        client = TestClient(app)
+
+        assert client.get("/v1/network", headers={"X-API-Key": "wrong"}).status_code == 401
+        assert client.get("/v1/network", headers={"X-API-Key": "wrong"}).status_code == 429
+        assert client.get("/v1/health").status_code == 200
+
+
+@pytest.mark.unit
+class TestFailedAuthThrottle:
+    """Unit behaviour of the throttle itself (APD-CASCOR-004)."""
+
+    def test_check_does_not_consume_budget(self):
+        throttle = FailedAuthThrottle(max_failures=1, window_seconds=60)
+        for _ in range(10):
+            assert throttle.check("1.2.3.4") == (False, 0)
+        throttle.record_failure("1.2.3.4")
+        blocked, retry_after = throttle.check("1.2.3.4")
+        assert blocked is True
+        assert retry_after >= 1
+
+    def test_is_keyed_per_source_ip(self):
+        throttle = FailedAuthThrottle(max_failures=1, window_seconds=60)
+        throttle.record_failure("1.2.3.4")
+        assert throttle.check("1.2.3.4")[0] is True
+        assert throttle.check("5.6.7.8")[0] is False
+
+    def test_window_rolls_over(self):
+        throttle = FailedAuthThrottle(max_failures=1, window_seconds=0)  # every check starts a new window
+        throttle.record_failure("1.2.3.4")
+        assert throttle.check("1.2.3.4")[0] is False
+
+    def test_disabled_never_blocks(self):
+        throttle = FailedAuthThrottle(max_failures=1, enabled=False)
+        for _ in range(10):
+            throttle.record_failure("1.2.3.4")
+        assert throttle.check("1.2.3.4") == (False, 0)
+
+    def test_reset_clears_state(self):
+        throttle = FailedAuthThrottle(max_failures=1, window_seconds=60)
+        throttle.record_failure("1.2.3.4")
+        assert throttle.check("1.2.3.4")[0] is True
+        throttle.reset()
+        assert throttle.check("1.2.3.4")[0] is False
+
+    def test_prunes_expired_entries(self):
+        """Bounded memory: a dict keyed by attacker-supplied source IPs is itself a DoS vector."""
+        throttle = FailedAuthThrottle(max_failures=100, window_seconds=0)
+        for i in range(FailedAuthThrottle._CLEANUP_INTERVAL + 10):
+            throttle.record_failure(f"10.0.0.{i % 255}")
+        assert len(throttle._failures) <= FailedAuthThrottle._MAX_ENTRIES
+
+    def test_build_factory_defaults_match_the_documented_budget(self):
+        throttle = build_failed_auth_throttle()
+        assert throttle.enabled is True
+        assert throttle.max_failures == 10


### PR DESCRIPTION
## Summary

Ports `FailedAuthThrottle` from `juniper-service-core` into juniper-cascor's fork of the
service-tier security code, closing **APD-CASCOR-004** from the
[ecosystem defect register](https://github.com/pcalnon/juniper-ml/blob/main/notes/JUNIPER_2026-08-14_JUNIPER-ECOSYSTEM_DEFECT-REGISTER.md).

Before this change the 401 path consumed **no rate-limit budget at all**. `RateLimiter` is keyed on
the authenticated identity (`key:{api_key}`, falling back to `ip:{client_ip}`), so it can only run
*after* authentication — and `SecurityMiddleware` never reaches it when auth raises. An attacker
guessing API keys, or simply flooding with garbage credentials, was throttled by nothing.

Sibling PR: [juniper-data#266](https://github.com/pcalnon/juniper-data/pull/266) (APD-DATA-001, the
identical port into the other fork).

## Context

[juniper-ml#1082](https://github.com/pcalnon/juniper-ml/pull/1082) added `FailedAuthThrottle` to the
shared `juniper-service-core` package. juniper-cascor maintains its **own copy** of the middleware
and security code rather than consuming that package, so the shared fix never reached it. This is the
register's headline theme — *a guard adopted in one copy of near-identical code and not in its
siblings* — and it is the exact case the `pre-auth-throttle` row of
`juniper-ml/tests/test_service_fork_drift.py` tracks as a `KNOWN_GAP`.

The natural experiment is worth stating plainly: **the same fix reached juniper-recurrence
automatically** (it imports the shared middleware) **and reached neither fork at all.** The only
differentiator was library-versus-copy.

## What changed

| File | Change |
| --- | --- |
| `src/api/security.py` | New `FailedAuthThrottle` class + `build_failed_auth_throttle()` pure factory |
| `src/api/middleware.py` | Pre-auth `check()` gate + `record_failure()` on a 401; optional 4th constructor arg |
| `src/tests/unit/api/test_api_middleware.py` | 13 new arms, plus one isolation fix (below) |

### The fix is two-part, and half of it is easy to miss

The throttle is not a drop-in class. `check()` runs *before* authentication, and
`record_failure(client_ip)` is gated on the response being a 401. **Porting only the `check()` half
ships a throttle that never accumulates — a silent no-op.** Both halves are here, and
`test_failed_auth_attempts_are_throttled` is written specifically to fail if `record_failure` is ever
dropped (verified by mutation: removing that one line fails 3 arms).

### Why 401 only

A 429 from the identity-keyed limiter is a quota outcome, not a credential guess. Counting it would
let an authenticated caller throttle *itself* out of the auth path merely by exceeding its own quota.
`test_quota_429_is_not_counted_as_an_authentication_failure` pins that.

### Why not reorder the existing limiter instead

Running the identity-keyed limiter first would mean `api_key` is always `None` at that point, so
every caller would share one `ip:` bucket — collapsing all authenticated callers behind a single NAT
into one quota. The right shape is two limiters: a coarse one before auth, the identity-keyed one
after.

## One pre-existing test needed isolating — please review this bit

`TestSecurityMiddlewareAuthRateLimitInterplay::test_failed_auth_does_not_increment_rate_limit`
started failing, and it is worth being explicit about why rather than burying it.

That test fires **exactly 10 failed auth attempts** (5 iterations × 2 requests), which is exactly the
throttle's default budget, and then asserts a *valid* key still gets through. With the throttle
enabled, the 11th request is blocked at the pre-auth gate — correctly. Once an IP has burned its
failed-attempt budget, it is throttled regardless of what credential the next request carries,
because `check()` necessarily runs before we know the key is good. That is the accepted trade-off of
an IP-keyed pre-auth throttle, and `juniper-service-core` behaves identically.

The test's actual subject is the **identity-keyed limiter's** counters (`limiter._counters == {}`),
not the throttle. So it now builds a deliberately generous throttle (`max_failures=100`) — keeping
the production-shaped code path enabled while isolating the property under test. This mirrors the
inverse move in service-core's own harness, which uses a generous `requests_per_minute` so that any
429 it observes must have come from the throttle.

Worth noting the mild irony: that test's docstring warns that swapping auth/rate-limit order "would
let an attacker exhaust a shared IP budget with forged keys, then lock out a legitimate principal."
The throttle does now allow a forged-key flood to lock out a legitimate principal *from that IP* —
but bounded to a 60-second window, on a coarse counter, rather than permanently poisoning that
principal's own quota. That is the intended design, not an oversight.

## Design decisions

**Mirrors service-core's optional 4th constructor parameter** rather than constructing internally.
This keeps the forks converged, gives tests an injection seam, and is **backward-compatible**:
`src/api/app.py:642`'s existing `add_middleware(SecurityMiddleware, api_key_auth=…, rate_limiter=…)`
call site is **unchanged** and simply receives an enabled throttle. `test_throttle_is_enabled_by_default`
covers that production path specifically, because a `None` default meaning "disabled" would have left
the running service exactly as unprotected as before.

**No settings field.** Neither `juniper-service-core` nor `juniper-recurrence` exposes an env knob for
the throttle, so adding a `CASCOR_*` one would diverge the forks further. Budgets are inline literal
defaults, matching this repo's own `RateLimiter.__init__` and service-core byte-for-byte.

**Enabled by default is safe** because budget is consumed only on a *failed* attempt — a caller
presenting a valid key is never counted, so well-behaved traffic sees no behaviour change whatsoever.

## Threat model, honestly stated

The register ranked this fourth of four deliberately, and that reasoning still holds: credentials are
high-entropy keys from Docker secrets, so online guessing is not the realistic threat. **What the
throttle buys is CPU and log-flood control** on an unauthenticated path. This is defence in depth, not
an incident fix.

## Testing

- `src/tests/unit/api` — **~2100 passed**, exit 0 (includes `test_api_middleware.py`: 46 passed).
- `black --line-length=512 --check`, `isort --profile=black --line-length=512 --check-only`,
  `flake8` (the strict source profile from `.pre-commit-config.yaml`), and the enforced
  `ruff --select ASYNC` async-route audit — all clean on every changed file.
- Mutation check: removing the `record_failure` call fails
  `test_failed_auth_attempts_are_throttled`, `test_throttle_is_enabled_by_default`, and
  `test_exempt_paths_bypass_the_throttle`.

## Follow-up (must land in order)

This is step **(b)** of a three-repo sequence. The `pre-auth-throttle` drift-gate row asserts the
guard is still *absent from both forks*, and both of its assertions are per-site — so in the window
where exactly one fork has landed, neither status value is green.

1. [juniper-data#266](https://github.com/pcalnon/juniper-data/pull/266) — juniper-data
2. **this PR** — juniper-cascor
3. juniper-ml — promote the drift row `KNOWN_GAP` → `ENFORCED` and close the register entries

Note that **no CI in this repo runs that gate** — it lives in juniper-ml, whose own `ci.yml` skips the
cross-repo arms because the siblings are not on disk. It fires only under a local
`JUNIPER_DRIFT_TEST_FORCE_LOCAL=1` run or on the weekly `docs-full-check.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
