### PR TITLE
fix(snapshots): one shared snapshot root at <repo>/cascor-snapshots

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -32,3 +32,14 @@ dist/
 .ruff_cache/
 .coverage
 coverage.xml
+
+# Snapshot artifacts and logs. Nothing COPYs them (the Dockerfile takes only
+# requirements.lock, pyproject.toml/README/LICENSE, and src/), but every
+# `docker compose build` still walks and stats them as build context: 1.8 GB /
+# ~27,900 files of snapshots plus ~3.2 GB of logs, on a context that is otherwise
+# ~192 MB. This is also a correctness guard -- a future `COPY . .` would otherwise
+# bake the snapshot archive into a published image.
+cascor-snapshots/
+cascor_snapshots/
+snapshots/*.h5
+logs/

--- a/.gitignore
+++ b/.gitignore
@@ -50,30 +50,47 @@ __init__.cpython*
 
 # CascadeCorrelationNetwork snapshot ARTIFACTS.
 #
-# `src/snapshots/` is an importable Python package (snapshot_serializer.py,
-# snapshot_cli.py, snapshot_common.py, ...) that ALSO receives .h5 artifacts at
-# runtime. Six of the rules here used to ignore the whole directory
-# (`src/snapshots/*`, `src/snapshots/`, `src/snapshots`, and the `**/snapshots`
-# equivalents), which swept in that tracked source: editing any module in it
-# required `git add -f`, and a glob in this directory is a code-deletion tool --
-# a cleanup once removed five snapshot MODULES and broke every boot (cascor#501).
+# The ONE snapshot root is `<repo>/cascor-snapshots/` -- the repo root, shared by
+# every stack origin: the direct CLI, the FastAPI service, and the container,
+# which bind-mounts this same host directory. Snapshots are project ASSETS, so
+# they live inside the Juniper tree where the whole-tree offline backup captures
+# them, and they are ignored here so they never enter git. Transfer between hosts
+# or users is out-of-band and user-driven; nothing here is published.
 #
-# Ignore the artifacts by extension/name instead, so the package stays visible.
-**/cascor/cascor_snapshots/*
-cascor_snapshot_*.h5
+# DIRECTORY-anchored on purpose. The rules this replaces ignored by FILENAME
+# (`cascor_snapshot_*.h5`), so an artifact with any other name in the same
+# directory was NOT ignored -- `git check-ignore --no-index` proves it -- and the
+# service tier's own `snapshot_<ISO>Z.h5` never matched at all. Anchoring on the
+# directory means the filename can change (Phase 6.1 adds a run id) without
+# quietly un-ignoring 27,000 files.
+#
+# The `/*` form, not `/cascor-snapshots/`. Git cannot re-include anything under a
+# directory it has excluded, so the bare-directory form would make the .gitkeep
+# below impossible -- and that .gitkeep is load-bearing twice over: the systemd
+# unit's ReadWritePaths needs the directory to EXIST at start, and a missing
+# docker bind-mount source is created root-owned by the daemon, which then EPERMs
+# the uid-1000 container on every save. Shipping the directory is what makes a
+# fresh clone work. (`logs/*` at the top of this file uses the same form.)
+/cascor-snapshots/*
+!/cascor-snapshots/.gitkeep
 
-src/snapshots/snapshot_*.h5
+# `src/snapshots/` is an importable Python package (snapshot_serializer.py,
+# snapshot_cli.py, snapshot_common.py, ...). Rules that ignored the whole
+# directory swept in that tracked source: editing any module required
+# `git add -f`, and a glob in that directory is a code-deletion tool -- a cleanup
+# once removed five snapshot MODULES and broke every boot (cascor#501). Artifacts
+# no longer land there; these by-name rules stay so a stray one is ignored rather
+# than surfacing as untracked, while the package source stays visible.
 src/snapshots/*.h5
+src/snapshots/snapshot_history.jsonl
 
-# The SERVICE tier now writes to <repo>/snapshots (repo root), not into the
-# src/snapshots package -- see api/lifecycle/manager.py _get_snapshots_dir. The
-# two src/snapshots patterns above are retained so any pre-move artifact left in
-# the package is still ignored rather than suddenly showing up as untracked.
+# Superseded roots. Kept ignored so an un-updated code path cannot quietly commit
+# artifacts into one of them:
+#   <repo>/snapshots            -- short-lived service root (cascor#537 -> the convention ruling)
+#   <repo>/src/cascor_snapshots -- the historical direct-CLI root
 /snapshots/
-
-**/snapshots/snapshot_*.h5
-**/snapshots/*.h5
-**/snapshots/snapshot_history.jsonl
+src/cascor_snapshots/
+cascor_snapshot_*.h5
 
 # Sensitive files and dirs
 .env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **One snapshot root for every stack origin: `<repo>/cascor-snapshots/`.** The direct-CLI tier
+  (`cascor_constants/constants_hdf5`) and the service tier (`api/lifecycle/manager._get_snapshots_dir`)
+  now resolve to the same repo-root directory, which the container also bind-mounts. Snapshots are
+  project **assets**, not per-origin scratch: a model saved by a container run is restored by a CLI run
+  and resumed by a service run, and the shared root is what makes that work without configuration.
+  `JUNIPER_CASCOR_SNAPSHOTS_DIR` still overrides both (W-6), unchanged, blank-is-unset intact.
+  Supersedes two roots — `src/cascor_snapshots/` (historical direct-CLI) and `<repo>/snapshots/` (the
+  short-lived service root introduced in #537, which never held a file). Design of record: juniper-ml
+  `notes/JUNIPER_2026-08-20_JUNIPER-ECOSYSTEM_SNAPSHOT-STORAGE-CONVENTION-DESIGN.md`.
+- **`namespaces = false` in `pyproject.toml` — the actual guard that keeps artifacts off PyPI.**
+  `[tool.setuptools.packages.find]` defaults to `namespaces = true` (PEP 420), whose finder requires
+  no `__init__.py` and filters names only on a dot — so a built wheel's `top_level.txt` listed
+  `cascor-snapshots`, `conf`, `data`, `docs`, `images`, `logs`, `notes`, `scripts`, `util`, **and the
+  two sibling distributions `juniper-cascor-model` / `juniper-cascor-protocol`**, which publish their
+  own wheels and must never ship inside this one. Disabling it drops exactly those eleven and keeps
+  all 29 real packages. Pinned by `TestPackagingExcludesArtifacts`.
+  - The hyphen in `cascor-snapshots` is **defence in depth, not a structural guarantee** — an earlier
+    draft of this change claimed setuptools "can never discover" a hyphenated directory. That is
+    false, and three independent reviews caught it: `find_namespace_packages` returns
+    `cascor-snapshots`, and `importlib.import_module("cascor-snapshots")` resolves it as a PEP 420
+    namespace package. What the hyphen does buy is real but smaller: it cannot be written as an
+    `import` statement, and plain `find_packages` skips it. The #501 class (a cleanup glob deleted
+    five snapshot MODULES and broke every boot) is closed by the artifact root holding no `.py`.
+- **`cascor-snapshots/.gitkeep` is tracked, and the ignore rule is `/cascor-snapshots/*`** rather than
+  the bare directory form — git cannot re-include a path under an excluded directory. Shipping the
+  directory is load-bearing twice: systemd **fails** a unit whose `ReadWritePaths=` names a missing
+  path (and under `ProtectSystem=strict` the service could not create it), and a missing docker
+  bind-mount source is created by the daemon as **root**, which then EPERMs the uid-1000 container on
+  every save. The three `ReadWritePaths=` entries also gain the `-` prefix; as shipped, two of them
+  named directories that no longer exist, so the unit could not start at all.
+- **`ENV JUNIPER_CASCOR_SNAPSHOTS_DIR=/app/cascor-snapshots` in the image**, so a bare `docker run`
+  and the Helm deployment are correct by default and orchestrators only mount over an already-correct
+  path. `.dockerignore` now excludes the artifact roots and `logs/`: nothing `COPY`s them, but every
+  build walked ~5 GB of context, and a future `COPY . .` would have baked the archive into a
+  published image.
+- **`snapshot_cli cleanup` is dry-run by default and refuses the shared root.** It previously deleted
+  immediately, with no confirmation and a `--keep 10` default — pointed at the consolidated archive
+  that removes 27,886 of 27,896 models. It also sorted by `mtime`, which in this archive is not
+  creation time (a copy reset every timestamp), so "keep the N most recent" did not select what it
+  claimed to. `--yes` to apply; `allow_shared_root=True` reserved for a ratified retention policy.
+- **`.gitignore` is now DIRECTORY-anchored for snapshots.** The rules this replaces ignored by
+  *filename* (`cascor_snapshot_*.h5`), so an artifact with any other name in the same directory was not
+  ignored — `git check-ignore --no-index` proves it — and the service tier's own `snapshot_<ISO>Z.h5`
+  never matched. `/cascor-snapshots/` means the filename can change (Phase 6.1 adds a run id) without
+  quietly un-ignoring the archive. The inert `**/cascor/cascor_snapshots/*` rule, which required a path
+  component named exactly `cascor` that no real path has, is retired.
+- `scripts/juniper-cascor.service` collapses its two snapshot `ReadWritePaths` entries into one for the
+  new root. Under `ProtectSystem=strict` + `ProtectHome=read-only` a missing entry EPERMs every
+  `POST /v1/snapshots` save silently, so this must stay in step with `_get_snapshots_dir`.
+- `util/rename_snapshots.bash` retargets `DEST_DIR`; the snapshot-artifact docs in
+  `docs/api/API_REFERENCE.md`, `docs/source/QUICK_START.md`, `docs/install/REFERENCE.md` and
+  `notes/API_REFERENCE.md` name the new root.
+
 ### Added
 
 - **Q-6: `JUNIPER_CASCOR_LOG_DIR` log-directory override, service + direct CLI** (CLI experimentation plan §11; H-7). Mirrors the W-6 `JUNIPER_CASCOR_SNAPSHOTS_DIR` override in shape and semantics, against the same class of problem: a

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --chown=juniper:juniper src/ ./src/
 
 # Create required directories
-RUN mkdir -p logs reports/junit data && chown -R juniper:juniper /app
+RUN mkdir -p logs reports/junit data cascor-snapshots && chown -R juniper:juniper /app
 
 USER juniper
 
@@ -84,6 +84,13 @@ ENV PYTHONPATH=/app/src
 ENV JUNIPER_CASCOR_HOST=127.0.0.1
 ENV JUNIPER_CASCOR_PORT=8200
 ENV JUNIPER_CASCOR_LOG_LEVEL=INFO
+# Declared in the IMAGE so every launch path is correct by default -- a bare `docker run`
+# (which this file's own header documents) and the Helm deployment, not just compose.
+# Left underived on purpose: the service tier used to compute this as parents[3]/"snapshots"
+# = /app/snapshots while compose mounted /app/data, one directory away, so every
+# containerized snapshot was written to the container's writable layer and lost on recreate.
+# Nothing errored. Orchestrators now only have to MOUNT over a path that is already right.
+ENV JUNIPER_CASCOR_SNAPSHOTS_DIR=/app/cascor-snapshots
 ENV JUNIPER_DATA_URL=http://localhost:8100
 
 # Build provenance (see the ARG block in the runtime stage above): exported so

--- a/cascor-snapshots/.gitkeep
+++ b/cascor-snapshots/.gitkeep
@@ -1,0 +1,12 @@
+# Keeps <repo>/cascor-snapshots/ present in a fresh clone.
+#
+# Not cosmetic. Two things break when this directory is absent:
+#   * scripts/juniper-cascor.service lists it in ReadWritePaths=. systemd fails a unit
+#     whose ReadWritePaths= names a missing path (unless prefixed with '-'), and under
+#     ProtectSystem=strict + ProtectHome=read-only the service could not create it anyway.
+#   * docker compose bind-mounts it. A missing bind source is created by the DAEMON, as
+#     root, and the uid-1000 container then EPERMs on every snapshot save -- silently,
+#     because the save path only warns.
+#
+# Everything else in here is ignored (.gitignore: /cascor-snapshots/*). Snapshots are
+# project assets that live in the tree for the offline backup, and never enter git.

--- a/conf/common.conf
+++ b/conf/common.conf
@@ -247,7 +247,7 @@ export REGRESSION_TESTS_DIR_NAME="regression"
 export RELEASE_DIR_NAME="release"
 export REPORTS_DIR_NAME="reports"
 export RESOURCES_DIR_NAME="resources"
-export SNAPSHOTS_DIR_NAME="snapshots"
+export SNAPSHOTS_DIR_NAME="cascor-snapshots"
 export SOURCE_DIR_NAME="src"
 export TARGET_DIR_NAME="target"
 export TEMP_DIR_NAME="temp"
@@ -321,7 +321,11 @@ export DEBUG_DIR="${SOURCE_DIR}/${DEBUG_DIR_NAME}"
 export PYTEST_CACHE_DIR="${SOURCE_DIR}/${PYTEST_CACHE_DIR_NAME}"
 export RELEASE_DIR="${SOURCE_DIR}/${RELEASE_DIR_NAME}"
 # Repo root, not SOURCE_DIR: src/snapshots is an importable Python package and must not
-# double as an artifact directory (cascor#501). Mirrors _get_snapshots_dir.
+# double as an artifact directory (cascor#501). Mirrors _get_snapshots_dir, which now
+# resolves <repo>/cascor-snapshots -- the ONE root shared by the direct CLI, the service,
+# and the container. The bare "snapshots" name this used to carry was the short-lived
+# service root and is superseded; keep this in step with _get_snapshots_dir and
+# constants_hdf5._HDF5_PROJECT_SNAPSHOTS_DIR.
 export SNAPSHOTS_DIR="${PROJ_DIR}/${SNAPSHOTS_DIR_NAME}"
 export TARGET_DIR="${SOURCE_DIR}/${TARGET_DIR_NAME}"
 export TESTS_DIR="${SOURCE_DIR}/${TESTS_DIR_NAME}"

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -704,7 +704,10 @@ print(f"Dataset shape: x={x_train.shape}, y={y_train.shape}")
 ## Serialization API
 
 **Code location**: `src/snapshots/` (the serializer package)  
-**Snapshot artifacts**: `<repo>/snapshots/` — the repo root, overridable with `JUNIPER_CASCOR_SNAPSHOTS_DIR`
+**Snapshot artifacts**: `<repo>/cascor-snapshots/` — the repo root, and the ONE root shared by the
+direct-CLI, service, and container tiers (the container bind-mounts this same host directory).
+Overridable with `JUNIPER_CASCOR_SNAPSHOTS_DIR`. Ignored by git; captured by the whole-tree offline
+backup; never published to PyPI.
 **Stability**: Stable
 
 ### CascadeHDF5Serializer

