### PR TITLE
fix(logger,gitignore): create the log dir on demand; stop ignoring the snapshots package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,21 +48,26 @@ __pycache__/*
 __init__.cpython*
 **/__init__.cpython*
 
-# CascadeCorrelationNetwork class snapshots
+# CascadeCorrelationNetwork snapshot ARTIFACTS.
+#
+# `src/snapshots/` is an importable Python package (snapshot_serializer.py,
+# snapshot_cli.py, snapshot_common.py, ...) that ALSO receives .h5 artifacts at
+# runtime. Six of the rules here used to ignore the whole directory
+# (`src/snapshots/*`, `src/snapshots/`, `src/snapshots`, and the `**/snapshots`
+# equivalents), which swept in that tracked source: editing any module in it
+# required `git add -f`, and a glob in this directory is a code-deletion tool --
+# a cleanup once removed five snapshot MODULES and broke every boot (cascor#501).
+#
+# Ignore the artifacts by extension/name instead, so the package stays visible.
 **/cascor/cascor_snapshots/*
 cascor_snapshot_*.h5
 
 src/snapshots/snapshot_*.h5
 src/snapshots/*.h5
-src/snapshots/*
-src/snapshots/
-src/snapshots
 
 **/snapshots/snapshot_*.h5
 **/snapshots/*.h5
-**/snapshots/*
-**/snapshots/
-**/snapshots
+**/snapshots/snapshot_history.jsonl
 
 # Sensitive files and dirs
 .env

--- a/src/log_config/logger/logger.py
+++ b/src/log_config/logger/logger.py
@@ -426,8 +426,27 @@ class Logger(logging.getLoggerClass()):
             _console_message = cls._logging_message(cls._formatter_string_console, cls._console_dict)
             _file_message = cls._logging_message(cls._formatter_string_file, cls._file_dict)
             print(f"+{_console_message(frame, tsp, level, message)}")
-            with open(cls._logging_file, "a") as f:
-                f.write(f"+{_file_message(frame, tsp, level, message)}\n")
+            _line = f"+{_file_message(frame, tsp, level, message)}\n"
+            try:
+                with open(cls._logging_file, "a") as f:
+                    f.write(_line)
+            except FileNotFoundError:
+                # The log directory may legitimately not exist yet:
+                #   * a fresh checkout or `git worktree add` has no `logs/`, and
+                #     `_logging_file` is resolved from the checkout root at IMPORT
+                #     time (see the class attribute above), so the very first
+                #     classmethod log call crashed the process before anything
+                #     else could run;
+                #   * `JUNIPER_CASCOR_LOG_DIR` (Q-6) lets an operator point the log
+                #     somewhere new, which makes "directory does not exist" a
+                #     first-class case rather than an edge one.
+                # `Logger.__init__` does create the directory, but only inside its
+                # dictConfig branch -- and classmethod calls can precede any
+                # instance being constructed. Create on demand and retry once;
+                # this costs nothing on the (overwhelmingly common) happy path.
+                os.makedirs(os.path.dirname(cls._logging_file) or ".", exist_ok=True)
+                with open(cls._logging_file, "a") as f:
+                    f.write(_line)
 
     ####################################################################################################################################
     # Define logging methods


### PR DESCRIPTION
## Summary

Two independent fixes, both surfaced while landing the optimizer-restore work — **Open Tasks 1 and 2**.

## 1. Logger crashed on a fresh checkout — and on any new `JUNIPER_CASCOR_LOG_DIR`

`Logger._logging_file` is a **class attribute resolved from the checkout root at import time**, and the classmethod write path opened it with no directory creation. A fresh `git clone` or `git worktree add` has no `logs/`, so the very first `Logger.info(...)` raised `FileNotFoundError` and took the process with it — before anything else could run.

`Logger.__init__` *does* create the directory, but only inside its `dictConfig` branch, and classmethod calls can precede any instance being constructed.

**Q-6 made this sharper, not milder.** `JUNIPER_CASCOR_LOG_DIR` now lets an operator point the log somewhere new, which makes "directory does not exist" a first-class case rather than an edge one — so the override had a latent hole:

| scenario | unpatched | patched |
|---|---|---|
| fresh worktree, no `logs/` | `FileNotFoundError`, exit 1 | logs fine, dir created |
| `JUNIPER_CASCOR_LOG_DIR` → non-existent dir | **`FileNotFoundError`, exit 1** | logs fine, dir created |

Fix: catch `FileNotFoundError` on the write, `os.makedirs(..., exist_ok=True)`, retry once. **Zero cost on the happy path** — no `makedirs` per log line.

## 2. `.gitignore` ignored the snapshots Python package, not just its artifacts

`src/snapshots/` is an importable package (`snapshot_serializer.py`, `snapshot_cli.py`, `snapshot_common.py`, …) that **also** receives `.h5` artifacts at runtime. Ten rules covered it, and **six ignored the whole directory** — `src/snapshots/*`, `src/snapshots/`, `src/snapshots`, plus the `**/snapshots` equivalents — sweeping in that tracked source.

Two consequences:

- Editing any module there required **`git add -f`**.
- **A glob in this directory is a code-deletion tool** — a cleanup once removed five snapshot *modules* and broke every boot (**cascor#501**).

Fix: ignore the artifacts by extension/name instead of blanket-ignoring the directory. Keeps every `.h5` pattern, **adds** `**/snapshots/snapshot_history.jsonl` (previously caught only by the directory-wide rules), drops the six directory-wide entries.

| check | result |
|---|---|
| `git status` after the change | clean — no new untracked noise |
| `git add src/snapshots/snapshot_serializer.py` | **succeeds without `-f`** |
| `.h5` artifacts | still ignored (`**/snapshots/*.h5`) |
| `snapshot_history.jsonl` | still ignored (new explicit rule) |
| other `snapshots/` dirs in tree | none — only `src/snapshots` and `src/cascor_snapshots` |

**Scope note:** this reduces friction and narrows the blast radius, but does **not** remove the underlying artifact/source coupling. Moving the snapshot directory out of the importable package is a separate, still-open item.

## Testing

| check | result |
|---|---|
| `tests/unit/` | **exit 0** |
| logger/logging-selected tests | **exit 0** |
| pre-commit | clean (black, isort, flake8, bandit, mypy, async-route audit) |
| negative control | unpatched logger **raises and exits 1** on the same call |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSsnngUBYSudSsvPQUWBRK
