### PR TITLE
fix(api): register CORS outermost so preflights are not answered 401

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 **Author**: Paul Calnon
 **License**: MIT License
 **Version**: 0.9.0
-**Last Updated**: 2026-08-14
+**Last Updated**: 2026-08-20
 
 ---
 
@@ -525,12 +525,25 @@ Registered in `src/api/app.py` via successive `app.add_middleware(...)` calls. S
 
 | Order (outer → inner) | Middleware | Module | Purpose |
 |-----------------------|-----------|--------|---------|
-| 1 | `RequestIdMiddleware` | `api.observability` | X-Request-ID propagation (always added last, so runs first) |
-| 2 | `PrometheusMiddleware` | `api.observability` | Metrics (only when `metrics_enabled`) |
-| 3 | `SecurityMiddleware` | `api.middleware` | API key auth + rate limiting (exempt paths) |
-| 4 | `SecurityHeadersMiddleware` | `api.middleware` | CSP, HSTS, X-Frame-Options, etc. |
-| 5 | `RequestBodyLimitMiddleware` | `api.middleware` | 10 MiB request body limit (CR-024 stream cap) |
-| 6 | `CORSMiddleware` | FastAPI/Starlette | CORS headers (only if origins are configured) |
+| 1 | `CORSMiddleware` | FastAPI/Starlette | CORS headers + preflight short-circuit (only if origins are configured) |
+| 2 | `RequestIdMiddleware` | `api.observability` | X-Request-ID propagation |
+| 3 | `PrometheusMiddleware` | `api.observability` | Metrics (only when `metrics_enabled`) |
+| 4 | `SecurityMiddleware` | `api.middleware` | API key auth + rate limiting (exempt paths) |
+| 5 | `SecurityHeadersMiddleware` | `api.middleware` | CSP, HSTS, X-Frame-Options, etc. |
+| 6 | `RequestBodyLimitMiddleware` | `api.middleware` | 10 MiB request body limit (CR-024 stream cap) |
+
+**`CORSMiddleware` must stay outermost — it is added last for exactly that reason.**
+A browser preflight carries no `X-API-Key`: the browser generates the preflight itself, and
+author-defined headers ride only on the actual request that follows. So any ordering that puts
+`SecurityMiddleware` outside CORS answers every preflight to a non-exempt path with 401, and no
+browser client on a configured origin can reach a protected endpoint. Running outermost also
+attaches the CORS headers to error responses (401/429), so a browser surfaces the real status
+instead of an opaque CORS failure.
+
+This is a stronger guarantee than an `OPTIONS` bypass in `SecurityMiddleware._is_exempt` would
+give: CORS short-circuits only a *genuine* preflight (one carrying
+`Access-Control-Request-Method`), so a plain `OPTIONS` request still authenticates. Pinned by
+`tests/unit/api/test_api_app.py::TestCorsPreflight`.
 
 WebSocket upgrade requests are **not** intercepted by `BaseHTTPMiddleware`, so `/ws/*` paths skip the body-limit and security-middleware HTTP paths entirely; they use WebSocket auth and message validation instead.
 

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -615,22 +615,10 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     app.state.settings = settings
 
-    # CORS: only enable when origins are explicitly configured.
-    allow_credentials = bool(settings.cors_origins) and "*" not in settings.cors_origins
-
-    if settings.cors_origins:
-        app.add_middleware(
-            CORSMiddleware,
-            allow_origins=settings.cors_origins,
-            allow_credentials=allow_credentials,
-            allow_methods=["*"],
-            allow_headers=["*"],
-        )
-
     # Request body size limit
     app.add_middleware(RequestBodyLimitMiddleware)
 
-    # Security headers (outermost — runs on every response)
+    # Security headers
     app.add_middleware(SecurityHeadersMiddleware)
 
     # Security (API key auth + rate limiting)
@@ -642,12 +630,36 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.add_middleware(SecurityMiddleware, api_key_auth=api_key_auth, rate_limiter=rate_limiter)
     app.state.api_key_auth = api_key_auth
 
-    # Observability middleware (added after SecurityMiddleware, before CORS)
-    # Middleware execution is LIFO: last added runs first.
-    # Order: RequestIdMiddleware → PrometheusMiddleware → SecurityMiddleware → SecurityHeaders → CORS
+    # Observability middleware
     if settings.metrics_enabled:
         app.add_middleware(PrometheusMiddleware, service_name="juniper-cascor", namespace="juniper_cascor")
     app.add_middleware(RequestIdMiddleware)