--- a/docs/install/REFERENCE.md
+++ b/docs/install/REFERENCE.md
@@ -407,8 +407,7 @@ client = JuniperDataClient(
 | `logs/` | Application log files | `.gitignore` |
 | `reports/` | Test and coverage reports | `.gitignore` |
 | `images/` | Generated visualizations and plots | Tracked |
-| `snapshots/` | HDF5 network snapshot files | `.gitignore` |
-| `src/cascor_snapshots/` | Additional snapshot storage | `.gitignore` |
+| `cascor-snapshots/` | Snapshot artifacts, all tiers (repo root; was `src/cascor_snapshots/`) | `.gitignore` |
 | `profiles/` | Profiling output files | `.gitignore` |
 
 ### data/

--- a/docs/source/QUICK_START.md
+++ b/docs/source/QUICK_START.md
@@ -143,7 +143,10 @@ The `CascadeCorrelationConfig` dataclass holds all network hyperparameters:
 ### Serialization Code
 
 **Code location**: `src/snapshots/` (the serializer package)  
-**Snapshot artifacts**: `<repo>/snapshots/` — the repo root, overridable with `JUNIPER_CASCOR_SNAPSHOTS_DIR`
+**Snapshot artifacts**: `<repo>/cascor-snapshots/` — the repo root, and the ONE root shared by the
+direct-CLI, service, and container tiers (the container bind-mounts this same host directory).
+Overridable with `JUNIPER_CASCOR_SNAPSHOTS_DIR`. Ignored by git; captured by the whole-tree offline
+backup; never published to PyPI.
 
 - `snapshot_serializer.py` - Main HDF5 save/load logic
 - `snapshot_utils.py` - Utility functions

--- a/juniper-cascor-model/cascor_constants/constants_hdf5/constants_hdf5.py
+++ b/juniper-cascor-model/cascor_constants/constants_hdf5/constants_hdf5.py
@@ -31,6 +31,8 @@
 #####################################################################################################################################################################################################
 import os
 import pathlib
+import sysconfig
+import warnings
 
 # import torch
 # import hd5py
@@ -43,18 +45,83 @@ _HDF5_PROJECT_CONSTANTS_DIR = _HDF5_PROJECT_HDF5_CONSTANTS_DIR.parent.resolve()
 _HDF5_PROJECT_SOURCE_DIR = _HDF5_PROJECT_CONSTANTS_DIR.parent.resolve()
 _HDF5_PROJECT_DIR = _HDF5_PROJECT_SOURCE_DIR.parent.resolve()
 
-_HDF5_PROJECT_SNAPSHOTS_DIR_NAME = "cascor_snapshots"
-# W-6 (CLI experimentation plan §11 / H-5): JUNIPER_CASCOR_SNAPSHOTS_DIR overrides the legacy
-# <repo>/src/cascor_snapshots so a per-run launcher can point the direct CLI's snapshots at its own
-# RUN_DIR/snapshots. Constants resolve at import time, so the override must be in the process env
-# before the first cascor_constants import (the launcher exports it before exec). A set-but-blank
-# value is treated as unset (the blank-env guard class). Shares one env var with the service tier
-# (api/lifecycle/manager.py _get_snapshots_dir).
+_HDF5_PROJECT_SNAPSHOTS_DIR_NAME = "cascor-snapshots"
+
+
+def _hdf5_module_is_installed() -> bool:
+    """True when this module was imported from a Python INSTALL tree.
+
+    ``cascor_constants`` is vendored verbatim into the published
+    ``juniper-cascor-model`` wheel, so this same file also runs from
+    ``site-packages`` inside the distributed worker. There, every path derived
+    from ``__file__`` points into the interpreter's own library tree:
+
+        source-relative default   ->  <site-packages>/cascor_snapshots
+        repo-root-relative default -> <python-lib>/cascor-snapshots
+
+    Both are wrong, and the second is worse -- it escapes ``site-packages``
+    entirely and writes into a directory that may be root-owned and is never
+    captured by the project's whole-tree offline backup. The package already had
+    to solve this exact class once for the log directory (see
+    ``juniper-cascor-model/tests/test_drift.py`` ``_PACKAGE_LOG_DIR_OVERRIDE``).
+
+    ``sysconfig``'s ``purelib`` / ``platlib`` containment is the precise test:
+    stdlib-only, no subprocess, and it does not guess from a neighbouring file
+    the way a ``pyproject.toml``-adjacency probe would -- that probe answers
+    wrongly inside the container, whose runtime stage copies only ``src/``.
+    """
+    here = pathlib.Path(__file__).resolve()
+    for key in ("purelib", "platlib"):
+        root = sysconfig.get_paths().get(key)
+        if not root:
+            continue
+        try:
+            if here.is_relative_to(pathlib.Path(root).resolve()):
+                return True
+        except (OSError, ValueError):  # pragma: no cover - defensive
+            continue
+    return False
+
+
+# W-6 (CLI experimentation plan §11 / H-5): JUNIPER_CASCOR_SNAPSHOTS_DIR overrides everything below,
+# so a per-run launcher can point the direct CLI at its own RUN_DIR/snapshots. Constants resolve at
+# import time, so the override must be in the process env before the first cascor_constants import
+# (the launcher exports it before exec). A set-but-blank value is treated as unset (the blank-env
+# guard class). Shares one env var with the service tier (api/lifecycle/manager.py
+# _get_snapshots_dir), which reads it at CALL time.
+#
+# Unset, in a CHECKOUT, the default is <repo>/cascor-snapshots -- the repo root, and the ONE
+# snapshot root shared by every stack origin on that host: this direct CLI, the FastAPI service, and
+# the container, which bind-mounts the same host directory. Snapshots are project ASSETS, not
+# per-origin scratch; a model saved by one origin is restored and resumed by another. Supersedes
+# <repo>/src/cascor_snapshots (this tier's historical root) and <repo>/snapshots (the service's
+# short-lived one). A linked git WORKTREE gets its own root, deliberately -- see the design's
+# "worktrees are a developer context, not a stack origin".
+#
+# Unset, from an INSTALLED copy, there is no project root to speak of, so we fall back to the
+# working directory and WARN. Every deployed path declares the variable explicitly (compose, the
+# systemd unit, the image's own ENV), so reaching this branch means something is unconfigured, and a
+# warning that names the variable beats silently writing into the interpreter's library tree.
+#
+# On the hyphen: it is defence in depth, NOT a structural guarantee. An earlier draft of this comment
+# claimed setuptools "can never discover" a hyphenated directory as a package. That is FALSE --
+# pyproject's [tool.setuptools.packages.find] defaults to namespaces=True (PEP 420), and
+# find_namespace_packages returns "cascor-snapshots" quite happily; a built wheel carries it in
+# top_level.txt. The structural fix is `namespaces = false` in pyproject.toml, which is where it now
+# lives. The hyphen still buys something real -- it cannot be written as `import cascor_snapshots`,
+# and plain find_packages skips it -- so it stays; it is just not the load-bearing part.
 _HDF5_PROJECT_SNAPSHOTS_DIR_OVERRIDE = os.environ.get("JUNIPER_CASCOR_SNAPSHOTS_DIR", "").strip()
 if _HDF5_PROJECT_SNAPSHOTS_DIR_OVERRIDE:
     _HDF5_PROJECT_SNAPSHOTS_DIR = pathlib.Path(_HDF5_PROJECT_SNAPSHOTS_DIR_OVERRIDE).expanduser()
+elif _hdf5_module_is_installed():
+    warnings.warn(
+        "JUNIPER_CASCOR_SNAPSHOTS_DIR is not set and cascor_constants was imported from an " "installed package, so there is no project root to derive a snapshot directory from. " f"Falling back to {pathlib.Path.cwd() / _HDF5_PROJECT_SNAPSHOTS_DIR_NAME}. Set " "JUNIPER_CASCOR_SNAPSHOTS_DIR to the shared snapshot root for this host.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
+    _HDF5_PROJECT_SNAPSHOTS_DIR = pathlib.Path.cwd().joinpath(_HDF5_PROJECT_SNAPSHOTS_DIR_NAME)
 else:
-    _HDF5_PROJECT_SNAPSHOTS_DIR = pathlib.Path(_HDF5_PROJECT_SOURCE_DIR).joinpath(_HDF5_PROJECT_SNAPSHOTS_DIR_NAME)
+    _HDF5_PROJECT_SNAPSHOTS_DIR = pathlib.Path(_HDF5_PROJECT_DIR).joinpath(_HDF5_PROJECT_SNAPSHOTS_DIR_NAME)
 
 
 # Define HDF5 Storage class Constants to provide reasonable defaults

--- a/juniper-cascor-model/tests/test_constants_dir_overrides.py
+++ b/juniper-cascor-model/tests/test_constants_dir_overrides.py
@@ -49,9 +49,9 @@ class TestSnapshotsDirOverride:
 
     VAR = "JUNIPER_CASCOR_SNAPSHOTS_DIR"
 
-    def test_unset_keeps_legacy_cascor_snapshots(self, monkeypatch):
+    def test_unset_resolves_to_canonical_root_name(self, monkeypatch):
         mod = _reload(hdf5_module, monkeypatch, self.VAR, None)
-        assert mod._HDF5_PROJECT_SNAPSHOTS_DIR.name == "cascor_snapshots"
+        assert mod._HDF5_PROJECT_SNAPSHOTS_DIR.name == "cascor-snapshots"
 
     def test_override_is_honoured(self, monkeypatch, tmp_path):
         target = tmp_path / "run-snapshots"
@@ -65,7 +65,31 @@ class TestSnapshotsDirOverride:
     @pytest.mark.parametrize("blank", ["", "   ", "\t"])
     def test_blank_value_is_treated_as_unset(self, monkeypatch, blank):
         mod = _reload(hdf5_module, monkeypatch, self.VAR, blank)
-        assert mod._HDF5_PROJECT_SNAPSHOTS_DIR.name == "cascor_snapshots"
+        assert mod._HDF5_PROJECT_SNAPSHOTS_DIR.name == "cascor-snapshots"
+
+
+class TestInstalledCopyFallback:
+    """This package IS the site-packages copy for the distributed worker, so the
+    installed-copy branch is its normal deployment shape rather than an edge case."""
+
+    def test_installed_copy_falls_back_to_cwd_and_warns(self, monkeypatch, tmp_path):
+        import sysconfig
+
+        real = sysconfig.get_paths
+        pkg_root = pathlib.Path(hdf5_module.__file__).resolve().parents[2]
+
+        def fake_get_paths(*a, **kw):
+            paths = dict(real(*a, **kw))
+            paths["purelib"] = str(pkg_root)
+            paths["platlib"] = str(pkg_root)
+            return paths
+
+        monkeypatch.setattr(sysconfig, "get_paths", fake_get_paths)
+        monkeypatch.chdir(tmp_path)
+        with pytest.warns(RuntimeWarning, match="JUNIPER_CASCOR_SNAPSHOTS_DIR"):
+            mod = _reload(hdf5_module, monkeypatch, "JUNIPER_CASCOR_SNAPSHOTS_DIR", None)
+        assert mod._HDF5_PROJECT_SNAPSHOTS_DIR == tmp_path / "cascor-snapshots"
+        assert not mod._HDF5_PROJECT_SNAPSHOTS_DIR.is_relative_to(pkg_root)
 
 
 class TestLogDirOverride:

--- a/notes/API_REFERENCE.md
+++ b/notes/API_REFERENCE.md
@@ -499,7 +499,10 @@ def generate_spiral_dataset(
 ## Serialization API
 
 **Code location**: `src/snapshots/` (the serializer package)  
-**Snapshot artifacts**: `<repo>/snapshots/` — the repo root, overridable with `JUNIPER_CASCOR_SNAPSHOTS_DIR`
+**Snapshot artifacts**: `<repo>/cascor-snapshots/` — the repo root, and the ONE root shared by the
+direct-CLI, service, and container tiers (the container bind-mounts this same host directory).
+Overridable with `JUNIPER_CASCOR_SNAPSHOTS_DIR`. Ignored by git; captured by the whole-tree offline
+backup; never published to PyPI.
 
 ### CascadeHDF5Serializer
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,17 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 where = [".", "src"]
 exclude = ["tests*", "backups*"]
+# namespaces = false is the STRUCTURAL guard that keeps artifact and documentation directories out
+# of the distribution. pyproject's find defaults to namespaces = true (PEP 420), whose finder has no
+# __init__.py requirement and no name filter beyond rejecting dots -- so with the default, a built
+# wheel's top_level.txt listed cascor-snapshots, conf, data, docs, images, logs, notes, scripts,
+# util, AND the two sibling sub-packages juniper-cascor-model / juniper-cascor-protocol, which have
+# their own distributions and must never ship inside this one.
+#
+# Turning it off drops exactly those eleven and keeps all 29 real packages (every directory that
+# carries an __init__.py). It is what actually satisfies "snapshots never reach PyPI" -- a hyphen in
+# the directory name does NOT, contrary to an earlier draft of this change.
+namespaces = false
 
 [project]
 name = "juniper-cascor"

--- a/requirements.lock
+++ b/requirements.lock
@@ -194,7 +194,7 @@ urllib3==2.7.0
     #   juniper-data-client
     #   requests
     #   sentry-sdk
-uvicorn==0.52.3
+uvicorn==0.52.4
     # via juniper-cascor (pyproject.toml)
 uvloop==0.22.1
     # via uvicorn

--- a/scripts/juniper-cascor.service
+++ b/scripts/juniper-cascor.service
@@ -40,16 +40,24 @@ CPUQuota=400%%
 NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=read-only
-ReadWritePaths=%h/Development/python/Juniper/juniper-cascor/logs
-ReadWritePaths=%h/Development/python/Juniper/juniper-cascor/data
-ReadWritePaths=%h/Development/python/Juniper/juniper-cascor/src/cascor_snapshots
-# The SERVICE tier writes <repo>/snapshots at the REPO ROOT
-# (api/lifecycle/manager.py _get_snapshots_dir); cascor_snapshots above is the direct-CLI
-# dir. Without this line, ProtectSystem=strict + ProtectHome=read-only EPERM every
-# POST /v1/snapshots save (latent — fixed with G-13). The service path moved out of
-# src/snapshots because that directory is an importable Python package (cascor#501);
-# keep this entry in step with _get_snapshots_dir or saves silently start failing.
-ReadWritePaths=%h/Development/python/Juniper/juniper-cascor/snapshots
+ReadWritePaths=-%h/Development/python/Juniper/juniper-cascor/logs
+ReadWritePaths=-%h/Development/python/Juniper/juniper-cascor/data
+# ONE snapshot root for every stack origin -- this service, the direct CLI, and the
+# container (which bind-mounts this same host directory). Replaces two entries that
+# tracked two now-superseded roots: src/cascor_snapshots (historical direct-CLI) and
+# <repo>/snapshots (the short-lived service root between cascor#537 and the
+# storage-convention ruling). Without an entry here, ProtectSystem=strict +
+# ProtectHome=read-only EPERM every POST /v1/snapshots save -- silently, since the
+# save path only warns. KEEP THIS IN STEP with _get_snapshots_dir
+# (api/lifecycle/manager.py) or saves start failing with no other signal.
+#
+# The leading '-' matters: systemd FAILS a unit whose ReadWritePaths= names a path that
+# does not exist, and under ProtectSystem=strict the service cannot create it itself.
+# Both entries this replaces lacked the prefix AND pointed at directories that no longer
+# exist, so the unit as shipped could not start -- a latent break the rename would have
+# carried forward. The directory is now also tracked via cascor-snapshots/.gitkeep, so a
+# fresh clone has it; the '-' is the belt to that braces.
+ReadWritePaths=-%h/Development/python/Juniper/juniper-cascor/cascor-snapshots
 PrivateTmp=true
 ProtectControlGroups=true
 ProtectKernelModules=true

--- a/src/api/lifecycle/manager.py
+++ b/src/api/lifecycle/manager.py
@@ -4469,22 +4469,37 @@ class TrainingLifecycleManager:
         long-lived processes see the current env. A set-but-blank value is
         treated as unset (the blank-env guard class).
 
-        The default is ``<repo>/snapshots`` — the REPO ROOT, deliberately not
-        ``<repo>/src/snapshots``. ``src/snapshots`` is an importable Python
-        package (``snapshot_serializer.py``, ``snapshot_cli.py``, ...), and
-        writing ``.h5`` artifacts into it coupled data to code: a cleanup glob
-        in that directory once deleted five snapshot MODULES and broke every
-        boot (cascor#501), and ``.gitignore`` had to blanket-ignore the
-        directory, so editing the tracked source required ``git add -f``. The
-        package stays where it is; only the artifact destination moves, landing
-        alongside ``logs/`` at the repo root.
+        The default is ``<repo>/cascor-snapshots`` — the REPO ROOT, and the ONE
+        snapshot root shared by every stack origin (direct CLI, this service, and
+        the container, which bind-mounts this same host directory). Snapshots are
+        project assets, not per-origin scratch: a model saved by a container run is
+        restored by a CLI run and resumed by a service run.
+
+        Two earlier destinations are superseded and must not come back:
+
+        * ``<repo>/src/snapshots`` — an importable Python package
+          (``snapshot_serializer.py``, ``snapshot_cli.py``, ...). Writing ``.h5``
+          artifacts into it coupled data to code: a cleanup glob there once deleted
+          five snapshot MODULES and broke every boot (cascor#501), and
+          ``.gitignore`` had to blanket-ignore the directory, so editing the
+          tracked source required ``git add -f``.
+        * ``<repo>/snapshots`` — the short-lived root this function used between
+          cascor#537 and the storage-convention ruling. It never held a file.
+
+        The **hyphen** in ``cascor-snapshots`` is load-bearing, not cosmetic: it is
+        not a valid Python identifier, so setuptools can never discover the
+        directory as a package and no cleanup can mistake it for code. That closes
+        the cascor#501 class structurally rather than by convention.
+
+        Design of record: juniper-ml
+        ``notes/JUNIPER_2026-08-20_JUNIPER-ECOSYSTEM_SNAPSHOT-STORAGE-CONVENTION-DESIGN.md``.
         """
         override = os.environ.get("JUNIPER_CASCOR_SNAPSHOTS_DIR", "").strip()
         if override:
             snapshots_dir = Path(override).expanduser()
         else:
             # parents[3] == the repo root (this file is src/api/lifecycle/manager.py).
-            snapshots_dir = Path(__file__).resolve().parents[3] / "snapshots"
+            snapshots_dir = Path(__file__).resolve().parents[3] / "cascor-snapshots"
         snapshots_dir.mkdir(parents=True, exist_ok=True)
         return snapshots_dir
 

--- a/src/cascor_constants/constants_hdf5/constants_hdf5.py
+++ b/src/cascor_constants/constants_hdf5/constants_hdf5.py
@@ -31,6 +31,8 @@
 #####################################################################################################################################################################################################
 import os
 import pathlib
+import sysconfig
+import warnings
 
 # import torch
 # import hd5py
@@ -43,18 +45,83 @@ _HDF5_PROJECT_CONSTANTS_DIR = _HDF5_PROJECT_HDF5_CONSTANTS_DIR.parent.resolve()
 _HDF5_PROJECT_SOURCE_DIR = _HDF5_PROJECT_CONSTANTS_DIR.parent.resolve()
 _HDF5_PROJECT_DIR = _HDF5_PROJECT_SOURCE_DIR.parent.resolve()
 
-_HDF5_PROJECT_SNAPSHOTS_DIR_NAME = "cascor_snapshots"
-# W-6 (CLI experimentation plan §11 / H-5): JUNIPER_CASCOR_SNAPSHOTS_DIR overrides the legacy
-# <repo>/src/cascor_snapshots so a per-run launcher can point the direct CLI's snapshots at its own
-# RUN_DIR/snapshots. Constants resolve at import time, so the override must be in the process env
-# before the first cascor_constants import (the launcher exports it before exec). A set-but-blank
-# value is treated as unset (the blank-env guard class). Shares one env var with the service tier
-# (api/lifecycle/manager.py _get_snapshots_dir).
+_HDF5_PROJECT_SNAPSHOTS_DIR_NAME = "cascor-snapshots"
+
+
+def _hdf5_module_is_installed() -> bool:
+    """True when this module was imported from a Python INSTALL tree.
+
+    ``cascor_constants`` is vendored verbatim into the published
+    ``juniper-cascor-model`` wheel, so this same file also runs from
+    ``site-packages`` inside the distributed worker. There, every path derived
+    from ``__file__`` points into the interpreter's own library tree:
+
+        source-relative default   ->  <site-packages>/cascor_snapshots
+        repo-root-relative default -> <python-lib>/cascor-snapshots
+
+    Both are wrong, and the second is worse -- it escapes ``site-packages``
+    entirely and writes into a directory that may be root-owned and is never
+    captured by the project's whole-tree offline backup. The package already had
+    to solve this exact class once for the log directory (see
+    ``juniper-cascor-model/tests/test_drift.py`` ``_PACKAGE_LOG_DIR_OVERRIDE``).
+
+    ``sysconfig``'s ``purelib`` / ``platlib`` containment is the precise test:
+    stdlib-only, no subprocess, and it does not guess from a neighbouring file
+    the way a ``pyproject.toml``-adjacency probe would -- that probe answers
+    wrongly inside the container, whose runtime stage copies only ``src/``.
+    """
+    here = pathlib.Path(__file__).resolve()
+    for key in ("purelib", "platlib"):
+        root = sysconfig.get_paths().get(key)
+        if not root:
+            continue
+        try:
+            if here.is_relative_to(pathlib.Path(root).resolve()):
+                return True
+        except (OSError, ValueError):  # pragma: no cover - defensive
+            continue
+    return False
+
+
+# W-6 (CLI experimentation plan §11 / H-5): JUNIPER_CASCOR_SNAPSHOTS_DIR overrides everything below,
+# so a per-run launcher can point the direct CLI at its own RUN_DIR/snapshots. Constants resolve at
+# import time, so the override must be in the process env before the first cascor_constants import
+# (the launcher exports it before exec). A set-but-blank value is treated as unset (the blank-env
+# guard class). Shares one env var with the service tier (api/lifecycle/manager.py
+# _get_snapshots_dir), which reads it at CALL time.
+#
+# Unset, in a CHECKOUT, the default is <repo>/cascor-snapshots -- the repo root, and the ONE
+# snapshot root shared by every stack origin on that host: this direct CLI, the FastAPI service, and
+# the container, which bind-mounts the same host directory. Snapshots are project ASSETS, not
+# per-origin scratch; a model saved by one origin is restored and resumed by another. Supersedes
+# <repo>/src/cascor_snapshots (this tier's historical root) and <repo>/snapshots (the service's
+# short-lived one). A linked git WORKTREE gets its own root, deliberately -- see the design's
+# "worktrees are a developer context, not a stack origin".
+#
+# Unset, from an INSTALLED copy, there is no project root to speak of, so we fall back to the
+# working directory and WARN. Every deployed path declares the variable explicitly (compose, the
+# systemd unit, the image's own ENV), so reaching this branch means something is unconfigured, and a
+# warning that names the variable beats silently writing into the interpreter's library tree.
+#
+# On the hyphen: it is defence in depth, NOT a structural guarantee. An earlier draft of this comment
+# claimed setuptools "can never discover" a hyphenated directory as a package. That is FALSE --
+# pyproject's [tool.setuptools.packages.find] defaults to namespaces=True (PEP 420), and
+# find_namespace_packages returns "cascor-snapshots" quite happily; a built wheel carries it in
+# top_level.txt. The structural fix is `namespaces = false` in pyproject.toml, which is where it now
+# lives. The hyphen still buys something real -- it cannot be written as `import cascor_snapshots`,
+# and plain find_packages skips it -- so it stays; it is just not the load-bearing part.
 _HDF5_PROJECT_SNAPSHOTS_DIR_OVERRIDE = os.environ.get("JUNIPER_CASCOR_SNAPSHOTS_DIR", "").strip()
 if _HDF5_PROJECT_SNAPSHOTS_DIR_OVERRIDE:
     _HDF5_PROJECT_SNAPSHOTS_DIR = pathlib.Path(_HDF5_PROJECT_SNAPSHOTS_DIR_OVERRIDE).expanduser()
+elif _hdf5_module_is_installed():
+    warnings.warn(
+        "JUNIPER_CASCOR_SNAPSHOTS_DIR is not set and cascor_constants was imported from an " "installed package, so there is no project root to derive a snapshot directory from. " f"Falling back to {pathlib.Path.cwd() / _HDF5_PROJECT_SNAPSHOTS_DIR_NAME}. Set " "JUNIPER_CASCOR_SNAPSHOTS_DIR to the shared snapshot root for this host.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
+    _HDF5_PROJECT_SNAPSHOTS_DIR = pathlib.Path.cwd().joinpath(_HDF5_PROJECT_SNAPSHOTS_DIR_NAME)
 else:
-    _HDF5_PROJECT_SNAPSHOTS_DIR = pathlib.Path(_HDF5_PROJECT_SOURCE_DIR).joinpath(_HDF5_PROJECT_SNAPSHOTS_DIR_NAME)
+    _HDF5_PROJECT_SNAPSHOTS_DIR = pathlib.Path(_HDF5_PROJECT_DIR).joinpath(_HDF5_PROJECT_SNAPSHOTS_DIR_NAME)
 
 
 # Define HDF5 Storage class Constants to provide reasonable defaults

--- a/src/snapshots/snapshot_cli.py
+++ b/src/snapshots/snapshot_cli.py
@@ -211,14 +211,24 @@ def compare_snapshots(filepath1: str, filepath2: str):
         return False
 
 
-def cleanup_old_snapshots(directory: str, keep_count: int = 10):
-    """Clean up old snapshot files."""
-    print(f"Cleaning up old snapshots in {directory} (keeping {keep_count} most recent)")
+def cleanup_old_snapshots(directory: str, keep_count: int = 10, yes: bool = False):
+    """Clean up old snapshot files.
+
+    Dry-run unless ``--yes`` is passed, and the shared snapshot root is refused outright
+    (``HDF5Utils.cleanup_old_files``). Both guards exist because this command previously
+    deleted immediately, with no confirmation and a ``--keep 10`` default -- pointed at the
+    consolidated archive that would have removed 27,886 of 27,896 models.
+    """
+    mode = "Deleting" if yes else "[dry-run] Would delete"
+    print(f"{mode} old snapshots in {directory} (keeping {keep_count} most recent)")
 
     try:
-        deleted_count = HDF5Utils.cleanup_old_files(directory, keep_count)
+        deleted_count = HDF5Utils.cleanup_old_files(directory, keep_count, dry_run=not yes)
         if deleted_count > 0:
-            print(f"✓ Deleted {deleted_count} old snapshot files")
+            verb = "Deleted" if yes else "Would delete"
+            print(f"✓ {verb} {deleted_count} old snapshot files")
+            if not yes:
+                print("  Nothing was removed. Re-run with --yes to apply.")
         else:
             print("No old files to delete")
         return True
@@ -274,6 +284,7 @@ Examples:
     cleanup_parser = subparsers.add_parser("cleanup", help="Clean up old snapshots")
     cleanup_parser.add_argument("directory", help="Directory to clean")
     cleanup_parser.add_argument("--keep", type=int, default=10, help="Number of recent files to keep (default: 10)")
+    cleanup_parser.add_argument("--yes", action="store_true", help="Actually delete (default: dry-run, deletes nothing)")
 
     args = parser.parse_args()
 
@@ -296,7 +307,7 @@ Examples:
         elif args.command == "compare":
             success = compare_snapshots(args.file1, args.file2)
         elif args.command == "cleanup":
-            success = cleanup_old_snapshots(args.directory, args.keep)
+            success = cleanup_old_snapshots(args.directory, args.keep, args.yes)
         else:
             parser.print_help()
             return 1

--- a/src/snapshots/snapshot_utils.py
+++ b/src/snapshots/snapshot_utils.py
@@ -6,6 +6,7 @@ Consolidated from hdf5_utilities.py with fixes for string handling.
 
 import datetime
 import os
+import pathlib
 import shutil
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
@@ -299,18 +300,71 @@ class HDF5Utils:
         return summary
 
     @staticmethod
-    def cleanup_old_files(directory: str, keep_count: int = 10) -> int:
+    def _is_shared_snapshot_root(directory: str) -> bool:
+        """True when ``directory`` is the host's shared snapshot root.
+
+        That root is a project ASSET store: it holds tens of thousands of models that
+        outlive every stack, is shared by the direct CLI, the service and the container
+        alike, and is captured by the whole-tree offline backup. Age-based retention over
+        it is a policy decision the owner has explicitly reserved -- see the snapshot
+        lifecycle design's Phase 4, which writes no retention policy until the archive can
+        say what each file IS. Deleting the 27,886 oldest of 27,896 files because a CLI
+        default said ``--keep 10`` is not that policy.
+        """
+        try:
+            resolved = pathlib.Path(directory).expanduser().resolve()
+        except (OSError, ValueError):
+            return False
+        override = os.environ.get("JUNIPER_CASCOR_SNAPSHOTS_DIR", "").strip()
+        candidates = []
+        if override:
+            candidates.append(pathlib.Path(override).expanduser())
+        # <repo>/cascor-snapshots -- this file is src/snapshots/snapshot_utils.py
+        candidates.append(pathlib.Path(__file__).resolve().parents[2] / "cascor-snapshots")
+        for candidate in candidates:
+            try:
+                if resolved == candidate.expanduser().resolve():
+                    return True
+            except (OSError, ValueError):  # pragma: no cover - defensive
+                continue
+        return False
+
+    @staticmethod
+    def cleanup_old_files(directory: str, keep_count: int = 10, *, dry_run: bool = True, allow_shared_root: bool = False) -> int:
         """
         Clean up old network files, keeping only the most recent ones.
 
         Args:
             directory: Directory containing network files
             keep_count: Number of most recent files to keep
+            dry_run: When True (the DEFAULT), report what would be deleted and delete
+                nothing. Deletion must be asked for explicitly.
+            allow_shared_root: Permit operating on the host's shared snapshot root.
+                Refused by default.
 
         Returns:
-            Number of files deleted
+            Number of files deleted -- or, under ``dry_run``, the number that WOULD be.
+
+        Two guards, both added because this function is reachable from a shipped CLI
+        (``snapshot_cli cleanup <dir> [--keep N]``) with no confirmation of any kind:
+
+        * **Dry-run by default.** This matches the safety contract the rest of the
+          ecosystem's destructive tooling already uses (``--dry-run`` default, ``--yes``
+          required). An age-ordered ``os.remove`` loop with a ``keep_count=10`` default is
+          not something that should happen because an argument was omitted.
+        * **Refuses the shared snapshot root.** ``mtime`` is not creation time in that
+          archive -- a copy reset every timestamp, so files named 2025-10 carry 2026
+          mtimes -- which makes "keep the 10 most recent" not merely dangerous but
+          *wrong*: it sorts by a field that does not mean what it appears to mean.
+
+        Neither guard restricts the intended use (pruning a per-run ``RUN_DIR/snapshots``);
+        both require an explicit opt-in for the case that destroys research data.
         """
         if not os.path.exists(directory):
+            return 0
+
+        if HDF5Utils._is_shared_snapshot_root(directory) and not allow_shared_root:
+            Logger.warning(f"HDF5Utils: refusing to clean up {directory}: it is the SHARED snapshot root, a " "project asset store protected from deletion. mtime is not creation time in that " "archive, so 'keep the N most recent' would not even select what it claims to. " "Pass allow_shared_root=True only with a ratified retention policy.")
             return 0
 
         # Find all HDF5 files
@@ -328,6 +382,10 @@ class HDF5Utils:
         # Delete old files
         deleted_count = 0
         for filepath, _ in hdf5_files[keep_count:]:
+            if dry_run:
+                deleted_count += 1
+                Logger.info(f"HDF5Utils: [dry-run] would delete old file: {filepath}")
+                continue
             try:
                 os.remove(filepath)
                 deleted_count += 1

--- a/src/tests/unit/api/test_w6_snapshots_dir_override.py
+++ b/src/tests/unit/api/test_w6_snapshots_dir_override.py
@@ -1,11 +1,17 @@
 """W-6 (CLI experimentation plan §11 / H-4+H-5) — ``JUNIPER_CASCOR_SNAPSHOTS_DIR`` override.
 
-Service tier: ``TrainingLifecycleManager._get_snapshots_dir`` must honour the env
-override at call time (created on demand), fall back to the legacy
-``<repo>/src/snapshots`` when unset, and treat a set-but-blank value as unset
-(the blank-env guard class). Direct-CLI tier: ``constants_hdf5`` resolves
-``_HDF5_PROJECT_SNAPSHOTS_DIR`` from the same env var at import time — pinned via
-a module re-exec so the test does not depend on this process's import order.
+Both tiers must honour the env override, treat a set-but-blank value as unset (the
+blank-env guard class), and — when unset — resolve to the ONE canonical root,
+``<repo>/cascor-snapshots``. Service tier reads at CALL time
+(``TrainingLifecycleManager._get_snapshots_dir``, created on demand); direct-CLI
+tier reads at IMPORT time (``constants_hdf5._HDF5_PROJECT_SNAPSHOTS_DIR``), pinned
+via a module re-exec so the test does not depend on this process's import order.
+
+The shared-default assertions are the point: a container, a systemd service, and a
+direct CLI run on one host must land in the SAME directory, because a snapshot
+saved by one is restored and resumed by another. Two earlier roots
+(``src/cascor_snapshots``, ``<repo>/snapshots``) are superseded and asserted
+against below so a revert cannot pass silently.
 """
 
 from __future__ import annotations
@@ -24,6 +30,7 @@ from api.lifecycle.manager import TrainingLifecycleManager
 pytestmark = pytest.mark.unit
 
 _SRC_DIR = Path(__file__).resolve().parent.parent.parent.parent
+_REPO_DIR = _SRC_DIR.parent
 _CONSTANTS_HDF5 = _SRC_DIR / "cascor_constants" / "constants_hdf5" / "constants_hdf5.py"
 
 
@@ -60,15 +67,15 @@ class TestServiceTierOverride:
         assert resolved == target
         assert resolved.is_dir()
 
-    def test_unset_falls_back_to_legacy_src_snapshots(self, mgr, monkeypatch):
+    def test_unset_falls_back_to_canonical_root(self, mgr, monkeypatch):
         monkeypatch.delenv("JUNIPER_CASCOR_SNAPSHOTS_DIR", raising=False)
         resolved = mgr._get_snapshots_dir()
-        assert resolved == _SRC_DIR.parent / "snapshots"
+        assert resolved == _REPO_DIR / "cascor-snapshots"
 
     def test_blank_value_is_treated_as_unset(self, mgr, monkeypatch):
         monkeypatch.setenv("JUNIPER_CASCOR_SNAPSHOTS_DIR", "   ")
         resolved = mgr._get_snapshots_dir()
-        assert resolved == _SRC_DIR.parent / "snapshots"
+        assert resolved == _REPO_DIR / "cascor-snapshots"
 
     def test_call_time_read_not_cached(self, mgr, tmp_path, monkeypatch):
         """Two calls under different env values resolve differently — the
@@ -81,15 +88,151 @@ class TestServiceTierOverride:
         assert mgr._get_snapshots_dir() == second
 
 
+class TestInstalledCopyFallback:
+    """From an INSTALLED copy there is no project root, and the repo-relative default would
+    resolve into the interpreter's own library tree (``<python-lib>/cascor-snapshots``) --
+    root-owned on a system Python, and never captured by the project's offline backup.
+
+    ``cascor_constants`` is vendored verbatim into the published ``juniper-cascor-model``
+    wheel, so this is a real deployment shape (the distributed worker), not a hypothetical.
+    """
+
+    @staticmethod
+    def _fake_installed(monkeypatch, root):
+        real = __import__("sysconfig").get_paths
+
+        def fake_get_paths(*a, **kw):
+            paths = dict(real(*a, **kw))
+            paths["purelib"] = str(root)
+            paths["platlib"] = str(root)
+            return paths
+
+        monkeypatch.setattr("sysconfig.get_paths", fake_get_paths)
+
+    def test_installed_copy_falls_back_to_cwd_and_warns(self, tmp_path, monkeypatch):
+        # Claim the module's own tree as "site-packages" so the guard fires.
+        self._fake_installed(monkeypatch, _SRC_DIR)
+        monkeypatch.chdir(tmp_path)
+        with pytest.warns(RuntimeWarning, match="JUNIPER_CASCOR_SNAPSHOTS_DIR"):
+            resolved = _reexec_constants_hdf5(None, monkeypatch)
+        assert resolved == tmp_path / "cascor-snapshots"
+
+    def test_installed_copy_never_resolves_into_the_python_tree(self, tmp_path, monkeypatch):
+        """The specific regression: the default must not land under purelib/platlib."""
+        self._fake_installed(monkeypatch, _SRC_DIR)
+        monkeypatch.chdir(tmp_path)
+        with pytest.warns(RuntimeWarning):
+            resolved = _reexec_constants_hdf5(None, monkeypatch)
+        assert not resolved.is_relative_to(_SRC_DIR)
+
+    def test_explicit_override_still_wins_when_installed(self, tmp_path, monkeypatch):
+        """A configured deployment must not warn -- compose, the systemd unit and the image
+        all set the variable, so the warning means genuinely unconfigured."""
+        self._fake_installed(monkeypatch, _SRC_DIR)
+        target = tmp_path / "configured"
+        import warnings as _w
+
+        with _w.catch_warnings():
+            _w.simplefilter("error", RuntimeWarning)
+            assert _reexec_constants_hdf5(str(target), monkeypatch) == target
+
+    def test_checkout_copy_is_not_treated_as_installed(self, monkeypatch):
+        monkeypatch.delenv("JUNIPER_CASCOR_SNAPSHOTS_DIR", raising=False)
+        import warnings as _w
+
+        with _w.catch_warnings():
+            _w.simplefilter("error", RuntimeWarning)
+            assert _reexec_constants_hdf5(None, monkeypatch) == _REPO_DIR / "cascor-snapshots"
+
+
 class TestDirectCliTierOverride:
     def test_env_override_wins(self, tmp_path, monkeypatch):
         target = tmp_path / "cli-snapshots"
         assert _reexec_constants_hdf5(str(target), monkeypatch) == target
 
-    def test_unset_keeps_legacy_cascor_snapshots(self, monkeypatch):
+    def test_unset_resolves_to_canonical_root(self, monkeypatch):
         resolved = _reexec_constants_hdf5(None, monkeypatch)
-        assert resolved == _SRC_DIR / "cascor_snapshots"
+        assert resolved == _REPO_DIR / "cascor-snapshots"
 
     def test_blank_value_is_treated_as_unset(self, monkeypatch):
         resolved = _reexec_constants_hdf5("", monkeypatch)
-        assert resolved == _SRC_DIR / "cascor_snapshots"
+        assert resolved == _REPO_DIR / "cascor-snapshots"
+
+
+class TestOneSharedRootAcrossTiers:
+    """The convention's actual guarantee: with no override, BOTH tiers land in the
+    same directory — the thing that makes a snapshot written by a container run
+    loadable by a CLI run on the same host."""
+
+    def test_both_tiers_resolve_to_the_same_directory(self, mgr, monkeypatch):
+        monkeypatch.delenv("JUNIPER_CASCOR_SNAPSHOTS_DIR", raising=False)
+        assert mgr._get_snapshots_dir() == _reexec_constants_hdf5(None, monkeypatch)
+
+    @pytest.mark.parametrize("superseded", ["snapshots", "src/cascor_snapshots", "src/snapshots"])
+    def test_superseded_roots_are_not_used(self, mgr, monkeypatch, superseded):
+        monkeypatch.delenv("JUNIPER_CASCOR_SNAPSHOTS_DIR", raising=False)
+        stale = _REPO_DIR / superseded
+        assert mgr._get_snapshots_dir() != stale
+        assert _reexec_constants_hdf5(None, monkeypatch) != stale
+
+    def test_canonical_root_name_is_not_a_python_identifier(self):
+        """The hyphen blocks the ``import cascor_snapshots`` statement form and keeps the
+        directory out of plain ``find_packages``.
+
+        It is NOT, on its own, what keeps the archive out of the distribution -- an earlier
+        version of this test claimed that. pyproject's ``[tool.setuptools.packages.find]``
+        defaults to ``namespaces = true`` (PEP 420), whose finder needs no ``__init__.py``
+        and rejects only names containing a dot, so ``find_namespace_packages`` returns
+        ``cascor-snapshots`` and a built wheel carries it in ``top_level.txt``. The
+        structural guard is ``namespaces = false`` in ``pyproject.toml``, pinned by
+        ``TestPackagingExcludesArtifacts`` below. The hyphen is defence in depth.
+        """
+        assert not "cascor-snapshots".isidentifier()
+
+
+class TestPackagingExcludesArtifacts:
+    """``namespaces = false`` is what actually keeps artifacts and sibling distributions
+    out of the juniper-cascor wheel (C-6: snapshots never reach PyPI)."""
+
+    @staticmethod
+    def _resolved_top_levels():
+        import tomllib
+
+        from setuptools.config import expand
+
+        cfg = tomllib.loads((_REPO_DIR / "pyproject.toml").read_text())
+        find = cfg["tool"]["setuptools"]["packages"]["find"]
+        pkgs = expand.find_packages(
+            where=find["where"],
+            exclude=find.get("exclude", []),
+            namespaces=find.get("namespaces", True),
+            root_dir=str(_REPO_DIR),
+        )
+        return {p.split(".")[0] for p in pkgs}
+
+    def test_namespaces_is_disabled(self):
+        import tomllib
+
+        cfg = tomllib.loads((_REPO_DIR / "pyproject.toml").read_text())
+        assert cfg["tool"]["setuptools"]["packages"]["find"]["namespaces"] is False
+
+    def test_snapshot_root_is_not_a_discovered_package(self):
+        tops = self._resolved_top_levels()
+        assert "cascor-snapshots" not in tops
+        assert "cascor_snapshots" not in tops
+
+    def test_sibling_distributions_are_not_bundled(self):
+        """juniper-cascor-model and juniper-cascor-protocol publish their own wheels and
+        must never ship inside this one; namespaces=true discovered both."""
+        tops = self._resolved_top_levels()
+        assert "juniper-cascor-model" not in tops
+        assert "juniper-cascor-protocol" not in tops
+
+    def test_non_code_directories_are_not_discovered(self):
+        tops = self._resolved_top_levels()
+        assert not tops & {"logs", "notes", "docs", "images", "conf", "data", "scripts", "util"}
+
+    def test_real_packages_survive(self):
+        """The guard must not cost coverage: every directory carrying an __init__.py stays."""
+        tops = self._resolved_top_levels()
+        assert {"api", "cascade_correlation", "cascor_constants", "snapshots"} <= tops

--- a/util/rename_snapshots.bash
+++ b/util/rename_snapshots.bash
@@ -21,7 +21,7 @@ LANG_DIR="python"
 PROJ_DIR="Juniper"
 REPO_DIR="juniper-cascor"
 SRCE_DIR="src/snapshots"
-DEST_DIR="src/cascor_snapshots"
+DEST_DIR="cascor-snapshots"   # repo-root canonical snapshot root (storage-convention ruling 2026-08-20)
 
 
 ########################################################################################################################################################################################################################


### PR DESCRIPTION
## Summary

Implements the owner's 2026-08-20 snapshot storage ruling: **one snapshot root,
`<repo>/cascor-snapshots/`, shared by every stack origin** — the direct CLI, the FastAPI service, and
the container (which bind-mounts this same host directory, in the companion juniper-deploy PR).
Snapshots are project **assets**, not per-origin scratch: a model saved by a container run is
restored by a CLI run and resumed by a service run.

Supersedes two roots: `src/cascor_snapshots/` (historical direct-CLI) and `<repo>/snapshots/` (the
short-lived service root from #537, which never held a file). `JUNIPER_CASCOR_SNAPSHOTS_DIR` still
overrides both tiers, unchanged, blank-is-unset intact — that per-run override is how
`experiment_stack.bash` isolates experiments and stays the sanctioned opt-out.

Design of record: juniper-ml `notes/JUNIPER_2026-08-20_JUNIPER-ECOSYSTEM_SNAPSHOT-STORAGE-CONVENTION-DESIGN.md`.

## The load-bearing part is not what the first draft said

The first draft of this change claimed the **hyphen** in `cascor-snapshots` was a structural guarantee
— "not a valid Python identifier, so setuptools can never discover it as a package." **That is false**,
and three independent reviews caught it before this PR was opened. Verified directly:

```
$ python -c "from setuptools import find_namespace_packages; print([p for p in find_namespace_packages(where='.') if 'snapshot' in p])"
['cascor-snapshots', ...]
$ python -c "import importlib; print(importlib.import_module('cascor-snapshots'))"
<module 'cascor-snapshots' (namespace) ...>
```

`[tool.setuptools.packages.find]` in pyproject defaults to `namespaces = true` (PEP 420) — no
`__init__.py` requirement, no name filter beyond rejecting dots.

**So the real fix is `namespaces = false`**, which is now in `pyproject.toml`. That drops exactly
eleven directories that were being discovered as packages — `cascor-snapshots`, `conf`, `data`,
`docs`, `images`, `logs`, `notes`, `scripts`, `util`, **and the sibling distributions
`juniper-cascor-model` / `juniper-cascor-protocol`**, which publish their own wheels and must never
ship inside this one — while keeping all 29 real packages. Pinned by `TestPackagingExcludesArtifacts`.

The hyphen stays as defence in depth (it blocks the `import` statement form and plain
`find_packages`), just re-filed as taste rather than as the guarantee.

## Three latent breaks found and fixed on the way

None of these are caused by the rename; all three would have been carried forward by it.

1. **The systemd unit could not start.** `ReadWritePaths=` **fails** a unit when the path is missing,
   and two of its entries named directories that no longer exist. All entries now take the `-`
   prefix, and `cascor-snapshots/.gitkeep` is tracked so a fresh clone has the directory. That
   `.gitkeep` also fixes the docker case: a missing bind-mount source is created by the **daemon, as
   root**, which then EPERMs the uid-1000 container on every save — silently, since the save path only
   warns. The ignore rule is `/cascor-snapshots/*` + `!…/.gitkeep`, not the bare directory form,
   because git cannot re-include a path under an excluded directory.

2. **`snapshot_cli cleanup` was an unguarded glob-deleter.** It deleted immediately, no confirmation,
   `--keep 10` default. Pointed at the consolidated archive that removes **27,886 of 27,896** models.
   Worse, it sorted by `mtime`, which in this archive is *not* creation time (a copy reset every
   timestamp), so "keep the N most recent" did not select what it claimed to. Now dry-run by default
   (`--yes` to apply) and it refuses the shared root outright; `allow_shared_root=True` is reserved
   for a ratified retention policy. Verified: dry-run reports 5 and deletes 0; live deletes 5; the
   shared root with `keep=0, dry_run=False` returns 0 and leaves every file.

3. **The image had no correct default.** The service tier computed `parents[3]/"snapshots"` =
   `/app/snapshots` while compose mounted `/app/data`, one directory away — so every containerized
   snapshot went to the container's writable layer and died on recreate, with nothing erroring.
   `ENV JUNIPER_CASCOR_SNAPSHOTS_DIR=/app/cascor-snapshots` is now in the Dockerfile, so a bare
   `docker run` and the Helm path are right by default and orchestrators only mount over an
   already-correct path.

## The wheel no longer resolves a snapshot root inside the Python tree

`cascor_constants` is vendored verbatim into the published `juniper-cascor-model`, so this same file
runs from `site-packages` in the distributed worker. Repo-root-relative resolution would have made
that **worse**, not better:

```
BEFORE (src-relative)    <site-packages>/cascor_snapshots
NAIVE  (root-relative)   <python-lib>/cascor-snapshots      ← escapes site-packages entirely
```

Resolution is now: env override → repo root **when not imported from an install tree** → cwd with a
`RuntimeWarning` naming the variable. The install-tree test is `sysconfig` `purelib`/`platlib`
containment — stdlib-only, no subprocess, and exact. A `pyproject.toml`-adjacency probe was
considered and rejected: it answers *wrongly* inside the container, whose runtime stage copies only
`src/`. Both copies stay **byte-identical**, so `test_drift.py` needs no new
`_INTENTIONAL_DIVERGENCE` entry.

## Also

- `.dockerignore` excludes the artifact roots and `logs/` — nothing `COPY`s them, but every build
  walked ~5 GB of context, and a future `COPY . .` would have baked the archive into a published image.
- `conf/common.conf`'s third definition of the root (`SNAPSHOTS_DIR`) repointed — it is sourced by
  `util/script_template.bash` and `util/get_code_stats.bash`.
- `util/rename_snapshots.bash` `DEST_DIR`; snapshot-artifact docs in `docs/api/API_REFERENCE.md`,
  `docs/source/QUICK_START.md`, `docs/install/REFERENCE.md`, `notes/API_REFERENCE.md`.

## Testing

- `tests/unit/api/test_w6_snapshots_dir_override.py` — 21 tests. New: both tiers resolve to the
  **same** directory unset (the convention's actual guarantee), the three superseded roots are
  asserted against so a revert cannot pass silently, the installed-copy fallback warns and never
  lands under `purelib`/`platlib`, a configured deployment does **not** warn, and the five
  `TestPackagingExcludesArtifacts` arms pin `namespaces = false`.
- `juniper-cascor-model/tests/test_constants_dir_overrides.py` + `test_drift.py` — 15 tests, byte-identity intact.
- `tests/unit/api/` + snapshot serializer suites, `--slow`: exit 0.
- `pre-commit` clean on all 20 files. Note for reviewers: black reformats only the `src/` copy, so
  the vendored copy must be re-synced after formatting or the drift gate fails — done here.

## Requirements

Closes the design's **S-1** open question. Also closes **INT-P3-010** (`cascor_snapshots` vs
`snapshots` directory confusion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kVS1qAXn4ZTdCEoDUWwyR
