### PR TITLE
fix(snapshots): D-B — a corrupt snapshot is 422, not 404

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -765,12 +765,25 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         """
         # Starlette's ``HTTPException.__init__`` auto-fills ``detail``
         # with ``HTTPStatus(status_code).phrase`` when the caller
-        # doesn't pass one, so ``exc.detail`` is always a string by
+        # doesn't pass one, so ``exc.detail`` is normally a string by
         # the time we get here. ``str()`` defends against future
         # subclasses that might return non-str detail objects.
-        message = str(exc.detail)
+        #
+        # API-09b (first use: D-B's snapshot error taxonomy): a route may instead pass
+        # ``detail={"code": "SEMANTIC_CODE", "message": "..."}`` when the caller needs a
+        # machine-readable discriminator that ``HTTP_NNN`` cannot express — two
+        # different failures sharing one status code, or one failure whose meaning
+        # clients must branch on without string-matching prose. String details are
+        # untouched, so every existing route keeps its exact shape.
+        detail = exc.detail
+        if isinstance(detail, dict) and "message" in detail:
+            code = str(detail.get("code") or f"HTTP_{exc.status_code}")
+            message = str(detail["message"])
+        else:
+            code = f"HTTP_{exc.status_code}"
+            message = str(detail)
         envelope = error_response(
-            code=f"HTTP_{exc.status_code}",
+            code=code,
             message=message,
         )
         return JSONResponse(

--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -27,6 +27,8 @@ from api.models.cascor_model import CascorModel
 from api.models.common import coerce_native_scalars as _common_coerce_native_scalars
 from api.observability import TRAINING_SESSION_STATUS_CANCELLED, TRAINING_SESSION_STATUS_FAILURE, TRAINING_SESSION_STATUS_SUCCESS, dec_training_sessions, inc_training_session_completed, inc_training_sessions, observe_training_step_duration, record_training_epoch, set_hidden_units, set_training_accuracy, set_training_loss
 from cascor_constants.constants_api import _PROJECT_API_DRAIN_THREAD_JOIN_TIMEOUT, _PROJECT_API_LIFECYCLE_DEFAULT_CANDIDATE_PATIENCE, _PROJECT_API_NETWORK_INPUT_SIZE_DEFAULT, _PROJECT_API_NETWORK_OUTPUT_SIZE_DEFAULT, _PROJECT_API_PROGRESS_QUEUE_GET_TIMEOUT, _PROJECT_API_PROGRESS_QUEUE_WAIT_TIMEOUT
+from snapshots.snapshot_load_status import SnapshotLoadResult
+from snapshots.snapshot_load_status import absent as snapshot_absent
 
 
 def _env_flag(name: str, *, default: bool) -> bool:
@@ -4558,29 +4560,34 @@ class TrainingLifecycleManager:
     # same set when locking it as read-only.
     _NETWORK_HISTORY_KEYS: tuple = ("train_loss", "value_loss", "train_accuracy", "value_accuracy")
 
-    def _load_snapshot_to_network(self, snapshot_id: str) -> bool:
+    def _load_snapshot_to_network(self, snapshot_id: str) -> SnapshotLoadResult:
         """Locate the snapshot, deserialize, and install on the lifecycle.
 
         Internal helper extracted from ``load_snapshot`` so each Phase 6E
         Sprint B operation (Restore / Replay / Resume / Retrain) can share
         the load semantics while diverging on post-load state mutations
         (FSM transitions, history resets, replay-session setup, etc.).
-        Returns True on success, False if the snapshot is missing or the
-        deserializer fails.
+
+        D-B: returns a :class:`SnapshotLoadResult` rather than a bare ``bool`` so the
+        four verbs can tell the caller *why* a load failed. It is falsy on failure, so
+        ``if not ok:`` call sites read unchanged. Absent is detected in two places —
+        here at the glob, and again inside ``load_network_result`` — which is why the
+        classification cannot live in the serializer alone.
         """
         snapshots_dir = self._get_snapshots_dir()
         matches = [f for f in snapshots_dir.glob("*.h5") if f.stem == snapshot_id]
         if not matches:
             self.logger.warning(f"Snapshot not found: {snapshot_id}")
-            return False
+            return snapshot_absent(f"no snapshot with id {snapshot_id!r}")
 
         from snapshots.snapshot_serializer import CascadeHDF5Serializer
 
         serializer = CascadeHDF5Serializer()
-        network = serializer.load_network(matches[0])
-        if network is None:
-            self.logger.error(f"Failed to load snapshot: {snapshot_id}")
-            return False
+        result = serializer.load_network_result(matches[0])
+        if not result:
+            self.logger.error(f"Failed to load snapshot {snapshot_id}: {result.status} — {result.detail}")
+            return result
+        network = result.network
 
         # WS-6 B-phase: the HDF5 deserializer yields a *bare* CCN — re-wrap it so the
         # manager keeps holding a CascorModel (a getter-only property would leave
@@ -4596,19 +4603,24 @@ class TrainingLifecycleManager:
         # ``/v1/network`` and ``GET /v1/training/params`` after every
         # Restore / Replay / Resume / Retrain load.
         self._sync_training_state_from_network()
-        return True
+        return result
 
-    def _snapshot_result(self, *, loaded: bool, snapshot_id: str, operation: str, reason: Optional[str] = None) -> Dict[str, Any]:
+    def _snapshot_result(self, *, loaded: bool, snapshot_id: str, operation: str, reason: Optional[str] = None, reason_code: Optional[str] = None) -> Dict[str, Any]:
         """Status dict for the snapshot load/restore/resume verbs (WS-6 B2b return
-        convergence toward the ServiceLifecycleManager seam). Internal contract: the
-        snapshot routes build their own HTTP payload via ``_build_unified_payload`` and
-        consume only ``loaded`` for error-mapping."""
+        convergence toward the ServiceLifecycleManager seam).
+
+        ``reason`` is human-readable; ``reason_code`` is the machine-readable
+        discriminator the routes map to a status code (D-B) — one of the
+        ``snapshot_load_status`` constants, or ``None`` for a non-load failure such as
+        an FSM rejection. The routes previously consumed only ``loaded``, so every
+        failure became the same 404 no matter what ``reason`` said."""
         return {
             "loaded": loaded,
             "snapshot_id": snapshot_id,
             "operation": operation,
             "fsm_state": self.state_machine.status.name,
             "reason": reason,
+            "reason_code": reason_code,
         }
 
     def load_snapshot(self, snapshot_id: str) -> Dict[str, Any]:
@@ -4636,9 +4648,9 @@ class TrainingLifecycleManager:
             self.logger.warning(f"load_snapshot rejected: lifecycle is {self.state_machine.status.name}")
             return self._snapshot_result(loaded=False, snapshot_id=snapshot_id, operation="restore", reason=f"rejected: lifecycle is {self.state_machine.status.name}")
 
-        ok = self._load_snapshot_to_network(snapshot_id)
-        if not ok:
-            return self._snapshot_result(loaded=False, snapshot_id=snapshot_id, operation="restore", reason="snapshot not found or failed to load")
+        outcome = self._load_snapshot_to_network(snapshot_id)
+        if not outcome:
+            return self._snapshot_result(loaded=False, snapshot_id=snapshot_id, operation="restore", reason=outcome.detail, reason_code=outcome.status)
 
         # CAN-015d (B-4): transition to Investigating and clear any
         # state from prior snapshot operations. The user explicitly
@@ -4680,9 +4692,9 @@ class TrainingLifecycleManager:
         if self.state_machine.is_started() or self.state_machine.is_paused() or self.state_machine.is_replaying():
             self.logger.warning(f"restore_for_retrain rejected: lifecycle is {self.state_machine.status.name}")
             return self._snapshot_result(loaded=False, snapshot_id=snapshot_id, operation="retrain", reason=f"rejected: lifecycle is {self.state_machine.status.name}")
-        ok = self._load_snapshot_to_network(snapshot_id)
-        if not ok:
-            return self._snapshot_result(loaded=False, snapshot_id=snapshot_id, operation="retrain", reason="snapshot not found or failed to load")
+        outcome = self._load_snapshot_to_network(snapshot_id)
+        if not outcome:
+            return self._snapshot_result(loaded=False, snapshot_id=snapshot_id, operation="retrain", reason=outcome.detail, reason_code=outcome.status)
 
         # Clear history arrays on the network. ``getattr`` rather than direct
         # attribute access so a network that doesn't expose ``history`` yet
@@ -4756,9 +4768,9 @@ class TrainingLifecycleManager:
             self.logger.warning(f"resume_from_snapshot rejected: lifecycle is {self.state_machine.status.name}")
             return self._snapshot_result(loaded=False, snapshot_id=snapshot_id, operation="resume", reason=f"rejected: lifecycle is {self.state_machine.status.name}")
 
-        ok = self._load_snapshot_to_network(snapshot_id)
-        if not ok:
-            return self._snapshot_result(loaded=False, snapshot_id=snapshot_id, operation="resume", reason="snapshot not found or failed to load")
+        outcome = self._load_snapshot_to_network(snapshot_id)
+        if not outcome:
+            return self._snapshot_result(loaded=False, snapshot_id=snapshot_id, operation="resume", reason=outcome.detail, reason_code=outcome.status)
 
         # Compute the resume-point epoch from the loaded network's
         # history. Use the longest array's length so a snapshot that's
@@ -4795,7 +4807,7 @@ class TrainingLifecycleManager:
         self.logger.info(f"Snapshot restored for resume: {snapshot_id} (resume_point_epoch={resume_point})")
         return self._snapshot_result(loaded=True, snapshot_id=snapshot_id, operation="resume")
 
-    def start_replay(self, snapshot_id: str) -> bool:
+    def start_replay(self, snapshot_id: str) -> Dict[str, Any]:
         """Load a snapshot and start a replay session (CAN-015c).
 
         Phase 6E Sprint B B-3. Loads the snapshot identically to
@@ -4815,14 +4827,19 @@ class TrainingLifecycleManager:
         installed.
 
         See ``notes/PHASE_6E_SPRINT_B_DESIGN.md`` §2.2.
+
+        D-B: returns the same ``_snapshot_result`` dict as its three sibling verbs.
+        It previously returned a bare ``bool``, which left it with no channel for a
+        failure reason at all — so replay was the one verb that could not distinguish
+        an absent snapshot from a corrupt one even in principle.
         """
         if self.state_machine.is_started() or self.state_machine.is_paused():
             self.logger.warning(f"start_replay rejected: training is {self.state_machine.status.name}")
-            return False
+            return self._snapshot_result(loaded=False, snapshot_id=snapshot_id, operation="replay", reason=f"rejected: lifecycle is {self.state_machine.status.name}")
 
-        ok = self._load_snapshot_to_network(snapshot_id)
-        if not ok:
-            return False
+        outcome = self._load_snapshot_to_network(snapshot_id)
+        if not outcome:
+            return self._snapshot_result(loaded=False, snapshot_id=snapshot_id, operation="replay", reason=outcome.detail, reason_code=outcome.status)
 
         # If a previous replay session was running, tear it down first
         # so its thread doesn't keep emitting against the new history.
@@ -4853,7 +4870,7 @@ class TrainingLifecycleManager:
         session.start_thread()
 
         self.logger.info(f"Snapshot replay started: {snapshot_id} (length={session.length})")