+
+    # CORS: only enable when origins are explicitly configured.
+    #
+    # Registered LAST so it executes OUTERMOST. Starlette's ``add_middleware``
+    # prepends, so execution order is the reverse of registration order:
+    #
+    #   CORS → RequestId → Prometheus → Security → SecurityHeaders
+    #        → RequestBodyLimit → routes
+    #
+    # CORS must sit OUTSIDE SecurityMiddleware. A browser preflight carries no
+    # ``X-API-Key``: the browser generates the preflight itself, and
+    # author-defined headers ride only on the actual request that follows. So
+    # with CORS innermost every preflight to a non-exempt path was answered 401
+    # and the browser never issued the real request. Outermost also attaches the
+    # CORS headers to error responses (401/429), so a browser can surface the
+    # real status instead of an opaque CORS failure.
+    allow_credentials = bool(settings.cors_origins) and "*" not in settings.cors_origins
+
+    if settings.cors_origins:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=settings.cors_origins,
+            allow_credentials=allow_credentials,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
 
     # REST Routes
     app.include_router(health.router, prefix="/v1")

--- a/src/tests/unit/api/test_api_app.py
+++ b/src/tests/unit/api/test_api_app.py
@@ -114,3 +114,91 @@ class TestAppFactory:
         body = response.json()
         assert body["status"] == "error"
         assert body["error"]["code"] == "INTERNAL_ERROR"
+
+
+@pytest.mark.unit
+class TestCorsPreflight:
+    """CORS must execute OUTSIDE SecurityMiddleware.
+
+    Regression coverage for APD-CASCOR-001b (sibling of APD-DATA-035). CORS was
+    registered first, which under Starlette's prepending ``add_middleware`` made
+    it the INNERMOST layer -- so ``SecurityMiddleware`` saw browser preflights
+    first and answered them 401. A preflight carries no ``X-API-Key`` by
+    construction, so no browser could ever reach a protected endpoint.
+    """
+
+    # A real, non-exempt route: not in ``api.middleware.EXEMPT_PATHS``.
+    PROTECTED_PATH = "/v1/network/stats"
+
+    @staticmethod
+    def _app():
+        """An app with BOTH a CORS origin and an API key, so auth is really active."""
+        return create_app(
+            Settings(
+                auto_start=False,
+                cors_origins=["http://localhost:3000"],
+                api_keys=["preflight-test-key"],
+            )
+        )
+
+    def test_cors_executes_outside_security_middleware(self):
+        """Order is the contract: index 0 runs outermost, so CORS must precede Security."""
+        order = [m.cls.__name__ for m in self._app().user_middleware]
+
+        assert "CORSMiddleware" in order, order
+        assert "SecurityMiddleware" in order, order
+        assert order.index("CORSMiddleware") < order.index("SecurityMiddleware"), f"CORS must run outside SecurityMiddleware, got outermost-first order {order}"
+
+    def test_preflight_to_protected_path_is_not_answered_401(self):
+        """The defect itself: a genuine preflight must get CORS headers, not 401."""
+        client = TestClient(self._app())
+
+        response = client.options(
+            self.PROTECTED_PATH,
+            headers={"Origin": "http://localhost:3000", "Access-Control-Request-Method": "GET"},
+        )
+
+        assert response.status_code != 401, "preflight was rejected by auth; it carries no API key by design"
+        assert response.status_code == 200
+        assert response.headers.get("access-control-allow-origin") == "http://localhost:3000"
+
+    def test_preflight_from_disallowed_origin_is_still_rejected(self):
+        """Negative control: moving CORS outermost must not accept arbitrary origins."""
+        client = TestClient(self._app())
+
+        response = client.options(
+            self.PROTECTED_PATH,
+            headers={"Origin": "http://evil.example", "Access-Control-Request-Method": "GET"},
+        )
+
+        assert response.headers.get("access-control-allow-origin") is None
+        assert response.status_code == 400
+
+    def test_non_preflight_options_still_requires_auth(self):
+        """The auth surface must not widen.
+
+        This is why the fix is a reorder and not an ``OPTIONS`` bypass inside
+        ``_is_exempt``: a bypass would exempt every ``OPTIONS`` request, while
+        CORS short-circuits only a genuine preflight (one carrying
+        ``Access-Control-Request-Method``).
+        """
+        client = TestClient(self._app())
+
+        with_origin = client.options(self.PROTECTED_PATH, headers={"Origin": "http://localhost:3000"})
+        bare = client.options(self.PROTECTED_PATH)
+
+        assert with_origin.status_code == 401
+        assert bare.status_code == 401
+
+    def test_auth_failure_still_carries_cors_headers(self):
+        """Outermost CORS also annotates error responses.
+
+        Without this a browser sees an opaque CORS failure instead of the real
+        401, which is why the misordering was hard to diagnose client-side.
+        """
+        client = TestClient(self._app())
+
+        response = client.get(self.PROTECTED_PATH, headers={"Origin": "http://localhost:3000"})
+
+        assert response.status_code == 401
+        assert response.headers.get("access-control-allow-origin") == "http://localhost:3000"


