### PR TITLE
fix(snapshots): move the service snapshot destination out of the importable package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,12 @@ cascor_snapshot_*.h5
 src/snapshots/snapshot_*.h5
 src/snapshots/*.h5
 
+# The SERVICE tier now writes to <repo>/snapshots (repo root), not into the
+# src/snapshots package -- see api/lifecycle/manager.py _get_snapshots_dir. The
+# two src/snapshots patterns above are retained so any pre-move artifact left in
+# the package is still ignored rather than suddenly showing up as untracked.
+/snapshots/
+
 **/snapshots/snapshot_*.h5
 **/snapshots/*.h5
 **/snapshots/snapshot_history.jsonl

--- a/conf/common.conf
+++ b/conf/common.conf
@@ -320,7 +320,9 @@ export BINARY_DIR="${SOURCE_DIR}/${BINARY_DIR_NAME}"
 export DEBUG_DIR="${SOURCE_DIR}/${DEBUG_DIR_NAME}"
 export PYTEST_CACHE_DIR="${SOURCE_DIR}/${PYTEST_CACHE_DIR_NAME}"
 export RELEASE_DIR="${SOURCE_DIR}/${RELEASE_DIR_NAME}"
-export SNAPSHOTS_DIR="${SOURCE_DIR}/${SNAPSHOTS_DIR_NAME}"
+# Repo root, not SOURCE_DIR: src/snapshots is an importable Python package and must not
+# double as an artifact directory (cascor#501). Mirrors _get_snapshots_dir.
+export SNAPSHOTS_DIR="${PROJ_DIR}/${SNAPSHOTS_DIR_NAME}"
 export TARGET_DIR="${SOURCE_DIR}/${TARGET_DIR_NAME}"
 export TESTS_DIR="${SOURCE_DIR}/${TESTS_DIR_NAME}"
 

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -703,7 +703,8 @@ print(f"Dataset shape: x={x_train.shape}, y={y_train.shape}")
 
 ## Serialization API
 
-**Location**: `src/snapshots/`
+**Code location**: `src/snapshots/` (the serializer package)  
+**Snapshot artifacts**: `<repo>/snapshots/` — the repo root, overridable with `JUNIPER_CASCOR_SNAPSHOTS_DIR`
 **Stability**: Stable
 
 ### CascadeHDF5Serializer

--- a/docs/source/QUICK_START.md
+++ b/docs/source/QUICK_START.md
@@ -142,7 +142,8 @@ The `CascadeCorrelationConfig` dataclass holds all network hyperparameters:
 
 ### Serialization Code
 
-**Location**: `src/snapshots/`
+**Code location**: `src/snapshots/` (the serializer package)  
+**Snapshot artifacts**: `<repo>/snapshots/` — the repo root, overridable with `JUNIPER_CASCOR_SNAPSHOTS_DIR`
 
 - `snapshot_serializer.py` - Main HDF5 save/load logic
 - `snapshot_utils.py` - Utility functions

--- a/notes/API_REFERENCE.md
+++ b/notes/API_REFERENCE.md
@@ -498,7 +498,8 @@ def generate_spiral_dataset(
 
 ## Serialization API
 
-**Location**: `src/snapshots/`
+**Code location**: `src/snapshots/` (the serializer package)  
+**Snapshot artifacts**: `<repo>/snapshots/` — the repo root, overridable with `JUNIPER_CASCOR_SNAPSHOTS_DIR`
 
 ### CascadeHDF5Serializer
 

--- a/scripts/juniper-cascor.service
+++ b/scripts/juniper-cascor.service
@@ -43,10 +43,13 @@ ProtectHome=read-only
 ReadWritePaths=%h/Development/python/Juniper/juniper-cascor/logs
 ReadWritePaths=%h/Development/python/Juniper/juniper-cascor/data
 ReadWritePaths=%h/Development/python/Juniper/juniper-cascor/src/cascor_snapshots
-# The SERVICE tier writes src/snapshots (api/lifecycle/manager.py _get_snapshots_dir);
-# cascor_snapshots above is the direct-CLI dir. Without this line, ProtectSystem=strict +
-# ProtectHome=read-only EPERM every POST /v1/snapshots save (latent — fixed with G-13).
-ReadWritePaths=%h/Development/python/Juniper/juniper-cascor/src/snapshots
+# The SERVICE tier writes <repo>/snapshots at the REPO ROOT
+# (api/lifecycle/manager.py _get_snapshots_dir); cascor_snapshots above is the direct-CLI
+# dir. Without this line, ProtectSystem=strict + ProtectHome=read-only EPERM every
+# POST /v1/snapshots save (latent — fixed with G-13). The service path moved out of
+# src/snapshots because that directory is an importable Python package (cascor#501);
+# keep this entry in step with _get_snapshots_dir or saves silently start failing.
+ReadWritePaths=%h/Development/python/Juniper/juniper-cascor/snapshots
 PrivateTmp=true
 ProtectControlGroups=true
 ProtectKernelModules=true

--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -4404,17 +4404,28 @@ class TrainingLifecycleManager:
         """Return the snapshots directory, creating it if needed.
 
         W-6 (CLI experimentation plan §11 / H-4): ``JUNIPER_CASCOR_SNAPSHOTS_DIR``
-        overrides the legacy hard-coded ``<repo>/src/snapshots`` so a per-run
-        launcher can point each cascor instance at its own ``RUN_DIR/snapshots``
-        (per-run config travels as process env, H-3). Read at call time — not
-        import time — so tests and long-lived processes see the current env. A
-        set-but-blank value is treated as unset (the blank-env guard class).
+        overrides the default so a per-run launcher can point each cascor
+        instance at its own ``RUN_DIR/snapshots`` (per-run config travels as
+        process env, H-3). Read at call time — not import time — so tests and
+        long-lived processes see the current env. A set-but-blank value is
+        treated as unset (the blank-env guard class).
+
+        The default is ``<repo>/snapshots`` — the REPO ROOT, deliberately not
+        ``<repo>/src/snapshots``. ``src/snapshots`` is an importable Python
+        package (``snapshot_serializer.py``, ``snapshot_cli.py``, ...), and
+        writing ``.h5`` artifacts into it coupled data to code: a cleanup glob
+        in that directory once deleted five snapshot MODULES and broke every
+        boot (cascor#501), and ``.gitignore`` had to blanket-ignore the
+        directory, so editing the tracked source required ``git add -f``. The
+        package stays where it is; only the artifact destination moves, landing
+        alongside ``logs/`` at the repo root.
         """
         override = os.environ.get("JUNIPER_CASCOR_SNAPSHOTS_DIR", "").strip()
         if override:
             snapshots_dir = Path(override).expanduser()
         else:
-            snapshots_dir = Path(__file__).resolve().parent.parent.parent / "snapshots"
+            # parents[3] == the repo root (this file is src/api/lifecycle/manager.py).
+            snapshots_dir = Path(__file__).resolve().parents[3] / "snapshots"
         snapshots_dir.mkdir(parents=True, exist_ok=True)
         return snapshots_dir
 

--- a/src/tests/unit/api/test_w6_snapshots_dir_override.py
+++ b/src/tests/unit/api/test_w6_snapshots_dir_override.py
@@ -63,12 +63,12 @@ class TestServiceTierOverride:
     def test_unset_falls_back_to_legacy_src_snapshots(self, mgr, monkeypatch):
         monkeypatch.delenv("JUNIPER_CASCOR_SNAPSHOTS_DIR", raising=False)
         resolved = mgr._get_snapshots_dir()
-        assert resolved == _SRC_DIR / "snapshots"
+        assert resolved == _SRC_DIR.parent / "snapshots"
 
     def test_blank_value_is_treated_as_unset(self, mgr, monkeypatch):
         monkeypatch.setenv("JUNIPER_CASCOR_SNAPSHOTS_DIR", "   ")
         resolved = mgr._get_snapshots_dir()
-        assert resolved == _SRC_DIR / "snapshots"
+        assert resolved == _SRC_DIR.parent / "snapshots"
 
     def test_call_time_read_not_cached(self, mgr, tmp_path, monkeypatch):
         """Two calls under different env values resolve differently — the


### PR DESCRIPTION
## Summary

**PR B of two** (PR A was #536). Moves the **service** snapshot destination out of the importable Python package.

`src/snapshots/` is a package — `snapshot_serializer.py`, `snapshot_cli.py`, `snapshot_common.py`, `snapshot_errors.py`, `snapshot_utils.py` — that also received `.h5` artifacts at runtime. That coupling has cost real breakage: a cleanup glob there once deleted **five snapshot modules** and broke every boot (**cascor#501**), and `.gitignore` had to blanket-ignore the directory, so editing the tracked source required `git add -f`.

**The package stays put.** Only the artifact destination moves, to `<repo>/snapshots` at the repo root, alongside `logs/`. Staying inside the checkout is deliberate — moving snapshots out of the checkout entirely is your separate open question.

## Every reference, enumerated by sweep rather than memory

Two constants would not have been enough:

| reference | change |
|---|---|
| `manager.py` `_get_snapshots_dir` | the service default → repo root |
| **`conf/common.conf`** | a **third**, shell-level definition of the same path; now derived from `PROJ_DIR`, not `SOURCE_DIR` |
| **`scripts/juniper-cascor.service`** | the `ReadWritePaths` allowlist — **highest-risk item in the set** |
| `.gitignore` | ignores the new repo-root home |
| `test_w6_snapshots_dir_override.py` | both default assertions |
| `docs/api/API_REFERENCE.md`, `docs/source/QUICK_START.md`, `notes/API_REFERENCE.md` | now distinguish **code** location from **artifact** location |

On the systemd entry specifically: under `ProtectSystem=strict` + `ProtectHome=read-only`, a missed path means **every `POST /v1/snapshots` save EPERMs**. That exact gap already shipped once and was fixed in G-13 — so it's the reference most likely to bite silently. The adjacent comment is refreshed with it.

## Deliberately *not* changed — each checked, not assumed

- **`.github/CODEOWNERS` `/src/snapshots/`** — that entry is about the Python package, which has not moved.
- **`src/cascor_snapshots/`** (direct-CLI tier) — has **no `__init__.py`**, so it isn't an importable package and doesn't have this problem.
- **juniper-canopy** — it reads `snapshot_history.jsonl` from its own `_snapshots_dir`, resolved from `JUNIPER_CANOPY_SNAPSHOT_DIR` (legacy `CASCOR_SNAPSHOT_DIR`) falling back to a **CWD-relative** `"./snapshots"`. It never derived from cascor's default, and juniper-deploy sets **no** snapshot env vars at all — so the two were already independent. No canopy change needed.

## No data is stranded

The service dir currently holds **no `.h5` artifacts** — they were relocated to `src/cascor_snapshots/` with convention-following names — and `list` / `get` / `restore` / `replay` all resolve through `_get_snapshots_dir`, so they move together. The two `src/snapshots/*.h5` ignore patterns are **retained** so any pre-move artifact left behind stays ignored rather than suddenly appearing untracked.

## Testing

| check | result |
|---|---|
| default resolves to `<repo>/snapshots` | **yes**, and confirmed **not** inside the `src/snapshots` package |
| W-6 override tests | **exit 0** — override still wins, blank still treated as unset |
| snapshot-selected api tests | **exit 0** |
| full `src/tests/unit/` | **exit 0** |
| pre-commit | clean incl. mypy, flake8, bandit, doc-link validator |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSsnngUBYSudSsvPQUWBRK
