### PR TITLE
fix(model): re-extract the drifted constants and make the drift gate actually run

### DIFF
--- a/.github/workflows/ci-cascor-model.yml
+++ b/.github/workflows/ci-cascor-model.yml
@@ -28,11 +28,29 @@ on:
     branches: [main]
     paths:
       - "juniper-cascor-model/**"
+      # The drift guard (juniper-cascor-model/tests/test_drift.py) compares the extracted
+      # trees against their src/ counterparts, so a change on the SRC side must trigger this
+      # workflow too. Filtering on juniper-cascor-model/** alone meant the gate never ran for
+      # the very edits that cause drift -- which is how the W-6 JUNIPER_CASCOR_SNAPSHOTS_DIR
+      # override reached the published package missing entirely.
+      - "src/candidate_unit/**"
+      - "src/utils/**"
+      - "src/log_config/**"
+      - "src/cascor_constants/**"
       - ".github/workflows/ci-cascor-model.yml"
   pull_request:
     branches: [main]
     paths:
       - "juniper-cascor-model/**"
+      # The drift guard (juniper-cascor-model/tests/test_drift.py) compares the extracted
+      # trees against their src/ counterparts, so a change on the SRC side must trigger this
+      # workflow too. Filtering on juniper-cascor-model/** alone meant the gate never ran for
+      # the very edits that cause drift -- which is how the W-6 JUNIPER_CASCOR_SNAPSHOTS_DIR
+      # override reached the published package missing entirely.
+      - "src/candidate_unit/**"
+      - "src/utils/**"
+      - "src/log_config/**"
+      - "src/cascor_constants/**"
       - ".github/workflows/ci-cascor-model.yml"
   workflow_dispatch:
 

--- a/juniper-cascor-model/cascor_constants/constants.py
+++ b/juniper-cascor-model/cascor_constants/constants.py
@@ -416,10 +416,26 @@ _PROJECT_SOURCE_DIR = _PROJECT_CONSTANTS_DIR.parent.resolve()
 _PROJECT_DIR = _PROJECT_SOURCE_DIR.parent.resolve()
 
 _PROJECT_LOG_DIR_NAME_DEFAULT = "logs"
-# juniper-cascor-model: honor JUNIPER_CASCOR_LOG_DIR so deployments (e.g. the distributed
-# worker, where this package lives in site-packages and the source-relative logs/ dir is
-# not writable) can redirect file logging without code changes. Unset -> source default.
-_PROJECT_LOG_DIR_DEFAULT = pathlib.Path(os.environ.get("JUNIPER_CASCOR_LOG_DIR") or pathlib.Path(_PROJECT_DIR, _PROJECT_LOG_DIR_NAME_DEFAULT))
+# Q-6 (CLI experimentation plan §11 / H-7): JUNIPER_CASCOR_LOG_DIR overrides the checkout-shared
+# <repo>/logs so a per-run launcher can point this process's file log at its own RUN_DIR/logs.
+# Mirrors the W-6 JUNIPER_CASCOR_SNAPSHOTS_DIR override (constants_hdf5.py) in shape and semantics.
+#
+# Why this is not merely a concurrency nicety: cascor's parent logger writes ONLY to this file --
+# stdout carries just candidate-worker lines -- so the markers that decide a run's verdict
+# ("Training completed", "Completed solving ...") exist nowhere else. Two cascor processes sharing a
+# checkout therefore interleave and rotate away each other's evidence. Not hypothetical: that is how
+# the F-P1-3 arm A/B logs were lost when a long-lived service rotated the shared file mid-arc.
+#
+# Constants resolve at import time, so the override must be in the process env before the first
+# cascor_constants import (the launcher exports it before exec). A set-but-blank value is treated as
+# unset (the blank-env guard class). Shares one env var with the service tier
+# (api/service_launcher.py and api/observability.py, both _resolve_log_dir), which reads it at call
+# time so the override holds even on their ImportError fallback path.
+_PROJECT_LOG_DIR_OVERRIDE = os.environ.get("JUNIPER_CASCOR_LOG_DIR", "").strip()
+if _PROJECT_LOG_DIR_OVERRIDE:
+    _PROJECT_LOG_DIR_DEFAULT = pathlib.Path(_PROJECT_LOG_DIR_OVERRIDE).expanduser()
+else:
+    _PROJECT_LOG_DIR_DEFAULT = pathlib.Path(_PROJECT_DIR, _PROJECT_LOG_DIR_NAME_DEFAULT)
 
 _PROJECT_CONFIG_DIR_NAME_DEFAULT = "conf"
 _PROJECT_CONFIG_DIR_DEFAULT = pathlib.Path(_PROJECT_DIR, _PROJECT_CONFIG_DIR_NAME_DEFAULT)