-        return True
+        return self._snapshot_result(loaded=True, snapshot_id=snapshot_id, operation="replay")
 
     def replay_control(self, action: str, **params: Any) -> Dict[str, Any]:
         """Apply a control action to the active replay session (CAN-015c).

--- a/src/api/routes/snapshots.py
+++ b/src/api/routes/snapshots.py
@@ -3,16 +3,44 @@
 import asyncio
 import logging
 import re
+from typing import NoReturn
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, field_validator
 
 from api.models.common import success_response
 from snapshots.snapshot_errors import SnapshotSaveError
+from snapshots.snapshot_load_status import SNAPSHOT_CORRUPT
 
 logger = logging.getLogger("juniper_cascor.api.routes.snapshots")
 
 router = APIRouter(prefix="/snapshots", tags=["snapshots"])
+
+
+def _raise_snapshot_load_error(snapshot_id: str, result: dict) -> NoReturn:
+    """Translate a failed snapshot load into the right HTTP error (D-B).
+
+    Every failure used to raise ``404 "not found or failed to load"``, fusing two
+    opposite operator situations: *pick a different snapshot* and *investigate data
+    loss*. A corrupt snapshot is now ``422`` — the request is well formed, the entity
+    is not processable — while ``404`` is reserved for one that genuinely is not there.
+
+    The detail is a dict so the envelope carries a machine-readable ``error.code``
+    alongside the prose; clients branch on that rather than string-matching a sentence.
+    ``409`` is deliberately not reused here: these routes already spend it on FSM
+    conflicts, and reusing it would trade one ambiguity for another.
+    """
+    reason = result.get("reason") or "no further detail"
+    if result.get("reason_code") == SNAPSHOT_CORRUPT:
+        raise HTTPException(
+            status_code=422,
+            detail={"code": "SNAPSHOT_CORRUPT", "message": f"Snapshot '{snapshot_id}' exists but could not be read: {reason}"},
+        )
+    raise HTTPException(
+        status_code=404,
+        detail={"code": "SNAPSHOT_ABSENT", "message": f"Snapshot '{snapshot_id}' not found"},
+    )
+
 
 # SEC-17: allowlist for snapshot identifiers. The lifecycle manager already
 # matches on file stems via ``glob("*.h5")`` so a crafted path with ``..``
@@ -249,7 +277,7 @@ async def restore_snapshot(request: Request, snapshot_id: str) -> dict:
     # snapshot is being read.
     result = await asyncio.to_thread(lifecycle.load_snapshot, snapshot_id)
     if not result["loaded"]:
-        raise HTTPException(status_code=404, detail=f"Snapshot '{snapshot_id}' not found or failed to load")
+        _raise_snapshot_load_error(snapshot_id, result)
     payload = _build_unified_payload(
         lifecycle,
         snapshot_id,
@@ -300,7 +328,7 @@ async def retrain_from_snapshot(request: Request, snapshot_id: str) -> dict:
     # are quick attribute writes — no need to fan out further.
     result = await asyncio.to_thread(lifecycle.restore_for_retrain, snapshot_id)
     if not result["loaded"]:
-        raise HTTPException(status_code=404, detail=f"Snapshot '{snapshot_id}' not found or failed to load")
+        _raise_snapshot_load_error(snapshot_id, result)
     payload = _build_unified_payload(
         lifecycle,
         snapshot_id,
@@ -347,7 +375,7 @@ async def resume_snapshot(request: Request, snapshot_id: str) -> dict:
     # PERF-CC-01: HDF5 I/O off the event loop, same as the other snapshot routes.
     result = await asyncio.to_thread(lifecycle.resume_from_snapshot, snapshot_id)
     if not result["loaded"]:
-        raise HTTPException(status_code=404, detail=f"Snapshot '{snapshot_id}' not found or failed to load")
+        _raise_snapshot_load_error(snapshot_id, result)
     payload = _build_unified_payload(
         lifecycle,
         snapshot_id,
@@ -402,9 +430,9 @@ async def start_replay_endpoint(request: Request, snapshot_id: str) -> dict:
         raise HTTPException(status_code=409, detail=f"Cannot start replay while training is {lifecycle.state_machine.status.name}")
     # PERF-CC-01: HDF5 I/O off the event loop. The thread spawn itself
     # is fast but lives on the worker so we don't need a separate path.
-    success = await asyncio.to_thread(lifecycle.start_replay, snapshot_id)
-    if not success:
-        raise HTTPException(status_code=404, detail=f"Snapshot '{snapshot_id}' not found or failed to load")
+    result = await asyncio.to_thread(lifecycle.start_replay, snapshot_id)
+    if not result["loaded"]:
+        _raise_snapshot_load_error(snapshot_id, result)
     payload = _build_unified_payload(
         lifecycle,
         snapshot_id,

--- a/src/snapshots/snapshot_load_status.py
+++ b/src/snapshots/snapshot_load_status.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+"""
+Shared vocabulary for *why* a snapshot load failed (D-B).
+
+Before this module the loader collapsed every failure into a bare ``None``, and the
+API collapsed that into ``404 "not found or failed to load"`` — fusing two opposite
+operator situations: *pick a different snapshot* and *investigate data loss*.
+
+The distinction can only be drawn where the cause is still known — at the load site —
+so the taxonomy lives in one place that the serializer, the lifecycle manager, and the
+API routes can all name. Design of record:
+``notes/JUNIPER_2026-08-20_JUNIPER-CASCOR_SNAPSHOT-ERROR-TAXONOMY-DESIGN.md``
+(juniper-ml#1193).
+"""
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+#: The load succeeded.
+SNAPSHOT_OK = "ok"
+
+#: No snapshot with that id exists. The operator should pick a different one.
+#: Maps to HTTP 404.
+SNAPSHOT_ABSENT = "snapshot_absent"
+
+#: A snapshot exists but cannot be read: bad format, missing groups, an unreadable
+#: file, or a config group that yields no network. The operator should investigate
+#: data loss. Maps to HTTP 422 — the request is well formed, the entity is not
+#: processable. Deliberately NOT 404 (a lie for a file that exists), NOT 500 (implies
+#: a retry might help), and NOT 409 (already used by these routes for FSM conflicts).
+SNAPSHOT_CORRUPT = "snapshot_corrupt"
+
+
+@dataclass(frozen=True)
+class SnapshotLoadResult:
+    """Outcome of a snapshot load, carrying the reason when it failed.
+
+    ``__bool__`` follows ``ok`` so the pre-existing ``if not loaded:`` call sites read
+    unchanged after being handed one of these instead of a bare ``bool``.
+    """
+
+    network: Optional[Any] = None
+    status: str = SNAPSHOT_OK
+    detail: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return self.status == SNAPSHOT_OK and self.network is not None
+
+    def __bool__(self) -> bool:
+        return self.ok
+
+
+def absent(detail: str) -> SnapshotLoadResult:
+    """A snapshot with that id does not exist."""
+    return SnapshotLoadResult(network=None, status=SNAPSHOT_ABSENT, detail=detail)
+
+
+def corrupt(detail: str) -> SnapshotLoadResult:
+    """A snapshot exists but cannot be read."""
+    return SnapshotLoadResult(network=None, status=SNAPSHOT_CORRUPT, detail=detail)
+
+
+def loaded(network: Any) -> SnapshotLoadResult:
+    """The load succeeded."""
+    return SnapshotLoadResult(network=network, status=SNAPSHOT_OK, detail="")

--- a/src/snapshots/snapshot_serializer.py
+++ b/src/snapshots/snapshot_serializer.py
@@ -92,6 +92,10 @@ from utils.activation import ActivationWithDerivative
 
 from .snapshot_common import calculate_tensor_checksum, load_numpy_array, load_tensor, read_str_attr, read_str_dataset, save_numpy_array, save_tensor, verify_tensor_checksum, write_str_attr, write_str_dataset
 from .snapshot_errors import SnapshotSaveError
+from .snapshot_load_status import SnapshotLoadResult
+from .snapshot_load_status import absent as snapshot_absent
+from .snapshot_load_status import corrupt as snapshot_corrupt
+from .snapshot_load_status import loaded as snapshot_loaded
 
 
 class CascadeHDF5Serializer:
@@ -264,8 +268,12 @@ class CascadeHDF5Serializer:
         """
         try:
             with h5py.File(filepath, "r") as hdf5_file:
-                if not self._validate_format(hdf5_file):
-                    return {"valid": False, "error": "Invalid format"}
+                # Report WHICH check failed. ``_validate_format`` covers far more than
+                # the format string — required groups, hidden-unit consistency, param
+                # datasets — so a flat "Invalid format" pointed the operator at the one
+                # thing that was usually fine.
+                if (format_detail := self._validate_format_detail(hdf5_file)) is not None:
+                    return {"valid": False, "error": format_detail}
 
                 # Extract summary information
                 summary = {
@@ -873,10 +881,56 @@ class CascadeHDF5Serializer:
                     save_numpy_array(data_group, key, dataset, compression, compression_opts)
         self.logger.debug("CascadeHDF5Serializer: Saved training data")
 
+    def load_network_result(self, filepath: Union[str, Path], restore_multiprocessing: bool = True) -> SnapshotLoadResult:
+        """
+        Load a CascadeCorrelationNetwork, reporting the reason on failure.
+
+        D-B: the load itself still goes through :meth:`load_network`, which stays the
+        seam every caller and test knows. Only when it comes back ``None`` does this
+        run a second, cheap pass to work out WHY — because that is the one thing the
+        bare ``None`` throws away, and the API then reported every cause as
+        ``404 "not found or failed to load"``, fusing *pick a different snapshot* with
+        *investigate data loss*.
+
+        Classifying after the fact rather than threading a reason through the loader
+        keeps the hot path and the public signature untouched; the extra file open
+        happens only on the error path.
+
+        Returns:
+            SnapshotLoadResult — ``network`` set and ``status == SNAPSHOT_OK`` on
+            success; otherwise ``SNAPSHOT_ABSENT`` or ``SNAPSHOT_CORRUPT`` with a
+            human-readable ``detail``.
+        """
+        network = self.load_network(filepath, restore_multiprocessing)
+        if network is not None:
+            return snapshot_loaded(network)
+        return self._classify_load_failure(filepath)
+
+    def _classify_load_failure(self, filepath: Union[str, Path]) -> SnapshotLoadResult:
+        """Work out why :meth:`load_network` returned ``None`` (D-B).
+
+        Absent is unambiguous. Everything else is corrupt: the file is there but the
+        deserializer could not turn it into a network — a rejected format, a missing
+        group, an unreadable file. ``_validate_format_detail`` supplies the specific
+        reason when it can, so the operator is told which check failed rather than
+        just "failed to load".
+        """
+        if not os.path.exists(filepath):
+            return snapshot_absent(f"no snapshot file at {filepath}")
+        try:
+            with h5py.File(filepath, "r") as hdf5_file:
+                detail = self._validate_format_detail(hdf5_file)
+        except Exception as exc:  # noqa: BLE001 - any read failure means corrupt
+            return snapshot_corrupt(f"unreadable snapshot: {exc}")
+        return snapshot_corrupt(detail or "snapshot could not be deserialized into a network")
+
     # def load_network(self, filepath: Union[str, Path], restore_multiprocessing: bool = True) -> Optional:  # Original - invalid Optional usage
     def load_network(self, filepath: Union[str, Path], restore_multiprocessing: bool = True) -> Optional[Any]:
         """
         Load a CascadeCorrelationNetwork from HDF5 format.
+
+        Returns ``None`` on every failure. Callers that need to distinguish *absent*
+        from *corrupt* (D-B) should use :meth:`load_network_result` instead.
 
         Args:
             filepath: Path to HDF5 file
@@ -911,6 +965,11 @@ class CascadeHDF5Serializer:
                 if restore_multiprocessing and "mp" in hdf5_file:
                     self._restore_multiprocessing_state(hdf5_file, network)
                 if not self._validate_shapes(network):
+                    # D-E (tracked separately, juniper-ml#1199): this only warns, and the
+                    # shape-broken network is installed on the live lifecycle anyway. One
+                    # violation class then trains silently on garbage. Deliberately NOT
+                    # changed here — reclassifying it as CORRUPT is a behaviour change over
+                    # ~170 currently-loadable archive files and needs its own decision.
                     self.logger.warning("CascadeHDF5Serializer: Network loaded but shape validation found issues")
             self.logger.info(f"CascadeHDF5Serializer: Successfully loaded network from {filepath}")
             return network
@@ -1623,9 +1682,26 @@ class CascadeHDF5Serializer:
         except Exception as e:
             return self._log_exception_stacktrace("Shape validation failed: ", e, False)
 
-    def _validate_format(self, hdf5_file: h5py.File) -> bool:  # noqa: C901 - validation requires multiple checks
+    def _validate_format(self, hdf5_file: h5py.File) -> bool:
         """
         Validate HDF5 file format with comprehensive checks.
+
+        Thin wrapper over :meth:`_validate_format_detail`, kept because callers and
+        tests treat format validation as a boolean gate.
+
+        Returns:
+            bool: True if file format is valid, False otherwise
+        """
+        return self._validate_format_detail(hdf5_file) is None
+
+    def _reject_format(self, message: str) -> str:
+        """Log a format rejection and return it as the reason string."""
+        self.logger.error(message)
+        return message
+
+    def _validate_format_detail(self, hdf5_file: h5py.File) -> Optional[str]:  # noqa: C901 - validation requires multiple checks
+        """
+        Validate HDF5 file format, returning WHICH check failed.
 
         Validates:
         - Format name and version compatibility
@@ -1633,8 +1709,13 @@ class CascadeHDF5Serializer:
         - Hidden units consistency
         - Parameter dataset shapes
 
+        Every branch already produced a precise error message; previously all of them
+        collapsed into a bare ``False``, and ``verify_saved_network`` reported the
+        result to the operator as ``'Invalid format'`` — pointing at the format string
+        even when the real problem was, say, a missing ``params`` group.
+
         Returns:
-            bool: True if file format is valid, False otherwise
+            None if the format is valid, otherwise the reason it was rejected.
         """
         try:
             # Check format identifier
@@ -1644,8 +1725,7 @@ class CascadeHDF5Serializer:
                 _HDF5_FORMAT_NAME_LEGACY,
                 _HDF5_FORMAT_NAME_CURRENT,
             ]:
-                self.logger.error(f"Invalid format: {format_name}")
-                return False
+                return self._reject_format(f"Invalid format: {format_name}")
 
             # Check format version compatibility
             format_version = read_str_attr(hdf5_file, "format_version", "1")
@@ -1654,8 +1734,7 @@ class CascadeHDF5Serializer:
                 serializer_major_version = int(self.format_version.split(".")[0])
 
                 if file_major_version > serializer_major_version:
-                    self.logger.error(f"Incompatible format version: file={format_version}, " f"serializer={self.format_version}")
-                    return False
+                    return self._reject_format(f"Incompatible format version: file={format_version}, " f"serializer={self.format_version}")
             except (ValueError, IndexError):
                 self.logger.warning(f"Could not parse format version: {format_version}")
 
@@ -1663,8 +1742,7 @@ class CascadeHDF5Serializer:
             required_groups = ["meta", "config", "params", "arch", "random"]
             for group in required_groups:
                 if group not in hdf5_file:
-                    self.logger.error(f"Missing required group: {group}")
-                    return False
+                    return self._reject_format(f"Missing required group: {group}")
 
             # Check for required datasets in params group
             if "params" in hdf5_file:
@@ -1672,14 +1750,11 @@ class CascadeHDF5Serializer:
                 if "output_layer" in params_group:
                     output_group = params_group["output_layer"]
                     if "weights" not in output_group:
-                        self.logger.error("Missing output layer weights dataset")
-                        return False
+                        return self._reject_format("Missing output layer weights dataset")
                     if "bias" not in output_group:
-                        self.logger.error("Missing output layer bias dataset")
-                        return False
+                        return self._reject_format("Missing output layer bias dataset")
                 else:
-                    self.logger.error("Missing output_layer group in params")
-                    return False
+                    return self._reject_format("Missing output_layer group in params")
 
             # Verify hidden units consistency
             if "hidden_units" in hdf5_file:
@@ -1688,8 +1763,7 @@ class CascadeHDF5Serializer:
                 actual_units = len([k for k in hidden_group.keys() if k.startswith("unit_")])
 
                 if num_units_attr != actual_units:
-                    self.logger.error(f"Hidden units count mismatch: num_units={num_units_attr}, " f"actual groups={actual_units}")
-                    return False
+                    return self._reject_format(f"Hidden units count mismatch: num_units={num_units_attr}, " f"actual groups={actual_units}")
 
                 # Verify each hidden unit has required datasets
                 for i in range(num_units_attr):
@@ -1697,17 +1771,15 @@ class CascadeHDF5Serializer:
                     if unit_name in hidden_group:
                         unit_group = hidden_group[unit_name]
                         if "weights" not in unit_group:
-                            self.logger.error(f"Hidden unit {i} missing weights dataset")
-                            return False
+                            return self._reject_format(f"Hidden unit {i} missing weights dataset")
                         if "bias" not in unit_group:
-                            self.logger.error(f"Hidden unit {i} missing bias dataset")
-                            return False
+                            return self._reject_format(f"Hidden unit {i} missing bias dataset")
 
             self.logger.debug("CascadeHDF5Serializer: Format validation passed")
-            return True
+            return None
 
         except Exception as e:
-            return self._log_exception_stacktrace("Format validation failed: ", e, False)
+            return self._log_exception_stacktrace("Format validation failed: ", e, f"format validation raised: {e}")
 
     def _log_exception_stacktrace(self, arg0, e, arg2):
         self.logger.error(f"{arg0}{e}")

--- a/src/tests/unit/api/test_lifecycle_manager.py
+++ b/src/tests/unit/api/test_lifecycle_manager.py
@@ -1533,7 +1533,7 @@ class TestReplayLifecycleIntegration:
         mgr.create_network(input_size=2, output_size=2)
         mgr.state_machine.handle_command(Command.START)
         with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path):
-            assert mgr.start_replay("anything") is False
+            assert mgr.start_replay("anything")["loaded"] is False
         assert mgr.state_machine.is_started()
         mgr.shutdown()
 
@@ -1542,7 +1542,7 @@ class TestReplayLifecycleIntegration:
 
         mgr = TrainingLifecycleManager()
         with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path):
-            assert mgr.start_replay("nonexistent") is False
+            assert mgr.start_replay("nonexistent")["loaded"] is False
         assert mgr.state_machine.is_stopped()
         assert mgr._replay_session is None
         mgr.shutdown()
@@ -1553,7 +1553,7 @@ class TestReplayLifecycleIntegration:
         ctxs = self._stub_load(mgr, tmp_path, {"train_loss": [0.1, 0.2, 0.3], "value_loss": [], "train_accuracy": [], "value_accuracy": []})
         with ctxs[0], ctxs[1]:
             try:
-                assert mgr.start_replay("snap") is True
+                assert mgr.start_replay("snap")["loaded"] is True
                 assert mgr.state_machine.is_replaying()
                 assert mgr._replay_session is not None
                 assert mgr._replay_session.snapshot_id == "snap"

--- a/src/tests/unit/api/test_lifecycle_manager_coverage_ext.py
+++ b/src/tests/unit/api/test_lifecycle_manager_coverage_ext.py
@@ -377,12 +377,18 @@ class TestSnapshotSaveLoad:
     def test_load_snapshot_injects_worker_coordinator(self, mgr, tmp_path):
         (tmp_path / "snap_wc.h5").write_bytes(b"stub")
         loaded_net = types.SimpleNamespace(set_worker_coordinator=MagicMock())
+        from snapshots.snapshot_load_status import loaded as _snapshot_loaded
+
         fake_serializer = MagicMock()
         fake_serializer.load_network.return_value = loaded_net
+        # D-B: the manager reads the classified result, so a whole-object mock has to
+        # stub it too — otherwise MagicMock returns a truthy stand-in and the wrong
+        # network is installed silently.
+        fake_serializer.load_network_result.return_value = _snapshot_loaded(loaded_net)
         mgr._worker_coordinator = MagicMock()
         with patch.object(mgr, "_get_snapshots_dir", return_value=tmp_path), patch("snapshots.snapshot_serializer.CascadeHDF5Serializer", return_value=fake_serializer), patch("api.lifecycle.manager.CascorModel", side_effect=lambda network: types.SimpleNamespace(network=network)):
             ok = mgr._load_snapshot_to_network("snap_wc")
-        assert ok is True
+        assert bool(ok) is True
         loaded_net.set_worker_coordinator.assert_called_once_with(mgr._worker_coordinator)
 
     def test_load_snapshot_not_found(self, mgr, tmp_path):
@@ -434,7 +440,7 @@ class TestReplayControlAndStart:
         _attach_network(mgr, net)
         with patch.object(mgr, "_load_snapshot_to_network", return_value=True):
             ok = mgr.start_replay("snap")
-        assert ok is True
+        assert ok["loaded"] is True
         prior.stop.assert_called_once()
 
     def test_replay_control_speed_requires_value(self, mgr):

--- a/src/tests/unit/api/test_snapshot_error_taxonomy.py
+++ b/src/tests/unit/api/test_snapshot_error_taxonomy.py
@@ -1,0 +1,214 @@
+"""
+D-B: a CORRUPT snapshot must be distinguishable from an ABSENT one.
+
+Both used to surface as ``404 "not found or failed to load"``, fusing two opposite
+operator situations — *pick a different snapshot* and *investigate data loss* — across
+all four verbs (restore / retrain / resume / replay).
+
+Design of record:
+``juniper-ml/notes/JUNIPER_2026-08-20_JUNIPER-CASCOR_SNAPSHOT-ERROR-TAXONOMY-DESIGN.md``.
+
+The arms that matter:
+- absent -> 404 / ``SNAPSHOT_ABSENT``
+- corrupt -> 422 / ``SNAPSHOT_CORRUPT``   (the arm that fails against the old code)
+- a VALID snapshot still loads on all four verbs (negative control — without it, a
+  change that classified everything as corrupt would pass every other arm)
+- the classification is per-verb, because the fusion was duplicated four times and a
+  fix applied to three is the likeliest way this ships half-done.
+"""
+
+import os
+import sys
+
+import h5py
+import pytest
+import torch
+from fastapi.testclient import TestClient
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
+
+from api.app import create_app  # noqa: E402
+from api.settings import Settings  # noqa: E402
+from cascade_correlation.cascade_correlation import CascadeCorrelationNetwork  # noqa: E402
+from cascade_correlation.cascade_correlation_config.cascade_correlation_config import CascadeCorrelationConfig  # noqa: E402
+from snapshots.snapshot_load_status import SNAPSHOT_ABSENT, SNAPSHOT_CORRUPT, SNAPSHOT_OK  # noqa: E402
+from snapshots.snapshot_serializer import CascadeHDF5Serializer  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+VERBS = ("restore", "retrain", "resume", "replay")
+
+
+@pytest.fixture
+def client():
+    settings = Settings(auto_start=False)
+    app = create_app(settings)
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def snapshots_dir(client, tmp_path, monkeypatch):
+    """Point the lifecycle at an empty temp snapshots directory."""
+    monkeypatch.setattr(client.app.state.lifecycle, "_get_snapshots_dir", lambda: tmp_path, raising=True)
+    return tmp_path
+
+
+def _write_valid_snapshot(directory, snapshot_id):
+    """A real, loadable snapshot written by the production serializer."""
+    config = CascadeCorrelationConfig(input_size=2, output_size=2, random_seed=42)
+    network = CascadeCorrelationNetwork(config=config)
+    network.train_output_layer(torch.randn(8, 2), torch.randn(8, 2), epochs=2)
+    path = directory / f"{snapshot_id}.h5"
+    assert CascadeHDF5Serializer().save_network(network, str(path))
+    return path
+
+
+def _write_corrupt_snapshot(directory, snapshot_id):
+    """A file that EXISTS but cannot be deserialized.
+
+    Valid HDF5 with a wrong ``format`` attribute, so it fails at the format gate rather
+    than at the file-open — the case most likely to be mistaken for "absent".
+    """
+    path = directory / f"{snapshot_id}.h5"
+    with h5py.File(path, "w") as hf:
+        hf.attrs["format"] = "not-a-juniper-snapshot"
+        hf.attrs["format_version"] = "1"
+    return path
+
+
+def _write_unreadable_snapshot(directory, snapshot_id):
+    """A file that is not HDF5 at all — fails inside the open, not at the format gate."""
+    path = directory / f"{snapshot_id}.h5"
+    path.write_bytes(b"this is not an HDF5 file")
+    return path
+
+
+class TestSerializerClassification:
+    """``load_network_result`` is where the reason still exists."""
+
+    def test_absent_is_classified_absent(self, tmp_path):
+        result = CascadeHDF5Serializer().load_network_result(tmp_path / "nope.h5")
+        assert result.status == SNAPSHOT_ABSENT
+        assert not result
+
+    def test_bad_format_is_classified_corrupt(self, tmp_path):
+        path = _write_corrupt_snapshot(tmp_path, "bad-format")
+        result = CascadeHDF5Serializer().load_network_result(path)
+        assert result.status == SNAPSHOT_CORRUPT
+        assert not result
+        # The reason names the failing check rather than "failed to load".
+        assert "format" in result.detail.lower()
+
+    def test_unreadable_file_is_classified_corrupt(self, tmp_path):
+        path = _write_unreadable_snapshot(tmp_path, "not-hdf5")
+        result = CascadeHDF5Serializer().load_network_result(path)
+        assert result.status == SNAPSHOT_CORRUPT
+        assert not result
+
+    def test_valid_snapshot_loads(self, tmp_path):
+        path = _write_valid_snapshot(tmp_path, "good")
+        result = CascadeHDF5Serializer().load_network_result(path)
+        assert result.status == SNAPSHOT_OK
+        assert result
+        assert result.network is not None
+
+
+class TestVerifySavedNetworkNamesTheFailingCheck:
+    """``verify_saved_network`` blamed the format string for every structural failure."""
+
+    def test_missing_group_is_not_reported_as_invalid_format(self, tmp_path):
+        path = tmp_path / "missing-groups.h5"
+        with h5py.File(path, "w") as hf:
+            # Correct format identifier; the model payload is what's missing.
+            hf.attrs["format"] = "juniper.cascor"
+            hf.attrs["format_version"] = "2"
+
+        result = CascadeHDF5Serializer().verify_saved_network(str(path))
+
+        assert result["valid"] is False
+        assert "Missing required group" in result["error"], "the operator was pointed at the format string, which was fine"
+
+    def test_genuinely_bad_format_still_says_so(self, tmp_path):
+        path = _write_corrupt_snapshot(tmp_path, "bad-format")
+        result = CascadeHDF5Serializer().verify_saved_network(str(path))
+        assert result["valid"] is False
+        assert "Invalid format" in result["error"]
+
+
+class TestRouteStatusMapping:
+    """The four verbs must agree, because the fusion was duplicated four times."""
+
+    @pytest.mark.parametrize("verb", VERBS)
+    def test_absent_snapshot_is_404(self, client, snapshots_dir, verb):
+        response = client.post(f"/v1/snapshots/nonexistent/{verb}")
+        assert response.status_code == 404
+        assert response.json()["error"]["code"] == "SNAPSHOT_ABSENT"
+
+    @pytest.mark.parametrize("verb", VERBS)
+    def test_corrupt_snapshot_is_422(self, client, snapshots_dir, verb):
+        """The arm that fails against the pre-D-B code, which returned 404 here."""
+        _write_corrupt_snapshot(snapshots_dir, "corrupt-snap")
+
+        response = client.post(f"/v1/snapshots/corrupt-snap/{verb}")
+
+        assert response.status_code == 422, "a snapshot that EXISTS but cannot be read must not be reported as missing"
+        assert response.json()["error"]["code"] == "SNAPSHOT_CORRUPT"
+        # The prose names the failing check, not just "failed to load".
+        assert "could not be read" in response.json()["error"]["message"]
+
+    @pytest.mark.parametrize("verb", VERBS)
+    def test_unreadable_snapshot_is_422(self, client, snapshots_dir, verb):
+        """Classification must not be keyed to one specific failure mode: this one
+        fails inside the file open rather than at the format gate."""
+        _write_unreadable_snapshot(snapshots_dir, "unreadable-snap")
+
+        response = client.post(f"/v1/snapshots/unreadable-snap/{verb}")
+
+        assert response.status_code == 422
+        assert response.json()["error"]["code"] == "SNAPSHOT_CORRUPT"
+
+    @pytest.mark.parametrize("verb", VERBS)
+    def test_valid_snapshot_still_succeeds(self, client, snapshots_dir, verb):
+        """Negative control. Without it, a change that classified EVERYTHING as
+        corrupt would pass every other arm in this file."""
+        _write_valid_snapshot(snapshots_dir, "good-snap")
+
+        response = client.post(f"/v1/snapshots/good-snap/{verb}")
+
+        assert response.status_code == 200, response.text
+        assert response.json()["data"]["snapshot_id"] == "good-snap"
+
+
+class TestStartReplayConverged:
+    """``start_replay`` returned a bare bool, so replay was the one verb that could
+    not carry a reason even in principle (design §6)."""
+
+    def test_returns_the_snapshot_result_shape(self, client, snapshots_dir):
+        result = client.app.state.lifecycle.start_replay("nonexistent")
+        assert isinstance(result, dict), "start_replay must return the same dict as its sibling verbs"
+        assert result["loaded"] is False
+        assert result["operation"] == "replay"
+        assert result["reason_code"] == SNAPSHOT_ABSENT
+
+    def test_carries_the_corrupt_reason(self, client, snapshots_dir):
+        _write_corrupt_snapshot(snapshots_dir, "corrupt-snap")
+        result = client.app.state.lifecycle.start_replay("corrupt-snap")
+        assert result["loaded"] is False
+        assert result["reason_code"] == SNAPSHOT_CORRUPT
+
+    def test_fsm_rejection_is_not_a_load_failure(self, client, snapshots_dir):
+        """An FSM conflict still has no ``reason_code`` — it is a 409 at the route,
+        and must not be mistaken for a missing snapshot."""
+        from api.lifecycle.state_machine import Command
+
+        lifecycle = client.app.state.lifecycle
+        lifecycle.create_network(input_size=2, output_size=2)
+        lifecycle.state_machine.handle_command(Command.START)
+        try:
+            result = lifecycle.start_replay("anything")
+            assert result["loaded"] is False
+            assert result["reason_code"] is None
+            assert "rejected" in result["reason"]
+        finally:
+            lifecycle.state_machine.handle_command(Command.RESET)

--- a/src/tests/unit/api/test_snapshot_route_coverage.py
+++ b/src/tests/unit/api/test_snapshot_route_coverage.py
@@ -256,14 +256,16 @@ class TestRestoreSnapshot:
         with patch.object(client.app.state.lifecycle, "load_snapshot", return_value={"loaded": False}):
             response = client.post("/v1/snapshots/nonexistent/restore")
             assert response.status_code == 404
-            assert "not found or failed to load" in response.json()["error"]["message"]
+            assert "not found" in response.json()["error"]["message"]
+            assert response.json()["error"]["code"] == "SNAPSHOT_ABSENT"
 
     def test_restore_snapshot_load_fails_returns_404(self, client):
         """restore_snapshot should return 404 when load_snapshot fails (returns False)."""
         with patch.object(client.app.state.lifecycle, "load_snapshot", return_value={"loaded": False}):
             response = client.post("/v1/snapshots/snap-bad/restore")
             assert response.status_code == 404
-            assert "not found or failed to load" in response.json()["error"]["message"]
+            assert "not found" in response.json()["error"]["message"]
+            assert response.json()["error"]["code"] == "SNAPSHOT_ABSENT"
 
     def test_restore_snapshot_runs_in_thread(self, client):
         """PERF-CC-01: load_snapshot must be invoked via asyncio.to_thread."""
@@ -337,7 +339,8 @@ class TestRetrainFromSnapshot:
         with patch.object(client.app.state.lifecycle, "restore_for_retrain", return_value={"loaded": False}):
             response = client.post("/v1/snapshots/nonexistent/retrain")
             assert response.status_code == 404
-            assert "not found or failed to load" in response.json()["error"]["message"]
+            assert "not found" in response.json()["error"]["message"]
+            assert response.json()["error"]["code"] == "SNAPSHOT_ABSENT"
 
     def test_retrain_snapshot_rejected_when_training_active(self, client):
         """STARTED must surface 409 at the route, not lifecycle 404."""
@@ -469,7 +472,8 @@ class TestResumeSnapshot:
         with patch.object(client.app.state.lifecycle, "resume_from_snapshot", return_value={"loaded": False}):
             response = client.post("/v1/snapshots/nonexistent/resume")
             assert response.status_code == 404
-            assert "not found or failed to load" in response.json()["error"]["message"]
+            assert "not found" in response.json()["error"]["message"]
+            assert response.json()["error"]["code"] == "SNAPSHOT_ABSENT"
 
     def test_resume_snapshot_rejected_when_training_active(self, client):
         """The pre-flight FSM check returns 409 when training is Started."""
@@ -773,7 +777,7 @@ class TestReplaySnapshot:
 
         def fake_start(snapshot_id):
             self._install_replay_session(lifecycle, snapshot_id, length=3)
-            return True
+            return {"loaded": True, "snapshot_id": snapshot_id, "operation": "replay", "reason": None, "reason_code": None}
 
         try:
             with patch.object(lifecycle, "start_replay", side_effect=fake_start):
@@ -791,7 +795,7 @@ class TestReplaySnapshot:
             self._teardown_replay_session(lifecycle)
 
     def test_start_replay_route_404_when_load_fails(self, client):
-        with patch.object(client.app.state.lifecycle, "start_replay", return_value=False):
+        with patch.object(client.app.state.lifecycle, "start_replay", return_value={"loaded": False, "reason": "no snapshot", "reason_code": "snapshot_absent"}):
             response = client.post("/v1/snapshots/nonexistent/replay")
             assert response.status_code == 404
 
@@ -815,7 +819,7 @@ class TestReplaySnapshot:
 
             captured["thread"] = threading.current_thread().name
             self._install_replay_session(client.app.state.lifecycle, snapshot_id)
-            return True
+            return {"loaded": True, "snapshot_id": snapshot_id, "operation": "replay", "reason": None, "reason_code": None}
 
         try:
             with patch.object(client.app.state.lifecycle, "start_replay", side_effect=fake_start):

--- a/src/tests/unit/api/test_ws6_manager_model_wiring.py
+++ b/src/tests/unit/api/test_ws6_manager_model_wiring.py
@@ -87,11 +87,11 @@ def test_hdf5_load_rewraps_bare_ccn(tmp_path, monkeypatch):
 
     loaded = _make_ccn()
     (tmp_path / "snap.h5").write_bytes(b"")  # presence only; load_network is stubbed
-    monkeypatch.setattr(snap_ser.CascadeHDF5Serializer, "load_network", lambda self, path: loaded, raising=True)
+    monkeypatch.setattr(snap_ser.CascadeHDF5Serializer, "load_network", lambda self, path, restore_multiprocessing=True: loaded, raising=True)
 
     mgr = TrainingLifecycleManager()
     monkeypatch.setattr(mgr, "_get_snapshots_dir", lambda: tmp_path, raising=True)
-    assert mgr._load_snapshot_to_network("snap") is True
+    assert bool(mgr._load_snapshot_to_network("snap")) is True
     assert isinstance(mgr.model, CascorModel)
     assert mgr.network is loaded  # the bare CCN got wrapped, exposed via the property
 


### PR DESCRIPTION
## Summary

Implements **D-B**: a corrupt snapshot is no longer reported as `404 Not Found`.

Restore / retrain / resume / replay all used to raise the same `404 "Snapshot 'X' not found or failed to load"`, fusing two opposite operator situations — *pick a different snapshot* and *investigate data loss*. A snapshot that exists but cannot be read now returns **`422`** with a machine-readable code; `404` is reserved for one that genuinely is not there.

Implements the design of record ([juniper-ml#1193](https://github.com/pcalnon/juniper-ml/pull/1193)) as decided by the owner on all four §10 questions: converge `start_replay`, `422` + machine-readable reason, and fold in the `verify_saved_network` wart.

## The shape

| Layer | Change |
|---|---|
| `snapshots/snapshot_load_status.py` (new) | The shared vocabulary — `SNAPSHOT_OK` / `SNAPSHOT_ABSENT` / `SNAPSHOT_CORRUPT` plus a `SnapshotLoadResult` whose `__bool__` follows `ok`, so `if not loaded:` call sites read unchanged. |
| `snapshot_serializer.py` | `load_network_result()` — the load still goes through `load_network`, and only a `None` return triggers a cheap second pass (`_classify_load_failure`) to work out why. |
| `snapshot_serializer.py` | `_validate_format_detail()` returns *which* check failed; `_validate_format()` is now a thin boolean wrapper over it. |
| `manager.py` | `_load_snapshot_to_network` returns the result; `_snapshot_result` carries `reason_code`; **`start_replay` converged** onto the same dict as its three siblings. |
| `routes/snapshots.py` | One `_raise_snapshot_load_error` helper behind all four verbs. |
| `app.py` | The error envelope accepts a dict detail carrying a semantic `error.code` — the API-09b path its own docstring already named. String details are untouched. |

## Two design decisions worth calling out

**`load_network` stays the seam.** My first cut had the manager call `load_network_result` and the serializer implement the classification inline. That broke 39 tests — not because the feature was wrong, but because I had moved the seam ~30 call sites patch. Inverting it (classify *after* a `None`, on the error path only) dropped the churn to 13, and every one of those 13 was a genuine contract change. The extra file open costs nothing on a path that only runs when a load has already failed.

**`409` was deliberately not reused.** These routes already spend `409` on FSM conflicts; reusing it for corrupt would trade one ambiguity for another. `500` was rejected too — it implies a retry might help, when a corrupt file is deterministic.

## `verify_saved_network`

`{"valid": False, "error": "Invalid format"}` came from the `_validate_format` gate *before any payload inspection* — so a snapshot with a perfectly good format string but a missing `params` group was reported as a format problem. It now names the failing check. A genuinely bad format still says "Invalid format", so the existing assertion at `test_snapshot_serializer_extended.py:78` keeps passing on its own merits.

## Verification

| Check | Result |
|---|---|
| New `tests/unit/api/test_snapshot_error_taxonomy.py` (25 tests) | pass |
| **Same file against the pre-D-B route mapping** | **12 fail** — all four verbs × both corrupt classes, plus the absent `code` arm |
| Full `tests/unit` (`--slow`) | pass, 0 failures |
| Full `tests/integration` (`--slow --integration`) | pass, 0 failures |
| **Golden trajectory** (`-m golden --golden`) | **pass** |
| `pre-commit` on all 10 changed files | pass |

The new suite covers each verb separately — the fusion was duplicated four times, and a fix applied to three is the likeliest way this ships half-done — plus two distinct corrupt classes (bad format vs. not-HDF5-at-all) so the classification is not keyed to one failure mode.

**The negative control matters most:** `test_valid_snapshot_still_succeeds` writes a real snapshot through the production serializer and asserts all four verbs return 200. Without it, a change that classified *everything* as corrupt would pass every other arm — and it correctly passes against both the old and new code, which is exactly what a control should do.

## Not in scope

`_validate_shapes` failure still only warns, and the shape-broken network is still installed on the live lifecycle. That is **D-E** ([juniper-ml#1199](https://github.com/pcalnon/juniper-ml/pull/1199)) — a different failure mode whose fix is a behaviour change over ~170 currently-loadable archive files, and it needs its own decision. A comment at the warn site now says so, so the next reader does not mistake it for an oversight. D-E's design notes that D-B had to land first, so that a rejected load has this `422` + reason channel to report through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01741j36XEPuyk3Bh3nFrWJP
