### PR TITLE
fix(resume): continue the restored output optimizer instead of discarding it

### DIFF
--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -4077,6 +4077,10 @@ class TrainingLifecycleManager:
             # optimizer's state dict is keyed by tensor identity —
             # ``current`` is the live key, ``new_tensor`` won't be
             # found until a new optimizer is constructed against it.
+            # No ``output_field``: ``output_optimizer`` optimizes only the output
+            # ``nn.Linear``, so it holds no state for a hidden unit and this is
+            # correctly a no-op. Kept as a call rather than dropped so a future
+            # hidden-unit optimizer inherits the guard.
             self._zero_optimizer_state_for(current)
             self.network.hidden_units[hidden_unit_index][field] = new_tensor
         else:
@@ -4088,7 +4092,7 @@ class TrainingLifecycleManager:
                     "detail": f"shape mismatch: {attr} expects {tuple(current.shape)}, got {tuple(new_tensor.shape)}",
                 }
             # Zero the optimizer state BEFORE reassignment (see above).
-            self._zero_optimizer_state_for(current)
+            self._zero_optimizer_state_for(current, output_field=field)
             requires_grad = bool(getattr(current, "requires_grad", False))
             if requires_grad:
                 new_tensor.requires_grad_(True)
@@ -4113,16 +4117,66 @@ class TrainingLifecycleManager:
         # forward-pass dtypes stay uniform with the existing network.
         return tensor.to(dtype=torch.float32)
 
-    def _zero_optimizer_state_for(self, parameter) -> None:
+    # ``train_output_layer`` builds the output layer as a single ``nn.Linear``,
+    # whose ``parameters()`` yield ``weight`` then ``bias``, so the output
+    # optimizer's flattened parameter list is always ``[weight, bias]`` in that
+    # order. That positional correspondence is the ONLY link between a
+    # network-level tensor (``output_weights`` / ``output_bias``) and the
+    # ``Parameter`` the optimizer keys its state by — the two are never the same
+    # object, which is why the identity lookup below can never match on its own.
+    _OUTPUT_OPTIMIZER_SLOTS: Dict[str, int] = {"weights": 0, "bias": 1}
+
+    def _resolve_optimizer_parameter(self, optimizer, parameter, output_field: Optional[str]):
+        """Find the ``Parameter`` whose optimizer state corresponds to ``parameter``.
+
+        Tries object identity first, so an optimizer that genuinely holds the
+        network-level tensor keeps working, then falls back to the positional slot
+        described on ``_OUTPUT_OPTIMIZER_SLOTS``. Returns None when no correspondence
+        can be established.
+        """
+        state = optimizer.state
+        # Identity, not ``in`` / ``.get`` — dict lookup would fall back to ``==``
+        # on a hash collision, and tensor ``==`` returns a tensor whose truth value
+        # raises rather than answering the question.
+        for key in state:
+            if key is parameter:
+                return key
+        if output_field is None:
+            return None
+        slot = self._OUTPUT_OPTIMIZER_SLOTS.get(output_field)
+        if slot is None:
+            return None
+        params = [p for group in getattr(optimizer, "param_groups", ()) for p in group.get("params", ())]
+        if slot >= len(params):
+            return None
+        candidate = params[slot]
+        # ``nn.Linear.weight`` is the transpose of ``output_weights``, so shapes
+        # differ by construction — but element counts must agree. A mismatch means
+        # the layout assumption no longer holds; zero nothing rather than the wrong
+        # buffer.
+        if candidate.numel() != parameter.numel():
+            self.logger.debug(f"_zero_optimizer_state_for: slot {slot} numel {candidate.numel()} != target numel {parameter.numel()}; skipping")
+            return None
+        return candidate
+
+    def _zero_optimizer_state_for(self, parameter, *, output_field: Optional[str] = None) -> None:
         """Zero out the optimizer's momentum/variance buffers for a
         single parameter, if the network exposes a step-LR optimizer
-        whose ``state`` keys include the parameter object identity.
+        whose ``state`` covers that parameter.
 
-        Best-effort: if the optimizer is None, missing state, or
-        keyed differently, the function is a no-op. The patched
-        weights still take effect; only the optimizer's stale
-        momentum survives, and the next training step will overwrite
-        it within a few iterations regardless.
+        ``output_field`` names which output-layer slot ``parameter`` corresponds to
+        (``"weights"`` / ``"bias"``); omit it for a tensor the output optimizer does
+        not hold. Without it this was a permanent no-op — it was called with
+        ``network.output_weights``, never with the ``nn.Linear`` ``Parameter`` the
+        optimizer actually keys state by — which was harmless only for as long as
+        ``train_output_layer`` threw the optimizer away on every call. Now that a
+        resume carries the moments forward (R3), a weight edit that skipped this
+        would be stepped with pre-edit Adam moments.
+
+        Best-effort: if the optimizer is None, missing state, or keyed
+        unrecognizably, the function is a no-op. The patched weights still take
+        effect; only the optimizer's stale momentum survives, and the next training
+        step will overwrite it within a few iterations regardless.
         """
         optimizer = getattr(self.network, "output_optimizer", None)
         if optimizer is None:
