### PR TITLE
fix(security): filter blank API keys before enabling authentication (APD-CASCOR-006)

### DIFF
--- a/src/api/security.py
+++ b/src/api/security.py
@@ -29,7 +29,15 @@ class APIKeyAuth:
         Args:
             api_keys: List of valid API keys. If None or empty, auth is disabled.
         """
-        self._api_keys: set[str] = set(api_keys) if api_keys else set()
+        # APD-CASCOR-006: blank / whitespace-only / non-string entries are filtered
+        # out BEFORE `_enabled` is derived. Without the filter,
+        # ``JUNIPER_CASCOR_API_KEYS='[""]'`` parses to ``['']``, sets
+        # ``_enabled = True``, and then validates an empty ``X-API-Key``. That is
+        # strictly worse than authentication being off, because the deployment
+        # believes it is protected. Byte-identical to the canonical filter in
+        # ``juniper_service_core.security.APIKeyAuth`` (security.py:44), which this
+        # fork otherwise shadows.
+        self._api_keys: set[str] = {k for k in (api_keys or []) if isinstance(k, str) and k.strip()}
         self._enabled = len(self._api_keys) > 0
 
     @property

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -452,7 +452,15 @@ class Settings(BaseSettings):
           a single-string Docker secret file naturally produces; matches
           the juniper-data parser).
         * Already a list (including JSON-deserialised lists from
-          ``pydantic-settings``) → returned as-is.
+          ``pydantic-settings``) → blank / whitespace-only entries dropped; an
+          all-blank list becomes ``None`` (auth disabled).
+
+        APD-CASCOR-006: both branches must filter. The comma-separated-string
+        branch always did; the list branch returned ``v`` untouched, so the JSON
+        form ``JUNIPER_CASCOR_API_KEYS='[""]'`` survived as ``['']`` and enabled
+        authentication that then accepted an empty ``X-API-Key``.
+        ``APIKeyAuth.__init__`` also filters -- that is the load-bearing guard, and
+        this is defence in depth at the boundary where the inconsistency lived.
 
         Without this validator the bare string read from a Docker secrets
         file (e.g. ``CHANGE_BEFORE_PRODUCTION_USE`` from
@@ -467,6 +475,9 @@ class Settings(BaseSettings):
             return None
         if isinstance(v, str):
             return [k.strip() for k in v.split(",") if k.strip()]
+        if isinstance(v, (list, tuple)):
+            cleaned = [k.strip() if isinstance(k, str) else k for k in v if not isinstance(k, str) or k.strip()]
+            return cleaned or None
         return v  # type: ignore[return-value]
 
     rate_limit_enabled: bool = _JUNIPER_CASCOR_API_RATELIMIT_DISABLED

--- a/src/tests/unit/api/test_api_security.py
+++ b/src/tests/unit/api/test_api_security.py
@@ -26,6 +26,49 @@ class TestAPIKeyAuth:
         auth = APIKeyAuth(["key1", "key2"])
         assert auth.enabled
 
+    def test_blank_key_does_not_enable_auth(self) -> None:
+        """APD-CASCOR-006: a blank key must not enable authentication.
+
+        ``JUNIPER_CASCOR_API_KEYS='[""]'`` parses to ``['']``. Without the filter
+        that set ``_enabled = True`` and then validated an empty ``X-API-Key`` --
+        strictly worse than auth being off, because the deployment believes it is
+        protected.
+        """
+        assert not APIKeyAuth([""]).enabled
+
+    def test_whitespace_only_key_does_not_enable_auth(self) -> None:
+        for blank in (" ", "\t", "\n", "   \t\n "):
+            assert not APIKeyAuth([blank]).enabled, f"{blank!r} must not enable auth"
+
+    def test_blank_key_never_validates(self) -> None:
+        """The impact, not just the flag: an empty key must never be accepted.
+
+        With ONLY a blank key auth is disabled, so ``validate`` is vacuously True --
+        which is why the meaningful assertion pairs a blank with a real key and
+        checks that the blank still does not admit an empty ``X-API-Key``.
+        """
+        auth = APIKeyAuth(["", "real-key"])
+        assert auth.enabled
+        assert auth.validate("real-key")
+        assert not auth.validate("")
+        assert not auth.validate(" ")
+
+    def test_blank_keys_are_dropped_but_real_ones_kept(self) -> None:
+        auth = APIKeyAuth(["", "  ", "real-key", "\t"])
+        assert auth.enabled
+        assert auth.validate("real-key")
+
+    def test_non_string_entries_are_dropped(self) -> None:
+        """A malformed JSON list must not crash or half-enable auth.
+
+        The filter runs before the element is hashed into the set, so an
+        unhashable entry cannot raise TypeError here.
+        """
+        assert not APIKeyAuth([None, 0, {}]).enabled  # type: ignore[list-item]
+        auth = APIKeyAuth([None, "real-key"])  # type: ignore[list-item]
+        assert auth.enabled
+        assert auth.validate("real-key")
+
     def test_validate_returns_true_when_disabled(self) -> None:
         """Validate should return True when auth is disabled."""
         auth = APIKeyAuth(None)
@@ -425,3 +468,40 @@ class TestSecurityModuleFunctions:
         limiter2 = get_rate_limiter()
         assert auth1 is not auth2
         assert limiter1 is not limiter2
+
+
+@pytest.mark.unit
+class TestApiKeysSettingsValidator:
+    """APD-CASCOR-006: both branches of ``_parse_api_keys`` must filter blanks.
+
+    The comma-separated-string branch always did; the list branch returned ``v``
+    untouched, which is why the JSON form was the reachable shape of this defect.
+    Mirrors the juniper-data sibling test of the same name.
+    """
+
+    @staticmethod
+    def _parse(value):
+        from api.settings import Settings
+
+        return Settings._parse_api_keys(value)
+
+    def test_json_list_of_one_blank_becomes_none(self) -> None:
+        """The exact reachable shape: JUNIPER_CASCOR_API_KEYS='[""]'."""
+        assert self._parse([""]) is None
+
+    def test_json_list_of_whitespace_becomes_none(self) -> None:
+        assert self._parse(["  ", "\t"]) is None
+
+    def test_json_list_keeps_real_keys_and_strips_them(self) -> None:
+        assert self._parse(["  real  ", ""]) == ["real"]
+
+    def test_comma_string_branch_still_filters(self) -> None:
+        """Regression guard on the branch that was already correct."""
+        assert self._parse("a, ,b") == ["a", "b"]
+
+    def test_none_and_empty_string_are_unchanged(self) -> None:
+        assert self._parse(None) is None
+        assert self._parse("") is None
+
+    def test_tuple_is_handled_like_a_list(self) -> None:
+        assert self._parse(("", "real")) == ["real"]


### PR DESCRIPTION
## Summary

Filters blank / whitespace-only / non-string API keys **before** authentication is enabled, closing
**APD-CASCOR-006** from the [ecosystem defect register](https://github.com/pcalnon/juniper-ml/blob/main/notes/JUNIPER_2026-08-14_JUNIPER-ECOSYSTEM_DEFECT-REGISTER.md).
This is the last open `blank-api-key-filter` row in the register's §2.3 copy-drift table.

`JUNIPER_CASCOR_API_KEYS='[""]'` parsed to `['']`, which set `_enabled = True` and then validated an
empty `X-API-Key`. That is **strictly worse than authentication being off**, because the deployment
believes it is protected.

Sibling PR: [juniper-data#267](https://github.com/pcalnon/juniper-data/pull/267) (APD-DATA-003, the
identical gap in the other fork).

## Context

`juniper-service-core/juniper_service_core/security.py:44` has carried this filter — with a comment
naming this exact failure — since before the register. juniper-cascor maintains its **own copy** of the
service-tier security code, so it never arrived. Same shape as the throttle port in #524: *a guard
adopted in one copy of near-identical code and not in its siblings*.

## What changed

| File | Change |
| --- | --- |
| `src/api/security.py` | `APIKeyAuth.__init__` filters blanks / non-strings before deriving `_enabled` |
| `src/api/settings.py` | `_parse_api_keys` list/tuple branch now filters too; an all-blank list becomes `None` |
| `src/tests/unit/api/test_api_security.py` | 11 new arms across `TestAPIKeyAuth` + a new `TestApiKeysSettingsValidator` |

The `security.py` change is **byte-identical to the canonical service-core line** — this fork already
uses a `set`, so unlike the juniper-data sibling (which deliberately keeps a `list` for
`compare_digest` timing) there is no container difference to preserve:

```python
self._api_keys: set[str] = {k for k in (api_keys or []) if isinstance(k, str) and k.strip()}
```

### Why both `security.py` and `settings.py`

`APIKeyAuth.__init__` is the load-bearing guard. The settings validator is where the *inconsistency*
lived and is fixed for defence in depth: the comma-separated-string branch always filtered
(`[k.strip() for k in v.split(",") if k.strip()]`), while the list branch returned `v` untouched — which
is precisely why the JSON list form was the reachable shape of this defect. That half was caught here by
its own new test after the first pass updated only the docstring.

### Complements existing coverage

This fork already had `test_validate_empty_string_key_is_invalid` (an empty `X-API-Key` must not match a
*real* key) and `test_call_raises_401_invalid_not_missing_for_empty_string`. Those cover the request
side; the new arms cover the **configuration** side — a blank key must never become a valid credential
in the first place.

## Reachability, stated honestly

With `enforce_auth_posture` running at boot, keys resolve through `real_keys` — the same blank filter — so
a blank key is a **boot failure** there, not a silent open service. Triggering this defect needed *both*
the JSON list form **and** auth-posture enforcement disabled. Real, and narrower than it first reads;
this closes the gap at the point of use rather than relying on a boot check that can be turned off.

## Testing

- `src/tests/unit/api/test_api_security.py` — 48 passed.
- `src/tests/unit/api` — exit 0, no failures.
- `black --line-length=512 --check`, `isort --profile=black --line-length=512 --check-only`, and
  `flake8` (the strict source profile from `.pre-commit-config.yaml`) — clean on all three files.

## Follow-up (must land in order)

Step **(b)** of the same three-repo sequence used for the throttle. The `blank-api-key-filter` row in
`juniper-ml/tests/test_service_fork_drift.py` asserts the guard is still *absent from both forks*, and
both assertions are per-site — so in the window where exactly one fork has landed, neither status value
is green.

1. [juniper-data#267](https://github.com/pcalnon/juniper-data/pull/267) — juniper-data
2. **this PR** — juniper-cascor
3. juniper-ml — promote the drift row `KNOWN_GAP` → `ENFORCED` and close the register entries

No CI in this repo runs that gate; it lives in juniper-ml, whose own `ci.yml` skips the cross-repo arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