### PR DESCRIPTION
## Summary

`CORSMiddleware` was registered **first**. Starlette's `add_middleware` *prepends*, so first-registered runs **innermost** — which put `SecurityMiddleware` *outside* CORS and let it see browser preflights before CORS ever ran. `_is_exempt` keys on path only (`src/api/middleware.py:238` — `return path in EXEMPT_PATHS`), with no `OPTIONS` bypass, so **every preflight to a non-exempt `/v1/*` path was answered 401**.

A preflight carries no `X-API-Key` by construction — the browser generates it, and author-defined headers ride only on the actual request that follows — so no browser client on a configured origin could reach a protected endpoint at all.

## Fix

Move the CORS block after `RequestIdMiddleware` so CORS is registered **last** and therefore executes **outermost**:

```
CORS -> RequestId -> Prometheus -> Security -> SecurityHeaders -> RequestBodyLimit -> routes
```

### Why a reorder and not an `OPTIONS` bypass

The register offers both. A bypass in `_is_exempt` would exempt **every** `OPTIONS` request from auth *and* rate limiting. CORS short-circuits only a **genuine** preflight — one carrying `Access-Control-Request-Method` — so a plain `OPTIONS` request still authenticates. That is pinned as a test in its own right (`test_non_preflight_options_still_requires_auth`), so the narrower surface cannot silently regress.

The reorder also fixes a **second symptom the register does not name**: a cross-origin request rejected by auth now carries the CORS headers, so a browser surfaces the real 401 instead of an opaque CORS failure.

## Verification

Against the real `create_app`, on the real non-exempt route `/v1/network/stats`:

| Case | Before | After |
|---|---|---|
| Preflight, allowed origin | 401, no ACAO | **200 + ACAO** |
| Preflight, disallowed origin | 401 | **400, no ACAO** (allowlist intact) |
| Non-preflight `OPTIONS`, no key | 401 | **401** (auth surface unchanged) |
| Cross-origin GET, no key | 401, no ACAO | **401 + ACAO** |

**Mutation-tested:** 4 of the 5 new tests fail against the unfixed ordering. The fifth (`non_preflight_options_still_requires_auth`) passes both before and after *by design* — it guards the OPTIONS-bypass alternative, not the reorder.

No existing test asserted middleware *order* (only membership), so nothing was pinning the buggy arrangement.

- `tests/unit/api/` green (exit 0)
- flake8 clean under the repo's own pre-commit args (`--max-line-length=512`, source and relaxed-test profiles)

## Also corrected

- The in-code ordering comment, which omitted `RequestBodyLimitMiddleware` entirely. That is **`APD-CASCOR-001a`**, unavoidably folded in — the register split it as "disjoint", but a reorder cannot land beside a now doubly-wrong comment.
- The `AGENTS.md` middleware table, which documented the old order, plus a note on why CORS must stay outermost.

## Requirements

Closes `APD-CASCOR-001b` and `APD-CASCOR-001a` — [ecosystem defect register](https://github.com/pcalnon/juniper-ml/blob/main/notes/JUNIPER_2026-08-14_JUNIPER-ECOSYSTEM_DEFECT-REGISTER.md). The juniper-data sibling `APD-DATA-035` is pcalnon/juniper-data#273; the juniper-ml register update follows both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYff26V49gHCedjrFosej6