--- a/juniper-cascor-model/cascor_constants/constants_api/constants_api_defaults.py
+++ b/juniper-cascor-model/cascor_constants/constants_api/constants_api_defaults.py
@@ -81,12 +81,22 @@ _PROJECT_API_MAX_DATASET_TARGETS: int = 100000
 # Lifecycle Manager Defaults (api/lifecycle/manager.py and api/lifecycle/monitor.py)
 #####################################################################################################################################################################################################
 
-# Lifecycle training-limit caps are intentionally large so the user (or the
+# Lifecycle training-limit caps were intentionally large so the user (or the
 # canopy UI), not the API default, chooses when to stop. Aligned with the
 # canopy / requirements-spec values per
 # juniper-ml/notes/code-review/JUNIPER_2026-04-08_JUNIPER-ECOSYSTEM_CANOPY-CASCOR-INTERFACE-ROADMAP.md
 # §3.5 (PR #122 raised these from 1e3/1e3/1e3; rolled back to small values
 # during the Waves 1-6 hardcoded-values cleanup #123 — V35d re-aligns).
+#
+# RETIRED as TrainingState seeds in C2b (training-runtime-defects plan §4 I-4 /
+# §12 Q1): they formed a second default layer that made /v1/training/status
+# disagree with /v1/network (the status projection now mirrors the live
+# network's effective values, and max_epochs is the Q1 derived cap — see
+# TrainingLifecycleManager.derive_epochs_cap). In particular the 1e11
+# _PROJECT_API_LIFECYCLE_DEFAULT_EPOCHS_MAX exceeded the PATCH model's own
+# le=1e6 ceiling, so canopy forms seeded from the echo were wholesale-rejected
+# 422 on every full-form apply. Kept (unreferenced by the lifecycle) only so
+# external importers of the constants surface do not break.
 _PROJECT_API_LIFECYCLE_DEFAULT_MAX_HIDDEN_UNITS: int = 10_000
 _PROJECT_API_LIFECYCLE_DEFAULT_EPOCHS_MAX: int = 100_000_000_000
 _PROJECT_API_LIFECYCLE_DEFAULT_MAX_ITERATIONS: int = 1_000_000

--- a/juniper-cascor-model/cascor_constants/constants_hdf5/constants_hdf5.py
+++ b/juniper-cascor-model/cascor_constants/constants_hdf5/constants_hdf5.py
@@ -29,6 +29,7 @@
 #
 #
 #####################################################################################################################################################################################################
+import os
 import pathlib
 
 # import torch
@@ -43,7 +44,17 @@ _HDF5_PROJECT_SOURCE_DIR = _HDF5_PROJECT_CONSTANTS_DIR.parent.resolve()
 _HDF5_PROJECT_DIR = _HDF5_PROJECT_SOURCE_DIR.parent.resolve()
 
 _HDF5_PROJECT_SNAPSHOTS_DIR_NAME = "cascor_snapshots"
-_HDF5_PROJECT_SNAPSHOTS_DIR = pathlib.Path(_HDF5_PROJECT_SOURCE_DIR).joinpath(_HDF5_PROJECT_SNAPSHOTS_DIR_NAME)
+# W-6 (CLI experimentation plan §11 / H-5): JUNIPER_CASCOR_SNAPSHOTS_DIR overrides the legacy
+# <repo>/src/cascor_snapshots so a per-run launcher can point the direct CLI's snapshots at its own
+# RUN_DIR/snapshots. Constants resolve at import time, so the override must be in the process env
+# before the first cascor_constants import (the launcher exports it before exec). A set-but-blank
+# value is treated as unset (the blank-env guard class). Shares one env var with the service tier
+# (api/lifecycle/manager.py _get_snapshots_dir).
+_HDF5_PROJECT_SNAPSHOTS_DIR_OVERRIDE = os.environ.get("JUNIPER_CASCOR_SNAPSHOTS_DIR", "").strip()
+if _HDF5_PROJECT_SNAPSHOTS_DIR_OVERRIDE:
+    _HDF5_PROJECT_SNAPSHOTS_DIR = pathlib.Path(_HDF5_PROJECT_SNAPSHOTS_DIR_OVERRIDE).expanduser()
+else:
+    _HDF5_PROJECT_SNAPSHOTS_DIR = pathlib.Path(_HDF5_PROJECT_SOURCE_DIR).joinpath(_HDF5_PROJECT_SNAPSHOTS_DIR_NAME)
 
 
 # Define HDF5 Storage class Constants to provide reasonable defaults

