### PR TITLE
chore(sequence-safety): drop the (Advisory) suffix from the required check

### DIFF
--- a/.github/workflows/sequence-safety.yml
+++ b/.github/workflows/sequence-safety.yml
@@ -52,7 +52,7 @@
 #    - juniper-ml notes/JUNIPER_2026-08-07_JUNIPER-ECOSYSTEM_SEQUENCE-SAFETY-ROLLOUT-PLAN.md (Wave 3)
 #####################################################################################################################################################################################################
 
-name: Sequence Safety (Advisory)
+name: Sequence Safety
 
 on:
   pull_request:
@@ -77,7 +77,7 @@ jobs:
   # base..HEAD. Standalone + advisory -- never a required context, never wired into the CI gate.
   # ═══════════════════════════════════════════════════════════════════════════════════════════════
   sequence-safety:
-    name: Sequence Safety (Advisory)
+    name: Sequence Safety
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Drops the `(Advisory)` suffix now that the screen is a REQUIRED status check (juniper-ml#1011, 2026-08-18). A required gate labelled advisory is misleading.

The job name **is** the required-context string, so this lands as part of a three-phase sequence: the old context was removed from the ruleset first (otherwise this very PR would be blocked by a context it no longer publishes), and the new context is added after merge. The screen is unenforced only for the window between those steps.

Refs pcalnon/juniper-ml#1011