@@ -4130,7 +4184,10 @@ class TrainingLifecycleManager:
         state = getattr(optimizer, "state", None)
         if not isinstance(state, dict):
             return
-        param_state = state.get(parameter)
+        target = self._resolve_optimizer_parameter(optimizer, parameter, output_field)
+        if target is None:
+            return
+        param_state = state.get(target)
         if not isinstance(param_state, dict):
             return
         for key, val in list(param_state.items()):

--- a/src/cascade_correlation/cascade_correlation.py
+++ b/src/cascade_correlation/cascade_correlation.py
@@ -2049,8 +2049,14 @@ class CascadeCorrelationNetwork:
         # INTENTIONAL: Recreate nn.Linear and optimizer on every call.
         # In Cascade Correlation, the output layer's parameter space changes each time
         # a hidden unit is added (input_size grows), so the previous nn.Linear and
-        # optimizer state are invalid.  Rebuilding from the current output_weights
+        # optimizer object are invalid.  Rebuilding from the current output_weights
         # ensures the optimizer tracks the correct parameter tensors.
+        #
+        # R3: recreating the OBJECT is still correct; discarding the accumulated
+        # optimizer STATE is not.  On a resume the parameter space is unchanged and
+        # the moments restored from the snapshot are the whole point of resuming, so
+        # ``_adopt_prior_output_optimizer_state`` below transfers them onto the new
+        # optimizer when — and only when — they still apply.
         output_layer = nn.Linear(input_size, self.output_size)
         with torch.no_grad():
             output_layer.weight.copy_(self.output_weights.t())  # Transpose because nn.Linear expects (out_features, in_features)
@@ -2060,8 +2066,13 @@ class CascadeCorrelationNetwork:
 
         # Use this layer for optimization (store as instance variable for HDF5 serialization)
         # Create or recreate optimizer using factory method (see INTENTIONAL note above)
+        # R3: capture the outgoing optimizer BEFORE the rebuild so its state can be
+        # carried over.  ``output_optimizer`` is assigned nowhere else and never in
+        # ``__init__``, so a bare attribute access raises on the first ``fit``.
+        prior_optimizer = getattr(self, "output_optimizer", None)
         self.output_optimizer = self._create_optimizer(output_layer.parameters())
         self.logger.debug(f"CascadeCorrelationNetwork: train_output_layer: Created optimizer: {type(self.output_optimizer).__name__}")
+        self._adopt_prior_output_optimizer_state(prior_optimizer, self.output_optimizer)
         optimizer = self.output_optimizer
         self.logger.debug(f"CascadeCorrelationNetwork: train_output_layer: Learning Rate: {self.learning_rate}, Optimizer: {type(optimizer).__name__}")
         self.logger.debug(f"CascadeCorrelationNetwork: train_output_layer: Output layer initialized with weights shape: {output_layer.weight.shape}, Bias shape: {output_layer.bias.shape}")
@@ -3260,6 +3271,83 @@ class CascadeCorrelationNetwork:
         optimizer = optimizer_map[config.optimizer_type]()
         self.logger.debug(f"CascadeCorrelationNetwork: _create_optimizer: Created {config.optimizer_type} optimizer with lr={config.learning_rate}")
         return optimizer