--- a/juniper-cascor-model/tests/test_constants_dir_overrides.py
+++ b/juniper-cascor-model/tests/test_constants_dir_overrides.py
@@ -1,0 +1,89 @@
+"""Env-var directory overrides in the extracted ``cascor_constants`` copy.
+
+These mirror ``juniper-cascor/src/tests/unit/api/test_w6_snapshots_dir_override.py``. The
+package copy needs its own coverage because the overrides resolve at **import time**, and
+because this package is what ``site-packages`` resolves ``cascor_constants`` to -- so a
+consumer importing it from outside the ``src/`` checkout gets these code paths, not src's.
+
+Both overrides previously diverged here:
+
+* **W-6** ``JUNIPER_CASCOR_SNAPSHOTS_DIR`` was absent from this copy entirely, so snapshots
+  landed in the source tree no matter what the launcher exported.
+* **Q-6** ``JUNIPER_CASCOR_LOG_DIR`` was honoured, but via a bare ``or`` rather than
+  ``.strip()``, so a whitespace-only value was truthy and produced a directory literally
+  named ``"   "``.
+
+Constants bind at import, so each case reloads the module under a patched environment.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pathlib
+
+import pytest
+
+import cascor_constants.constants as constants_module
+import cascor_constants.constants_hdf5.constants_hdf5 as hdf5_module
+
+
+def _reload(module, monkeypatch, var, value):
+    """Reload ``module`` with ``var`` set to ``value`` (or removed when ``None``)."""
+    if value is None:
+        monkeypatch.delenv(var, raising=False)
+    else:
+        monkeypatch.setenv(var, value)
+    return importlib.reload(module)
+
+
+@pytest.fixture(autouse=True)
+def _restore_modules():
+    """Always reload both modules back to the ambient environment."""
+    yield
+    importlib.reload(hdf5_module)
+    importlib.reload(constants_module)
+
+
+class TestSnapshotsDirOverride:
+    """W-6: ``JUNIPER_CASCOR_SNAPSHOTS_DIR``."""
+
+    VAR = "JUNIPER_CASCOR_SNAPSHOTS_DIR"
+
+    def test_unset_keeps_legacy_cascor_snapshots(self, monkeypatch):
+        mod = _reload(hdf5_module, monkeypatch, self.VAR, None)
+        assert mod._HDF5_PROJECT_SNAPSHOTS_DIR.name == "cascor_snapshots"
+
+    def test_override_is_honoured(self, monkeypatch, tmp_path):
+        target = tmp_path / "run-snapshots"
+        mod = _reload(hdf5_module, monkeypatch, self.VAR, str(target))
+        assert mod._HDF5_PROJECT_SNAPSHOTS_DIR == target
+
+    def test_user_home_is_expanded(self, monkeypatch):
+        mod = _reload(hdf5_module, monkeypatch, self.VAR, "~/snap-probe")
+        assert mod._HDF5_PROJECT_SNAPSHOTS_DIR == pathlib.Path.home() / "snap-probe"
+
+    @pytest.mark.parametrize("blank", ["", "   ", "\t"])
+    def test_blank_value_is_treated_as_unset(self, monkeypatch, blank):
+        mod = _reload(hdf5_module, monkeypatch, self.VAR, blank)
+        assert mod._HDF5_PROJECT_SNAPSHOTS_DIR.name == "cascor_snapshots"
+
+
+class TestLogDirOverride:
+    """Q-6: ``JUNIPER_CASCOR_LOG_DIR``."""
+
+    VAR = "JUNIPER_CASCOR_LOG_DIR"
+
+    def test_unset_keeps_project_logs(self, monkeypatch):
+        mod = _reload(constants_module, monkeypatch, self.VAR, None)
+        assert mod._PROJECT_LOG_DIR_DEFAULT.name == mod._PROJECT_LOG_DIR_NAME_DEFAULT
+
+    def test_override_is_honoured(self, monkeypatch, tmp_path):
+        target = tmp_path / "run-logs"
+        mod = _reload(constants_module, monkeypatch, self.VAR, str(target))
+        assert mod._PROJECT_LOG_DIR_DEFAULT == target
+
+    @pytest.mark.parametrize("blank", ["", "   ", "\t"])
+    def test_blank_value_is_treated_as_unset(self, monkeypatch, blank):
+        """A whitespace-only value must not become a directory named "   "."""
+        mod = _reload(constants_module, monkeypatch, self.VAR, blank)
+        assert mod._PROJECT_LOG_DIR_DEFAULT.name == mod._PROJECT_LOG_DIR_NAME_DEFAULT

--- a/juniper-cascor-model/tests/test_drift.py
+++ b/juniper-cascor-model/tests/test_drift.py
@@ -32,7 +32,13 @@ _INTENTIONAL_DIVERGENCE = frozenset({Path("log_config/logger/logger.py")})
 
 # Files whose only intended divergence is normalized away before comparison, so any other
 # drift in them is still caught.
-_NORMALIZED_DIVERGENCE = frozenset({Path("cascor_constants/constants.py")})
+#
+# EMPTY as of the 2026-08-19 re-extraction: cascor_constants/constants.py used to carry a
+# package-local rewrite of the JUNIPER_CASCOR_LOG_DIR override, which was normalized away
+# here. That rewrite also dropped the ``.strip()`` blank guard, so a whitespace-only value
+# produced a directory literally named "   ". The file is now extracted verbatim, so there
+# is nothing left to normalize -- and any future drift in it is caught byte-for-byte.
+_NORMALIZED_DIVERGENCE: frozenset = frozenset()
 
 _PACKAGE_LOG_DIR_OVERRIDE = """# juniper-cascor-model: honor JUNIPER_CASCOR_LOG_DIR so deployments (e.g. the distributed
 # worker, where this package lives in site-packages and the source-relative logs/ dir is


