### PR TITLE
fix(runtime): apply one BLAS thread policy at BOTH entry points (#531)

### DIFF
--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,1 +1,16 @@
-"""JuniperCascor Service API."""
+"""JuniperCascor Service API.
+
+The BLAS thread policy is applied HERE, and it has to be here rather than in ``api.app``: the
+variables are read once when BLAS first loads, ``api.app`` imports ``torch`` at module level, and
+this package's ``__init__`` is what runs before it. Placing the call any later would be silently
+inert -- the same failure mode that made the setting entry-point-dependent in the first place
+(juniper-cascor#531).
+
+The direct CLI applies the identical policy from the identical helper at the top of ``main.py``.
+Default is a no-op, which is what this tier has always done; ``JUNIPER_CASCOR_BLAS_THREADS`` opts
+into a cap on both paths at once.
+"""
+
+from parallelism.blas_threads import configure_blas_threads
+
+configure_blas_threads()

--- a/src/cascade_correlation/cascade_correlation.py
+++ b/src/cascade_correlation/cascade_correlation.py
@@ -3862,18 +3862,21 @@ class CascadeCorrelationNetwork:
         logger = Logger
         from queue import Empty
 
-        # PARALLEL-FIX (RC-1): Pin PyTorch internal thread pool to configured thread count per worker.
-        # Without this, each worker defaults to using ALL CPU cores for BLAS/autograd threads,
-        # causing N_workers * M_threads oversubscription that effectively serializes execution.
-        # Environment variables must be set before any BLAS operation; torch.set_num_threads()
-        # controls the PyTorch ATen thread pool directly.
+        # PARALLEL-FIX (RC-1): pin the PyTorch ATen thread pool per worker. Without this each
+        # worker defaults to using ALL CPU cores for BLAS/autograd threads, causing
+        # N_workers * M_threads oversubscription that effectively serializes execution. THIS is
+        # the oversubscription guard, it works, and it runs identically on both entry points.
+        #
+        # The three environment variables are deliberately NOT set here (#531). They are read once
+        # when BLAS first loads -- which, in a forkserver-created worker, happened in an ancestor
+        # process long before this line -- so assigning them here could never resize this worker's
+        # pool. It only made the code read as though the worker controlled its own budget, which
+        # is what delayed finding the real, entry-point-level asymmetry. The pool size is settled
+        # by parallelism.blas_threads at entry-point import time; see that module.
         import torch as _torch
 
         _thread_count_str = str(max(1, worker_thread_count))
         _torch.set_num_threads(max(1, worker_thread_count))
-        os.environ["OMP_NUM_THREADS"] = _thread_count_str
-        os.environ["MKL_NUM_THREADS"] = _thread_count_str
-        os.environ["OPENBLAS_NUM_THREADS"] = _thread_count_str
         logger.debug(f"CascadeCorrelationNetwork: _worker_loop: PyTorch thread count pinned to {_thread_count_str} for worker process isolation")
 
         logger.debug("CascadeCorrelationNetwork: _worker_loop: Worker process started")

--- a/src/main.py
+++ b/src/main.py
@@ -39,15 +39,23 @@ import logging.config
 import os
 import sys
 
-# PARALLEL-FIX (RC-1): Set BLAS thread environment variables BEFORE any library that uses
-# BLAS (numpy, torch, scipy) is imported. These environment variables are read once when the
-# BLAS library is first loaded; setting them after import has no effect. This prevents the
-# parent process from spawning excessive internal threads that would compete with worker
-# processes during parallel candidate training.
-# Values here are defaults; they can be overridden by the user's environment.
-os.environ.setdefault("OMP_NUM_THREADS", "2")
-os.environ.setdefault("MKL_NUM_THREADS", "2")
-os.environ.setdefault("OPENBLAS_NUM_THREADS", "2")
+# PARALLEL-FIX (RC-1), corrected in #531: the BLAS thread policy is now shared with the SERVICE
+# entry point instead of living here alone. Must run BEFORE any BLAS-importing module (numpy,
+# torch, scipy) -- these variables are read once at library load and are inherited, unchangeably,
+# by every forkserver-created candidate worker.
+#
+# This used to hard-cap all three to 2. The service enters via `uvicorn api.app:create_app`, never
+# executed it, and so loaded BLAS uncapped -- two entry points into the same trainer running
+# different thread pools by accident of which file started the process. Measured cost: the capped
+# path's candidate phase ran 1.52x the uncapped path's on identical data and initialisation, with
+# 1.30x attributable to the cap (juniper-cascor#531). The default is now a no-op, matching the
+# service; `JUNIPER_CASCOR_BLAS_THREADS` opts back in.
+#
+# RC-1's actual oversubscription fix -- torch.set_num_threads() per worker and for the parent --
+# is untouched and does not depend on these variables.
+from parallelism.blas_threads import configure_blas_threads
+
+configure_blas_threads()
 
 from dotenv import load_dotenv
 

--- a/src/parallelism/blas_threads.py
+++ b/src/parallelism/blas_threads.py
@@ -1,0 +1,84 @@
+"""Single source of truth for the process-wide BLAS thread policy.
+
+WHY THIS MODULE EXISTS
+----------------------
+The BLAS thread-count environment variables (``OMP_NUM_THREADS`` and friends) are read **once**,
+when the BLAS library is first loaded; setting them afterwards has no effect. Candidate workers are
+created from a ``forkserver`` context, so each worker inherits the pool of the process it descends
+from and can never resize it. That makes these variables an entry-point-time decision with
+permanent, process-tree-wide consequences.
+
+Until this module existed the decision was made in only ONE of the two entry points. ``main.py``
+(direct CLI) capped all three to ``2``; ``uvicorn api.app:create_app`` never executed that code and
+``src/api/`` set nothing, so the service loaded BLAS with the runtime's own default. Two entry
+points into the same trainer therefore ran with different thread pools -- not by configuration, but
+by which file the process happened to start in.
+
+The cost was measured, not assumed (juniper-cascor#531): on identical data, identical network
+initialisation and an identical config, the capped path's candidate phase ran **1.52x** the
+uncapped path's, and the cap accounted for **1.30x** of that. It acted through two channels --
+throughput (1.26x -> 1.14x as the budget rose) and, less obviously, **epoch count** (1.21x ->
+1.03x), because thread count changes BLAS reduction order, hence floating-point results, hence
+where a patience-based candidate early-stopping loop terminates. A tighter cap therefore did not
+merely slow each epoch down, it caused *more epochs to be run*.
+
+WHAT THE POLICY IS
+------------------
+Default: **do nothing**, leaving the runtime's own choice. That is exactly what the service tier has
+always done, it is the faster of the two behaviours as measured, and it means every service-tier
+result recorded to date remains valid. The direct CLI changes to match it.
+
+Opt in with ``JUNIPER_CASCOR_BLAS_THREADS=<n>`` to cap all three variables. The capability RC-1
+(commit ``aa46ad5``) introduced is retained -- it simply stops being an accident of entry point.
+
+WHAT THIS IS *NOT*
+------------------
+This is not the oversubscription guard. That is RC-1's real fix and it is untouched: each candidate
+worker calls ``torch.set_num_threads(max(1, worker_thread_count))`` (``cascade_correlation.py:3873``,
+default ``worker_thread_count = 1``) and the parent calls
+``torch.set_num_threads(max(2, worker_thread_count * 2))`` (``:1126``). Both run on both paths and
+neither depends on these environment variables. The service is the live proof: it has never set them
+and its candidate pool runs fully parallel.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+#: The variables every common BLAS backend reads at load time.
+BLAS_THREAD_VARS = ("OMP_NUM_THREADS", "MKL_NUM_THREADS", "OPENBLAS_NUM_THREADS")
+
+#: Opt-in override. Unset (or blank) means "leave the runtime's default alone".
+BLAS_THREADS_ENV = "JUNIPER_CASCOR_BLAS_THREADS"
+
+
+def configure_blas_threads() -> str | None:
+    """Apply the BLAS thread policy. Call BEFORE importing numpy / torch / scipy.
+
+    Returns the value applied, or ``None`` when the policy is a no-op (the default).
+
+    ``setdefault`` semantics are deliberate: an operator who exports ``OMP_NUM_THREADS`` directly
+    still wins, so this never overrides a deployment that has already made the decision.
+
+    A malformed override is reported on stderr and ignored rather than raised. This runs before
+    logging is configured and before the application exists; aborting a training run over a
+    mistyped tuning knob would be a worse failure than proceeding on the documented default.
+    """
+    raw = os.environ.get(BLAS_THREADS_ENV, "").strip()
+    if not raw:
+        return None
+
+    try:
+        count = int(raw)
+    except ValueError:
+        print(f"[cascor] {BLAS_THREADS_ENV}={raw!r} is not an integer -- ignoring, using the BLAS default", file=sys.stderr)
+        return None
+    if count < 1:
+        print(f"[cascor] {BLAS_THREADS_ENV}={raw!r} must be >= 1 -- ignoring, using the BLAS default", file=sys.stderr)
+        return None
+
+    value = str(count)
+    for var in BLAS_THREAD_VARS:
+        os.environ.setdefault(var, value)
+    return value

--- a/src/tests/unit/test_blas_thread_policy.py
+++ b/src/tests/unit/test_blas_thread_policy.py
@@ -1,0 +1,135 @@
+"""BLAS thread policy: one policy, applied identically by BOTH entry points (#531).
+
+The defect these tests lock down was not a wrong value -- it was a policy that existed in only one
+of two entry points. ``main.py`` capped OMP/MKL/OPENBLAS to 2 before importing torch; the service
+enters through ``uvicorn api.app:create_app``, never ran that code, and loaded BLAS uncapped. Since
+the variables are read once at library load and candidate workers are forkserver children, every
+worker inherited its entry point's pool permanently. Measured: the capped path's candidate phase ran
+1.52x the uncapped path's on identical data and initialisation, 1.30x of it attributable to the cap.
+
+So the behavioural tests below matter less than the two structural ones at the bottom: they are what
+stop the asymmetry growing back.
+"""
+
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from parallelism import blas_threads  # noqa: E402
+
+SRC = Path(__file__).resolve().parents[2]
+
+
+class _EnvIsolated(unittest.TestCase):
+    """Each test gets a pristine copy of the three variables plus the override."""
+
+    def setUp(self) -> None:
+        self._saved = {k: os.environ.get(k) for k in (*blas_threads.BLAS_THREAD_VARS, blas_threads.BLAS_THREADS_ENV)}
+        for key in self._saved:
+            os.environ.pop(key, None)
+
+    def tearDown(self) -> None:
+        for key, value in self._saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+class ConfigureBlasThreadsTest(_EnvIsolated):
+    def test_default_is_a_no_op(self) -> None:
+        """Unset override MUST leave the runtime's own choice alone.
+
+        This is the whole behavioural change: the service tier has always run this way, it is the
+        faster of the two measured behaviours, and keeping it as the default is what preserves every
+        service-tier result recorded before the fix.
+        """
+        self.assertIsNone(blas_threads.configure_blas_threads())
+        for var in blas_threads.BLAS_THREAD_VARS:
+            self.assertNotIn(var, os.environ, f"{var} must not be set when the policy is a no-op")
+
+    def test_blank_override_is_a_no_op(self) -> None:
+        os.environ[blas_threads.BLAS_THREADS_ENV] = "   "
+        self.assertIsNone(blas_threads.configure_blas_threads())
+        self.assertNotIn("OMP_NUM_THREADS", os.environ)
+
+    def test_override_sets_all_three(self) -> None:
+        os.environ[blas_threads.BLAS_THREADS_ENV] = "3"
+        self.assertEqual(blas_threads.configure_blas_threads(), "3")
+        for var in blas_threads.BLAS_THREAD_VARS:
+            self.assertEqual(os.environ[var], "3")
+
+    def test_explicit_operator_value_wins(self) -> None:
+        """setdefault semantics: a deployment that already decided is never overridden."""
+        os.environ[blas_threads.BLAS_THREADS_ENV] = "3"
+        os.environ["OMP_NUM_THREADS"] = "9"
+        blas_threads.configure_blas_threads()
+        self.assertEqual(os.environ["OMP_NUM_THREADS"], "9")
+        self.assertEqual(os.environ["MKL_NUM_THREADS"], "3")
+
+    def test_malformed_override_is_ignored_not_raised(self) -> None:
+        """A mistyped tuning knob must not abort a training run before logging even exists."""
+        for bad in ("abc", "0", "-4", "2.5"):
+            with self.subTest(value=bad):
+                os.environ[blas_threads.BLAS_THREADS_ENV] = bad
+                for var in blas_threads.BLAS_THREAD_VARS:
+                    os.environ.pop(var, None)
+                self.assertIsNone(blas_threads.configure_blas_threads())
+                self.assertNotIn("OMP_NUM_THREADS", os.environ)
+
+    def test_module_is_import_cheap(self) -> None:
+        """It must import without pulling in a BLAS-linked library.
+
+        The helper's entire job is to run BEFORE numpy/torch load. If importing it dragged one of
+        them in, the policy would be applied after the pool was already fixed -- inert, and silently
+        so. Checked in a subprocess because this test process has already imported torch.
+        """
+        code = "import sys; import parallelism.blas_threads; print('torch' in sys.modules, 'numpy' in sys.modules)"
+        # nosec B603 - argv is a fixed literal (this interpreter, -c, a constant string); no shell,
+        # no user input, no PATH lookup. The subprocess is the point of the test: this process has
+        # already imported torch, so import-cheapness can only be observed in a fresh interpreter.
+        out = subprocess.run([sys.executable, "-c", code], cwd=SRC, capture_output=True, text=True, timeout=120)  # nosec B603
+        self.assertEqual(out.returncode, 0, out.stderr)
+        self.assertEqual(out.stdout.strip(), "False False", "blas_threads must not import torch or numpy")
+
+
+class EntryPointParityTest(unittest.TestCase):
+    """Structural: BOTH entry points apply the policy, and NEITHER hard-codes a cap (#531)."""
+
+    def test_both_entry_points_call_the_shared_helper(self) -> None:
+        for rel in ("main.py", "api/__init__.py"):
+            with self.subTest(entry_point=rel):
+                text = (SRC / rel).read_text(encoding="utf-8")
+                self.assertIn("configure_blas_threads", text, f"{rel} must apply the shared BLAS thread policy")
+
+    def test_no_entry_point_hardcodes_blas_thread_vars(self) -> None:
+        """Anti-resurrection: the whole defect was one entry point setting these on its own.
+
+        ``parallelism/blas_threads.py`` is the sole legitimate site. Anything else assigning these
+        recreates the asymmetry -- and, in a worker, would be inert as well as wrong.
+        """
+        offenders = []
+        for path in SRC.rglob("*.py"):
+            rel = path.relative_to(SRC).as_posix()
+            if rel.startswith(("tests/", "backups/")) or rel == "parallelism/blas_threads.py":
+                continue
+            text = path.read_text(encoding="utf-8", errors="replace")
+            for var in blas_threads.BLAS_THREAD_VARS:
+                # Assignment through either os.environ form; a bare mention in a comment is fine.
+                if f'os.environ["{var}"]' in text or f'os.environ.setdefault("{var}"' in text:
+                    offenders.append(f"{rel}: assigns {var}")
+        self.assertEqual(offenders, [], "BLAS thread vars must be set only by parallelism.blas_threads:\n  " + "\n  ".join(offenders))
+
+    def test_worker_still_pins_torch_threads(self) -> None:
+        """RC-1's real oversubscription fix must survive this change untouched."""
+        text = (SRC / "cascade_correlation/cascade_correlation.py").read_text(encoding="utf-8")
+        self.assertIn("_torch.set_num_threads(max(1, worker_thread_count))", text)
+        self.assertIn("torch.set_num_threads(parent_thread_count)", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #531.

## Problem

The BLAS thread environment variables were set in exactly **one of the two entry points**:

```python
# src/main.py:48-50 — the DIRECT CLI only
os.environ.setdefault("OMP_NUM_THREADS", "2")   # + MKL_, OPENBLAS_
```

The service enters through `uvicorn api.app:create_app`, never executes that code, and `git grep -nE "NUM_THREADS|set_num_threads" -- src/api` returns nothing. `main.py`'s own comment states why that is permanent: the variables *"are read once when the BLAS library is first loaded; setting them after import has no effect."* Candidate workers are **forkserver** children, so each inherits its entry point's pool and can never resize it.

Two entry points into the same trainer therefore ran with different thread pools — not by configuration, but by which file the process happened to start in.

## Measurement

Cap 16 / pool 8, `dataset.params.seed: 42` so both arms share dataset **and** network initialisation, all arms cap-bound at 16 units:

| arm | candidate phase | per-epoch rate | total span |
| --- | --- | --- | --- |
| service (unset) | 944 s | 0.02102 s | **961 s** |
| CLI, `OMP=16` | 1103 s (1.17×) | 0.02394 s | 1156 s |
| CLI, **default → 2** | 1432 s (1.52×) | 0.02641 s | 1485 s |

The **output** phase was 16 s on every arm — the difference is confined to candidate training, which is ~98% of the span at these caps.

## The change

- **`src/parallelism/blas_threads.py`** — the policy, in one place. Stdlib-only and import-cheap, because its entire job is to run *before* numpy/torch load.
- **Both entry points call it.** The service call site is **`api/__init__.py`, not `api/app.py`** — `app.py` imports torch at module level, so a call there would be silently inert, which is the same failure mode that made this entry-point-dependent to begin with.
- **Default is a no-op**, matching what the service has always done. `JUNIPER_CASCOR_BLAS_THREADS=<n>` opts back in, so RC-1's capability is retained rather than deleted. `setdefault` semantics mean an operator who exports `OMP_NUM_THREADS` still wins.
- **Dropped the inert `os.environ[...]` re-export** in `train_candidate_worker` — it could never resize an already-loaded pool, and it made the code read as though the worker controlled its own budget.

**RC-1's actual oversubscription fix is untouched**: each worker still calls `torch.set_num_threads(max(1, worker_thread_count))` and the parent still calls `torch.set_num_threads(max(2, worker_thread_count * 2))`. The service is the live proof those suffice — it has never set the environment variables and its candidate pool runs fully parallel (8 forked workers at ~90% CPU each, confirmed by `ps` during a run).

## Verification

- **Service behaviour is bit-identical.** A patched service reproduces the pre-change baseline exactly: train **0.8075**, val **0.7450**, 16 units. Behaviour-preserving for the service; a change only for the CLI.
- **Default is genuinely inert**: `configure_blas_threads()` → `None`, `OMP_NUM_THREADS` unset, `torch.get_num_threads()` = 8.
- **9 new tests**, including two structural guards — both entry points must call the shared helper, and no file outside the policy module may assign these variables — plus one pinning RC-1's `torch.set_num_threads` calls in place.

## Scope note — what this PR does NOT claim

An earlier attempt to attribute an **accuracy** difference to thread count was **withdrawn**: single runs could not separate it from run-to-run variance. This PR is justified by entry-point parity and by the wall-clock measurement above, nothing more.

The underlying reproducibility defect that made that attribution unsafe — identical configs diverging mid-run, ~10 pp validation spread, roughly 1 run in 5 — is filed separately as **#532** and is **not** addressed here. It is the more serious of the two findings and deserves its own change.