+
+    def _adopt_prior_output_optimizer_state(self, prior_optimizer, optimizer) -> bool:
+        """Carry a prior output optimizer's accumulated state onto a freshly built one.
+
+        R3 (resume follow-on). ``train_output_layer`` rebuilds the output ``nn.Linear``
+        and its optimizer on every call because Cascade Correlation grows the output
+        layer's parameter space each time a hidden unit is installed. That is right on
+        a grow pass and wrong on a resume, where the space is unchanged and the
+        optimizer restored from the snapshot is precisely what the operator asked to
+        continue from — Adam's moments and its step counter were being discarded, so a
+        resumed run silently restarted the output layer's optimization.
+
+        Reusing the restored optimizer OBJECT is not an option, and fails silently if
+        attempted. The snapshot loader binds it to a throwaway ``nn.Linear`` that it
+        builds itself (``snapshots/snapshot_serializer.py``), whose ``Parameter``\\ s are
+        not the ones ``train_output_layer`` just created. Shapes are identical by
+        construction, so a shape check on the object PASSES — and then
+        ``loss.backward()`` populates ``.grad`` on the new layer's parameters while
+        ``optimizer.step()`` iterates the old ones, whose ``.grad`` is ``None``. The
+        step is a no-op, the unchanged weights are copied back, loss is still logged
+        and callbacks still fire: the output layer stops training with no error
+        anywhere. Torch's optimizer ``state_dict`` is POSITIONALLY indexed, so routing
+        the state through it re-binds it to the new parameters instead.
+
+        Hyperparameters are deliberately NOT adopted. ``load_state_dict`` replaces
+        ``param_groups`` wholesale, which would silently revert a live
+        ``PATCH /v1/training/params`` learning-rate change back to the snapshot's
+        value. The current config wins for hyperparameters; the snapshot wins for
+        state.
+
+        Returns:
+            True when state was adopted. False — a no-op leaving the freshly built
+            optimizer untouched — in every other case: a cold start with no prior
+            optimizer, a topology change that grew the parameter space, an optimizer
+            type change, a prior that never stepped, or a malformed prior state.
+        """
+        if prior_optimizer is None or optimizer is None:
+            return False
+
+        # Compare against the optimizer just built from the CURRENT config rather
+        # than against the config's ``optimizer_type`` string: ``_create_optimizer``
+        # silently falls back to Adam for an unrecognized type, so comparing the
+        # strings would disagree with what was actually constructed.
+        if type(prior_optimizer) is not type(optimizer):
+            self.logger.debug(f"CascadeCorrelationNetwork: _adopt_prior_output_optimizer_state: optimizer type changed ({type(prior_optimizer).__name__} -> {type(optimizer).__name__}); starting from fresh state")
+            return False
+
+        prior_params = [p for group in getattr(prior_optimizer, "param_groups", ()) for p in group.get("params", ())]
+        new_params = [p for group in optimizer.param_groups for p in group.get("params", ())]
+        if len(prior_params) != len(new_params) or any(tuple(a.shape) != tuple(b.shape) for a, b in zip(prior_params, new_params)):
+            # The normal grow-pass outcome: ``input_size`` grew with the new hidden
+            # unit, so the prior moments describe a parameter space that no longer
+            # exists. This is the branch that keeps the golden trajectory byte-stable.
+            self.logger.debug("CascadeCorrelationNetwork: _adopt_prior_output_optimizer_state: output parameter space changed; starting from fresh optimizer state")
+            return False
+
+        if not getattr(prior_optimizer, "state", None):
+            self.logger.debug("CascadeCorrelationNetwork: _adopt_prior_output_optimizer_state: prior optimizer carries no state; nothing to adopt")
+            return False
+
+        # Snapshot the current config's hyperparameters before ``load_state_dict``
+        # overwrites ``param_groups`` with the persisted ones.
+        hyperparameters = [{key: value for key, value in group.items() if key != "params"} for group in optimizer.param_groups]
+        try:
+            optimizer.load_state_dict(prior_optimizer.state_dict())
+        except (KeyError, ValueError, TypeError) as exc:
+            # Torch validates group and parameter counts before mutating anything, so
+            # the freshly built optimizer is still intact here. Degrade to fresh state
+            # rather than failing the training pass.
+            self.logger.warning(f"CascadeCorrelationNetwork: _adopt_prior_output_optimizer_state: could not adopt prior optimizer state ({exc}); starting from fresh state")
+            return False
+
+        for group, saved in zip(optimizer.param_groups, hyperparameters):
+            group.update(saved)
+
+        self.logger.debug(f"CascadeCorrelationNetwork: _adopt_prior_output_optimizer_state: adopted {type(optimizer).__name__} state ({len(optimizer.state)} parameter entries) at lr={optimizer.param_groups[0].get('lr')}")
+        return True
 
     @staticmethod
     def train_candidate_worker(task_data_input: tuple = None, parallel: bool = True, progress_callback=None) -> None:

--- a/src/tests/unit/api/test_patch_weights.py
+++ b/src/tests/unit/api/test_patch_weights.py
@@ -305,3 +305,72 @@ class TestOptimizerStateZeroOut:
         new_values = torch.zeros_like(lc.network.output_weights).tolist()
         result = lc.patch_weights(target="output", field="weights", values=new_values)
         assert result["status"] == lc._PATCH_OK
+
+
+class TestZeroOptimizerStateWithRealOptimizer:
+    """The same zero-out, against the optimizer production actually builds.
+
+    Every other test in this file keys a mock optimizer's ``state`` by the
+    network-level tensor (``network.output_weights``). Production never does:
+    ``train_output_layer`` builds an ``nn.Linear`` and hands ITS ``Parameter``\\ s to
+    the optimizer, so the identity lookup could never match and the zero-out was a
+    permanent no-op that the mocks reported as working. That was harmless only
+    while the optimizer was thrown away on every call; now that a resume carries
+    the moments forward (R3), an edit stepped with pre-edit moments is a real
+    defect. These tests use a REAL optimizer so the correspondence is exercised.
+    """
+
+    @staticmethod
+    def _warm_real_optimizer(lc):
+        """Give the network a genuine, stepped ``output_optimizer``."""
+        x = torch.randn(8, 2, dtype=torch.float32)
+        y = torch.randn(8, 1, dtype=torch.float32)
+        lc.network.train_output_layer(x, y, epochs=3)
+        optimizer = lc.network.output_optimizer
+        # Fill the running buffers with a recognizably non-zero pattern.
+        for entry in optimizer.state.values():
+            for key, val in entry.items():
+                if isinstance(val, torch.Tensor) and val.dim() > 0:
+                    entry[key] = torch.full_like(val, 0.5)
+        return optimizer
+
+    def _slot_state(self, optimizer, slot):
+        params = [p for group in optimizer.param_groups for p in group["params"]]
+        return optimizer.state[params[slot]]
+
+    def test_patching_output_weights_zeroes_the_real_slot(self):
+        lc = _make_lifecycle_with_network()
+        optimizer = self._warm_real_optimizer(lc)
+        assert torch.count_nonzero(self._slot_state(optimizer, 0)["exp_avg"]) > 0
+
+        new_values = torch.zeros_like(lc.network.output_weights).tolist()
+        result = lc.patch_weights(target="output", field="weights", values=new_values)
+
+        assert result["status"] == lc._PATCH_OK
+        weight_state = self._slot_state(optimizer, 0)
+        assert torch.all(weight_state["exp_avg"] == 0), "pre-edit moments survived an output-weight patch"
+        assert torch.all(weight_state["exp_avg_sq"] == 0)
+        # The bias slot was not edited, so its moments must be left alone.
+        assert torch.count_nonzero(self._slot_state(optimizer, 1)["exp_avg"]) > 0, "patching weights must not clear the bias slot"
+
+    def test_patching_output_bias_zeroes_only_the_bias_slot(self):
+        lc = _make_lifecycle_with_network()
+        optimizer = self._warm_real_optimizer(lc)
+
+        new_values = torch.zeros_like(lc.network.output_bias).tolist()
+        result = lc.patch_weights(target="output", field="bias", values=new_values)
+
+        assert result["status"] == lc._PATCH_OK
+        assert torch.all(self._slot_state(optimizer, 1)["exp_avg"] == 0), "pre-edit moments survived an output-bias patch"
+        assert torch.count_nonzero(self._slot_state(optimizer, 0)["exp_avg"]) > 0, "patching bias must not clear the weight slot"
+
+    def test_step_counter_is_preserved_across_a_patch(self):
+        """Only the running statistics carry pre-edit bias; the step count does not."""
+        lc = _make_lifecycle_with_network()
+        optimizer = self._warm_real_optimizer(lc)
+        before = float(self._slot_state(optimizer, 0)["step"])
+
+        result = lc.patch_weights(target="output", field="weights", values=torch.zeros_like(lc.network.output_weights).tolist())
+
+        assert result["status"] == lc._PATCH_OK
+        assert float(self._slot_state(optimizer, 0)["step"]) == before

--- a/src/tests/unit/test_p1_fixes.py
+++ b/src/tests/unit/test_p1_fixes.py
@@ -108,6 +108,54 @@ def _save_and_reload_network_hdf5_helper(tmpdir, network, CascadeCorrelationNetw
     print("✅ PASS: Optimizer saved and restored successfully")
 
 
+def test_2b_optimizer_state_survives_resume():
+    """R3: restoring the optimizer is only half the contract — training must USE it.
+
+    Test 2 above proves the optimizer round-trips through HDF5. It was still
+    discarded the moment training resumed: ``train_output_layer`` rebuilt the
+    optimizer unconditionally on every call, so a resumed run restarted the output
+    layer's optimization from zero moments while reporting a successful restore.
+    """
+    print("\n[Test 2b] Optimizer state survives a resume...")
+    _verify_optimizer_state_survives_resume_helper()
+
+
+def _verify_optimizer_state_survives_resume_helper():
+    from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork
+    from cascade_correlation.cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig
+
+    def step_count(optimizer):
+        entry = next(iter(optimizer.state.values()))
+        return int(float(entry["step"]))
+
+    config = CascadeCorrelationConfig(input_size=2, output_size=1)
+    network = CascadeCorrelationNetwork(config=config)
+    x, y = torch.randn(10, 2), torch.randn(10, 1)
+    network.train_output_layer(x, y, epochs=4)
+    warm_step = step_count(network.output_optimizer)
+    assert warm_step == 4, f"expected 4 optimizer steps, got {warm_step}"  # trunk-ignore(bandit/B101)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        filepath = Path(tmpdir) / "resume_contract.h5"
+        assert network.save_to_hdf5(str(filepath), include_training_state=True), "Save should succeed"  # trunk-ignore(bandit/B101)
+        resumed = CascadeCorrelationNetwork.load_from_hdf5(str(filepath))
+
+    assert resumed is not None, "Network should load successfully"  # trunk-ignore(bandit/B101)
+    assert step_count(resumed.output_optimizer) == warm_step, "Restore alone should preserve the step counter"  # trunk-ignore(bandit/B101)
+
+    weights_before = resumed.output_weights.detach().clone()
+    resumed.train_output_layer(x, y, epochs=3)
+
+    # Continued, not restarted.
+    assert step_count(resumed.output_optimizer) == warm_step + 3, f"Resume must continue the optimizer: expected {warm_step + 3} steps, got {step_count(resumed.output_optimizer)}"  # trunk-ignore(bandit/B101)
+    # ...and the layer genuinely trained. Carrying state over by reusing the
+    # restored optimizer OBJECT would satisfy the step assertion above while
+    # stepping parameters the live layer does not own — a silent no-op.
+    assert not torch.equal(weights_before, resumed.output_weights.detach()), "Output weights did not move — optimizer stepped parameters the layer does not own"  # trunk-ignore(bandit/B101)
+
+    print(f"✅ PASS: Optimizer continued at step {step_count(resumed.output_optimizer)} (was {warm_step}) and the layer trained")
+
+
 def test_3_training_counters_persistence():
     """Test that training counters are persisted in HDF5."""
     print("\n[Test 3] Training counter persistence...")

--- a/src/tests/unit/test_snapshot_serializer_coverage_final.py
+++ b/src/tests/unit/test_snapshot_serializer_coverage_final.py
@@ -231,6 +231,185 @@ class TestLoadOptimizerStateHelper:
 
 
 # ---------------------------------------------------------------------------
+# R3 resume follow-on: the restored optimizer's STATE must survive the rebuild
+# that ``train_output_layer`` performs on every call.
+# ---------------------------------------------------------------------------
+def _optimizer_step(optimizer):
+    """Number of steps the optimizer has taken, or None if it has no state."""
+    if not optimizer.state:
+        return None
+    entry = next(iter(optimizer.state.values()))
+    step = entry.get("step")
+    return None if step is None else int(float(step))
+
+
+def _round_trip(network):
+    """Save ``network`` through the real writer and return the loaded copy."""
+    serializer = _make_serializer()
+    with tempfile.NamedTemporaryFile(suffix=".h5", delete=False) as f:
+        filepath = f.name
+    try:
+        assert serializer.save_network(network, filepath)
+        loaded = serializer.load_network(filepath, restore_multiprocessing=False)
+    finally:
+        os.unlink(filepath)
+    assert loaded is not None
+    return loaded
+
+
+def _grow_output_space(network):
+    """Install a hidden unit through the SAME helpers the cascade-grow path uses.
+
+    ``add_unit`` / ``add_units_as_layer`` both route through these two, so the
+    parameter-space change this produces is the real one rather than a
+    test-shaped imitation.
+    """
+    prev_in = network.output_weights.shape[0]
+    network._install_hidden_unit(
+        weights=torch.randn(prev_in, dtype=torch.float32),
+        bias=torch.tensor([0.0], dtype=torch.float32),
+        activation_fn=network.activation_fn,
+        correlation=0.5,
+    )
+    network._resize_output_layer_for_new_units(num_added=1, prev_input_size=prev_in)
+
+
+class TestOutputOptimizerStateReuse:
+    """``train_output_layer`` rebuilds the optimizer every call; R3 makes it carry
+    the prior state over when — and only when — that state still applies."""
+
+    @pytest.mark.unit
+    def test_resume_continues_optimizer_step_rather_than_restarting(self):
+        """The headline contract: a resumed run continues the snapshot's optimizer.
+
+        Before R3 the restored optimizer was replaced by a fresh one before its first
+        step, so the step counter restarted at 0 and Adam's moments were discarded —
+        the resumed run silently re-derived momentum the snapshot already held.
+        """
+        set_deterministic_behavior(seed=42)
+        network = _make_network()
+        x, y = torch.randn(10, 2), torch.randn(10, 2)
+        network.train_output_layer(x, y, epochs=3)
+        warm_step = _optimizer_step(network.output_optimizer)
+        assert warm_step == 3
+
+        loaded = _round_trip(network)
+        assert _optimizer_step(loaded.output_optimizer) == warm_step, "restore itself must preserve the step counter"
+
+        loaded.train_output_layer(x, y, epochs=2)
+        assert _optimizer_step(loaded.output_optimizer) == warm_step + 2, "resume must CONTINUE the optimizer, not restart it"
+
+    @pytest.mark.unit
+    def test_resumed_output_layer_actually_trains(self):
+        """Adoption must not cost the training step itself.
+
+        The obvious implementation — reuse the restored optimizer OBJECT once its
+        ``param_groups`` shapes match — passes a shape check and then silently stops
+        training: the loader binds that optimizer to a throwaway ``nn.Linear`` it
+        built itself, so ``loss.backward()`` fills ``.grad`` on the layer
+        ``train_output_layer`` created while ``step()`` iterates the loader's, whose
+        ``.grad`` is None. Loss is still logged and callbacks still fire, so only an
+        assertion that the weights MOVED catches it.
+        """
+        set_deterministic_behavior(seed=42)
+        network = _make_network()
+        x, y = torch.randn(10, 2), torch.randn(10, 2)
+        network.train_output_layer(x, y, epochs=3)
+
+        loaded = _round_trip(network)
+        before = loaded.output_weights.detach().clone()
+        loaded.train_output_layer(x, y, epochs=2)
+
+        assert not torch.equal(before, loaded.output_weights.detach()), "output weights did not move — the optimizer stepped parameters the layer does not own"
+
+    @pytest.mark.unit
+    def test_growth_still_rebuilds_optimizer_state(self):
+        """Negative control — without it the continuity test above proves nothing.
+
+        Adding a hidden unit grows the output layer's parameter space, so the prior
+        moments describe parameters that no longer exist and MUST be dropped. This is
+        also why the fix is golden-neutral: every grow-loop call site runs right after
+        a unit is installed.
+        """
+        set_deterministic_behavior(seed=42)
+        network = _make_network()
+        x, y = torch.randn(10, 2), torch.randn(10, 2)
+        network.train_output_layer(x, y, epochs=3)
+        assert _optimizer_step(network.output_optimizer) == 3
+
+        _grow_output_space(network)
+        network.train_output_layer(x, y, epochs=2)
+
+        assert _optimizer_step(network.output_optimizer) == 2, "a grown parameter space must start from fresh optimizer state"
+
+    @pytest.mark.unit
+    def test_optimizer_type_change_refuses_adoption(self):
+        """``PATCH /v1/training/params`` can change ``optimizer_type``; SGD must not
+        inherit Adam's moments."""
+        set_deterministic_behavior(seed=42)
+        network = _make_network()
+        x, y = torch.randn(10, 2), torch.randn(10, 2)
+        network.train_output_layer(x, y, epochs=3)
+        assert type(network.output_optimizer).__name__ == "Adam"
+
+        network.config.optimizer_config.optimizer_type = "SGD"
+        network.train_output_layer(x, y, epochs=2)
+
+        assert type(network.output_optimizer).__name__ == "SGD"
+        assert _optimizer_step(network.output_optimizer) is None, "SGD keeps no step counter; Adam's state must not have been adopted"
+
+    @pytest.mark.unit
+    def test_current_learning_rate_wins_over_snapshot(self):
+        """State comes from the snapshot, hyperparameters from the live config.
+
+        ``load_state_dict`` replaces ``param_groups`` wholesale, so adopting it
+        verbatim would silently revert a live learning-rate patch to the snapshot's
+        value.
+        """
+        set_deterministic_behavior(seed=42)
+        network = _make_network()
+        x, y = torch.randn(10, 2), torch.randn(10, 2)
+        network.train_output_layer(x, y, epochs=3)
+        snapshot_lr = network.output_optimizer.param_groups[0]["lr"]
+
+        loaded = _round_trip(network)
+        patched_lr = snapshot_lr * 3.0
+        loaded.config.optimizer_config.learning_rate = patched_lr
+        loaded.train_output_layer(x, y, epochs=2)
+
+        assert loaded.output_optimizer.param_groups[0]["lr"] == pytest.approx(patched_lr), "a patched learning rate must survive optimizer-state adoption"
+        assert _optimizer_step(loaded.output_optimizer) == 5, "the state itself must still have been adopted"
+
+    @pytest.mark.unit
+    def test_cold_start_has_no_prior_optimizer(self):
+        """A fresh network has no ``output_optimizer`` ATTRIBUTE at all, so the
+        adoption path must read it defensively — a bare access raises on first fit."""
+        set_deterministic_behavior(seed=42)
+        network = _make_network()
+        assert not hasattr(network, "output_optimizer") or network.output_optimizer is None
+
+        network.train_output_layer(torch.randn(10, 2), torch.randn(10, 2), epochs=2)
+
+        assert network.output_optimizer is not None
+        assert _optimizer_step(network.output_optimizer) == 2
+
+    @pytest.mark.unit
+    def test_none_optimizer_after_topology_edit_refuses_adoption(self):
+        """``add_hidden_unit_manual`` / a degraded restore set ``output_optimizer`` to
+        None; the same ``getattr`` guard has to cover that without a separate flag."""
+        set_deterministic_behavior(seed=42)
+        network = _make_network()
+        x, y = torch.randn(10, 2), torch.randn(10, 2)
+        network.train_output_layer(x, y, epochs=3)
+
+        network.output_optimizer = None
+        network.train_output_layer(x, y, epochs=2)
+
+        assert network.output_optimizer is not None
+        assert _optimizer_step(network.output_optimizer) == 2
+
+
+# ---------------------------------------------------------------------------
 # Hidden units history save/load round trip
 # ---------------------------------------------------------------------------
 class TestHiddenUnitsHistory:


### PR DESCRIPTION
## Summary

Closes the R3 resume follow-on: a resumed run now **continues** the snapshot's output optimizer instead of silently restarting it.

Steps 1–3 of the owner's iterative loop — restore a snapshotted network, replay it, edit it — have worked since `5f15a45` fixed optimizer *restore*. Step 4 threw the result away. `train_output_layer` opened with an **unconditional**

```python
self.output_optimizer = self._create_optimizer(output_layer.parameters())
```

so the faithfully-restored optimizer was replaced before its first step. Adam's moments and step counter were discarded on every resume, and the run re-derived momentum the snapshot already held — while reporting a successful restore.

## The fix

`train_output_layer` still rebuilds the `nn.Linear` and the optimizer **object** on every call — that part was always correct, because Cascade Correlation grows the output layer's parameter space each time a hidden unit is installed. What changes is that the accumulated **state** is now carried across, via a new `_adopt_prior_output_optimizer_state`, when and only when it still applies.

### Why the obvious implementation is wrong

Reusing the restored optimizer *object* once its `param_groups` shapes match **fails silently**, and it is worth recording why so nobody re-derives it later.

The snapshot loader binds the restored optimizer to a throwaway `nn.Linear` that it builds itself (`snapshots/snapshot_serializer.py:1119`, bound at `:1135`). `train_output_layer` builds a *different* layer. The shapes are identical by construction, so a shape check **passes** — and then `loss.backward()` populates `.grad` on the new layer's Parameters while `optimizer.step()` iterates the old ones, whose `.grad` is `None`. The step is a no-op, the unchanged weights are copied back, loss is still logged and callbacks still fire: **the output layer stops training with no error anywhere.**

Torch's optimizer `state_dict` is positionally indexed, so routing the state through it re-binds it to the freshly-created Parameters instead. That is what this PR does.

`test_resumed_output_layer_actually_trains` exists specifically to catch that failure mode — it asserts the weights *moved*, which is the only assertion the broken shape looks wrong under. Verified: against a deliberately-installed reuse-the-object implementation, 4 of the 7 new tests fail, including that one with byte-identical weights after 2 epochs.

### Refusal cases (all no-ops that keep the fresh optimizer)

| Case | Why |
|---|---|
| Cold start | `output_optimizer` is never assigned in `__init__`; read via `getattr(..., None)`, as a bare access raises on the first `fit` |
| Parameter space grew | The normal grow-pass outcome — prior moments describe parameters that no longer exist |
| `optimizer_type` changed | `PATCH /v1/training/params` can change it; SGD must not inherit Adam's moments |
| `output_optimizer is None` | Set by `add_hidden_unit_manual` / `remove_hidden_unit_manual` / a degraded restore — the same `getattr` guard covers it, so no separate topology flag is needed |
| Malformed prior state | `load_state_dict` validates before mutating, so the fresh optimizer is intact; degrade rather than fail the pass |

### Hyperparameters are deliberately not adopted

`load_state_dict` replaces `param_groups` wholesale, which would silently revert a live `PATCH /v1/training/params` learning-rate change back to the snapshot's value. **Current config wins for hyperparameters; the snapshot wins for state.**

## Second half: the guard that makes this safe

`_zero_optimizer_state_for` was **inert**. It looked up `optimizer.state.get(parameter)` by tensor identity but was passed `network.output_weights` — never the `nn.Linear` Parameter the optimizer actually keys state by, so it could never match.

That was harmless only for as long as the optimizer was thrown away on every call. Once a resume carries the moments forward, a `PATCH /v1/network/weights` edit would be **stepped with pre-edit Adam moments**. Fixing reuse without fixing this guard would have shipped a new defect.

It now resolves the target by identity first, then by positional slot (`weights` → 0, `bias` → 1, the fixed `nn.Linear.parameters()` order), with a `numel` sanity check. Hidden-unit patches stay a no-op — correctly, since `output_optimizer` holds no hidden-unit parameters — and that is now documented as intent rather than left looking like an oversight.

Every pre-existing test for this guard built a `MagicMock` optimizer keyed by the network tensor, i.e. a shape production never has, so they reported it working while it did nothing. The three new tests in `TestZeroOptimizerStateWithRealOptimizer` use a real, stepped optimizer.

## Verification

| Check | Result |
|---|---|
| **Golden trajectory** (`-m golden --golden --slow --integration`) | **PASS** — the fix is golden-neutral |
| Full `tests/unit` (with `--slow`) | PASS (exit 0) |
| `tests/integration/api/test_can_015h_roundtrip.py` | PASS |
| `pre-commit` on all 5 changed files | PASS |
| New tests vs. **baseline** code | 2 fail (step 2 vs 5 — the optimizer restarted) + 2 fail on the inert guard |
| New tests vs. the **trap** implementation | 4 fail, incl. "output weights did not move" |

Golden-neutrality is structural, not luck: in the growth loop `train_output_layer` is only ever called immediately after a unit is installed (`:4594` after `add_units_as_layer`, `:4823` via `_retrain_output_layer`), so the parameter space always grew and a correct check always recreates. The only unchanged-space call site is the initial pass in `fit` (`:1891`), which on a cold start has no optimizer at all. **A golden diff here would mean a bug, not an expected baseline shift.**

## Note for the owner — not addressed here

`resume_from_snapshot` re-reads the snapshot from disk (`_load_snapshot_to_network` → `load_network`), so `/resume` discards **all in-memory edits**, not just the optimizer. The working loop is therefore restore → replay → edit → **re-snapshot** → resume. Relatedly, the edit endpoints hard-require `is_investigating()`, which is the state `/restore` produces — not the `RESUME_READY` that `/resume` produces — so editing necessarily happens before resuming. Both are pre-existing behaviour and unchanged by this PR; flagging them because they shape how the iterative workflow has to be driven.

## Test plan

```bash
conda activate JuniperCascor1
cd src

# the two suites 5f15a45 touched, plus the manager-side guard
python -m pytest tests/unit/test_p1_fixes.py \
                 tests/unit/test_snapshot_serializer_coverage_final.py \
                 tests/unit/api/test_patch_weights.py -q --slow

# the gate that matters
OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 CASCOR_NUM_PROCESSES=1 \
  python -m pytest -m golden --golden --slow --integration \
    tests/integration/test_golden_trajectory.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01741j36XEPuyk3Bh3nFrWJP