### PR DESCRIPTION
## Summary

**PR A of two** for the snapshot-directory work: reconcile the constants divergence first, as a defect independent of any move. (PR B moves the service default.)

The reference sweep found that the **published** `juniper-cascor-model` package had silently diverged from `src/` — and that the guard which exists to catch exactly that **could not fire for the changes that cause it**.

## The divergence — three files

| file | divergence |
|---|---|
| `constants_hdf5.py` | **W-6 `JUNIPER_CASCOR_SNAPSHOTS_DIR` override absent entirely.** site-packages resolves `cascor_constants` to *this* package, so any consumer importing it from outside the `src/` checkout silently ignored the env var and wrote snapshots into the source tree. |
| `constants.py` | `JUNIPER_CASCOR_LOG_DIR` *was* honoured (deliberately, for the distributed worker) — but via a bare `or`, dropping the `.strip()` blank guard. A **whitespace-only** value is truthy, so `JUNIPER_CASCOR_LOG_DIR="   "` produced a directory literally named `"   "` instead of being treated as unset. |
| `constants_api_defaults.py` | comment-only drift. No functional difference. |

> **Correction to what I reported earlier:** I first said the model copy had *neither* override. That was wrong for Q-6 — I grepped the variable name rather than the behaviour. Q-6 was present, just without the blank guard.

All three are **re-extracted verbatim** rather than hand-patched — the drift guard's own stated remedy. Since `constants.py` is now byte-identical, its `_NORMALIZED_DIVERGENCE` entry is **dropped**: nothing left to normalize, and future drift in it is caught byte-for-byte.

## Why it went unnoticed — the gate's path filter excluded the drifting side

`ci-cascor-model.yml` triggered on `juniper-cascor-model/**` only, while `tests/test_drift.py` compares those trees against their `src/` counterparts. **A change landing in `src/cascor_constants/` — exactly what W-6 and Q-6 were — never triggered the workflow.**

The filter now also covers `src/{candidate_unit,utils,log_config,cascor_constants}/**`, so the gate fires whichever side moves.

## The workflow has been red for a month

`CI — juniper-cascor-model` last ran **2026-07-21**, and **all five most recent runs failed** — and they only ran at all because dependabot touched the workflow file. The drift test fails deterministically on pristine `main` today, so that is the near-certain cause. This change should return it to green.

## Testing

| check | result |
|---|---|
| `tests/test_drift.py` | **3 passed** (was 1 failed / 2 passed on pristine main) |
| `juniper-cascor-model` suite | **424 passed**, 1 pre-existing failure — see below |
| `juniper-cascor` `src/tests/unit/` | **exit 0** |
| behaviour probe vs the **model** copy | both overrides honoured; whitespace-only now correctly treated as unset |
| pre-commit | clean |

The one remaining failure, `test_utils_optional_deps::TestColumnarImportGuard`, **also fails on pristine main** and is a local-environment gap: `columnar>=1.4.0` *is* declared in the package's pyproject but is absent from `JuniperCascor1`, so CI installs it and that test passes there. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSsnngUBYSudSsvPQUWBRK
